### PR TITLE
refactor(net)!: name the hop identifier Hop, and fix three API shapes the review found

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -129,7 +129,7 @@ moq <MoQ side>  play [playback options]
     mDNS, no relay or internet needed. See [LAN Cluster](#lan-cluster-mdns).
 
 Any combination may be given at once (e.g. dial a relay *and* accept incoming
-sessions). `--origin <id>` pins the process's origin id (default: fresh and
+sessions). `--hop <id>` pins the process's Hop ID (default: fresh and
 random per run); see [Redundant Publishers](#redundant-publishers-11).
 
 - **`import`** routes media INTO MoQ (a source fills the Origin); **`export`**
@@ -347,7 +347,7 @@ moq --connect https://relay.example.com/anon \
     -- export --broadcast event.hang hls --listen 0.0.0.0:8080
 ```
 
-Every stage shares one connection, one origin id, and one Origin, and each keeps
+Every stage shares one connection, one Hop ID, and one Origin, and each keeps
 its own `--help` (`moq import rtmp --help`). A stage without `--broadcast` falls
 back to the process-wide one, so a single-stage command can keep naming the
 broadcast before the verb.
@@ -374,7 +374,7 @@ Rules worth knowing:
 
 ### Redundant Publishers (1+1)
 
-Relays key a broadcast's content identity on the publisher's origin id (the
+Relays key a broadcast's content identity on the publisher's Hop ID (the
 first hop of its announcements). Two publishers of the same broadcast that
 share an id are treated as interchangeable sources: relays hold both routes
 and fail over between them at a group boundary, so killing one leaves viewers
@@ -387,16 +387,16 @@ whenever routing prefers another (not only on failure), splicing at the next
 group boundary, so encoders that drift (for example segment-numbered tracks
 from processes started at different times) tear down subscribers on the
 switch. Independent publishers with different tracks or timelines MUST use
-different origin ids; the newcomer then takes the broadcast over instead of
+different Hop IDs; the newcomer then takes the broadcast over instead of
 joining. Run the same command from two aligned encoders, pinning the same id
 on both:
 
 ```bash
-moq --origin 42 --connect https://relay-a.example.com/anon --broadcast event.hang import ts
-moq --origin 42 --connect https://relay-b.example.com/anon --broadcast event.hang import ts
+moq --hop 42 --connect https://relay-a.example.com/anon --broadcast event.hang import ts
+moq --hop 42 --connect https://relay-b.example.com/anon --broadcast event.hang import ts
 ```
 
-Leave `--origin` unset everywhere else. The default fresh id per run is what
+Leave `--hop` unset everywhere else. The default fresh id per run is what
 makes a restarted encoder look like new content (ending subscriptions and
 invalidating caches) instead of silently splicing mid-stream. A publisher with
 a *different* id takes the broadcast over the moment it announces, ending the

--- a/doc/bin/relay/cluster.md
+++ b/doc/bin/relay/cluster.md
@@ -140,9 +140,9 @@ port. Startup readiness only proves an interface announced, not that anything
 answered, so a firewall shows up as a pair that never meshes rather than as a
 relay that fails to start.
 
-## Origin id
+## Hop ID
 
-Each relay has an origin id: the value it adds to a broadcast's hop list for loop detection and shortest-path routing. On `moq-lite`, and on a `moqt-17`-or-later session that negotiated the cluster extension, each end declares it at setup so the other can avoid announcing (or serving) a path that already flows through it. Older sessions carry no identity, so a peer only has one if you assign it. By default a fresh random id is picked on every start, which is fine for loop detection but means a relay looks like a brand-new node each time it restarts.
+Each relay has a Hop ID: the value it adds to a broadcast's hop list for loop detection and shortest-path routing. On `moq-lite`, and on a `moqt-17`-or-later session that negotiated the cluster extension, each end declares it at setup so the other can avoid announcing (or serving) a path that already flows through it. Older sessions carry no identity, so a peer only has one if you assign it. By default a fresh random id is picked on every start, which is fine for loop detection but means a relay looks like a brand-new node each time it restarts.
 
 Set `cluster.id` to pin a stable id across restarts:
 

--- a/doc/bin/relay/http.md
+++ b/doc/bin/relay/http.md
@@ -153,7 +153,7 @@ session over one UDP socket, so it never calls `accept` and cannot exhaust it.
 Returns this relay's local view of cluster nodes. A node is included when it is
 visible through the `.internal/origins` discovery namespace or has an
 established outbound cluster connection. An inbound connection is attached
-only after its SETUP origin id maps to one unique node advertisement. Sessions
+only after its SETUP Hop ID maps to one unique node advertisement. Sessions
 without a unique match are omitted.
 
 ```json
@@ -161,7 +161,7 @@ without a unique match are omitted.
   "nodes": [
     {
       "node": "https://relay-b.example/",
-      "origin_id": "200",
+      "hop_id": "200",
       "announced": {
         "hops": ["200"],
         "hop_count": 1,
@@ -182,7 +182,7 @@ as the cluster stands, so it reads 0 through a relay already carrying the
 broadcast; `cold_cost` prices the same route with those discounts removed, which
 is what tells two warm relays apart. A node can be visible
 without a direct connection, directly connected without an advertisement, or
-both. Origin ids are decimal strings because the wire supports values larger
+both. Hop IDs are decimal strings because the wire supports values larger
 than JavaScript's precise integer range.
 
 A connection `id` is the same id the session's log lines carry in their
@@ -192,8 +192,8 @@ exactly one session. It is process-local and only lasts for that session, so
 don't persist it or compare it across relays.
 
 Inbound association is best-effort correlation, not authenticated node
-identity. The SETUP origin id is self-declared, and `/nodes` associates it only
-when one visible advertisement has the same origin id. Do not use this endpoint
+identity. The SETUP Hop ID is self-declared, and `/nodes` associates it only
+when one visible advertisement has the same Hop ID. Do not use this endpoint
 for authorization or other security decisions.
 
 ## See Also

--- a/doc/lib/rs/env/native.md
+++ b/doc/lib/rs/env/native.md
@@ -87,7 +87,7 @@ Wire an [`origin::Producer`](https://docs.rs/moq-net/latest/moq_net/origin/struc
 ```rust
 // Publish into an origin wired before connecting: it outlives any one session,
 // so the broadcast survives a reconnect. Hold the connection to keep redialing.
-let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 let _connection = client.with_publisher(origin.consume()).connect(url);
 
 let route = moq_net::broadcast::Route::new().with_announce(true);
@@ -106,7 +106,7 @@ Subscribing works the same way round: wire an origin in before connecting and re
 ```rust
 // Consume into an origin wired before connecting, so announcements keep flowing
 // across a reconnect. Hold the connection to keep redialing.
-let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 let mut announced = origin.consume().announced();
 let _connection = client.with_subscriber(origin).connect(url);
 

--- a/doc/lib/rs/env/wasm.md
+++ b/doc/lib/rs/env/wasm.md
@@ -77,7 +77,7 @@ let transport = moq_wasm::transport::connect(url, Default::default()).await?;
 
 // Hand the transport to moq-net and run the MoQ handshake. The origin's driver
 // runs its lifecycle work: give it the runtime's timers and spawn it yourself.
-let (origin, origin_driver) = moq_net::origin::Producer::new(moq_net::Origin::random().into());
+let (origin, origin_driver) = moq_net::origin::Producer::new(moq_net::Hop::random().into());
 wasm_bindgen_futures::spawn_local(origin_driver.run(moq_wasm::runtime::Runtime));
 let mut consumer = origin.consume();
 
@@ -93,7 +93,7 @@ let session = moq_net::Client::new()
 ```
 
 Only the transport setup differs from [native](/lib/rs/env/native); the
-[`Origin`](https://docs.rs/moq-net/latest/moq_net/struct.Origin.html),
+[`origin`](https://docs.rs/moq-net/latest/moq_net/origin/index.html),
 broadcast, track, group, and frame APIs are the same.
 
 ## Next steps

--- a/doc/lib/rs/index.md
+++ b/doc/lib/rs/index.md
@@ -284,13 +284,15 @@ let url = url::Url::parse("https://cdn.moq.dev/anon")?;
 let connection = client.connect(url);
 ```
 
-To publish or consume, wire an [`Origin`](https://docs.rs/moq-net/latest/moq_net/struct.Origin.html)
+To publish or consume, wire an [`origin::Producer`](https://docs.rs/moq-net/latest/moq_net/origin/struct.Producer.html)
 into the client before connecting. The origin outlives any individual session, so
-your broadcasts and subscriptions carry across reconnects:
+your broadcasts and subscriptions carry across reconnects. It is built from a
+[`Hop`](https://docs.rs/moq-net/latest/moq_net/struct.Hop.html), this relay's id in a
+broadcast's hop chain:
 
 ```rust
 // Subscribe: wait for broadcasts to be announced.
-let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 let mut announced = origin.consume().announced();
 let _connection = client.with_subscriber(origin).connect(url);
 

--- a/drafts/draft-lcurley-moq-lite.md
+++ b/drafts/draft-lcurley-moq-lite.md
@@ -357,9 +357,9 @@ This is the only loop defense moq-lite requires, and it catches loops of any len
 A conforming sender never sends one (see below), so a receiver MAY instead close the session with a protocol violation; discarding is what keeps a mesh working when one member does not conform.
 A Hop ID of 0 means unknown and never matches anything; withholding an ID trades loop detection for privacy.
 
-A publisher MUST NOT advertise a path whose entries contain the origin the subscriber declared in its SETUP (see [Origin Parameter](#origin-parameter)).
+A publisher MUST NOT advertise a path whose entries contain the Hop ID the subscriber declared in its SETUP (see [Hop Parameter](#hop-parameter)).
 The receiver can only discard it, and acting on it would form a loop, so sending one is never useful.
-Of the paths that remain a publisher SHOULD advertise the best, and nothing when every known path contains that origin.
+Of the paths that remain a publisher SHOULD advertise the best, and nothing when every known path contains that Hop ID.
 Selection is per subscriber, so a subscriber that the serving path flows through still receives the best standby path, which is what lets it fail over if its own copy dies.
 The per-subscriber winner changing travels as an ANNOUNCE_UPDATE; the last qualifying path appearing or disappearing travels as an ANNOUNCE_START or ANNOUNCE_END.
 
@@ -672,7 +672,7 @@ The following Setup Parameters are defined:
 |------|-----------|-------------|
 | 0x4  | Cost      | Cost (i)    |
 |------|-----------|-------------|
-| 0x5  | Origin    | Hop ID (i)  |
+| 0x5  | Hop       | Hop ID (i)  |
 |------|-----------|-------------|
 
 ### Probe Parameter {#probe-parameter}
@@ -727,8 +727,8 @@ Both endpoints send it and the two values need not match: the parameter prices t
 
 A declared cost is an assertion, not an instruction: a receiver MAY charge a locally configured value instead, so a peer cannot reprice its neighbours by declaring itself cheap.
 
-### Origin Parameter {#origin-parameter}
-The Origin Parameter declares the sender's Hop ID: the identity it stamps onto announcements it forwards.
+### Hop Parameter {#hop-parameter}
+The Hop Parameter declares the sender's Hop ID: the identity it stamps onto announcements it forwards.
 The Parameter Value is a variable-length integer; a value of 0 carries no identity and is equivalent to omitting the parameter.
 
 Declaring it at setup gives the receiver the peer's identity before any other stream arrives, so route selection applies the same exclusion to the peer's subscriptions as to its announcements (see [Routing](#routing)), even on a session that never opens an Announce Stream.
@@ -1343,8 +1343,8 @@ The `Message Length` describes the payload size on the wire.
 - Added a SETUP `Cost` parameter (0x4) declaring what subscribing from the sender costs, added by the receiver to every announcement that sender forwards. Both endpoints send their own, so the two directions are priced independently, and a receiver MAY charge a locally configured value instead. Unpriced directions default to 1, degrading to shortest-path routing.
 - Removed `Exclude Hop` from ANNOUNCE_REQUEST. The receiver's hop-based loop check already discards a looped announcement, so the field only saved the wasted send.
 - Stated the receiver's loop check normatively in ANNOUNCE_START: an announcement whose reconstructed path contains the receiver's own Hop ID is neither forwarded nor selected as a route.
-- Added a SETUP `Origin` parameter (0x5): each endpoint declares its Hop ID at session setup, carrying session-wide the identity `Exclude Hop` carried per announce stream, and filtering subscriptions as well as announcements (including sessions that never open an Announce Stream).
-- Made advertisement selection per subscriber: a publisher MUST NOT advertise a path containing the subscriber's declared origin and otherwise advertises the best remaining one (a subscriber the serving path flows through receives the best standby instead of nothing), MUST serve subscriptions by the same exclusion, and the actively-carrying cost discount applies only to the serving path. This is how redundant publishers fail over across a mesh.
+- Added a SETUP `Hop` parameter (0x5): each endpoint declares its Hop ID at session setup, carrying session-wide the identity `Exclude Hop` carried per announce stream, and filtering subscriptions as well as announcements (including sessions that never open an Announce Stream).
+- Made advertisement selection per subscriber: a publisher MUST NOT advertise a path containing the subscriber's declared Hop ID and otherwise advertises the best remaining one (a subscriber the serving path flows through receives the best standby instead of nothing), MUST serve subscriptions by the same exclusion, and the actively-carrying cost discount applies only to the serving path. This is how redundant publishers fail over across a mesh.
 - Defined same-path advertisements with the same non-zero Epoch as interchangeable content a relay may splice across at a Position. When both Epochs are 0, identity falls back to a shared non-zero first Hop ID; differing or unknown identities never splice.
 - Added `Frame Start` and `Frame End` to SUBSCRIBE and SUBSCRIBE_UPDATE, qualifying the start and end group with a frame index so a subscription can begin or end partway through a group. `Frame Start` is a plain index qualifying the `Group Start` group; `Frame End` is the index + 1, matching `Group End`, and MUST be 0 when `Group End` is absent.
 - Added `Frame Start` and `Frame End` to FETCH, bounding the returned frames within the group. A publisher that cannot serve the full range resets the stream.
@@ -1484,7 +1484,7 @@ The `Increase` Probe level (see [Probe Parameter](#probe-parameter)) lets a subs
 GOAWAY carries an optional New Session URI that asks the peer to reconnect elsewhere. A malicious or compromised peer could use this to redirect a client to an attacker-controlled server. A recipient MUST validate the URI against local policy (scheme, authority, and port) before reconnecting, and MUST NOT reconnect if validation fails (see [GOAWAY](#goaway)). Migrated subscriptions carry no implicit trust from the prior session; the new session is authenticated independently.
 
 ## Routing Metadata and Privacy
-Hop IDs (see [ANNOUNCE_OK](#announce-ok) and [ANNOUNCE_START](#announce-start)) expose the relay path of a broadcast, which may reveal internal topology. A relay that does not wish to disclose its position MAY use the reserved value 0 ("unknown") instead of a stable identifier, at the cost of losing loop detection through itself (see [Routing](#routing)). The origin-based announcement filter (see [Origin Parameter](#origin-parameter)) exists for loop avoidance, not access control: a subscriber cannot verify that a publisher honored it, so it MUST NOT be relied upon to hide a broadcast from a peer that declared its origin.
+Hop IDs (see [ANNOUNCE_OK](#announce-ok) and [ANNOUNCE_START](#announce-start)) expose the relay path of a broadcast, which may reveal internal topology. A relay that does not wish to disclose its position MAY use the reserved value 0 ("unknown") instead of a stable identifier, at the cost of losing loop detection through itself (see [Routing](#routing)). The Hop ID announcement filter (see [Hop Parameter](#hop-parameter)) exists for loop avoidance, not access control: a subscriber cannot verify that a publisher honored it, so it MUST NOT be relied upon to hide a broadcast from a peer that declared its Hop ID.
 
 ## Resource Exhaustion
 A peer can open many streams (subscriptions, announcements, fetches) or request large announce prefixes. Implementations SHOULD bound the number of concurrent subscriptions, announce matches, and cached groups, and SHOULD rely on QUIC flow control and stream limits to backpressure a misbehaving peer (see [ANNOUNCE_REQUEST](#announce-request)). Expiration (see [Expiration](#expiration)) bounds how long stale groups consume memory and flow control.

--- a/go/wrapper/errors.go
+++ b/go/wrapper/errors.go
@@ -60,8 +60,10 @@ var (
 	ErrForbidden = ffi.ErrMoqErrorForbidden
 	// ErrNotFound is returned when the requested track or group is not available.
 	ErrNotFound = ffi.ErrMoqErrorNotFound
-	// ErrUnsupported is returned when the requested operation is not supported.
+	// ErrUnsupported is returned when the requested operation is not supported by this build or peer, however it is asked for.
 	ErrUnsupported = ffi.ErrMoqErrorUnsupported
+	// ErrAlreadyCommitted is returned when a track already reading in one group order is asked for the other; subscribe again for a second cursor.
+	ErrAlreadyCommitted = ffi.ErrMoqErrorAlreadyCommitted
 	// ErrLog is returned when installing or configuring the native log subscriber fails.
 	ErrLog = ffi.ErrMoqErrorLog
 )

--- a/js/net/src/connection/handshake.ts
+++ b/js/net/src/connection/handshake.ts
@@ -1,4 +1,4 @@
-import { type Origin, randomOrigin } from "../hop.ts";
+import { type Hop, randomHop } from "../hop.ts";
 import * as Ietf from "../ietf/index.ts";
 import { Reader, Stream, Writer } from "../stream.ts";
 
@@ -27,7 +27,7 @@ export async function exchangeSetup(
 
 	// One id per session, like the moq-lite connection: nothing in this process forwards
 	// between sessions, so there is nothing for a shared id to detect.
-	const self = randomOrigin();
+	const self = randomHop();
 	Ietf.Cluster.intoSetup(params, self, version);
 
 	const setupMsg = new Ietf.Setup({ parameters: params });
@@ -56,7 +56,7 @@ async function sendSetup(transport: WebTransport, version: Ietf.IetfVersion, set
 async function receiveSetup(
 	transport: WebTransport,
 	version: Ietf.IetfVersion,
-): Promise<{ reader: Reader; solicit: boolean | undefined; cluster: Origin | undefined }> {
+): Promise<{ reader: Reader; solicit: boolean | undefined; cluster: Hop | undefined }> {
 	const uniReader = transport.incomingUnidirectionalStreams.getReader() as ReadableStreamDefaultReader<
 		ReadableStream<Uint8Array>
 	>;

--- a/js/net/src/hop.ts
+++ b/js/net/src/hop.ts
@@ -2,7 +2,7 @@
  * Endpoint identity within a hop chain, shared by both wire protocols.
  *
  * moq-lite carries these natively on every announcement; moq-transport carries them
- * via the MoQ Cluster extension (see `ietf/cluster.ts`). Mirrors `Origin` in
+ * via the MoQ Cluster extension (see `ietf/cluster.ts`). Mirrors `Hop` in
  * `rs/moq-net`.
  *
  * @module
@@ -10,19 +10,23 @@
 import * as z from "zod/mini";
 
 /**
- * A relay origin id, encoded as a 62-bit varint on the wire.
+ * One relay's identity in a broadcast's hop chain, encoded as a 62-bit varint on the wire.
  *
- * The {@link OriginSchema} validates any incoming value and brands it so the
- * type system enforces "only validated origins flow into hop lists." Internal
- * code that synthesizes an id (e.g. {@link randomOrigin}) uses
- * `OriginSchema.parse(...)` to produce a branded value from the raw bigint.
+ * Names a *hop*, not an {@link !Origin | Origin} routing table: this is the id a relay
+ * stamps into a chain as an announcement passes through, so a receiver can spot its own
+ * id and reject a loop. The wire calls the SETUP parameter carrying it `Origin`, which is
+ * why the spec and this type disagree on the name.
+ *
+ * The {@link HopSchema} validates any incoming value and brands it so the type system
+ * enforces "only validated ids flow into hop chains." Internal code that synthesizes one
+ * (e.g. {@link randomHop}) uses `HopSchema.parse(...)` to brand a raw bigint.
  */
-export const OriginSchema = z
+export const HopSchema = z
 	.bigint()
-	.check(z.refine((value) => value >= 0n && value < 1n << 62n, "Origin must be a non-negative 62-bit integer"))
-	.brand("Origin");
+	.check(z.refine((value) => value >= 0n && value < 1n << 62n, "Hop must be a non-negative 62-bit integer"))
+	.brand("Hop");
 
-export type Origin = z.infer<typeof OriginSchema>;
+export type Hop = z.infer<typeof HopSchema>;
 
 /**
  * The reserved id 0, meaning "no identity".
@@ -31,7 +35,7 @@ export type Origin = z.infer<typeof OriginSchema>;
  * be 0, so it identifies nothing: it is never a loop, never a publisher two chains have
  * in common, and never excluded from an advertisement.
  */
-export const UNKNOWN_ORIGIN: Origin = OriginSchema.parse(0n);
+export const UNKNOWN_HOP: Hop = HopSchema.parse(0n);
 
 /**
  * Maximum length of a hop chain. Must match `MAX_HOPS` in Rust's `model/origin.rs`.
@@ -42,7 +46,7 @@ export const UNKNOWN_ORIGIN: Origin = OriginSchema.parse(0n);
 export const MAX_HOPS = 32;
 
 /**
- * Generate a fresh origin with a random non-zero id.
+ * Generate a fresh hop with a random non-zero id.
  *
  * `crypto.getRandomValues` is overkill for best-effort loop detection, but
  * used for slightly better distribution than `Math.random` at negligible cost.
@@ -51,13 +55,13 @@ export const MAX_HOPS = 32;
  * decode `AnnounceInterest.exclude_hop` as a u53 (number) and throw on anything
  * > 2^53-1. To keep those clients alive against fresh peers, we cap the random
  * id at 53 bits. Restore to 62 bits once the u62 fix has propagated to deployed
- * bundles. Mirrors `Origin::random` in rs/moq-net.
+ * bundles. Mirrors `Hop::random` in rs/moq-net.
  */
-export function randomOrigin(): Origin {
+export function randomHop(): Hop {
 	const buf = new BigUint64Array(1);
 	crypto.getRandomValues(buf);
 	// Mask to 53 bits.
 	const raw = buf[0] & 0x1f_ffff_ffff_ffffn;
 	// Guard against the (astronomically unlikely) zero draw.
-	return OriginSchema.parse(raw === 0n ? 1n : raw);
+	return HopSchema.parse(raw === 0n ? 1n : raw);
 }

--- a/js/net/src/hop.ts
+++ b/js/net/src/hop.ts
@@ -14,8 +14,7 @@ import * as z from "zod/mini";
  *
  * Names a *hop*, not an {@link !Origin | Origin} routing table: this is the id a relay
  * stamps into a chain as an announcement passes through, so a receiver can spot its own
- * id and reject a loop. The wire calls the SETUP parameter carrying it `Origin`, which is
- * why the spec and this type disagree on the name.
+ * id and reject a loop. The SETUP parameter that carries it session-wide is `Hop` too.
  *
  * The {@link HopSchema} validates any incoming value and brands it so the type system
  * enforces "only validated ids flow into hop chains." Internal code that synthesizes one

--- a/js/net/src/ietf/cluster.test.ts
+++ b/js/net/src/ietf/cluster.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { ProtocolViolation } from "../error.ts";
-import { type Origin, OriginSchema, UNKNOWN_ORIGIN } from "../hop.ts";
+import { type Hop, HopSchema, UNKNOWN_HOP } from "../hop.ts";
 import * as Path from "../path.ts";
 import { Reader, Writer } from "../stream.ts";
 import * as Cluster from "./cluster.ts";
@@ -11,11 +11,11 @@ import { type IetfVersion, Version } from "./version.ts";
 
 const VERSION = Version.DRAFT_19;
 
-function origin(id: bigint): Origin {
-	return OriginSchema.parse(id);
+function origin(id: bigint): Hop {
+	return HopSchema.parse(id);
 }
 
-function hops(...ids: bigint[]): Origin[] {
+function hops(...ids: bigint[]): Hop[] {
 	return ids.map(origin);
 }
 
@@ -135,7 +135,7 @@ test("Cluster: a path that cannot have come from a conforming sender is rejected
 });
 
 test("Cluster: the setup options round trip", async () => {
-	for (const declared of [origin(42n), UNKNOWN_ORIGIN]) {
+	for (const declared of [origin(42n), UNKNOWN_HOP]) {
 		const params = new SetupOptions();
 		Cluster.intoSetup(params, declared, VERSION);
 
@@ -173,7 +173,7 @@ test("Cluster: we advertise our own id, and only once negotiated", () => {
 	expect(Cluster.negotiated({ self })).toBe(false);
 
 	// A peer that declared the reserved 0 negotiated, and excludes nothing.
-	expect(Cluster.negotiated({ self, peer: UNKNOWN_ORIGIN })).toBe(true);
+	expect(Cluster.negotiated({ self, peer: UNKNOWN_HOP })).toBe(true);
 	expect(Cluster.advertise({ self, peer: origin(9n) })).toEqual({ hops: [self], cost: 0n });
 });
 
@@ -181,7 +181,7 @@ test("Cluster: a loop is detected by any non-zero id", () => {
 	const advert = { hops: hops(0n, 5n), cost: 0n };
 
 	// A receiver whose own id is 0 cannot detect loops through itself.
-	expect(Cluster.loops(advert, UNKNOWN_ORIGIN)).toBe(false);
+	expect(Cluster.loops(advert, UNKNOWN_HOP)).toBe(false);
 	expect(Cluster.loops(advert, origin(5n))).toBe(true);
 	expect(Cluster.loops(advert, origin(6n))).toBe(false);
 });

--- a/js/net/src/ietf/cluster.ts
+++ b/js/net/src/ietf/cluster.ts
@@ -24,7 +24,7 @@
  */
 
 import { ProtocolViolation, reason } from "../error.ts";
-import { MAX_HOPS, type Origin, OriginSchema, UNKNOWN_ORIGIN } from "../hop.ts";
+import { type Hop, HopSchema, MAX_HOPS, UNKNOWN_HOP } from "../hop.ts";
 import type { Reader } from "../stream.ts";
 import * as Varint from "../varint.ts";
 import { Parameters, SetupOption, type SetupOptions } from "./parameters.ts";
@@ -50,7 +50,7 @@ export function supported(version: IetfVersion): boolean {
  */
 export interface Hops {
 	/** Our own Hop ID, declared in SETUP and stamped onto every advertisement we send. */
-	self: Origin;
+	self: Hop;
 
 	/**
 	 * The peer's Hop ID, or `undefined` when it declared no RELAY_HOPS.
@@ -61,7 +61,7 @@ export interface Hops {
 	 * message. A peer that declared the reserved 0 negotiated the extension but withheld its
 	 * identity, so the parameters flow and there is simply nothing to exclude.
 	 */
-	peer?: Origin;
+	peer?: Hop;
 }
 
 /**
@@ -74,7 +74,7 @@ export interface Hops {
  */
 export interface Advert {
 	/** HOP_PATH: the path this advertisement traversed, publisher first, sender last. */
-	hops: Origin[];
+	hops: Hop[];
 
 	/** ROUTE_COST: the marginal cost of subscribing via this advertisement. Absent on the
 	 * wire means 0, so an endpoint that prices nothing sends nothing. */
@@ -86,7 +86,7 @@ export interface Advert {
  *
  * @internal
  */
-export function fromSetup(params: SetupOptions, version: IetfVersion): Origin | undefined {
+export function fromSetup(params: SetupOptions, version: IetfVersion): Hop | undefined {
 	if (!supported(version)) return undefined;
 
 	// RELAY_HOPS is odd, so its value is a length-prefixed byte string holding the sender's
@@ -97,7 +97,7 @@ export function fromSetup(params: SetupOptions, version: IetfVersion): Origin | 
 
 	const [origin, rest] = Varint.decodeLeadingOnes(value);
 	if (rest.length !== 0) throw new Error("trailing bytes in RELAY_HOPS");
-	return OriginSchema.parse(origin);
+	return HopSchema.parse(origin);
 }
 
 /**
@@ -105,7 +105,7 @@ export function fromSetup(params: SetupOptions, version: IetfVersion): Origin | 
  *
  * @internal
  */
-export function intoSetup(params: SetupOptions, self: Origin, version: IetfVersion) {
+export function intoSetup(params: SetupOptions, self: Hop, version: IetfVersion) {
 	if (!supported(version)) return;
 	params.setBytes(SetupOption.RelayHops, Varint.encodeLeadingOnes(self));
 }
@@ -145,8 +145,8 @@ export function advertise(ids: Hops | undefined): Advert | undefined {
  *
  * @internal
  */
-export function loops(advert: Advert, self: Origin): boolean {
-	return self !== UNKNOWN_ORIGIN && advert.hops.includes(self);
+export function loops(advert: Advert, self: Hop): boolean {
+	return self !== UNKNOWN_HOP && advert.hops.includes(self);
 }
 
 /**
@@ -211,12 +211,12 @@ export function fromParams(params: Parameters): Advert {
 		const value = params.hopPath;
 		if (value === undefined) throw new Error("advertisement is missing HOP_PATH");
 
-		const hops: Origin[] = [];
+		const hops: Hop[] = [];
 		let rest = value;
 		while (rest.length > 0) {
 			// A short read here means the entries did not exactly fill the length.
 			const [hop, remain] = Varint.decodeLeadingOnes(rest);
-			hops.push(OriginSchema.parse(hop));
+			hops.push(HopSchema.parse(hop));
 			rest = remain;
 
 			// Bail before the buffer does: a hostile length would otherwise cost us one
@@ -236,14 +236,14 @@ export function fromParams(params: Parameters): Advert {
  * than we accept, or a non-zero Hop ID appearing twice (a loop). Duplicate zeros are legal,
  * since 0 identifies nothing.
  */
-function validate(hops: Origin[]) {
+function validate(hops: Hop[]) {
 	if (hops.length === 0) throw new Error("hop path is empty");
 	if (hops.length > MAX_HOPS) throw new Error(`hop count ${hops.length} exceeds maximum ${MAX_HOPS}`);
 
 	// MAX_HOPS is 32, so the quadratic scan is cheaper than allocating a set.
 	for (let i = 0; i < hops.length; i++) {
 		const hop = hops[i];
-		if (hop === UNKNOWN_ORIGIN) continue;
+		if (hop === UNKNOWN_HOP) continue;
 		if (hops.indexOf(hop, i + 1) !== -1) throw new Error(`hop ${hop} appears twice in the hop path`);
 	}
 }

--- a/js/net/src/ietf/publisher.test.ts
+++ b/js/net/src/ietf/publisher.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { Producer as GroupProducer } from "../group.ts";
-import { type Origin, OriginSchema } from "../hop.ts";
+import { type Hop, HopSchema } from "../hop.ts";
 import { createMockTransportPair } from "../mock.ts";
 import { Producer as OriginProducer } from "../origin.ts";
 import * as Path from "../path.ts";
@@ -514,9 +514,9 @@ test("closing the session ends the unsolicited announce loop", async () => {
  * not read ours either, so sending it the parameters would be a protocol violation.
  */
 test("an advertisement carries our hop id once the peer declared one", async () => {
-	const self: Origin = OriginSchema.parse(7n);
+	const self: Hop = HopSchema.parse(7n);
 
-	for (const peer of [OriginSchema.parse(9n), undefined]) {
+	for (const peer of [HopSchema.parse(9n), undefined]) {
 		const pair = createMockTransportPair(ALPN.DRAFT_19);
 		const { pub, origin } = publisher(pair.server, { cluster: { self, peer } });
 		origin.publish(Path.from("mine"));

--- a/js/net/src/ietf/subscriber.test.ts
+++ b/js/net/src/ietf/subscriber.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import type * as announce from "../announced.ts";
-import { type Origin, OriginSchema } from "../hop.ts";
+import { type Hop, HopSchema } from "../hop.ts";
 import { createMockTransportPair } from "../mock.ts";
 import * as Path from "../path.ts";
 import { Stream } from "../stream.ts";
@@ -335,8 +335,8 @@ test("concurrent legacy publish_namespace requests take one reference", async ()
 });
 
 /** The Hop IDs a cluster-negotiated session declared, ours first. */
-const SELF: Origin = OriginSchema.parse(7n);
-const PEER: Origin = OriginSchema.parse(9n);
+const SELF: Hop = HopSchema.parse(7n);
+const PEER: Hop = HopSchema.parse(9n);
 
 /**
  * A peer that knows our Hop ID never advertises a path that already ran through us, so
@@ -441,7 +441,7 @@ test("a PUBLISH_NAMESPACE update that starts looping back is detached", async ()
 	const announced = subscriber.announced(Path.empty());
 	await acceptSubscribeNamespace(pair.client);
 
-	const advert = (hops: Origin[]) =>
+	const advert = (hops: Hop[]) =>
 		new PublishNamespace({
 			requestId: 0n,
 			trackNamespace: Path.from("theirs"),

--- a/js/net/src/lite/announce.test.ts
+++ b/js/net/src/lite/announce.test.ts
@@ -139,7 +139,7 @@ test("AnnounceOk accepts the reserved unknown origin", async () => {
 	const msg = new AnnounceOk(UNKNOWN_HOP, 3);
 	const reader = new Reader(undefined, await bytes((w) => msg.encode(w, Version.DRAFT_05)));
 	const got = await AnnounceOk.decode(reader, Version.DRAFT_05);
-	expect(got.origin).toBe(UNKNOWN_HOP);
+	expect(got.hop).toBe(UNKNOWN_HOP);
 	expect(got.active).toBe(3);
 });
 
@@ -147,7 +147,7 @@ test("AnnounceOk round-trips a declared origin", async () => {
 	const msg = new AnnounceOk(HopSchema.parse(42n), 1);
 	const reader = new Reader(undefined, await bytes((w) => msg.encode(w, Version.DRAFT_05)));
 	const got = await AnnounceOk.decode(reader, Version.DRAFT_05);
-	expect(got.origin).toBe(HopSchema.parse(42n));
+	expect(got.hop).toBe(HopSchema.parse(42n));
 	expect(got.active).toBe(1);
 });
 

--- a/js/net/src/lite/announce.test.ts
+++ b/js/net/src/lite/announce.test.ts
@@ -113,7 +113,7 @@ async function requestRoundTrip(msg: AnnounceRequest, version: Version): Promise
 	return AnnounceRequest.decode(reader, version);
 }
 
-// Draft04/05 carry the subscriber's origin id so the publisher can skip reflected
+// Draft04/05 carry the subscriber's Hop ID so the publisher can skip reflected
 // announces before they hit the wire.
 test("AnnounceRequest carries excludeHop on draft-05", async () => {
 	const got = await requestRoundTrip(new AnnounceRequest(Path.from("room/"), 42n), Version.DRAFT_05);

--- a/js/net/src/lite/announce.test.ts
+++ b/js/net/src/lite/announce.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { ProtocolViolation } from "../error.ts";
-import { OriginSchema, UNKNOWN_ORIGIN } from "../hop.ts";
+import { HopSchema, UNKNOWN_HOP } from "../hop.ts";
 import * as Path from "../path.ts";
 import { Reader, Writer } from "../stream.ts";
 import {
@@ -40,7 +40,7 @@ async function roundTrip(msg: AnnounceBroadcast, version: Version): Promise<Anno
 }
 
 test("AnnounceBroadcast round-trips on draft-05", async () => {
-	const hops = [OriginSchema.parse(7n)];
+	const hops = [HopSchema.parse(7n)];
 	const gotActive = await roundTrip({ status: "active", suffix: Path.from("room/cam"), hops }, Version.DRAFT_05);
 	expect(gotActive).toEqual({ status: "active", suffix: Path.from("room/cam"), hops });
 
@@ -49,7 +49,7 @@ test("AnnounceBroadcast round-trips on draft-05", async () => {
 });
 
 test("AnnounceBroadcast round-trips on draft-06", async () => {
-	const hops = [OriginSchema.parse(7n)];
+	const hops = [HopSchema.parse(7n)];
 	// An absent cost encodes as zero and decodes explicitly.
 	const gotActive = await roundTrip({ status: "active", suffix: Path.from("room/cam"), hops }, Version.DRAFT_06);
 	expect(gotActive).toEqual({ status: "active", suffix: Path.from("room/cam"), hops, cost: { warm: 0n, cold: 0n } });
@@ -136,24 +136,24 @@ test("AnnounceRequest drops excludeHop on draft-06", async () => {
 // withholds it to obscure its routing. Rejecting it tore down the announce stream of a
 // conforming publisher.
 test("AnnounceOk accepts the reserved unknown origin", async () => {
-	const msg = new AnnounceOk(UNKNOWN_ORIGIN, 3);
+	const msg = new AnnounceOk(UNKNOWN_HOP, 3);
 	const reader = new Reader(undefined, await bytes((w) => msg.encode(w, Version.DRAFT_05)));
 	const got = await AnnounceOk.decode(reader, Version.DRAFT_05);
-	expect(got.origin).toBe(UNKNOWN_ORIGIN);
+	expect(got.origin).toBe(UNKNOWN_HOP);
 	expect(got.active).toBe(3);
 });
 
 test("AnnounceOk round-trips a declared origin", async () => {
-	const msg = new AnnounceOk(OriginSchema.parse(42n), 1);
+	const msg = new AnnounceOk(HopSchema.parse(42n), 1);
 	const reader = new Reader(undefined, await bytes((w) => msg.encode(w, Version.DRAFT_05)));
 	const got = await AnnounceOk.decode(reader, Version.DRAFT_05);
-	expect(got.origin).toBe(OriginSchema.parse(42n));
+	expect(got.origin).toBe(HopSchema.parse(42n));
 	expect(got.active).toBe(1);
 });
 
 test("a hop chain that revisits a hop is refused in both directions", async () => {
-	const four = OriginSchema.parse(4n);
-	const eight = OriginSchema.parse(8n);
+	const four = HopSchema.parse(4n);
+	const eight = HopSchema.parse(8n);
 	const looped: AnnounceBroadcast = { status: "active", suffix: Path.from("room"), hops: [four, eight, four] };
 
 	// Outbound: refused before it reaches the wire. A receiver must close the session over
@@ -166,7 +166,7 @@ test("a hop chain that revisits a hop is refused in both directions", async () =
 	const legal: AnnounceBroadcast = {
 		status: "active",
 		suffix: Path.from("room"),
-		hops: [four, eight, OriginSchema.parse(9n)],
+		hops: [four, eight, HopSchema.parse(9n)],
 	};
 	const forged = await bytes((w) => encodeAnnounceBroadcast(w, legal, Version.DRAFT_06));
 	const nine = forged.lastIndexOf(9);
@@ -185,7 +185,7 @@ test("a hop chain that revisits a hop is refused in both directions", async () =
 
 	// Repeated unknowns are not a loop: 0 identifies nothing, so any number of hops may
 	// be unknown. A lite-03 announcement is nothing but these.
-	const unknown = OriginSchema.parse(0n);
+	const unknown = HopSchema.parse(0n);
 	const anonymous: AnnounceBroadcast = {
 		status: "active",
 		suffix: Path.from("room"),

--- a/js/net/src/lite/announce.ts
+++ b/js/net/src/lite/announce.ts
@@ -354,11 +354,11 @@ export class AnnounceInit {
 /// {@link UNKNOWN_HOP} when the responder has no identity to give. `active` is
 /// the number of initial Announce messages that follow immediately.
 export class AnnounceOk {
-	origin: Hop;
+	hop: Hop;
 	active: number;
 
-	constructor(origin: Hop, active: number) {
-		this.origin = origin;
+	constructor(hop: Hop, active: number) {
+		this.hop = hop;
 		this.active = active;
 	}
 
@@ -369,7 +369,7 @@ export class AnnounceOk {
 	}
 
 	async #encode(w: Writer) {
-		await w.u62(this.origin);
+		await w.u62(this.hop);
 		await w.u53(this.active);
 	}
 

--- a/js/net/src/lite/announce.ts
+++ b/js/net/src/lite/announce.ts
@@ -1,5 +1,5 @@
 import { ProtocolViolation } from "../error.ts";
-import { MAX_HOPS, type Origin, OriginSchema, UNKNOWN_ORIGIN } from "../hop.ts";
+import { type Hop, HopSchema, MAX_HOPS, UNKNOWN_HOP } from "../hop.ts";
 import * as Path from "../path.ts";
 import type { Reader, Writer } from "../stream.ts";
 import * as Message from "./message.ts";
@@ -48,7 +48,7 @@ export type AnnounceBroadcast =
 	/** A broadcast is now available, carrying the path suffix, the hop chain, and
 	 * (lite-06+) the route cost. An absent cost encodes as zero; it decodes as
 	 * `undefined` on a wire with no room for one. */
-	| { status: "active"; suffix: Path.Valid; hops: Origin[]; cost?: Cost }
+	| { status: "active"; suffix: Path.Valid; hops: Hop[]; cost?: Cost }
 	/** Pre-lite-06: a broadcast is no longer available, retracted by path. */
 	| { status: "ended"; suffix: Path.Valid }
 	/** Lite06+: a broadcast is no longer available, retracted by announce id.
@@ -56,16 +56,16 @@ export type AnnounceBroadcast =
 	| { status: "endedId"; id: bigint }
 	/** Lite06+: atomically replace the announcement with this id (e.g. a new hop
 	 * chain after a relay failover, or a route whose cost moved). The id stays live. */
-	| { status: "restart"; id: bigint; hops: Origin[]; cost?: Cost };
+	| { status: "restart"; id: bigint; hops: Hop[]; cost?: Cost };
 
 // Both wire rules on a hop chain, applied to what we send and to what we receive: a
 // chain that revisits a hop looped, so neither forwarding it nor subscribing through it
-// is safe, and a receiver must end the session over one. `UNKNOWN_ORIGIN` identifies
+// is safe, and a receiver must end the session over one. `UNKNOWN_HOP` identifies
 // nothing, so any number of hops may be unknown.
 //
 // `ProtocolViolation` so a receipt takes the session down rather than the one stream,
 // matching what `ietf/cluster.ts` throws for the identical rule.
-function checkHops(hops: Origin[]) {
+function checkHops(hops: Hop[]) {
 	if (hops.length > MAX_HOPS) {
 		throw new ProtocolViolation(`hop count ${hops.length} exceeds maximum ${MAX_HOPS}`);
 	}
@@ -73,14 +73,14 @@ function checkHops(hops: Origin[]) {
 	// MAX_HOPS is 32, so the quadratic scan is cheaper than allocating a set.
 	for (let i = 0; i < hops.length; i++) {
 		const hop = hops[i];
-		if (hop === UNKNOWN_ORIGIN) continue;
+		if (hop === UNKNOWN_HOP) continue;
 		if (hops.indexOf(hop, i + 1) !== -1) {
 			throw new ProtocolViolation(`hop ${hop} appears twice in the chain`);
 		}
 	}
 }
 
-async function encodeHops(w: Writer, version: Version, hops: Origin[]) {
+async function encodeHops(w: Writer, version: Version, hops: Hop[]) {
 	checkHops(hops);
 	switch (version) {
 		case Version.DRAFT_01:
@@ -90,7 +90,7 @@ async function encodeHops(w: Writer, version: Version, hops: Origin[]) {
 			await w.u53(hops.length);
 			break;
 		default:
-			// Lite04+: hop count + individual Origin varints.
+			// Lite04+: hop count + individual Hop varints.
 			await w.u53(hops.length);
 			for (const origin of hops) {
 				await w.u62(origin);
@@ -99,7 +99,7 @@ async function encodeHops(w: Writer, version: Version, hops: Origin[]) {
 	}
 }
 
-async function decodeHops(r: Reader, version: Version): Promise<Origin[]> {
+async function decodeHops(r: Reader, version: Version): Promise<Hop[]> {
 	switch (version) {
 		case Version.DRAFT_01:
 		case Version.DRAFT_02:
@@ -109,15 +109,15 @@ async function decodeHops(r: Reader, version: Version): Promise<Origin[]> {
 			if (count > MAX_HOPS) throw new Error(`hop count ${count} exceeds maximum ${MAX_HOPS}`);
 			// Lite03 carries only a hop count, not individual ids, so every entry is
 			// the reserved "no identity" id.
-			return new Array<Origin>(count).fill(UNKNOWN_ORIGIN);
+			return new Array<Hop>(count).fill(UNKNOWN_HOP);
 		}
 		default: {
-			// Lite04+: hop count + individual Origin varints.
+			// Lite04+: hop count + individual Hop varints.
 			const count = await r.u53();
 			if (count > MAX_HOPS) throw new Error(`hop count ${count} exceeds maximum ${MAX_HOPS}`);
-			const hops: Origin[] = [];
+			const hops: Hop[] = [];
 			for (let i = 0; i < count; i++) {
-				hops.push(OriginSchema.parse(await r.u62()));
+				hops.push(HopSchema.parse(await r.u62()));
 			}
 			checkHops(hops);
 			return hops;
@@ -264,7 +264,7 @@ export async function decodeAnnounceBroadcastMaybe(
  */
 export class AnnounceRequest {
 	prefix: Path.Valid;
-	/** Lite04/05 only: the 62-bit Origin id of the peer asking for announces, which the
+	/** Lite04/05 only: the 62-bit Hop id of the peer asking for announces, which the
 	 * publisher uses to skip announces that already passed through it. Zero means "no
 	 * exclusion". Not on the wire elsewhere, so a value set here is ignored when encoding
 	 * for another version and decodes as zero.
@@ -351,13 +351,13 @@ export class AnnounceInit {
 ///
 /// `origin` is the responder's origin id, which the subscriber stamps onto each
 /// announce's hop chain (the publisher no longer stamps itself), or the reserved
-/// {@link UNKNOWN_ORIGIN} when the responder has no identity to give. `active` is
+/// {@link UNKNOWN_HOP} when the responder has no identity to give. `active` is
 /// the number of initial Announce messages that follow immediately.
 export class AnnounceOk {
-	origin: Origin;
+	origin: Hop;
 	active: number;
 
-	constructor(origin: Origin, active: number) {
+	constructor(origin: Hop, active: number) {
 		this.origin = origin;
 		this.active = active;
 	}
@@ -377,7 +377,7 @@ export class AnnounceOk {
 		// The draft reserves 0 for "unknown": the responder was never assigned an id, or
 		// withholds it to obscure its routing. It names nobody, so callers must not stamp
 		// it onto a hop chain, but it is a legal message and not grounds to drop the stream.
-		const origin = OriginSchema.parse(await r.u62());
+		const origin = HopSchema.parse(await r.u62());
 		const active = await r.u53();
 		return new AnnounceOk(origin, active);
 	}

--- a/js/net/src/lite/announce.ts
+++ b/js/net/src/lite/announce.ts
@@ -349,7 +349,7 @@ export class AnnounceInit {
 /// Sent by the publisher as the first message on an announce stream, before any
 /// individual Announce messages. Lite05+ only; the successor to AnnounceInit.
 ///
-/// `origin` is the responder's origin id, which the subscriber stamps onto each
+/// `origin` is the responder's Hop ID, which the subscriber stamps onto each
 /// announce's hop chain (the publisher no longer stamps itself), or the reserved
 /// {@link UNKNOWN_HOP} when the responder has no identity to give. `active` is
 /// the number of initial Announce messages that follow immediately.

--- a/js/net/src/lite/connection.ts
+++ b/js/net/src/lite/connection.ts
@@ -80,7 +80,7 @@ export class Connection implements Established {
 
 	/** Random per-connection origin id. Shared by Publisher (for outbound hop
 	 * chains) and Subscriber (available for optional self-filtering on announces). */
-	readonly origin: Hop;
+	readonly hop: Hop;
 
 	// The peer's SETUP, recorded once its Setup stream is read (lite-05+). Streams whose
 	// encoding depends on a negotiated capability (e.g. PROBE) wait on this. undefined
@@ -123,9 +123,9 @@ export class Connection implements Established {
 
 		this.probe = this.#probe;
 
-		this.origin = randomHop();
-		this.#publisher = new Publisher(this.#quic, this.#version, this.origin, publish);
-		this.#subscriber = new Subscriber(this.#quic, this.#version, this.origin, this.#probe, this.#peerSetup);
+		this.hop = randomHop();
+		this.#publisher = new Publisher(this.#quic, this.#version, this.hop, publish);
+		this.#subscriber = new Subscriber(this.#quic, this.#version, this.hop, this.#probe, this.#peerSetup);
 
 		void this.#run();
 	}
@@ -215,7 +215,7 @@ export class Connection implements Established {
 		try {
 			await writer.u53(DataType.Setup);
 			const probe = await probeLevel(this.#quic, this.#version);
-			await new Setup({ probe, origin: this.origin }).encode(writer, this.#version);
+			await new Setup({ probe, hop: this.hop }).encode(writer, this.#version);
 			writer.close();
 		} catch (err: unknown) {
 			writer.reset(err);

--- a/js/net/src/lite/connection.ts
+++ b/js/net/src/lite/connection.ts
@@ -78,7 +78,7 @@ export class Connection implements Established {
 	/** The peer's PROBE estimates; see {@link Established.probe}. */
 	readonly probe: Getter<Probe>;
 
-	/** Random per-connection origin id. Shared by Publisher (for outbound hop
+	/** Random per-connection Hop ID. Shared by Publisher (for outbound hop
 	 * chains) and Subscriber (available for optional self-filtering on announces). */
 	readonly hop: Hop;
 

--- a/js/net/src/lite/connection.ts
+++ b/js/net/src/lite/connection.ts
@@ -5,7 +5,7 @@ import type { Established } from "../connection/established.ts";
 import { type Probe, type Stats, transportStats } from "../connection/stats.ts";
 import { type Transport, transportOf } from "../connection/transport.ts";
 import { error, fromClose } from "../error.ts";
-import { type Origin, randomOrigin } from "../hop.ts";
+import { type Hop, randomHop } from "../hop.ts";
 import type { Consumer as OriginConsumer } from "../origin.ts";
 import * as Path from "../path.ts";
 import { type Reader, Readers, Stream, Writer } from "../stream.ts";
@@ -80,7 +80,7 @@ export class Connection implements Established {
 
 	/** Random per-connection origin id. Shared by Publisher (for outbound hop
 	 * chains) and Subscriber (available for optional self-filtering on announces). */
-	readonly origin: Origin;
+	readonly origin: Hop;
 
 	// The peer's SETUP, recorded once its Setup stream is read (lite-05+). Streams whose
 	// encoding depends on a negotiated capability (e.g. PROBE) wait on this. undefined
@@ -123,7 +123,7 @@ export class Connection implements Established {
 
 		this.probe = this.#probe;
 
-		this.origin = randomOrigin();
+		this.origin = randomHop();
 		this.#publisher = new Publisher(this.#quic, this.#version, this.origin, publish);
 		this.#subscriber = new Subscriber(this.#quic, this.#version, this.origin, this.#probe, this.#peerSetup);
 

--- a/js/net/src/lite/publisher.test.ts
+++ b/js/net/src/lite/publisher.test.ts
@@ -1,6 +1,6 @@
 import { expect, spyOn, test } from "bun:test";
 import { Producer as GroupProducer } from "../group.ts";
-import { randomOrigin } from "../hop.ts";
+import { randomHop } from "../hop.ts";
 import { createMockTransportPair } from "../mock.ts";
 import { Producer as OriginProducer } from "../origin.ts";
 import * as Path from "../path.ts";
@@ -31,7 +31,7 @@ function replayUpdate(props: ConstructorParameters<typeof SubscribeUpdate>[0]) {
 async function subscribeEnd(sequences: number[]): Promise<number> {
 	const pair = createMockTransportPair(ALPN_05);
 	const origin = new OriginProducer();
-	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomOrigin(), origin.consume());
+	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomHop(), origin.consume());
 
 	const broadcast = origin.publish(Path.from("test"));
 	const track = broadcast.createTrack("video");
@@ -94,7 +94,7 @@ async function groupSendOrders(options: { priority: number; sequences: number[];
 	const groups = sequences.map((sequence) => new GroupProducer(sequence));
 	const pair = createMockTransportPair(ALPN_05);
 	const origin = new OriginProducer();
-	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomOrigin(), origin.consume());
+	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomHop(), origin.consume());
 
 	const broadcast = origin.publish(Path.from("test"));
 	const track = broadcast.createTrack("video");
@@ -178,7 +178,7 @@ test("lite draft-05: a subscribe update re-ranks the whole subscription", async 
 test("lite draft-05: a subscribe update re-ranks a group already on the wire", async () => {
 	const pair = createMockTransportPair(ALPN_05);
 	const origin = new OriginProducer();
-	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomOrigin(), origin.consume());
+	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomHop(), origin.consume());
 
 	const broadcast = origin.publish(Path.from("test"));
 	const track = broadcast.createTrack("video");
@@ -231,7 +231,7 @@ test("lite draft-05: a subscribe update re-ranks a group already on the wire", a
 test("lite draft-05: a subscribe update during the stream open still ranks the group", async () => {
 	const pair = createMockTransportPair(ALPN_05);
 	const origin = new OriginProducer();
-	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomOrigin(), origin.consume());
+	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomHop(), origin.consume());
 
 	const broadcast = origin.publish(Path.from("test"));
 	const track = broadcast.createTrack("video");
@@ -291,7 +291,7 @@ test("lite draft-05: many concurrent groups share one subscription listener", as
 	const count = 120;
 	const pair = createMockTransportPair(ALPN_05);
 	const origin = new OriginProducer();
-	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomOrigin(), origin.consume());
+	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomHop(), origin.consume());
 
 	const broadcast = origin.publish(Path.from("test"));
 	const track = broadcast.createTrack("video");
@@ -345,7 +345,7 @@ test("lite draft-05: many concurrent groups share one subscription listener", as
 test("lite draft-05: the fetch response ranks the publisher's own writes", async () => {
 	const pair = createMockTransportPair(ALPN_05);
 	const origin = new OriginProducer();
-	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomOrigin(), origin.consume());
+	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomHop(), origin.consume());
 
 	const broadcast = origin.publish(Path.from("test"));
 	const track = broadcast.createTrack("video");
@@ -440,7 +440,7 @@ async function servedSubscription(
 	const frames = options.frames ?? ["hello"];
 	const pair = createMockTransportPair(version === Version.DRAFT_06 ? ALPN_06_WIP : ALPN_05);
 	const origin = new OriginProducer();
-	const publisher = new Publisher(pair.server, version, randomOrigin(), origin.consume());
+	const publisher = new Publisher(pair.server, version, randomHop(), origin.consume());
 
 	const broadcast = origin.publish(Path.from("test"));
 	const track = broadcast.createTrack("video", { maxAge: options.maxAge });
@@ -919,7 +919,7 @@ async function serve(
 ): Promise<{ start?: number; end?: number; served: Served[] }> {
 	const pair = createMockTransportPair(ALPN_06_WIP);
 	const origin = new OriginProducer();
-	const publisher = new Publisher(pair.server, Version.DRAFT_06, randomOrigin(), origin.consume());
+	const publisher = new Publisher(pair.server, Version.DRAFT_06, randomHop(), origin.consume());
 
 	const broadcast = origin.publish(Path.from("test"));
 	const track = broadcast.createTrack("video");
@@ -1101,7 +1101,7 @@ async function saturatedGroup() {
 	};
 
 	const origin = new OriginProducer();
-	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomOrigin(), origin.consume());
+	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomHop(), origin.consume());
 	const broadcast = origin.publish(Path.from("test"));
 	const track = broadcast.createTrack("video");
 
@@ -1181,7 +1181,7 @@ test("lite draft-05: a blocked group header is reset when the group expires", as
 	pair.server.createUnidirectionalStream = async () => writable;
 
 	const origin = new OriginProducer();
-	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomOrigin(), origin.consume());
+	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomHop(), origin.consume());
 	const broadcast = origin.publish(Path.from("test"));
 	const track = broadcast.createTrack("video");
 	const client = await Stream.open(pair.client);
@@ -1263,7 +1263,7 @@ test("runProbe rounds a fractional smoothedRtt instead of killing the stream", a
 	const pair = createMockTransportPair(ALPN_05, {
 		stats: { estimatedSendRate: 1_000_000, smoothedRtt: 12.34 },
 	});
-	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomOrigin());
+	const publisher = new Publisher(pair.server, Version.DRAFT_05, randomHop());
 
 	// The subscriber opens the probe stream; the publisher only replies on it.
 	const client = await Stream.open(pair.client);

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -310,7 +310,7 @@ export class Publisher {
 	// can detect loops and prefer shorter paths. Created by Connection and
 	// shared with Subscriber, which can optionally use it to filter out its
 	// own announcements.
-	readonly origin: Hop;
+	readonly hop: Hop;
 
 	#quic: WebTransport;
 
@@ -340,10 +340,10 @@ export class Publisher {
 	 *
 	 * @internal
 	 */
-	constructor(quic: WebTransport, version: Version, origin: Hop, publish?: OriginConsumer) {
+	constructor(quic: WebTransport, version: Version, hop: Hop, publish?: OriginConsumer) {
 		this.#quic = quic;
 		this.version = version;
-		this.origin = origin;
+		this.hop = hop;
 		this.#broadcasts = publish?.broadcasts ?? new Signal(new Map());
 
 		// Grab the datagram writer up front when the transport carries datagrams (no group
@@ -396,7 +396,7 @@ export class Publisher {
 					for (const suffix of active.keys()) {
 						await encodeAnnounceBroadcast(
 							stream.writer,
-							{ status: "active", suffix, hops: [this.origin] },
+							{ status: "active", suffix, hops: [this.hop] },
 							this.version,
 						);
 					}
@@ -405,7 +405,7 @@ export class Publisher {
 
 				// Report our origin id once via AnnounceOk and the count of initial announces
 				// that follow; the subscriber stamps our origin onto each hop chain, so we omit it.
-				const ok = new AnnounceOk(this.origin, active.size);
+				const ok = new AnnounceOk(this.hop, active.size);
 				await ok.encode(stream.writer, this.version);
 				for (const suffix of active.keys()) {
 					if (hasAnnounceId(this.version)) {
@@ -461,7 +461,7 @@ export class Publisher {
 			for (const [added, front] of newActive) {
 				if (active.get(added) === front) continue;
 				console.debug(`announce: broadcast=${added} active=true`);
-				const hops = hasAnnounceOk(this.version) ? [] : [this.origin];
+				const hops = hasAnnounceOk(this.version) ? [] : [this.hop];
 				if (hasAnnounceId(this.version)) {
 					announceIds.set(added, nextAnnounceId++);
 				}

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -403,7 +403,7 @@ export class Publisher {
 					break;
 				}
 
-				// Report our origin id once via AnnounceOk and the count of initial announces
+				// Report our Hop ID once via AnnounceOk and the count of initial announces
 				// that follow; the subscriber stamps our origin onto each hop chain, so we omit it.
 				const ok = new AnnounceOk(this.hop, active.size);
 				await ok.encode(stream.writer, this.version);

--- a/js/net/src/lite/publisher.ts
+++ b/js/net/src/lite/publisher.ts
@@ -2,7 +2,7 @@ import { type Dispose, type Getter, Signal } from "@moq/signals";
 import type * as broadcast from "../broadcast.ts";
 import { error, reason, StreamCode, toTransport } from "../error.ts";
 import type * as group from "../group.ts";
-import type { Origin } from "../hop.ts";
+import type { Hop } from "../hop.ts";
 import { hooks } from "../internal.ts";
 import type { Consumer as OriginConsumer } from "../origin.ts";
 import * as Path from "../path.ts";
@@ -310,7 +310,7 @@ export class Publisher {
 	// can detect loops and prefer shorter paths. Created by Connection and
 	// shared with Subscriber, which can optionally use it to filter out its
 	// own announcements.
-	readonly origin: Origin;
+	readonly origin: Hop;
 
 	#quic: WebTransport;
 
@@ -335,12 +335,12 @@ export class Publisher {
 	 * Creates a new Publisher instance.
 	 * @param quic - The WebTransport session to use
 	 * @param version - Negotiated protocol version
-	 * @param origin - Origin id shared with the Subscriber
+	 * @param origin - Hop id shared with the Subscriber
 	 * @param publish - The origin whose broadcasts this session serves; omit to publish nothing
 	 *
 	 * @internal
 	 */
-	constructor(quic: WebTransport, version: Version, origin: Origin, publish?: OriginConsumer) {
+	constructor(quic: WebTransport, version: Version, origin: Hop, publish?: OriginConsumer) {
 		this.#quic = quic;
 		this.version = version;
 		this.origin = origin;

--- a/js/net/src/lite/setup.test.ts
+++ b/js/net/src/lite/setup.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { OriginSchema } from "../hop.ts";
+import { HopSchema } from "../hop.ts";
 import { Reader, Writer } from "../stream.ts";
 import * as Varint from "../varint.ts";
 import { ProbeLevel, Role, Setup } from "./setup.ts";
@@ -128,7 +128,7 @@ test("unknown probe level saturates to Increase", async () => {
 });
 
 test("SETUP with origin round-trips", async () => {
-	const origin = OriginSchema.parse(42n);
+	const origin = HopSchema.parse(42n);
 	const got = await roundTrip(new Setup({ origin }));
 	expect(got.origin).toBe(origin);
 });

--- a/js/net/src/lite/setup.test.ts
+++ b/js/net/src/lite/setup.test.ts
@@ -10,7 +10,7 @@ import { Version } from "./version.ts";
 const PARAM_PROBE = 0x1n;
 const PARAM_PATH = 0x2n;
 const PARAM_ROLE = 0x3n;
-const PARAM_ORIGIN = 0x5n;
+const PARAM_HOP = 0x5n;
 
 function concat(chunks: Uint8Array[]): Uint8Array {
 	const total = chunks.reduce((sum, c) => sum + c.byteLength, 0);
@@ -127,16 +127,16 @@ test("unknown probe level saturates to Increase", async () => {
 	expect(got.probe).toBe(ProbeLevel.Increase);
 });
 
-test("SETUP with origin round-trips", async () => {
-	const origin = HopSchema.parse(42n);
-	const got = await roundTrip(new Setup({ origin }));
-	expect(got.origin).toBe(origin);
+test("SETUP with hop round-trips", async () => {
+	const hop = HopSchema.parse(42n);
+	const got = await roundTrip(new Setup({ hop }));
+	expect(got.hop).toBe(hop);
 });
 
-test("origin 0 decodes as absent", async () => {
+test("hop 0 decodes as absent", async () => {
 	// 0 carries no identity (it cannot be excluded), so it decodes as undefined.
-	const got = await decodeParam(PARAM_ORIGIN, Varint.encode(0));
-	expect(got.origin).toBeUndefined();
+	const got = await decodeParam(PARAM_HOP, Varint.encode(0));
+	expect(got.hop).toBeUndefined();
 });
 
 test("SETUP is rejected before draft-05", async () => {

--- a/js/net/src/lite/setup.ts
+++ b/js/net/src/lite/setup.ts
@@ -5,7 +5,7 @@
  * @module
  */
 
-import { type Origin, OriginSchema } from "../hop.ts";
+import { type Hop, HopSchema } from "../hop.ts";
 import type { Reader, Writer } from "../stream.ts";
 import * as Varint from "../varint.ts";
 import * as Message from "./message.ts";
@@ -170,7 +170,7 @@ export interface SetupProps {
 	/** See {@link Setup.role}. Defaults to {@link Role.Both}. */
 	role?: Role;
 	/** See {@link Setup.origin}. Omitted by default. */
-	origin?: Origin;
+	origin?: Hop;
 }
 
 /**
@@ -206,7 +206,7 @@ export class Setup {
 	 * per-stream `exclude_hop` in its favor). `undefined` when the endpoint declares
 	 * no identity; a wire value of 0 decodes the same way.
 	 */
-	origin?: Origin;
+	origin?: Hop;
 
 	constructor({ probe, path, role, origin }: SetupProps = {}) {
 		this.probe = probe ?? ProbeLevel.None;
@@ -256,7 +256,7 @@ export class Setup {
 
 		// 0 carries no identity (it cannot be excluded), so it decodes as absent.
 		const originRaw = params.getVarint(PARAM_ORIGIN);
-		const origin = originRaw === undefined || originRaw === 0n ? undefined : OriginSchema.parse(originRaw);
+		const origin = originRaw === undefined || originRaw === 0n ? undefined : HopSchema.parse(originRaw);
 
 		return new Setup({ probe, path, role, origin });
 	}

--- a/js/net/src/lite/setup.ts
+++ b/js/net/src/lite/setup.ts
@@ -17,8 +17,8 @@ const PARAM_PROBE = 0x1n;
 const PARAM_PATH = 0x2n;
 /** Setup Parameter id for the client's intended {@link Role} (client-only). */
 const PARAM_ROLE = 0x3n;
-/** Setup Parameter id for the endpoint's origin (hop) id. */
-const PARAM_ORIGIN = 0x5n;
+/** Setup Parameter id for the endpoint's Hop ID. */
+const PARAM_HOP = 0x5n;
 
 /** Cap on the number of parameters in a bag, matching the Rust decoder. */
 const MAX_PARAMS = 64;
@@ -169,8 +169,8 @@ export interface SetupProps {
 	path?: string;
 	/** See {@link Setup.role}. Defaults to {@link Role.Both}. */
 	role?: Role;
-	/** See {@link Setup.origin}. Omitted by default. */
-	origin?: Hop;
+	/** See {@link Setup.hop}. Omitted by default. */
+	hop?: Hop;
 }
 
 /**
@@ -201,18 +201,18 @@ export class Setup {
 	role: Role;
 
 	/**
-	 * This endpoint's origin (hop) id. The peer uses it to filter announcements and
+	 * This endpoint's Hop ID. The peer uses it to filter announcements and
 	 * subscriptions whose route flows through this endpoint (lite-06 removed the
 	 * per-stream `exclude_hop` in its favor). `undefined` when the endpoint declares
 	 * no identity; a wire value of 0 decodes the same way.
 	 */
-	origin?: Hop;
+	hop?: Hop;
 
-	constructor({ probe, path, role, origin }: SetupProps = {}) {
+	constructor({ probe, path, role, hop }: SetupProps = {}) {
 		this.probe = probe ?? ProbeLevel.None;
 		this.path = path;
 		this.role = role ?? Role.Both;
-		this.origin = origin;
+		this.hop = hop;
 	}
 
 	static #guard(version: Version) {
@@ -234,8 +234,8 @@ export class Setup {
 		if (this.role !== Role.Both) {
 			params.setVarint(PARAM_ROLE, this.role);
 		}
-		if (this.origin !== undefined && this.origin !== 0n) {
-			params.setVarint(PARAM_ORIGIN, this.origin);
+		if (this.hop !== undefined && this.hop !== 0n) {
+			params.setVarint(PARAM_HOP, this.hop);
 		}
 		await params.encode(w);
 	}
@@ -255,10 +255,10 @@ export class Setup {
 		const role = roleCode === undefined ? Role.Both : roleFromCode(roleCode);
 
 		// 0 carries no identity (it cannot be excluded), so it decodes as absent.
-		const originRaw = params.getVarint(PARAM_ORIGIN);
-		const origin = originRaw === undefined || originRaw === 0n ? undefined : HopSchema.parse(originRaw);
+		const hopRaw = params.getVarint(PARAM_HOP);
+		const hop = hopRaw === undefined || hopRaw === 0n ? undefined : HopSchema.parse(hopRaw);
 
-		return new Setup({ probe, path, role, origin });
+		return new Setup({ probe, path, role, hop });
 	}
 
 	/** Encode the SETUP message with its size prefix. Throws on pre-lite-05 versions. */

--- a/js/net/src/lite/subscriber.test.ts
+++ b/js/net/src/lite/subscriber.test.ts
@@ -2,7 +2,7 @@ import { expect, spyOn, test } from "bun:test";
 import { Signal } from "@moq/signals";
 import type { Probe as ProbeStats } from "../connection/stats.ts";
 import { error, reason } from "../error.ts";
-import { OriginSchema, UNKNOWN_ORIGIN } from "../hop.ts";
+import { HopSchema, UNKNOWN_HOP } from "../hop.ts";
 import * as Path from "../path.ts";
 import { Writer } from "../stream.ts";
 import * as Time from "../time.ts";
@@ -19,7 +19,7 @@ test("closing the subscriber suppresses probe stream warnings", async () => {
 			writable: new WritableStream<Uint8Array>(),
 		}),
 	} as unknown as WebTransport;
-	const subscriber = new Subscriber(quic, Version.DRAFT_03, OriginSchema.parse(1n), new Signal<ProbeStats>({}));
+	const subscriber = new Subscriber(quic, Version.DRAFT_03, HopSchema.parse(1n), new Signal<ProbeStats>({}));
 	const warn = spyOn(console, "warn").mockImplementation(() => {});
 
 	try {
@@ -65,7 +65,7 @@ function announceHarness(version: Version, origin = 1n) {
 		},
 	} as unknown as WebTransport;
 
-	const subscriber = new Subscriber(quic, version, OriginSchema.parse(origin));
+	const subscriber = new Subscriber(quic, version, HopSchema.parse(origin));
 
 	const send = async (f: (w: Writer) => Promise<void>) => {
 		const written: Uint8Array[] = [];
@@ -123,10 +123,10 @@ function announceHarness(version: Version, origin = 1n) {
 	};
 }
 
-const PUBLISHER_A = OriginSchema.parse(7n);
-const PUBLISHER_B = OriginSchema.parse(8n);
-const PUBLISHER_C = OriginSchema.parse(9n);
-const PEER = OriginSchema.parse(2n);
+const PUBLISHER_A = HopSchema.parse(7n);
+const PUBLISHER_B = HopSchema.parse(8n);
+const PUBLISHER_C = HopSchema.parse(9n);
+const PEER = HopSchema.parse(2n);
 
 test("a restart from the same publisher is a route change, not a republish", async () => {
 	const { subscriber, send, settle } = announceHarness(Version.DRAFT_06);
@@ -174,7 +174,7 @@ test("a lite-05 duplicate announce follows the same restart rule", async () => {
 	await settle();
 
 	await send((w) => new AnnounceOk(PEER, 0).encode(w, Version.DRAFT_05));
-	const active = (hops: ReturnType<typeof OriginSchema.parse>[]) => (w: Writer) =>
+	const active = (hops: ReturnType<typeof HopSchema.parse>[]) => (w: Writer) =>
 		encodeAnnounceBroadcast(w, { status: "active", suffix: Path.from("room"), hops }, Version.DRAFT_05);
 
 	await send(active([PUBLISHER_A]));
@@ -200,7 +200,7 @@ test("a restart from an unidentified publisher replaces rather than reroutes", a
 	const announced = subscriber.announced(Path.empty());
 	await settle();
 
-	await send((w) => new AnnounceOk(UNKNOWN_ORIGIN, 0).encode(w, Version.DRAFT_06));
+	await send((w) => new AnnounceOk(UNKNOWN_HOP, 0).encode(w, Version.DRAFT_06));
 	await send((w) =>
 		encodeAnnounceBroadcast(w, { status: "active", suffix: Path.from("room"), hops: [] }, Version.DRAFT_06),
 	);
@@ -266,7 +266,7 @@ async function runProbeScript(version: Version, probes: Probe[], initial: ProbeS
 	} as unknown as WebTransport;
 
 	const signal = new Signal<ProbeStats>(initial);
-	const subscriber = new Subscriber(quic, version, OriginSchema.parse(1n), signal);
+	const subscriber = new Subscriber(quic, version, HopSchema.parse(1n), signal);
 	const running = subscriber.runProbe();
 
 	await Promise.resolve();
@@ -321,7 +321,7 @@ test("an announce skipped as a reflected loop still holds its path", async () =>
 	await send((w) =>
 		encodeAnnounceBroadcast(
 			w,
-			{ status: "active", suffix: Path.from("room"), hops: [OriginSchema.parse(SELF)] },
+			{ status: "active", suffix: Path.from("room"), hops: [HopSchema.parse(SELF)] },
 			Version.DRAFT_06,
 		),
 	);
@@ -362,7 +362,7 @@ test("a restart replaces an announce that was skipped as a reflected loop", asyn
 	await send((w) =>
 		encodeAnnounceBroadcast(
 			w,
-			{ status: "active", suffix: Path.from("room"), hops: [OriginSchema.parse(SELF)] },
+			{ status: "active", suffix: Path.from("room"), hops: [HopSchema.parse(SELF)] },
 			Version.DRAFT_06,
 		),
 	);
@@ -392,7 +392,7 @@ test("retiring an id whose announce was skipped ends nothing", async () => {
 	await send((w) =>
 		encodeAnnounceBroadcast(
 			w,
-			{ status: "active", suffix: Path.from("room"), hops: [OriginSchema.parse(SELF)] },
+			{ status: "active", suffix: Path.from("room"), hops: [HopSchema.parse(SELF)] },
 			Version.DRAFT_06,
 		),
 	);
@@ -457,7 +457,7 @@ test("a duplicate start is reported even when its own route reflects", async () 
 	await send((w) =>
 		encodeAnnounceBroadcast(
 			w,
-			{ status: "active", suffix: Path.from("room"), hops: [OriginSchema.parse(SELF)] },
+			{ status: "active", suffix: Path.from("room"), hops: [HopSchema.parse(SELF)] },
 			Version.DRAFT_06,
 		),
 	);

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -120,7 +120,7 @@ export class Subscriber {
 
 	// Shared with the Publisher so callers can optionally filter out their
 	// own announcements on a per-call basis (see {@link AnnouncedOptions}).
-	readonly origin: Hop;
+	readonly hop: Hop;
 
 	// Our subscribed tracks. `timescale` resolves once known (from TRACK_INFO on
 	// lite-05+, or implicit defaults on older drafts); group streams block on it
@@ -158,13 +158,13 @@ export class Subscriber {
 	constructor(
 		quic: WebTransport,
 		version: Version,
-		origin: Hop,
+		hop: Hop,
 		probe?: Signal<ProbeStats>,
 		peerSetup?: Signal<Setup | undefined>,
 	) {
 		this.#quic = quic;
 		this.version = version;
-		this.origin = origin;
+		this.hop = hop;
 		this.#probe = probe;
 		this.#peerSetup = peerSetup;
 	}
@@ -187,7 +187,7 @@ export class Subscriber {
 		// whose hop chain already passed through us. Encoding drops it on every other
 		// version, where we drop the reflected announce on receipt instead. Matches the
 		// Rust subscriber's `exclude_hop: self.self_origin.id` in `run_announce_prefix`.
-		const msg = new AnnounceRequest(prefix, this.origin);
+		const msg = new AnnounceRequest(prefix, this.hop);
 
 		// Drop reflected announces so callers asking for "someone else's broadcasts"
 		// don't re-see their own publishes. A caller can always ask for this, and it is
@@ -221,7 +221,7 @@ export class Subscriber {
 				// nobody, so folding it into a chain would stamp a placeholder that cannot
 				// close a loop or tell two publishers apart. Treat it as absent instead,
 				// which is the loop-blind route the draft describes.
-				responderOrigin = ok.origin === UNKNOWN_HOP ? undefined : ok.origin;
+				responderOrigin = ok.hop === UNKNOWN_HOP ? undefined : ok.hop;
 			}
 
 			// Every advertisement the peer currently has live, keyed by suffix (at most one
@@ -355,7 +355,7 @@ export class Subscriber {
 				// list, so fold it back in before checking.
 				if (hops !== undefined && dropReflected) {
 					const full = responderOrigin !== undefined ? [...hops, responderOrigin] : hops;
-					if (full.includes(this.origin)) {
+					if (full.includes(this.hop)) {
 						// A reflected restart means the peer's remaining route loops back through
 						// us, so the route is gone even though the message says active. The
 						// advertisement stays live: the peer still holds the path and its id still

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -62,7 +62,7 @@ function supportsTrackStream(version: Version): boolean {
 export interface AnnouncedOptions {
 	/**
 	 * If true, skip announcements whose hop chain contains this connection's
-	 * own origin id. Useful for meshes that reflect announces back. Defaults
+	 * own Hop ID. Useful for meshes that reflect announces back. Defaults
 	 * to false for backwards compatibility: existing code (notably hang.live)
 	 * relies on seeing its own publishes as the signal that a namespace
 	 * published successfully.
@@ -183,7 +183,7 @@ export class Subscriber {
 
 	async #runAnnounced(announced: announce.Producer, prefix: Path.Valid, options: AnnouncedOptions): Promise<void> {
 		console.debug(`announced: prefix=${prefix}`);
-		// Lite04/05: send our own session-level origin id so the peer can skip announces
+		// Lite04/05: send our own session-level Hop ID so the peer can skip announces
 		// whose hop chain already passed through us. Encoding drops it on every other
 		// version, where we drop the reflected announce on receipt instead. Matches the
 		// Rust subscriber's `exclude_hop: self.self_origin.id` in `run_announce_prefix`.
@@ -211,7 +211,7 @@ export class Subscriber {
 			await stream.writer.u53(StreamId.Announce);
 			await msg.encode(stream.writer, this.version);
 
-			// Lite05+: the publisher reports its own origin id before any announces.
+			// Lite05+: the publisher reports its own Hop ID before any announces.
 			// It no longer stamps itself onto each hop chain, so we append it here to
 			// keep the ignoreSelf loop check seeing the full chain.
 			let responderOrigin: Hop | undefined;

--- a/js/net/src/lite/subscriber.ts
+++ b/js/net/src/lite/subscriber.ts
@@ -5,7 +5,7 @@ import type { Probe as ProbeStats } from "../connection/stats.ts";
 import { BroadcastCache } from "../consume.ts";
 import { error, ProtocolViolation, reason } from "../error.ts";
 import * as netGroup from "../group.ts";
-import { type Origin, UNKNOWN_ORIGIN } from "../hop.ts";
+import { type Hop, UNKNOWN_HOP } from "../hop.ts";
 import * as Path from "../path.ts";
 import { type Reader, Stream } from "../stream.ts";
 import * as Time from "../time.ts";
@@ -120,7 +120,7 @@ export class Subscriber {
 
 	// Shared with the Publisher so callers can optionally filter out their
 	// own announcements on a per-call basis (see {@link AnnouncedOptions}).
-	readonly origin: Origin;
+	readonly origin: Hop;
 
 	// Our subscribed tracks. `timescale` resolves once known (from TRACK_INFO on
 	// lite-05+, or implicit defaults on older drafts); group streams block on it
@@ -149,7 +149,7 @@ export class Subscriber {
 	 * Creates a new Subscriber instance.
 	 * @param quic - The WebTransport session to use
 	 * @param version - The protocol version
-	 * @param origin - Origin id shared with the Publisher
+	 * @param origin - Hop id shared with the Publisher
 	 * @param probe - Optional sink for the peer's PROBE estimates
 	 * @param peerSetup - Optional peer SETUP slot for capability gating (lite-05+)
 	 *
@@ -158,7 +158,7 @@ export class Subscriber {
 	constructor(
 		quic: WebTransport,
 		version: Version,
-		origin: Origin,
+		origin: Hop,
 		probe?: Signal<ProbeStats>,
 		peerSetup?: Signal<Setup | undefined>,
 	) {
@@ -214,14 +214,14 @@ export class Subscriber {
 			// Lite05+: the publisher reports its own origin id before any announces.
 			// It no longer stamps itself onto each hop chain, so we append it here to
 			// keep the ignoreSelf loop check seeing the full chain.
-			let responderOrigin: Origin | undefined;
+			let responderOrigin: Hop | undefined;
 			if (hasAnnounceOk(this.version)) {
 				const ok = await AnnounceOk.decode(stream.reader, this.version);
 				// A responder that withholds its identity sends the reserved 0. It names
 				// nobody, so folding it into a chain would stamp a placeholder that cannot
 				// close a loop or tell two publishers apart. Treat it as absent instead,
 				// which is the loop-blind route the draft describes.
-				responderOrigin = ok.origin === UNKNOWN_ORIGIN ? undefined : ok.origin;
+				responderOrigin = ok.origin === UNKNOWN_HOP ? undefined : ok.origin;
 			}
 
 			// Every advertisement the peer currently has live, keyed by suffix (at most one
@@ -236,7 +236,7 @@ export class Subscriber {
 			// `publisher` is what lets a restart tell a route change (same publisher,
 			// subscriptions resume) from a replacement (a new generation took the path,
 			// nothing carries over).
-			type Advertisement = { publisher: Origin | undefined; live: boolean };
+			type Advertisement = { publisher: Hop | undefined; live: boolean };
 			const advertised = new Map<Path.Valid, Advertisement>();
 
 			switch (this.version) {
@@ -285,7 +285,7 @@ export class Subscriber {
 				let suffix: Path.Valid;
 				let active: boolean;
 				// Present on active/restart; ended messages never carry hops worth checking.
-				let hops: Origin[] | undefined;
+				let hops: Hop[] | undefined;
 
 				switch (announce.status) {
 					case "active":
@@ -374,8 +374,8 @@ export class Subscriber {
 					// A publisher with no identity (an empty chain from a peer that withheld its
 					// own id, or a lite-03 UNKNOWN placeholder) never proves continuity: two such
 					// advertisements can be unrelated publishers. Mirrors the
-					// `publisher == Origin::UNKNOWN` arm of the Rust `restart_announce`.
-					const identified = publisher !== undefined && publisher !== UNKNOWN_ORIGIN;
+					// `publisher == Hop::UNKNOWN` arm of the Rust `restart_announce`.
+					const identified = publisher !== undefined && publisher !== UNKNOWN_HOP;
 
 					// A second advertisement for a path we already carry is a restart: either an
 					// explicit ANNOUNCE_UPDATE, or (lite-05) a duplicate ANNOUNCE.

--- a/js/net/src/lite/version.ts
+++ b/js/net/src/lite/version.ts
@@ -110,7 +110,7 @@ export function hasAnnounceId(version: Version): boolean {
 }
 
 /** Whether ANNOUNCE_REQUEST carries the Exclude Hop field: the subscriber's own
- * origin id, which the publisher uses to skip announces whose hop chain already
+ * Hop ID, which the publisher uses to skip announces whose hop chain already
  * passed through the subscriber. Present in lite-04 and lite-05 only.
  *
  * The receiver's own reflected-announce check drops those announces anyway (and

--- a/js/net/src/stream.ts
+++ b/js/net/src/stream.ts
@@ -296,7 +296,7 @@ export class Reader {
 	// Returns a Number using 53-bits, the max Javascript can use for integer math.
 	// Values > 2^53-1 are coerced to a Number (precision is lost) and logged. We
 	// downgrade overflow from throw to warn so a stray u64 field on the wire (e.g.
-	// a peer's session-level Origin id) doesn't tear down the whole stream/session.
+	// a peer's session-level Hop ID) doesn't tear down the whole stream/session.
 	async u53(): Promise<number> {
 		const v = await this.u62();
 		if (v > Varint.MAX_U53) {

--- a/rs/hang/examples/subscribe.rs
+++ b/rs/hang/examples/subscribe.rs
@@ -10,7 +10,7 @@ async fn main() -> anyhow::Result<()> {
 	moq_tokio::Log::new(tracing::Level::DEBUG).init()?;
 
 	// Create an origin that the session can publish incoming broadcasts to.
-	let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+	let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 	let consumer = origin.consume();
 
 	// Run the subscription and the session in parallel.

--- a/rs/hang/examples/video.rs
+++ b/rs/hang/examples/video.rs
@@ -8,7 +8,7 @@ async fn main() -> anyhow::Result<()> {
 	moq_tokio::Log::new(tracing::Level::DEBUG).init()?;
 
 	// Create an origin that we can publish to and the session can consume from.
-	let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+	let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 
 	// Run the broadcast production and the session in parallel.
 	// This is a simple example of how you can concurrently run multiple tasks.

--- a/rs/libmoq/src/origin.rs
+++ b/rs/libmoq/src/origin.rs
@@ -39,7 +39,7 @@ impl Origin {
 	pub fn create(&mut self) -> Result<Id, Error> {
 		// Every FFI entry point runs inside `RUNTIME.enter()`, so the driver
 		// lands on the dedicated libmoq runtime.
-		self.active.insert(moq_tokio::origin::spawn(moq_net::Origin::random()))
+		self.active.insert(moq_tokio::origin::spawn(moq_net::Hop::random()))
 	}
 
 	pub fn get(&self, id: Id) -> Result<&moq_net::origin::Producer, Error> {

--- a/rs/moq-bench/src/connection.rs
+++ b/rs/moq-bench/src/connection.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use moq_tokio::Status;
-use moq_tokio::moq_net::{self, Origin, bytes::Bytes};
+use moq_tokio::moq_net::{self, Hop, bytes::Bytes};
 use moq_tokio::moq_net::{broadcast, track};
 use rand::RngExt;
 use serde::{Deserialize, Serialize};
@@ -96,9 +96,9 @@ pub async fn run(ctx: Connection) {
 	let url = config.client.url.clone().expect("url required");
 
 	// Publish side: an origin we fill with our broadcasts and hand to the session.
-	let publish = moq_tokio::origin::spawn(Origin::random());
+	let publish = moq_tokio::origin::spawn(Hop::random());
 	// Consume side: the session fills this with peer announcements.
-	let consume = moq_tokio::origin::spawn(Origin::random());
+	let consume = moq_tokio::origin::spawn(Hop::random());
 
 	let namespace = format!("{}/{run_id:08x}", config.name());
 	let discovery = if config.publishes() {
@@ -682,7 +682,7 @@ mod tests {
 		tokio::time::pause();
 
 		let stats = Arc::new(Stats::default());
-		let origin = moq_tokio::origin::spawn(Origin::random());
+		let origin = moq_tokio::origin::spawn(Hop::random());
 
 		// The relay-internal broadcast: announced, but with no bench data track.
 		let _internal = origin
@@ -725,7 +725,7 @@ mod tests {
 	#[tokio::test]
 	async fn named_subscription_waits_for_the_exact_broadcast() {
 		let stats = Arc::new(Stats::default());
-		let origin = moq_tokio::origin::spawn(Origin::random());
+		let origin = moq_tokio::origin::spawn(Hop::random());
 		let consume = origin.consume();
 		let task = tokio::spawn(subscribe_named(consume, "bench/run/chat".into(), stats.clone()));
 

--- a/rs/moq-boy/src/main.rs
+++ b/rs/moq-boy/src/main.rs
@@ -225,7 +225,7 @@ async fn run(config: &Config) -> Result<()> {
 	let client = config.client.clone().init(config.quic.clone())?;
 
 	// Publish origin: the game session broadcast.
-	let publish_origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+	let publish_origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 	let default_game_prefix = format!("{}/game", config.prefix);
 	let default_viewer_prefix = format!("{}/viewer", config.prefix);
 	let game_prefix = config.prefix_game.as_deref().unwrap_or(&default_game_prefix);
@@ -240,7 +240,7 @@ async fn run(config: &Config) -> Result<()> {
 	// Consume origin: viewer broadcasts under the viewer prefix.
 	// JS publishes viewer feedback at "{viewer_prefix}/{name}/{viewerId}"
 	let viewer_path = format!("{viewer_prefix}/{name}");
-	let consume_origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+	let consume_origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 	let mut viewer_consumer = consume_origin
 		.with_root(&viewer_path)
 		.expect("viewer prefix should be valid")

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -338,15 +338,20 @@ pub struct MoqSide {
 	#[usage(long, alias = "name", help_heading = "MoQ")]
 	pub broadcast: Option<String>,
 
-	/// Fix this process's origin id instead of minting a fresh random one.
+	/// Fix this process's Hop ID instead of minting a fresh random one.
 	///
-	/// The origin id is the first hop of every announcement this process
+	/// The Hop ID is the first hop of every announcement this process
 	/// publishes, and relays treat it as the broadcast's content identity:
 	/// redundant publishers of the same broadcast share an id so relays fail
 	/// over between them at a group boundary. Leave unset outside a redundant
 	/// (1+1) chain; the default fresh id per run is what makes a restarted
 	/// publisher look like new content instead of silently splicing.
-	#[usage(long, env = "MOQ_ORIGIN", help_heading = "MoQ")]
+	#[usage(long, env = "MOQ_HOP", help_heading = "MoQ")]
+	pub hop: Option<u64>,
+
+	/// The released spelling of [`Self::hop`], kept in the parser only so a
+	/// process that still passes it is told what to pass instead.
+	#[usage(name = "origin", long = "origin", env = "MOQ_ORIGIN", hide = true)]
 	pub origin: Option<u64>,
 
 	/// MoQ client config (`--connect`, `--connect-bind`, `--connect-tls-*`, ...).
@@ -379,15 +384,18 @@ impl MoqSide {
 		let mut found = self.client.deprecated();
 		found.extend(self.quic.deprecated());
 		found.extend(self.server.deprecated());
+		if self.origin.is_some() {
+			found.flag("--origin", Some("MOQ_ORIGIN"), "--hop / MOQ_HOP");
+		}
 		found
 	}
 
-	/// Mint the origin all broadcasts route through: the pinned `--origin` id
-	/// when set, otherwise fresh and random.
+	/// Mint the origin all broadcasts route through, identified by the pinned
+	/// `--hop` id when set and a fresh random one otherwise.
 	pub fn origin(&self) -> anyhow::Result<moq_net::origin::Producer> {
 		use anyhow::Context;
-		Ok(moq_tokio::origin::spawn(match self.origin {
-			Some(id) => moq_net::Hop::new(id).with_context(|| format!("invalid --origin {id}"))?,
+		Ok(moq_tokio::origin::spawn(match self.hop {
+			Some(id) => moq_net::Hop::new(id).with_context(|| format!("invalid --hop {id}"))?,
 			None => moq_net::Hop::random(),
 		}))
 	}
@@ -475,8 +483,8 @@ impl MoqSide {
 	/// of the resolved side: every one of these flags has a `MOQ_*` variable, and a
 	/// shell that exports one for the publishing it usually does has not asked this
 	/// verb for anything. A call site that picked the wrong view would read correctly
-	/// and be wrong, so there is only one view to pick. `--origin` is in the list for
-	/// the same reason it used to be out of it -- an ambient `MOQ_ORIGIN` no longer
+	/// and be wrong, so there is only one view to pick. `--hop` is in the list for
+	/// the same reason it used to be out of it -- an ambient `MOQ_HOP` no longer
 	/// reaches here, so a typed one can be refused like the rest.
 	fn reject(&self, command: &str) -> anyhow::Result<()> {
 		#[cfg(feature = "cluster-lan")]
@@ -493,7 +501,7 @@ impl MoqSide {
 			("--cluster-lan", self.lan()),
 			("--cluster-lan-secret", cluster_secret),
 			("--broadcast", self.broadcast.is_some()),
-			("--origin", self.origin.is_some()),
+			("--hop", self.hop.is_some()),
 		];
 		let ignored = ignored.into_iter().find(|(_, given)| *given).map(|(flag, _)| flag);
 		#[cfg(unix)]
@@ -847,6 +855,33 @@ mod tests {
 		] {
 			assert!(reported.contains(line), "missing {line:?} from {reported}");
 		}
+	}
+
+	/// `moq-cli`'s own rename rides the same refusal as the flags it flattens from
+	/// `moq-tokio`, and lands in the same message.
+	///
+	/// Both halves matter: `--origin` must not silently pin a Hop ID onto the field
+	/// `--hop` now owns, and the migration has to name the environment variable too,
+	/// since a deployment that sets `MOQ_ORIGIN` never typed the flag.
+	#[test]
+	fn the_released_origin_spelling_is_refused_with_a_migration() {
+		let Err(err) = Invocation::try_parse_from([
+			"moq",
+			"--origin",
+			"42",
+			"--connect",
+			"http://relay/anon",
+			"export",
+			"ts",
+		]) else {
+			panic!("--origin must not start a run");
+		};
+
+		let reported = err.to_string();
+		assert!(
+			reported.contains("--origin / MOQ_ORIGIN -> --hop / MOQ_HOP"),
+			"missing the migration from {reported}"
+		);
 	}
 
 	/// A stage carries config of its own, and the check has to reach it.

--- a/rs/moq-cli/src/args.rs
+++ b/rs/moq-cli/src/args.rs
@@ -387,8 +387,8 @@ impl MoqSide {
 	pub fn origin(&self) -> anyhow::Result<moq_net::origin::Producer> {
 		use anyhow::Context;
 		Ok(moq_tokio::origin::spawn(match self.origin {
-			Some(id) => moq_net::Origin::new(id).with_context(|| format!("invalid --origin {id}"))?,
-			None => moq_net::Origin::random(),
+			Some(id) => moq_net::Hop::new(id).with_context(|| format!("invalid --origin {id}"))?,
+			None => moq_net::Hop::random(),
 		}))
 	}
 

--- a/rs/moq-cli/src/cluster.rs
+++ b/rs/moq-cli/src/cluster.rs
@@ -456,7 +456,7 @@ mod tests {
 
 	fn lan(credential: &str) -> Lan {
 		Lan {
-			origin: moq_tokio::origin::spawn(moq_net::Origin::random()),
+			origin: moq_tokio::origin::spawn(moq_net::Hop::random()),
 			credential: credential.to_string(),
 			client: moq_tokio::connect::Config::default(),
 		}
@@ -598,8 +598,8 @@ mod tests {
 	/// so the test needs no multicast and stays CI-safe.
 	#[tokio::test]
 	async fn session_shares_origin_bidirectionally() {
-		let origin_a = moq_tokio::origin::spawn(moq_net::Origin::random());
-		let origin_b = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let origin_a = moq_tokio::origin::spawn(moq_net::Hop::random());
+		let origin_b = moq_tokio::origin::spawn(moq_net::Hop::random());
 
 		// Published before the session exists; announcements flow once it connects.
 		let _from_a = origin_a
@@ -655,8 +655,8 @@ mod tests {
 	/// origin is attached: reaching the listener is not membership.
 	#[tokio::test]
 	async fn mesh_rejects_a_dial_without_the_proof() {
-		let origin_a = moq_tokio::origin::spawn(moq_net::Origin::random());
-		let origin_b = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let origin_a = moq_tokio::origin::spawn(moq_net::Hop::random());
+		let origin_b = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let _from_b = origin_b
 			.create_broadcast("from-b", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("failed to create broadcast");
@@ -696,7 +696,7 @@ mod tests {
 	/// user who passed `--listen` did ask to serve, so that case still does.
 	#[tokio::test]
 	async fn a_mesh_only_listener_refuses_ordinary_clients() {
-		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let _published = origin
 			.create_broadcast("secret-stream", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("failed to create broadcast");
@@ -722,7 +722,7 @@ mod tests {
 		config.tls = moq_tokio::tls::Connect::default();
 		config.tls.fingerprint = vec![peer.fingerprint.clone().expect("fingerprint")];
 		config.once = Some(true);
-		let stolen = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let stolen = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let url = peer.urls.into_iter().next().expect("an address");
 		let connection = config
 			.init(Default::default())

--- a/rs/moq-cli/src/complete.rs
+++ b/rs/moq-cli/src/complete.rs
@@ -596,7 +596,7 @@ async fn catalog(
 /// what tells a relay two sessions carry the same content.
 async fn dial(side: &MoqSide, deadline: Instant) -> Option<(moq_net::origin::Producer, moq_tokio::Connection)> {
 	let url = side.client.url.clone()?;
-	let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+	let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 
 	// Building the client reads the TLS material off disk synchronously, so it goes on
 	// the blocking pool and under the deadline like everything else: a `--connect-tls-root`
@@ -772,7 +772,7 @@ mod tests {
 	/// because the shell exports a relay for the publishing it usually does.
 	#[tokio::test]
 	async fn the_environment_cannot_ask_for_a_moq_side() {
-		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let route = moq_net::broadcast::Route::new().with_announce(true);
 		let _alpha = origin.create_broadcast("alpha", route).expect("alpha");
 		let connect = relay(&origin);
@@ -867,7 +867,7 @@ mod tests {
 	#[tokio::test]
 	async fn a_relay_on_the_line_answers_broadcast() {
 		let _env = EnvGuard::clear(&["MOQ_CONNECT"]);
-		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let route = moq_net::broadcast::Route::new().with_announce(true);
 		let _alpha = origin.create_broadcast("alpha", route.clone()).expect("alpha");
 		let _nested = origin.create_broadcast("room/beta", route).expect("beta");
@@ -891,7 +891,7 @@ mod tests {
 		let _env = EnvGuard::clear(&["MOQ_CONNECT"]);
 		use hang::catalog::{AudioCodec, AudioConfig, H264, VideoConfig};
 
-		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let route = moq_net::broadcast::Route::new().with_announce(true);
 
 		// Two broadcasts with different renditions, so a completer reading the wrong
@@ -937,7 +937,7 @@ mod tests {
 	#[tokio::test]
 	async fn the_catalog_format_on_the_line_is_honored() {
 		let _env = EnvGuard::clear(&["MOQ_CONNECT"]);
-		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let route = moq_net::broadcast::Route::new().with_announce(true);
 		let mut broadcast = origin.create_broadcast("room", route).expect("broadcast");
 

--- a/rs/moq-cli/src/complete.rs
+++ b/rs/moq-cli/src/complete.rs
@@ -591,7 +591,7 @@ async fn catalog(
 
 /// Open a throwaway subscribe-only session to the relay `--connect` names.
 ///
-/// The origin id is fresh and random rather than the pinned `--origin`: this
+/// The Hop ID is fresh and random rather than the pinned `--hop`: this
 /// session is not the publisher the user is about to start, and a shared id is
 /// what tells a relay two sessions carry the same content.
 async fn dial(side: &MoqSide, deadline: Instant) -> Option<(moq_net::origin::Producer, moq_tokio::Connection)> {
@@ -672,7 +672,7 @@ mod tests {
 		// A stage offers its own flags, and none of the globals it would refuse.
 		let staged = complete("moq --connect http://x/y import fmp4 -- export fmp4 --").await;
 		assert!(!staged.is_empty(), "a later stage completed nothing");
-		for global in ["--connect", "--origin", "--broadcast"] {
+		for global in ["--connect", "--hop", "--broadcast"] {
 			assert!(
 				!staged.iter().any(|candidate| candidate == global),
 				"{global} leaked into a stage that refuses it: {staged:?}"

--- a/rs/moq-cli/src/main.rs
+++ b/rs/moq-cli/src/main.rs
@@ -273,7 +273,7 @@ impl Directions {
 /// An invocation that both imports and exports attaches both directions to the
 /// same session rather than opening two, which is how a relay peers with another
 /// relay. Loops are the network's problem, not ours: an announcement carries the
-/// hops it crossed, and our own origin id is one of them, so a broadcast we
+/// hops it crossed, and our own Hop ID is one of them, so a broadcast we
 /// publish is never announced back to us.
 ///
 /// Returns an allocator over the uplink's bandwidth estimate, for the sources that

--- a/rs/moq-cli/src/play.rs
+++ b/rs/moq-cli/src/play.rs
@@ -955,7 +955,7 @@ mod tests {
 	async fn subscribe_waits_for_the_announcement() {
 		tokio::time::pause();
 
-		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let consumer = origin.consume();
 
 		// Resolving straight away, which is what the media task used to do.

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -502,7 +502,7 @@ mod tests {
 
 	async fn manufacture_input() -> Vec<u8> {
 		// Create the broadcast on a throwaway origin so the exporter can resolve it by path.
-		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let mut broadcast = origin
 			.create_broadcast("cli", moq_net::broadcast::Route::new().with_announce(true))
 			.unwrap();
@@ -594,7 +594,7 @@ mod tests {
 		// Publish side: `Publish::new(Ts)` builds a `ts::Import<Ext>`, so the verbatim
 		// streams land in the broadcast instead of being dropped by the media-only path.
 		// The broadcast is created on a throwaway origin so the exporter can resolve it by path.
-		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let broadcast = origin
 			.create_broadcast("cli", moq_net::broadcast::Route::new().with_announce(true))
 			.unwrap();

--- a/rs/moq-cli/src/rtc.rs
+++ b/rs/moq-cli/src/rtc.rs
@@ -71,7 +71,7 @@ pub async fn listen_export(origin: moq_net::origin::Consumer, name: String, list
 		.with_context(|| format!("failed to scope origin to broadcast `{name}`"))?;
 	// A WHEP server only reads; it still needs a publisher handle for the shared
 	// glue, so hand it an unused, empty Origin producer.
-	let publisher = moq_tokio::origin::spawn(moq_net::Origin::random());
+	let publisher = moq_tokio::origin::spawn(moq_net::Hop::random());
 	let server = moq_rtc::Server::new(server_config(&listen), publisher, subscriber);
 	serve(server.subscribe_router(), "WHEP", listen).await
 }

--- a/rs/moq-cli/src/transcode.rs
+++ b/rs/moq-cli/src/transcode.rs
@@ -107,11 +107,11 @@ pub async fn run(moq: MoqSide, args: Args, net: Net) -> anyhow::Result<()> {
 		.url
 		.clone()
 		.context("`transcode` requires a relay: pass --connect <url>")?;
-	let publish = moq_tokio::origin::spawn(moq_net::Origin::random());
+	let publish = moq_tokio::origin::spawn(moq_net::Hop::random());
 	// A session drop closes the source broadcast and ends the run: the outage is
 	// surfaced rather than transcoded over. The reconnect loop covers the dial;
 	// restarting after a mid-run drop is the caller's call.
-	let remote = moq_tokio::origin::spawn(moq_net::Origin::random());
+	let remote = moq_tokio::origin::spawn(moq_net::Hop::random());
 	let session = net
 		.client(moq.client.clone())?
 		.with_publisher(&publish)

--- a/rs/moq-ffi/src/consumer.rs
+++ b/rs/moq-ffi/src/consumer.rs
@@ -371,7 +371,7 @@ fn map_fetch_error(err: moq_net::Error) -> MoqError {
 /// `moq_net` makes the choice a handle you consume the subscriber into, which a foreign
 /// binding can't express in its type system, so the handle commits on the first group
 /// read instead: whichever group cursor a caller reaches for first is the one this
-/// track keeps, and reaching for the other afterwards is [`MoqError::Unsupported`].
+/// track keeps, and reaching for the other afterwards is [`MoqError::AlreadyCommitted`].
 /// Datagrams are a separate cursor on either handle, so reading them never commits.
 enum Cursor {
 	/// No group read has happened yet; the track can still commit either way.
@@ -389,7 +389,7 @@ struct TrackInner {
 }
 
 impl TrackInner {
-	/// The arrival cursor, committing this track to it, or [`MoqError::Unsupported`]
+	/// The arrival cursor, committing this track to it, or [`MoqError::AlreadyCommitted`]
 	/// once it committed to sequence order.
 	fn arrival(&mut self) -> Result<&mut moq_net::track::Subscriber, MoqError> {
 		if let Cursor::Uncommitted(_) = &self.track {
@@ -400,11 +400,14 @@ impl TrackInner {
 		}
 		match &mut self.track {
 			Cursor::Arrival(track) => Ok(track),
-			_ => Err(MoqError::Unsupported),
+			Cursor::Ordered(_) => Err(MoqError::AlreadyCommitted),
+			// Only reachable if a previous conversion unwound mid-swap, leaving the
+			// handle with no subscriber to read: poisoned, not misused.
+			Cursor::Uncommitted(_) | Cursor::Converting => Err(MoqError::Closed),
 		}
 	}
 
-	/// The sequence cursor, committing this track to it, or [`MoqError::Unsupported`]
+	/// The sequence cursor, committing this track to it, or [`MoqError::AlreadyCommitted`]
 	/// once it committed to arrival order.
 	fn ordered(&mut self) -> Result<&mut moq_net::track::Ordered, MoqError> {
 		// Only move the subscriber out when there is one to convert: `ordered()` consumes
@@ -417,7 +420,9 @@ impl TrackInner {
 		}
 		match &mut self.track {
 			Cursor::Ordered(track) => Ok(track),
-			_ => Err(MoqError::Unsupported),
+			Cursor::Arrival(_) => Err(MoqError::AlreadyCommitted),
+			// See `arrival`: unreachable unless the handle was left mid-conversion.
+			Cursor::Uncommitted(_) | Cursor::Converting => Err(MoqError::Closed),
 		}
 	}
 
@@ -442,7 +447,9 @@ impl TrackInner {
 		let datagram = match &mut self.track {
 			Cursor::Uncommitted(track) | Cursor::Arrival(track) => track.recv_datagram().await?,
 			Cursor::Ordered(track) => track.recv_datagram().await?,
-			Cursor::Converting => return Err(MoqError::Unsupported),
+			// Poisoned mid-conversion; see `arrival`. Datagrams never commit a cursor,
+			// so this is the only way they can fail on a live handle.
+			Cursor::Converting => return Err(MoqError::Closed),
 		};
 		let Some(datagram) = datagram else {
 			return Ok(None);
@@ -490,7 +497,7 @@ impl MoqTrackConsumer {
 	///
 	/// The first call commits this track to arrival order: sequence-order reads
 	/// ([`Self::next_group`], [`Self::read_frame`]) fail with
-	/// [`MoqError::Unsupported`] afterwards.
+	/// [`MoqError::AlreadyCommitted`] afterwards.
 	pub async fn recv_group(&self) -> Result<Option<Arc<MoqGroupConsumer>>, MoqError> {
 		self.task
 			.run(|mut state| async move {
@@ -508,7 +515,7 @@ impl MoqTrackConsumer {
 	/// returned, skipping late arrivals. Returns `None` when the track ends.
 	///
 	/// The first call commits this track to sequence order: arrival-order reads
-	/// ([`Self::recv_group`]) fail with [`MoqError::Unsupported`] afterwards.
+	/// ([`Self::recv_group`]) fail with [`MoqError::AlreadyCommitted`] afterwards.
 	pub async fn next_group(&self) -> Result<Option<Arc<MoqGroupConsumer>>, MoqError> {
 		self.task
 			.run(|mut state| async move {

--- a/rs/moq-ffi/src/error.rs
+++ b/rs/moq-ffi/src/error.rs
@@ -73,8 +73,22 @@ pub enum MoqError {
 	NotFound,
 
 	/// The requested operation is not supported.
+	///
+	/// A statement about this build or this peer, not about the call: the feature is
+	/// unavailable however the caller asks for it. Caller misuse gets its own error, so
+	/// that a binding can tell "MoQ can't do this here" from "you held it wrong".
 	#[error("unsupported")]
 	Unsupported,
+
+	/// This track already committed to the other delivery order.
+	///
+	/// A track is read in arrival order or in sequence order, never both, and the first
+	/// group read picks which. Reaching for the other one afterwards is this error rather
+	/// than [`Self::Unsupported`]: both orders work fine here, the track just isn't
+	/// reading in the one you asked for. Read the track through a second consumer if you
+	/// genuinely need both.
+	#[error("already committed to the other delivery order")]
+	AlreadyCommitted,
 
 	/// A route carried an invalid hop id or too many hops.
 	#[error("invalid route: {0}")]

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -20,7 +20,7 @@ pub struct MoqOriginOptions {
 /// and observe them with `MoqBroadcastConsumer::route_updates`.
 #[derive(Clone, Default, uniffi::Record)]
 pub struct MoqRoute {
-	/// Origin ids of the relay hops the broadcast traversed, oldest first.
+	/// Hop IDs of the relay hops the broadcast traversed, oldest first.
 	#[uniffi(default = [])]
 	pub hops: Vec<u64>,
 	/// Preference among routes serving the same broadcast: lower wins. A publisher

--- a/rs/moq-ffi/src/origin.rs
+++ b/rs/moq-ffi/src/origin.rs
@@ -54,7 +54,7 @@ impl TryFrom<MoqRoute> for moq_net::broadcast::Route {
 			.with_cost(route.cost)
 			.with_announce(route.announce);
 		for id in route.hops {
-			let origin = moq_net::Origin::new(id).map_err(|e| MoqError::InvalidRoute(e.to_string()))?;
+			let origin = moq_net::Hop::new(id).map_err(|e| MoqError::InvalidRoute(e.to_string()))?;
 			out = out
 				.with_hop(origin)
 				.map_err(|e| MoqError::InvalidRoute(e.to_string()))?;
@@ -170,7 +170,7 @@ impl MoqOriginProducer {
 	}
 
 	fn from_options(options: MoqOriginOptions) -> Self {
-		let mut info = moq_net::origin::Info::new(moq_net::Origin::random());
+		let mut info = moq_net::origin::Info::new(moq_net::Hop::random());
 		if let Some(capacity) = options.cache_capacity_bytes {
 			let config = moq_net::cache::Config::default()
 				.with_capacity(capacity)
@@ -209,14 +209,14 @@ pub(crate) fn resolve_pair(
 ) -> (moq_net::origin::Producer, moq_net::origin::Producer) {
 	if publish.is_none() && consume.is_none() {
 		// Clones of a Producer share the underlying origin, so this is one origin, not two.
-		let shared = spawn(moq_net::Origin::random().into());
+		let shared = spawn(moq_net::Hop::random().into());
 		return (shared.clone(), shared);
 	}
 
 	let resolve = |origin: Option<&Arc<MoqOriginProducer>>| {
 		origin
 			.map(|o| o.inner().clone())
-			.unwrap_or_else(|| spawn(moq_net::Origin::random().into()))
+			.unwrap_or_else(|| spawn(moq_net::Hop::random().into()))
 	};
 	(resolve(publish), resolve(consume))
 }

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -1856,7 +1856,7 @@ async fn raw_track_next_group_is_repeatable() {
 	}
 
 	// The arrival cursor is gone once the track committed to sequence order.
-	assert!(matches!(consumer.recv_group().await, Err(MoqError::Unsupported)));
+	assert!(matches!(consumer.recv_group().await, Err(MoqError::AlreadyCommitted)));
 }
 
 /// The first group read commits the cursor either way: mixing arrival and sequence
@@ -1887,8 +1887,8 @@ async fn raw_track_group_order_commits_on_first_read() {
 		.unwrap()
 		.expect("expected a group");
 	assert_eq!(group.sequence(), 0);
-	assert!(matches!(consumer.next_group().await, Err(MoqError::Unsupported)));
-	assert!(matches!(consumer.read_frame().await, Err(MoqError::Unsupported)));
+	assert!(matches!(consumer.next_group().await, Err(MoqError::AlreadyCommitted)));
+	assert!(matches!(consumer.read_frame().await, Err(MoqError::AlreadyCommitted)));
 
 	// The commitment refuses the other cursor without poisoning this one.
 	track

--- a/rs/moq-gst/src/sink/session.rs
+++ b/rs/moq-gst/src/sink/session.rs
@@ -241,7 +241,7 @@ impl Session {
 		// Producer setup may touch tokio time (group eviction), so run it inside the runtime context.
 		let _rt = RUNTIME.enter();
 
-		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let mut broadcast = origin.create_broadcast(
 			&settings.broadcast,
 			moq_net::broadcast::Route::new().with_announce(true),

--- a/rs/moq-gst/src/source/imp.rs
+++ b/rs/moq-gst/src/source/imp.rs
@@ -354,7 +354,7 @@ async fn run_session(
 	let mut config = moq_tokio::connect::Config::default();
 	config.tls.insecure = Some(settings.tls_disable_verify);
 
-	let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+	let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 	let origin_consumer = origin.consume();
 	let client = config.init(Default::default())?.with_subscriber(origin);
 

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -352,7 +352,7 @@ async fn watch(
 mod tests {
 	/// Build an origin producer, spawning its driver on the ambient runtime.
 	fn produce_origin() -> moq_net::origin::Producer {
-		let (producer, driver) = moq_net::origin::Producer::new(moq_net::Origin::random().into());
+		let (producer, driver) = moq_net::origin::Producer::new(moq_net::Hop::random().into());
 		if tokio::runtime::Handle::try_current().is_ok() {
 			tokio::spawn(driver.run(moq_tokio::runtime::Runtime::<()>::new()));
 		} else {
@@ -832,7 +832,7 @@ mod tests {
 	}
 
 	// A same-path republish takes the origin leaf over with a brand new broadcast (an ordinary
-	// publisher is `Origin::UNKNOWN`, which never counts as the same publisher, so even a plain
+	// publisher is `Hop::UNKNOWN`, which never counts as the same publisher, so even a plain
 	// reconnect qualifies). Renditions derived from the old broadcast's catalog must not serve the
 	// replacement's media: its group numbering restarts, so those bytes would be served under the
 	// replaced broadcast's segment number, duration, and PROGRAM-DATE-TIME.

--- a/rs/moq-hls/src/export/upstream.rs
+++ b/rs/moq-hls/src/export/upstream.rs
@@ -4,7 +4,7 @@
 /// [`moq_mux::Source`] it came from so a rendition can still follow a cross-broadcast reference.
 ///
 /// The two travel together because resolving the catalog path by name is not idempotent. A
-/// same-path republish is a takeover (`Origin::UNKNOWN` never counts as the same publisher, so
+/// same-path republish is a takeover (`Hop::UNKNOWN` never counts as the same publisher, so
 /// every ordinary publisher reconnect qualifies), and that installs a brand new broadcast at the
 /// leaf. A rendition that looked its media up by path would then serve the replacement's groups
 /// under the manifest, segment numbering, and `PROGRAM-DATE-TIME` of the broadcast it replaced.

--- a/rs/moq-hls/src/server/mod.rs
+++ b/rs/moq-hls/src/server/mod.rs
@@ -144,7 +144,7 @@ async fn evict_closed(inner: Arc<Inner>, name: String, broadcaster: Arc<Broadcas
 mod tests {
 	/// Build an origin producer, spawning its driver on the ambient runtime.
 	fn produce_origin() -> moq_net::origin::Producer {
-		let (producer, driver) = moq_net::origin::Producer::new(moq_net::Origin::random().into());
+		let (producer, driver) = moq_net::origin::Producer::new(moq_net::Hop::random().into());
 		if tokio::runtime::Handle::try_current().is_ok() {
 			tokio::spawn(driver.run(moq_tokio::runtime::Runtime::<()>::new()));
 		} else {

--- a/rs/moq-mux/src/source.rs
+++ b/rs/moq-mux/src/source.rs
@@ -216,7 +216,7 @@ impl BroadcastConfig for hang::catalog::TextConfig {
 /// Test helper: build an origin producer, spawning its driver on the ambient runtime.
 #[cfg(test)]
 pub(crate) fn produce_origin() -> moq_net::origin::Producer {
-	let (producer, driver) = moq_net::origin::Producer::new(moq_net::Origin::random().into());
+	let (producer, driver) = moq_net::origin::Producer::new(moq_net::Hop::random().into());
 	if tokio::runtime::Handle::try_current().is_ok() {
 		tokio::spawn(driver.run(moq_tokio::runtime::Runtime::<()>::new()));
 	} else {

--- a/rs/moq-native/CHANGELOG.md
+++ b/rs/moq-native/CHANGELOG.md
@@ -98,7 +98,7 @@ All notable changes to this project will be documented in this file.
 
 ### Other
 
-- add Client::with_peer_origin for peers that declare no identity ([#2577](https://github.com/moq-dev/moq/pull/2577))
+- add Client::with_peer_hop for peers that declare no identity ([#2577](https://github.com/moq-dev/moq/pull/2577))
 
 ## [0.19.5](https://github.com/moq-dev/moq/compare/moq-native-v0.19.4...moq-native-v0.19.5) - 2026-07-31
 

--- a/rs/moq-net/CHANGELOG.md
+++ b/rs/moq-net/CHANGELOG.md
@@ -140,7 +140,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Other
 
 - *(kio)* rename WaiterCell to Park ([#2583](https://github.com/moq-dev/moq/pull/2583))
-- add Client::with_peer_origin for peers that declare no identity ([#2577](https://github.com/moq-dev/moq/pull/2577))
+- add Client::with_peer_hop for peers that declare no identity ([#2577](https://github.com/moq-dev/moq/pull/2577))
 
 ## [0.2.6](https://github.com/moq-dev/moq/compare/moq-net-v0.2.5...moq-net-v0.2.6) - 2026-07-31
 

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -172,7 +172,7 @@ impl Client {
 				role: lite::Role::from_origins(self.publish.is_some(), self.subscribe.is_some()),
 				cost: self.cost,
 				// Filled by `lite::start` from the attached origin handles.
-				origin: None,
+				hop: None,
 			}
 		} else {
 			lite::Setup::default()

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -19,7 +19,7 @@ pub struct Client {
 	versions: Versions,
 	setup_path: Option<String>,
 	cost: Option<u64>,
-	peer_origin: Option<crate::Origin>,
+	peer_hop: Option<crate::Hop>,
 }
 
 impl Client {
@@ -121,8 +121,8 @@ impl Client {
 	///   no loop detection of its own.
 	///
 	/// An identity the peer does declare wins over this one.
-	pub fn with_peer_origin(mut self, origin: crate::Origin) -> Self {
-		self.peer_origin = Some(origin);
+	pub fn with_peer_hop(mut self, hop: crate::Hop) -> Self {
+		self.peer_hop = Some(hop);
 		self
 	}
 
@@ -145,7 +145,7 @@ impl Client {
 			.subscribe
 			.clone()
 			.map(|origin| origin.with_stats(self.stats.clone()));
-		let publish = match self.peer_origin {
+		let publish = match self.peer_hop {
 			Some(peer) => publish.map(|origin| origin.excluding(peer)),
 			None => publish,
 		};
@@ -184,7 +184,7 @@ impl Client {
 			setup_stream: None,
 			publish,
 			subscribe,
-			peer_origin: self.peer_origin,
+			peer_hop: self.peer_hop,
 			version,
 			our_setup,
 			peer_setup: None,
@@ -255,7 +255,7 @@ impl Client {
 					client: true,
 					publish: publish.clone(),
 					subscribe: subscribe.clone(),
-					peer_origin: self.peer_origin,
+					peer_hop: self.peer_hop,
 					cost: self.cost,
 					version: ietf::Version::Draft19,
 					path: self.setup_path.clone(),
@@ -289,7 +289,7 @@ impl Client {
 					client: true,
 					publish: publish.clone(),
 					subscribe: subscribe.clone(),
-					peer_origin: self.peer_origin,
+					peer_hop: self.peer_hop,
 					cost: self.cost,
 					version: ietf::Version::Draft18,
 					path: self.setup_path.clone(),
@@ -323,7 +323,7 @@ impl Client {
 					client: true,
 					publish: publish.clone(),
 					subscribe: subscribe.clone(),
-					peer_origin: self.peer_origin,
+					peer_hop: self.peer_hop,
 					cost: self.cost,
 					version: ietf::Version::Draft17,
 					path: self.setup_path.clone(),
@@ -428,7 +428,7 @@ impl Client {
 					setup_stream: Some(stream),
 					publish: publish.clone(),
 					subscribe: subscribe.clone(),
-					peer_origin: self.peer_origin,
+					peer_hop: self.peer_hop,
 					version: v,
 					// This path only handles versions negotiated via the bidi SETUP exchange
 					// (pre-lite-05), which have no Setup Stream.
@@ -464,7 +464,7 @@ impl Client {
 					client: true,
 					publish: publish.clone(),
 					subscribe: subscribe.clone(),
-					peer_origin: self.peer_origin,
+					peer_hop: self.peer_hop,
 					cost: self.cost,
 					version: v,
 					path: None,
@@ -782,7 +782,7 @@ mod tests {
 			.with_protocol(crate::version::ALPN_LITE_05);
 
 		// A subscribe origin is what makes the client open an announce stream at all.
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let client = Client::new()
 			.with_versions([Version::Lite(lite::Version::Lite05)].into())
 			.with_subscriber(origin);

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -109,7 +109,7 @@ impl Client {
 	/// extension, and moq-transport peers that don't negotiate the MoQ Cluster
 	/// extension (or predate it, on `moqt-16` and earlier).
 	/// Broadcasts received from such a peer are normally attributed to the reserved
-	/// origin 0 ("unknown"), which identifies nothing: it never proves continuity,
+	/// Hop ID 0 ("unknown"), which identifies nothing: it never proves continuity,
 	/// so their advertisements neither splice nor survive a restart in place. This
 	/// knob pins a real identity instead, exactly as if the peer had declared it:
 	///

--- a/rs/moq-net/src/ietf/cluster.rs
+++ b/rs/moq-net/src/ietf/cluster.rs
@@ -193,7 +193,7 @@ pub struct Peer {
 	/// What the peer put in RELAY_HOPS, or `None` when it did not negotiate the
 	/// extension. Read [`Self::identity`] for the identity; this field answers whether
 	/// the extension is on, which is a different question when the peer declared 0.
-	pub origin: Option<Hop>,
+	pub hop: Option<Hop>,
 
 	/// What the peer said subscribing from it costs, or `None` when it priced nothing
 	/// (meaning [`DEFAULT_COST`]). Directional: this prices what we pull from the peer,
@@ -205,7 +205,7 @@ impl Peer {
 	/// Whether the peer negotiated the extension, which is what decides the NAMESPACE
 	/// encoding. True even for a peer that declared the reserved 0.
 	pub fn negotiated(&self) -> bool {
-		self.origin.is_some()
+		self.hop.is_some()
 	}
 
 	/// The identity the peer declared, or `None` when it declared none.
@@ -214,7 +214,7 @@ impl Peer {
 	/// which reads here exactly like declaring nothing at all. The receiver assigns one
 	/// instead, so there is no third state for callers to get wrong.
 	pub fn identity(&self) -> Option<Hop> {
-		self.origin.filter(|origin| *origin != Hop::UNKNOWN)
+		self.hop.filter(|hop| *hop != Hop::UNKNOWN)
 	}
 }
 
@@ -237,20 +237,20 @@ pub fn peer_from_setup(params: &super::Parameters, version: Version) -> Result<P
 
 	// RELAY_HOPS is odd, so its value is a length-prefixed byte string holding the
 	// sender's Hop ID as a single varint.
-	let origin = match params.get_bytes(super::ParameterBytes::RelayHops) {
+	let hop = match params.get_bytes(super::ParameterBytes::RelayHops) {
 		Some(mut bytes) => {
 			// 0 is legal here: the peer speaks the extension but withholds its identity.
-			let origin = Hop::decode(&mut bytes, version)?;
+			let hop = Hop::decode(&mut bytes, version)?;
 			if bytes.has_remaining() {
 				return Err(DecodeError::TrailingBytes);
 			}
-			Some(origin)
+			Some(hop)
 		}
 		None => None,
 	};
 
 	Ok(Peer {
-		origin,
+		hop,
 		cost: params.get_varint(super::ParameterVarInt::RelayCost),
 	})
 }
@@ -279,7 +279,7 @@ mod tests {
 
 	const VERSION: Version = Version::Draft19;
 
-	fn origin(id: u64) -> Hop {
+	fn hop(id: u64) -> Hop {
 		Hop::new(id).unwrap()
 	}
 
@@ -288,7 +288,7 @@ mod tests {
 			.iter()
 			.map(|&id| match id {
 				0 => Hop::UNKNOWN,
-				id => origin(id),
+				id => hop(id),
 			})
 			.collect::<Vec<_>>();
 		HopPath::new(Hops::try_from(hops).unwrap())
@@ -347,7 +347,7 @@ mod tests {
 		// no longer lets one be built: only a non-conforming sender produces this.
 		let mut value = Vec::new();
 		for id in [4u64, 8, 4] {
-			origin(id).encode(&mut value, VERSION).unwrap();
+			hop(id).encode(&mut value, VERSION).unwrap();
 		}
 
 		let mut buf = BytesMut::new();
@@ -368,11 +368,11 @@ mod tests {
 	#[test]
 	fn forward_refuses_a_chain_it_cannot_extend() {
 		let mut hops = Hops::new();
-		hops.push(origin(1)).unwrap();
-		hops.push(origin(3)).unwrap();
+		hops.push(hop(1)).unwrap();
+		hops.push(hop(3)).unwrap();
 
 		assert_eq!(
-			Advert::forward(&hops, 5, origin(3)),
+			Advert::forward(&hops, 5, hop(3)),
 			Err(crate::InvalidHop::Duplicate),
 			"appending an id the chain already names must not produce an advertisement"
 		);
@@ -381,10 +381,10 @@ mod tests {
 		// than on the id already being there.
 		let mut full = Hops::new();
 		let mut next = 1;
-		while full.push(origin(next)).is_ok() {
+		while full.push(hop(next)).is_ok() {
 			next += 1;
 		}
-		assert_eq!(Advert::forward(&full, 0, origin(next)), Err(crate::InvalidHop::TooMany));
+		assert_eq!(Advert::forward(&full, 0, hop(next)), Err(crate::InvalidHop::TooMany));
 	}
 
 	#[test]
@@ -404,7 +404,7 @@ mod tests {
 		// Entries must exactly fill Length. Chop the last byte off a multi-byte hop id
 		// and shrink the length to match, so the value ends mid-varint.
 		let mut value = Vec::new();
-		origin(300).encode(&mut value, VERSION).unwrap();
+		hop(300).encode(&mut value, VERSION).unwrap();
 		assert!(value.len() > 1, "300 should not fit in one byte");
 		value.pop();
 
@@ -418,12 +418,12 @@ mod tests {
 	#[test]
 	fn forward_appends_self() {
 		let mut hops = Hops::new();
-		hops.push(origin(1)).unwrap();
-		hops.push(origin(2)).unwrap();
+		hops.push(hop(1)).unwrap();
+		hops.push(hop(2)).unwrap();
 
-		let advert = Advert::forward(&hops, 5, origin(3)).unwrap();
+		let advert = Advert::forward(&hops, 5, hop(3)).unwrap();
 		assert_eq!(advert.hops, hop_path(&[1, 2, 3]));
-		assert_eq!(advert.hops.hops().iter().next().copied(), Some(origin(1)));
+		assert_eq!(advert.hops.hops().iter().next().copied(), Some(hop(1)));
 		assert_eq!(advert.cost, 5);
 	}
 
@@ -435,8 +435,8 @@ mod tests {
 		};
 		// A receiver whose own id is 0 cannot detect loops through itself.
 		assert!(!advert.loops(Hop::UNKNOWN));
-		assert!(advert.loops(origin(5)));
-		assert!(!advert.loops(origin(6)));
+		assert!(advert.loops(hop(5)));
+		assert!(!advert.loops(hop(6)));
 	}
 
 	#[test]
@@ -468,29 +468,29 @@ mod tests {
 		assert_eq!(peer.identity(), None);
 
 		let anonymous = Peer {
-			origin: Some(Hop::UNKNOWN),
+			hop: Some(Hop::UNKNOWN),
 			cost: Some(0),
 		};
 		assert!(anonymous.negotiated());
 		assert_eq!(anonymous.identity(), None);
 
 		let named = Peer {
-			origin: Some(origin(9)),
+			hop: Some(hop(9)),
 			cost: None,
 		};
 		assert!(named.negotiated());
-		assert_eq!(named.identity(), Some(origin(9)));
+		assert_eq!(named.identity(), Some(hop(9)));
 	}
 
 	#[test]
 	fn link_cost_prefers_local_policy_over_the_peer() {
 		let unpriced = Peer::default();
 		let priced = Peer {
-			origin: Some(origin(9)),
+			hop: Some(hop(9)),
 			cost: Some(7),
 		};
 		let free = Peer {
-			origin: Some(origin(9)),
+			hop: Some(hop(9)),
 			cost: Some(0),
 		};
 
@@ -509,7 +509,7 @@ mod tests {
 
 	#[test]
 	fn setup_options_round_trip() {
-		for (self_hop, cost) in [(origin(42), Some(0)), (origin(42), Some(9)), (Hop::UNKNOWN, None)] {
+		for (self_hop, cost) in [(hop(42), Some(0)), (hop(42), Some(9)), (Hop::UNKNOWN, None)] {
 			let mut params = super::super::Parameters::default();
 			peer_into_setup(&mut params, self_hop, cost, VERSION);
 
@@ -519,7 +519,7 @@ mod tests {
 			let decoded = super::super::Parameters::decode(&mut bytes, VERSION).unwrap();
 
 			let peer = peer_from_setup(&decoded, VERSION).unwrap();
-			assert_eq!(peer.origin, Some(self_hop));
+			assert_eq!(peer.hop, Some(self_hop));
 			assert_eq!(peer.cost, cost);
 		}
 	}
@@ -536,7 +536,7 @@ mod tests {
 		// Draft-14..16 exchange SETUP over the legacy control stream, which this
 		// extension does not cover; we neither send nor read the options there.
 		let mut params = super::super::Parameters::default();
-		peer_into_setup(&mut params, origin(42), Some(3), Version::Draft16);
+		peer_into_setup(&mut params, hop(42), Some(3), Version::Draft16);
 		assert!(params.get_bytes(super::super::ParameterBytes::RelayHops).is_none());
 		assert!(!peer_from_setup(&params, Version::Draft16).unwrap().negotiated());
 	}

--- a/rs/moq-net/src/ietf/cluster.rs
+++ b/rs/moq-net/src/ietf/cluster.rs
@@ -4,7 +4,7 @@
 //! namespaces loops forever and has no basis for choosing between two peers
 //! advertising the same namespace. This extension adds it:
 //!
-//! - each endpoint declares its own [`Origin`](crate::Origin) (Hop ID) via the
+//! - each endpoint declares its own [`Hop`](crate::Hop) (Hop ID) via the
 //!   RELAY_HOPS Setup Option, which is also what negotiates the extension;
 //! - each endpoint prices what subscribing from it costs via the RELAY_COST Setup
 //!   Option, so the two directions are priced independently;
@@ -18,7 +18,7 @@
 use bytes::Buf;
 
 use crate::coding::{Decode, DecodeError, Encode, EncodeError};
-use crate::{Origin, OriginList};
+use crate::{Hop, Hops};
 
 use super::{Param, Version};
 
@@ -61,29 +61,29 @@ pub fn supported(version: Version) -> bool {
 /// The HOP_PATH parameter value: bare varints filling the parameter length, with no
 /// count of their own. That is the only thing separating this from the moq-lite hop
 /// chain, which counts its entries; the list itself is the same
-/// [`OriginList`](crate::OriginList).
+/// [`Hops`](crate::Hops).
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-pub struct HopPath(OriginList);
+pub struct HopPath(Hops);
 
 impl HopPath {
 	/// Wrap a hop chain.
 	///
-	/// [`OriginList`] already refuses a repeated non-zero entry, so the only wire rule
+	/// [`Hops`] already refuses a repeated non-zero entry, so the only wire rule
 	/// left to check is that the list is non-empty; [`Self::validate`] does that on
 	/// decode, where an empty parameter can arrive.
-	pub fn new(hops: OriginList) -> Self {
+	pub fn new(hops: Hops) -> Self {
 		Self(hops)
 	}
 
 	/// Borrow the hop chain.
-	pub fn hops(&self) -> &OriginList {
+	pub fn hops(&self) -> &Hops {
 		&self.0
 	}
 
 	/// Reject a path that cannot have come from a conforming sender.
 	///
 	/// Only the empty list is left to catch: the other rule, that a non-zero Hop ID may
-	/// not appear twice, is enforced by [`OriginList`] wherever a chain is built, so it
+	/// not appear twice, is enforced by [`Hops`] wherever a chain is built, so it
 	/// holds on the outbound path too rather than only where one was parsed.
 	fn validate(&self) -> Result<(), DecodeError> {
 		match self.0.is_empty() {
@@ -108,10 +108,10 @@ impl Param for HopPath {
 		let value = Vec::<u8>::decode(r, version)?;
 		let mut buf = bytes::Bytes::from(value);
 
-		let mut hops = OriginList::new();
+		let mut hops = Hops::new();
 		while buf.has_remaining() {
 			// A short read here means the entries did not exactly fill the length.
-			hops.push(Origin::decode(&mut buf, version)?)?;
+			hops.push(Hop::decode(&mut buf, version)?)?;
 		}
 
 		let path = Self(hops);
@@ -146,22 +146,22 @@ impl Advert {
 	/// is to advertise a different route rather than send this one: a receiver must
 	/// close the session over a repeated Hop ID, so a malformed chain we build costs
 	/// someone else their session rather than degrading our own routing.
-	pub fn forward(hops: &OriginList, cost: u64, self_origin: Origin) -> Result<Self, crate::InvalidHop> {
+	pub fn forward(hops: &Hops, cost: u64, self_hop: Hop) -> Result<Self, crate::InvalidHop> {
 		let mut hops = hops.clone();
-		hops.push(self_origin)?;
+		hops.push(self_hop)?;
 		Ok(Self {
 			hops: HopPath::new(hops),
 			cost,
 		})
 	}
 
-	/// Whether this advertisement looped back through `self_origin`.
+	/// Whether this advertisement looped back through `self_hop`.
 	///
 	/// A receiver discards such an advertisement: forwarding it would extend the loop,
 	/// and subscribing through it would route the receiver back to itself. Hop ID 0
 	/// identifies nothing, so a receiver that withheld its own identity detects nothing.
-	pub fn loops(&self, self_origin: Origin) -> bool {
-		self_origin != Origin::UNKNOWN && self.hops.hops().contains(&self_origin)
+	pub fn loops(&self, self_hop: Hop) -> bool {
+		self_hop != Hop::UNKNOWN && self.hops.hops().contains(&self_hop)
 	}
 
 	/// The route this advertisement describes, after charging the link it arrived on.
@@ -193,7 +193,7 @@ pub struct Peer {
 	/// What the peer put in RELAY_HOPS, or `None` when it did not negotiate the
 	/// extension. Read [`Self::identity`] for the identity; this field answers whether
 	/// the extension is on, which is a different question when the peer declared 0.
-	pub origin: Option<Origin>,
+	pub origin: Option<Hop>,
 
 	/// What the peer said subscribing from it costs, or `None` when it priced nothing
 	/// (meaning [`DEFAULT_COST`]). Directional: this prices what we pull from the peer,
@@ -213,8 +213,8 @@ impl Peer {
 	/// Declaring the reserved 0 turns the extension on while withholding an identity,
 	/// which reads here exactly like declaring nothing at all. The receiver assigns one
 	/// instead, so there is no third state for callers to get wrong.
-	pub fn identity(&self) -> Option<Origin> {
-		self.origin.filter(|origin| *origin != Origin::UNKNOWN)
+	pub fn identity(&self) -> Option<Hop> {
+		self.origin.filter(|origin| *origin != Hop::UNKNOWN)
 	}
 }
 
@@ -240,7 +240,7 @@ pub fn peer_from_setup(params: &super::Parameters, version: Version) -> Result<P
 	let origin = match params.get_bytes(super::ParameterBytes::RelayHops) {
 		Some(mut bytes) => {
 			// 0 is legal here: the peer speaks the extension but withholds its identity.
-			let origin = Origin::decode(&mut bytes, version)?;
+			let origin = Hop::decode(&mut bytes, version)?;
 			if bytes.has_remaining() {
 				return Err(DecodeError::TrailingBytes);
 			}
@@ -258,15 +258,13 @@ pub fn peer_from_setup(params: &super::Parameters, version: Version) -> Result<P
 /// Write our cluster Setup Options into a SETUP parameter block.
 ///
 /// `cost` is the price we put on this link, which only the dialing side declares.
-pub fn peer_into_setup(params: &mut super::Parameters, self_origin: Origin, cost: Option<u64>, version: Version) {
+pub fn peer_into_setup(params: &mut super::Parameters, self_hop: Hop, cost: Option<u64>, version: Version) {
 	if !supported(version) {
 		return;
 	}
 
 	let mut id = Vec::new();
-	self_origin
-		.encode(&mut id, version)
-		.expect("a varint always fits a Vec");
+	self_hop.encode(&mut id, version).expect("a varint always fits a Vec");
 	params.set_bytes(super::ParameterBytes::RelayHops, id);
 
 	if let Some(cost) = cost {
@@ -281,19 +279,19 @@ mod tests {
 
 	const VERSION: Version = Version::Draft19;
 
-	fn origin(id: u64) -> Origin {
-		Origin::new(id).unwrap()
+	fn origin(id: u64) -> Hop {
+		Hop::new(id).unwrap()
 	}
 
 	fn hop_path(ids: &[u64]) -> HopPath {
 		let hops = ids
 			.iter()
 			.map(|&id| match id {
-				0 => Origin::UNKNOWN,
+				0 => Hop::UNKNOWN,
 				id => origin(id),
 			})
 			.collect::<Vec<_>>();
-		HopPath::new(OriginList::try_from(hops).unwrap())
+		HopPath::new(Hops::try_from(hops).unwrap())
 	}
 
 	fn round_trip(path: &HopPath) -> Result<HopPath, DecodeError> {
@@ -345,7 +343,7 @@ mod tests {
 	#[test]
 	fn hop_path_rejects_repeated_hop() {
 		// A non-zero id appearing twice is a loop, which the receiver must reject. The
-		// bytes are forged rather than encoded from a `HopPath`, because `OriginList`
+		// bytes are forged rather than encoded from a `HopPath`, because `Hops`
 		// no longer lets one be built: only a non-conforming sender produces this.
 		let mut value = Vec::new();
 		for id in [4u64, 8, 4] {
@@ -369,7 +367,7 @@ mod tests {
 	/// build costs someone else their session rather than degrading our own routing.
 	#[test]
 	fn forward_refuses_a_chain_it_cannot_extend() {
-		let mut hops = OriginList::new();
+		let mut hops = Hops::new();
 		hops.push(origin(1)).unwrap();
 		hops.push(origin(3)).unwrap();
 
@@ -381,7 +379,7 @@ mod tests {
 
 		// Fill the chain with distinct ids, so the next append fails on length rather
 		// than on the id already being there.
-		let mut full = OriginList::new();
+		let mut full = Hops::new();
 		let mut next = 1;
 		while full.push(origin(next)).is_ok() {
 			next += 1;
@@ -419,7 +417,7 @@ mod tests {
 
 	#[test]
 	fn forward_appends_self() {
-		let mut hops = OriginList::new();
+		let mut hops = Hops::new();
 		hops.push(origin(1)).unwrap();
 		hops.push(origin(2)).unwrap();
 
@@ -436,7 +434,7 @@ mod tests {
 			cost: 0,
 		};
 		// A receiver whose own id is 0 cannot detect loops through itself.
-		assert!(!advert.loops(Origin::UNKNOWN));
+		assert!(!advert.loops(Hop::UNKNOWN));
 		assert!(advert.loops(origin(5)));
 		assert!(!advert.loops(origin(6)));
 	}
@@ -470,7 +468,7 @@ mod tests {
 		assert_eq!(peer.identity(), None);
 
 		let anonymous = Peer {
-			origin: Some(Origin::UNKNOWN),
+			origin: Some(Hop::UNKNOWN),
 			cost: Some(0),
 		};
 		assert!(anonymous.negotiated());
@@ -511,9 +509,9 @@ mod tests {
 
 	#[test]
 	fn setup_options_round_trip() {
-		for (self_origin, cost) in [(origin(42), Some(0)), (origin(42), Some(9)), (Origin::UNKNOWN, None)] {
+		for (self_hop, cost) in [(origin(42), Some(0)), (origin(42), Some(9)), (Hop::UNKNOWN, None)] {
 			let mut params = super::super::Parameters::default();
-			peer_into_setup(&mut params, self_origin, cost, VERSION);
+			peer_into_setup(&mut params, self_hop, cost, VERSION);
 
 			let mut buf = BytesMut::new();
 			params.encode(&mut buf, VERSION).unwrap();
@@ -521,7 +519,7 @@ mod tests {
 			let decoded = super::super::Parameters::decode(&mut bytes, VERSION).unwrap();
 
 			let peer = peer_from_setup(&decoded, VERSION).unwrap();
-			assert_eq!(peer.origin, Some(self_origin));
+			assert_eq!(peer.origin, Some(self_hop));
 			assert_eq!(peer.cost, cost);
 		}
 	}

--- a/rs/moq-net/src/ietf/peer.rs
+++ b/rs/moq-net/src/ietf/peer.rs
@@ -69,7 +69,7 @@ mod tests {
 	async fn first_write_wins() {
 		let first = Peer {
 			cluster: cluster::Peer {
-				origin: Some(crate::Hop::new(42).unwrap()),
+				hop: Some(crate::Hop::new(42).unwrap()),
 				cost: Some(3),
 			},
 			solicit: None,
@@ -79,7 +79,7 @@ mod tests {
 		slot.set(first);
 		slot.set(Peer {
 			cluster: cluster::Peer {
-				origin: Some(crate::Hop::new(99).unwrap()),
+				hop: Some(crate::Hop::new(99).unwrap()),
 				cost: Some(0),
 			},
 			solicit: Some(true),

--- a/rs/moq-net/src/ietf/peer.rs
+++ b/rs/moq-net/src/ietf/peer.rs
@@ -69,7 +69,7 @@ mod tests {
 	async fn first_write_wins() {
 		let first = Peer {
 			cluster: cluster::Peer {
-				origin: Some(crate::Origin::new(42).unwrap()),
+				origin: Some(crate::Hop::new(42).unwrap()),
 				cost: Some(3),
 			},
 			solicit: None,
@@ -79,7 +79,7 @@ mod tests {
 		slot.set(first);
 		slot.set(Peer {
 			cluster: cluster::Peer {
-				origin: Some(crate::Origin::new(99).unwrap()),
+				origin: Some(crate::Hop::new(99).unwrap()),
 				cost: Some(0),
 			},
 			solicit: Some(true),

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -2129,7 +2129,7 @@ mod tests {
 		let (publisher, _consumer, _routes) = echo_harness(assigned).await;
 
 		let withheld = cluster::Peer {
-			origin: Some(crate::Hop::UNKNOWN),
+			hop: Some(crate::Hop::UNKNOWN),
 			cost: None,
 		};
 		assert!(withheld.negotiated(), "the extension is on");
@@ -2139,7 +2139,7 @@ mod tests {
 		assert_eq!(publisher.exclude(&absent), assigned, "so does declaring nothing");
 
 		let named = cluster::Peer {
-			origin: Some(declared),
+			hop: Some(declared),
 			cost: None,
 		};
 		assert_eq!(publisher.exclude(&named), declared, "a declared identity wins");
@@ -2178,7 +2178,7 @@ mod tests {
 		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
 
 		let peer = cluster::Peer {
-			origin: Some(crate::Hop::UNKNOWN),
+			hop: Some(crate::Hop::UNKNOWN),
 			cost: None,
 		};
 		let echoed = consumer.get_broadcast("from/peer").unwrap();

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -268,12 +268,12 @@ pub(super) struct Publisher<S: crate::transport::poll::Session, R: crate::runtim
 	// Our own Hop ID, stamped onto every advertisement we forward. Taken from the
 	// origin we consume so it matches the local relay identity across every session,
 	// which is what makes cross-session loop detection work.
-	self_origin: crate::Origin,
-	// The identity assigned to the peer by the caller (`Client::with_peer_origin`, or
+	self_hop: crate::Hop,
+	// The identity assigned to the peer by the caller (`Client::with_peer_hop`, or
 	// the per-session default a server hands every request), used when the peer declares
 	// none itself. A peer that negotiates the MoQ Cluster extension declares its own,
 	// which wins unless it withheld it as the reserved 0.
-	peer_origin: Option<crate::Origin>,
+	peer_hop: Option<crate::Hop>,
 	// What the peer declared in its SETUP, filled when that stream is read.
 	peer_setup: peer::PeerSetup,
 	version: Version,
@@ -290,17 +290,17 @@ where
 		session: S,
 		origin: origin::Consumer,
 		control: Control,
-		peer_origin: Option<crate::Origin>,
+		peer_hop: Option<crate::Hop>,
 		peer_setup: peer::PeerSetup,
 		version: Version,
 	) -> Self {
 		Self {
 			runtime,
 			session,
-			self_origin: *origin,
+			self_hop: *origin,
 			origin,
 			control,
-			peer_origin,
+			peer_hop,
 			peer_setup,
 			version,
 		}
@@ -340,7 +340,7 @@ where
 	/// and the announce loops read this peer's routes through.
 	fn excluding(&self, peer: &cluster::Peer) -> origin::Consumer {
 		match self.exclude(peer) {
-			crate::Origin::UNKNOWN => self.origin.clone(),
+			crate::Hop::UNKNOWN => self.origin.clone(),
 			exclude => self.origin.clone().excluding(exclude),
 		}
 	}
@@ -348,12 +348,12 @@ where
 	/// The Hop ID whose paths must not be advertised (or served) back to this peer.
 	///
 	/// A peer that declared an identity supplies its own; otherwise fall back to the one
-	/// we assigned it (`Client::with_peer_origin` when dialing, `Request::with_peer_origin`
+	/// we assigned it (`Client::with_peer_hop` when dialing, `Request::with_peer_hop`
 	/// or a fresh per-session id when accepting), since moq-transport carries no identity
 	/// of its own. A peer that declared the reserved 0 declared no identity, so it takes
 	/// the fallback like any other anonymous peer.
-	fn exclude(&self, peer: &cluster::Peer) -> crate::Origin {
-		peer.identity().or(self.peer_origin).unwrap_or(crate::Origin::UNKNOWN)
+	fn exclude(&self, peer: &cluster::Peer) -> crate::Hop {
+		peer.identity().or(self.peer_hop).unwrap_or(crate::Hop::UNKNOWN)
 	}
 
 	/// Pick what to advertise to this peer for one broadcast.
@@ -365,7 +365,7 @@ where
 		let routes = watch.broadcast.routes();
 		let exclude = self.exclude(peer);
 
-		for (route, serving) in crate::broadcast::advertisable_routes(&routes, self.self_origin, exclude) {
+		for (route, serving) in crate::broadcast::advertisable_routes(&routes, self.self_hop, exclude) {
 			if !peer.negotiated() {
 				return Advert::Plain;
 			}
@@ -375,7 +375,7 @@ where
 			let cost = crate::broadcast::outgoing_cost(&watch.demand, route, serving).warm;
 			// Our own Hop ID is always the last entry, so the peer reconstructs the full
 			// path. A chain with no room left is a loop in all but name; try the next route.
-			match cluster::Advert::forward(&route.hops, cost, self.self_origin) {
+			match cluster::Advert::forward(&route.hops, cost, self.self_hop) {
 				Ok(advert) => return Advert::Cluster(advert),
 				Err(_) => continue,
 			}
@@ -1246,7 +1246,7 @@ where
 		// model uses this exposure to park a reflected copy before it can replace
 		// the source we are currently advertising to that peer.
 		let origin = match self.exclude(&peer) {
-			crate::Origin::UNKNOWN => origin,
+			crate::Hop::UNKNOWN => origin,
 			exclude => origin.excluding(exclude),
 		};
 
@@ -2051,14 +2051,14 @@ mod tests {
 	/// `from/us`, which does not. The producers are returned so the routes outlive
 	/// the assertions.
 	async fn echo_harness(
-		assigned: crate::Origin,
+		assigned: crate::Hop,
 	) -> (
 		Publisher<SinkSession, TestRuntime>,
 		origin::Consumer,
 		Vec<crate::broadcast::Producer>,
 	) {
-		let other = crate::Origin::new(778).unwrap();
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let other = crate::Hop::new(778).unwrap();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let consumer = origin.consume();
 
 		let session = crate::lite::test_transport::SinkSession::new(Default::default());
@@ -2072,7 +2072,7 @@ mod tests {
 			Version::Draft16,
 		);
 
-		let mut echoed_hops = crate::OriginList::new();
+		let mut echoed_hops = crate::Hops::new();
 		echoed_hops.push(assigned).unwrap();
 		let echoed = origin
 			.create_broadcast(
@@ -2083,7 +2083,7 @@ mod tests {
 			)
 			.unwrap();
 
-		let mut local_hops = crate::OriginList::new();
+		let mut local_hops = crate::Hops::new();
 		local_hops.push(other).unwrap();
 		let local = origin
 			.create_broadcast(
@@ -2099,12 +2099,12 @@ mod tests {
 	}
 
 	/// A broadcast whose every route flows through the peer's assigned identity
-	/// (`Client::with_peer_origin`) is never advertised to that peer; it would only
+	/// (`Client::with_peer_hop`) is never advertised to that peer; it would only
 	/// echo the peer's own content back at it. A broadcast with an independent
 	/// route still is.
 	#[tokio::test(start_paused = true)]
 	async fn assigned_peer_origin_filters_echoed_announces() {
-		let assigned = crate::Origin::new(777).unwrap();
+		let assigned = crate::Hop::new(777).unwrap();
 		let (publisher, consumer, _routes) = echo_harness(assigned).await;
 
 		let peer = cluster::Peer::default();
@@ -2124,12 +2124,12 @@ mod tests {
 	/// [`a_declared_zero_chain_is_still_advertised_back`] for what it gets instead.
 	#[tokio::test(start_paused = true)]
 	async fn withheld_peer_origin_falls_back_to_assigned() {
-		let assigned = crate::Origin::new(777).unwrap();
-		let declared = crate::Origin::new(9).unwrap();
+		let assigned = crate::Hop::new(777).unwrap();
+		let declared = crate::Hop::new(9).unwrap();
 		let (publisher, _consumer, _routes) = echo_harness(assigned).await;
 
 		let withheld = cluster::Peer {
-			origin: Some(crate::Origin::UNKNOWN),
+			origin: Some(crate::Hop::UNKNOWN),
 			cost: None,
 		};
 		assert!(withheld.negotiated(), "the extension is on");
@@ -2152,8 +2152,8 @@ mod tests {
 	/// back.
 	#[tokio::test(start_paused = true)]
 	async fn a_declared_zero_chain_is_still_advertised_back() {
-		let assigned = crate::Origin::new(777).unwrap();
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let assigned = crate::Hop::new(777).unwrap();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let consumer = origin.consume();
 
 		let publisher = Publisher::new(
@@ -2167,8 +2167,8 @@ mod tests {
 		);
 
 		// The chain as ingress stores it: the peer named itself 0.
-		let mut hops = crate::OriginList::new();
-		hops.push(crate::Origin::UNKNOWN).unwrap();
+		let mut hops = crate::Hops::new();
+		hops.push(crate::Hop::UNKNOWN).unwrap();
 		let _echoed = origin
 			.create_broadcast(
 				"from/peer",
@@ -2178,7 +2178,7 @@ mod tests {
 		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
 
 		let peer = cluster::Peer {
-			origin: Some(crate::Origin::UNKNOWN),
+			origin: Some(crate::Hop::UNKNOWN),
 			cost: None,
 		};
 		let echoed = consumer.get_broadcast("from/peer").unwrap();
@@ -2195,14 +2195,14 @@ mod tests {
 	/// spin on it forever.
 	#[tokio::test]
 	async fn linger_clears_when_the_advert_stops_being_discounted() {
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let broadcast = origin
 			.clone()
 			.create_broadcast("cam", crate::broadcast::Route::announced())
 			.unwrap();
 
 		let mut watch = Watched::new(broadcast.consume());
-		let hops = crate::OriginList::try_from(vec![crate::Origin::new(7).unwrap()]).unwrap();
+		let hops = crate::Hops::try_from(vec![crate::Hop::new(7).unwrap()]).unwrap();
 
 		// Discounted (cost 0) and drained: the linger is running.
 		watch.set_sent(Advert::Cluster(cluster::Advert {
@@ -2241,9 +2241,9 @@ mod tests {
 	/// withdraw when the last one detaches.
 	#[tokio::test]
 	async fn namespace_follows_route_eligibility_changes() {
-		let assigned = crate::Origin::new(777).unwrap();
-		let clean_publisher = crate::Origin::new(778).unwrap();
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let assigned = crate::Hop::new(777).unwrap();
+		let clean_publisher = crate::Hop::new(778).unwrap();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 
 		let gate = kio::Producer::new(true);
 		let session = SinkSession::gated_bi(gate.consume());
@@ -2259,7 +2259,7 @@ mod tests {
 		);
 
 		// The broadcast starts with only a route through the assigned peer.
-		let mut tainted_hops = crate::OriginList::new();
+		let mut tainted_hops = crate::Hops::new();
 		tainted_hops.push(assigned).unwrap();
 		let _tainted = origin
 			.create_broadcast(
@@ -2285,7 +2285,7 @@ mod tests {
 
 		// A clean source splices in: no origin announce fires, only the route table
 		// changes. The namespace must now be advertised.
-		let mut clean_hops = crate::OriginList::new();
+		let mut clean_hops = crate::Hops::new();
 		clean_hops.push(clean_publisher).unwrap();
 		let clean = origin
 			.create_broadcast(
@@ -2342,7 +2342,7 @@ mod tests {
 	async fn a_refusal_that_forbids_retrying_is_not_retried() {
 		const VERSION: Version = Version::Draft17;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let _cam = origin
 			.create_broadcast("lonely-cam", crate::broadcast::Route::announced())
 			.unwrap();
@@ -2430,7 +2430,7 @@ mod tests {
 	async fn v14_subscribe_namespace_is_answered_with_publish_namespace() {
 		const VERSION: Version = Version::Draft14;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let consumer = origin.consume();
 
 		// Announced before the peer subscribes: it must only hit the wire after.
@@ -2520,7 +2520,7 @@ mod tests {
 	async fn a_peer_that_declared_nothing_is_told_unsolicited() {
 		const VERSION: Version = Version::Draft17;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let _local = origin
 			.create_broadcast("local-cam", crate::broadcast::Route::announced())
 			.unwrap();
@@ -2568,7 +2568,7 @@ mod tests {
 	async fn advertise_both_ways(solicit: Option<bool>) -> (usize, usize) {
 		const VERSION: Version = Version::Draft17;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let _cam = origin
 			.create_broadcast("cam", crate::broadcast::Route::announced())
 			.unwrap();
@@ -2642,7 +2642,7 @@ mod tests {
 	async fn a_parked_open_still_lets_a_namespace_be_withdrawn() {
 		const VERSION: Version = Version::Draft14;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let first = origin
 			.create_broadcast("first-cam", crate::broadcast::Route::announced())
 			.unwrap();
@@ -2724,14 +2724,14 @@ mod tests {
 	/// that can never happen: not a spin, but a session that never sleeps.
 	#[tokio::test(start_paused = true)]
 	async fn a_namespace_that_stops_being_advertisable_stops_being_deferred() {
-		let assigned = crate::Origin::new(777).unwrap();
+		let assigned = crate::Hop::new(777).unwrap();
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 
 		// Every route flows through the peer's own identity, so split horizon says this
 		// must never be advertised back to it: `select` wants nothing, which is what the
 		// peer already holds.
-		let mut hops = crate::OriginList::new();
+		let mut hops = crate::Hops::new();
 		hops.push(assigned).unwrap();
 		let _echoed = origin
 			.create_broadcast(
@@ -2777,7 +2777,7 @@ mod tests {
 	async fn a_route_change_still_waits_out_a_refusal() {
 		const VERSION: Version = Version::Draft17;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let cam = origin
 			.create_broadcast("solo-cam", crate::broadcast::Route::announced())
 			.unwrap();
@@ -2840,7 +2840,7 @@ mod tests {
 	async fn a_modern_withdrawal_is_the_fin_alone() {
 		const VERSION: Version = Version::Draft17;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let cam = origin
 			.create_broadcast("solo-cam", crate::broadcast::Route::announced())
 			.unwrap();
@@ -2895,7 +2895,7 @@ mod tests {
 	async fn a_silent_answer_still_lets_the_next_namespace_be_advertised() {
 		const VERSION: Version = Version::Draft14;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let _first = origin
 			.create_broadcast("first-cam", crate::broadcast::Route::announced())
 			.unwrap();
@@ -2947,7 +2947,7 @@ mod tests {
 	async fn a_namespace_refused_a_stream_is_retried_on_its_own() {
 		const VERSION: Version = Version::Draft14;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let _cam = origin
 			.create_broadcast("lonely-cam", crate::broadcast::Route::announced())
 			.unwrap();
@@ -3014,7 +3014,7 @@ mod tests {
 	}
 
 	fn harness(version: Version) -> Harness {
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let session = crate::lite::test_transport::ScriptedSession::per_stream(vec![Vec::new()]);
 		let log = session.log.clone();
 

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -437,7 +437,7 @@ pub struct PeerSetup<S: crate::transport::poll::Session> {
 
 /// The Hop ID this session declares and detects loops against.
 ///
-/// Both halves of a session share the process's origin identity, so either one names
+/// Both halves of a session share the process's Hop ID, so either one names
 /// it; the publish half is just the usual one to be set. A session with neither half
 /// has no content to route, so a throwaway id is all it can offer.
 fn self_hop(publish: Option<&origin::Consumer>, subscribe: Option<&origin::Producer>) -> Hop {

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -947,7 +947,7 @@ mod tests {
 			// makes the cluster parameters mandatory in both directions.
 			peer_declared: Some(peer::Peer {
 				cluster: cluster::Peer {
-					origin: Some(crate::Hop::new(2).unwrap()),
+					hop: Some(crate::Hop::new(2).unwrap()),
 					cost: None,
 				},
 				..Default::default()

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -1,6 +1,6 @@
 use crate::origin;
 use crate::{
-	Error, Origin, SessionError,
+	Error, Hop, SessionError,
 	coding::{Decode, DecodeError, Encode, Reader, Stream, Writer},
 	ietf::{self, FetchHeader, RequestId},
 	setup,
@@ -36,9 +36,9 @@ pub struct Config<S: crate::transport::poll::Session, R: crate::runtime::Runtime
 	pub subscribe: Option<origin::Producer>,
 
 	/// The origin (hop) id to assign the peer when it declares none itself. See
-	/// `Client::with_peer_origin`; a peer that negotiates the MoQ Cluster extension
+	/// `Client::with_peer_hop`; a peer that negotiates the MoQ Cluster extension
 	/// declares its own, which wins.
-	pub peer_origin: Option<Origin>,
+	pub peer_hop: Option<Hop>,
 
 	/// What crossing this link costs. Declared in our SETUP (see
 	/// [`cluster::RELAY_COST`]) for the peer to charge, and charged locally on what the
@@ -82,7 +82,7 @@ where
 		client,
 		publish,
 		subscribe,
-		peer_origin,
+		peer_hop,
 		cost,
 		version,
 		path,
@@ -102,13 +102,13 @@ where
 		// detection works. Read BEFORE the placeholders below: their ids are random and
 		// identify nothing, so declaring one would compare incoming paths against an
 		// identity no other session shares.
-		let self_origin = self_origin(publish.as_ref(), subscribe.as_ref());
+		let self_hop = self_hop(publish.as_ref(), subscribe.as_ref());
 
 		// moq-transport threads concrete origins through the publisher/subscriber.
 		// An unset half gets an empty origin: an empty publish origin announces
 		// nothing, and an empty subscribe origin issues no SUBSCRIBE_NAMESPACE.
-		let publish = publish.unwrap_or_else(|| origin::Producer::empty(Origin::random()).consume());
-		let subscribe = subscribe.unwrap_or_else(|| origin::Producer::empty(Origin::random()));
+		let publish = publish.unwrap_or_else(|| origin::Producer::empty(Hop::random()).consume());
+		let subscribe = subscribe.unwrap_or_else(|| origin::Producer::empty(Hop::random()));
 
 		// What the peer declared in its SETUP. Seeded now when that stream was already
 		// read (the legacy handshake, or a gated server accept), and filled by the uni
@@ -139,7 +139,7 @@ where
 					adapter.clone(),
 					publish,
 					control.clone(),
-					peer_origin,
+					peer_hop,
 					peer_setup.clone(),
 					version,
 				);
@@ -149,9 +149,9 @@ where
 					adapter.clone(),
 					subscribe,
 					control,
-					peer_origin,
+					peer_hop,
 					peer_setup.clone(),
-					self_origin,
+					self_hop,
 					cost,
 					version,
 					tasks.clone(),
@@ -276,7 +276,7 @@ where
 					let session = session.clone();
 					let goaway = goaway.clone();
 					async move {
-						if let Err(err) = run_setup(runtime, session, version, path, self_origin, cost, goaway).await {
+						if let Err(err) = run_setup(runtime, session, version, path, self_hop, cost, goaway).await {
 							tracing::warn!(%err, "setup send error");
 						}
 						std::future::pending::<()>().await;
@@ -289,7 +289,7 @@ where
 					session.clone(),
 					publish,
 					control.clone(),
-					peer_origin,
+					peer_hop,
 					peer_setup.clone(),
 					version,
 				);
@@ -299,9 +299,9 @@ where
 					session.clone(),
 					subscribe,
 					control,
-					peer_origin,
+					peer_hop,
 					peer_setup.clone(),
-					self_origin,
+					self_hop,
 					cost,
 					version,
 					tasks,
@@ -440,11 +440,11 @@ pub struct PeerSetup<S: crate::transport::poll::Session> {
 /// Both halves of a session share the process's origin identity, so either one names
 /// it; the publish half is just the usual one to be set. A session with neither half
 /// has no content to route, so a throwaway id is all it can offer.
-fn self_origin(publish: Option<&origin::Consumer>, subscribe: Option<&origin::Producer>) -> Origin {
+fn self_hop(publish: Option<&origin::Consumer>, subscribe: Option<&origin::Producer>) -> Hop {
 	publish
 		.map(|origin| **origin)
 		.or_else(|| subscribe.map(|origin| **origin))
-		.unwrap_or_else(Origin::random)
+		.unwrap_or_else(Hop::random)
 }
 
 /// Server (draft-17+): read the peer's SETUP off its uni stream before starting the
@@ -511,7 +511,7 @@ fn peer_from_params(params: &ietf::Parameters, version: Version) -> Result<peer:
 /// also our GOAWAY channel, so a fired drain trigger encodes the GOAWAY here.
 ///
 /// `path` is the request path we advertise (clients on URL-less transports); a
-/// server passes `None`. `self_origin` and `cost` are the MoQ Cluster options, which
+/// server passes `None`. `self_hop` and `cost` are the MoQ Cluster options, which
 /// declare our identity and (client-only) what this link costs to cross. The MoQ Solicit
 /// declaration is unconditional, so it takes no argument.
 async fn run_setup<S: crate::transport::poll::Session, R: crate::runtime::Runtime>(
@@ -519,7 +519,7 @@ async fn run_setup<S: crate::transport::poll::Session, R: crate::runtime::Runtim
 	mut session: S,
 	version: Version,
 	path: Option<String>,
-	self_origin: Origin,
+	self_hop: Hop,
 	cost: Option<u64>,
 	goaway: crate::goaway::Protocol,
 ) -> Result<(), Error> {
@@ -533,7 +533,7 @@ async fn run_setup<S: crate::transport::poll::Session, R: crate::runtime::Runtim
 	if let Some(path) = path {
 		parameters.set_bytes(ietf::ParameterBytes::Path, path.into_bytes());
 	}
-	cluster::peer_into_setup(&mut parameters, self_origin, cost, version);
+	cluster::peer_into_setup(&mut parameters, self_hop, cost, version);
 	solicit::into_setup(&mut parameters, version);
 	let parameters = parameters.encode_bytes(version)?;
 
@@ -926,7 +926,7 @@ mod tests {
 		// bound it: paused time makes the deadline fire the moment nothing else can run.
 		tokio::time::pause();
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let session = crate::lite::test_transport::ScriptedSession::new(namespace_without_hop_path(VERSION).await);
 		let log = session.log.clone();
 
@@ -938,7 +938,7 @@ mod tests {
 			client: true,
 			publish: None,
 			subscribe: Some(origin),
-			peer_origin: None,
+			peer_hop: None,
 			cost: None,
 			version: VERSION,
 			path: None,
@@ -947,7 +947,7 @@ mod tests {
 			// makes the cluster parameters mandatory in both directions.
 			peer_declared: Some(peer::Peer {
 				cluster: cluster::Peer {
-					origin: Some(crate::Origin::new(2).unwrap()),
+					origin: Some(crate::Hop::new(2).unwrap()),
 					cost: None,
 				},
 				..Default::default()
@@ -975,7 +975,7 @@ mod tests {
 	/// called `run_subscribe_namespace` itself.
 	#[tokio::test]
 	async fn every_permitted_prefix_gets_its_own_subscribe_namespace() {
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let scoped = origin
 			.with_root("rootns")
 			.and_then(|rooted| rooted.scope(&[crate::Path::new("cam"), crate::Path::new("mic")]))
@@ -993,7 +993,7 @@ mod tests {
 			client: true,
 			publish: None,
 			subscribe: Some(scoped),
-			peer_origin: None,
+			peer_hop: None,
 			cost: None,
 			version: Version::Draft18,
 			path: None,
@@ -1027,7 +1027,7 @@ mod tests {
 	/// The scripted peer answers nothing, so an advertisement parks after writing. That is
 	/// enough: the question is only whether the bytes went out unasked.
 	async fn announce_occurrences(peer_declared: Option<peer::Peer>) -> usize {
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let _cam = origin
 			.create_broadcast("solo-cam", crate::broadcast::Route::new().with_announce(true))
 			.unwrap();
@@ -1045,7 +1045,7 @@ mod tests {
 			client: true,
 			publish: Some(origin.consume()),
 			subscribe: None,
-			peer_origin: None,
+			peer_hop: None,
 			cost: None,
 			version: Version::Draft18,
 			path: None,
@@ -1113,17 +1113,17 @@ mod tests {
 	/// here would never be recognized as a loop.
 	#[test]
 	fn the_hop_id_comes_from_whichever_origin_the_caller_set() {
-		let ours = crate::Origin::new(42).unwrap();
+		let ours = crate::Hop::new(42).unwrap();
 
 		let publish = crate::origin::Info::new(ours).produce();
-		assert_eq!(self_origin(Some(&publish.consume()), None), ours, "the publish half");
+		assert_eq!(self_hop(Some(&publish.consume()), None), ours, "the publish half");
 
 		let subscribe = crate::origin::Info::new(ours).produce();
-		assert_eq!(self_origin(None, Some(&subscribe)), ours, "the subscribe half alone");
+		assert_eq!(self_hop(None, Some(&subscribe)), ours, "the subscribe half alone");
 
 		// Neither half: nothing to route, so any id will do as long as it is ours.
 		let publish = crate::origin::Info::new(ours).produce();
-		assert_eq!(self_origin(Some(&publish.consume()), Some(&subscribe)), ours);
+		assert_eq!(self_hop(Some(&publish.consume()), Some(&subscribe)), ours);
 	}
 
 	/// Drive `start` against a peer whose incoming streams die before their first
@@ -1141,7 +1141,7 @@ mod tests {
 		// deadline fire the moment nothing else can run.
 		tokio::time::pause();
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let log = session.log.clone();
 
 		let (driver, _goaway) = start(Config {
@@ -1152,7 +1152,7 @@ mod tests {
 			client: true,
 			publish: None,
 			subscribe: Some(origin),
-			peer_origin: None,
+			peer_hop: None,
 			cost: None,
 			version: VERSION,
 			path: None,

--- a/rs/moq-net/src/ietf/subscribe_namespace.rs
+++ b/rs/moq-net/src/ietf/subscribe_namespace.rs
@@ -303,11 +303,8 @@ mod tests {
 	}
 
 	fn hop_path(ids: &[u64]) -> cluster::HopPath {
-		let hops = ids
-			.iter()
-			.map(|&id| crate::Origin::new(id).unwrap())
-			.collect::<Vec<_>>();
-		cluster::HopPath::new(crate::OriginList::try_from(hops).unwrap())
+		let hops = ids.iter().map(|&id| crate::Hop::new(id).unwrap()).collect::<Vec<_>>();
+		cluster::HopPath::new(crate::Hops::try_from(hops).unwrap())
 	}
 
 	/// The extended NAMESPACE appends a Parameters field carrying the path and cost;

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -193,7 +193,7 @@ struct BroadcastState {
 	// The first entry of the advertised path: the original publisher. `None` on an
 	// advertisement that carried no path at all, which is every one on a session
 	// without the MoQ Cluster extension. See [`Advertised::publisher`].
-	publisher: Option<crate::Origin>,
+	publisher: Option<crate::Hop>,
 }
 
 /// What one advertisement said, once its parameters are resolved against the session.
@@ -203,7 +203,7 @@ struct Advertised {
 
 	/// The original publisher: the first entry of HOP_PATH. Two advertisements that
 	/// share a non-zero one carry interchangeable content, so a new path splices in.
-	/// A different one, or `Some(Origin::UNKNOWN)` (which identifies nothing), is a
+	/// A different one, or `Some(Hop::UNKNOWN)` (which identifies nothing), is a
 	/// distinct publisher reusing the namespace and must not splice. That comparison
 	/// only applies between separate advertisements; see [`Arrival`].
 	///
@@ -211,7 +211,7 @@ struct Advertised {
 	/// compare and nothing ever replaces the source on identity grounds. That covers
 	/// base moq-transport entirely: PUBLISH_NAMESPACE and NAMESPACE for one namespace
 	/// are then two messages describing a single source, not two publishers.
-	publisher: Option<crate::Origin>,
+	publisher: Option<crate::Hop>,
 }
 
 /// How an advertisement relates to whatever already holds the path.
@@ -242,18 +242,18 @@ pub(super) struct Subscriber<S: crate::transport::poll::Session, R: crate::runti
 	// this session when the peer declares none of its own (see `session_route`). Base
 	// moq-transport carries no hop ids, so a peer only has an identity if it negotiated
 	// the MoQ Cluster extension or the caller assigned it one
-	// (`Client::with_peer_origin`), which also makes the route recognizable across
+	// (`Client::with_peer_hop`), which also makes the route recognizable across
 	// sessions dialing the same relay.
 	//
-	// Otherwise this is `Origin::UNKNOWN` (0), the reserved "no identity" value.
+	// Otherwise this is `Hop::UNKNOWN` (0), the reserved "no identity" value.
 	// Minting one here is not this layer's call: the peer never learns the id, so
 	// only the side that assigned it can exclude it for loop detection, and whether
 	// two sessions should look like one identity or two is the caller's policy. A
 	// server answers it per accepted session; a client only when it knows the peer.
-	session_origin: crate::Origin,
+	session_hop: crate::Hop,
 	// Our own Hop ID, which an advertisement must not already contain: one that does
 	// looped back through us.
-	self_origin: crate::Origin,
+	self_hop: crate::Hop,
 	// What the peer declared in its SETUP.
 	peer_setup: peer::PeerSetup,
 	// Local policy for what pulling from this peer costs, overriding whatever it
@@ -311,9 +311,9 @@ where
 		session: S,
 		origin: origin::Producer,
 		control: Control,
-		peer_origin: Option<crate::Origin>,
+		peer_hop: Option<crate::Hop>,
 		peer_setup: peer::PeerSetup,
-		self_origin: crate::Origin,
+		self_hop: crate::Hop,
 		cost: Option<u64>,
 		version: Version,
 		tasks: Tasks,
@@ -324,8 +324,8 @@ where
 			session,
 			origin,
 			control,
-			session_origin: peer_origin.unwrap_or(crate::Origin::UNKNOWN),
-			self_origin,
+			session_hop: peer_hop.unwrap_or(crate::Hop::UNKNOWN),
+			self_hop,
 			peer_setup,
 			cost,
 			state: Default::default(),
@@ -347,7 +347,7 @@ where
 	/// The route for an advertisement that carries no path of its own.
 	///
 	/// Base moq-transport has no hops on the wire, so the chain is a single entry
-	/// attributed to this session (`Origin::UNKNOWN` unless the peer or the caller
+	/// attributed to this session (`Hop::UNKNOWN` unless the peer or the caller
 	/// supplied an identity).
 	///
 	/// That entry doubles as the content identity, which is what makes an assigned
@@ -368,8 +368,8 @@ where
 	/// Price such a link with [`crate::Client::with_cost`] rather than trusting the
 	/// default.
 	fn session_route(&self, peer: &cluster::Peer) -> broadcast::Route {
-		let mut hops = crate::OriginList::new();
-		hops.push(self.session_origin)
+		let mut hops = crate::Hops::new();
+		hops.push(self.session_hop)
 			.expect("an empty hop chain has room for one entry");
 		broadcast::Route::new()
 			.with_hops(hops)
@@ -393,21 +393,13 @@ where
 			});
 		};
 
-		if advert.loops(self.self_origin) {
+		if advert.loops(self.self_hop) {
 			return None;
 		}
 
 		Some(Advertised {
 			route: advert.route(cluster::link_cost(self.cost, peer)),
-			publisher: Some(
-				advert
-					.hops
-					.hops()
-					.iter()
-					.next()
-					.copied()
-					.unwrap_or(crate::Origin::UNKNOWN),
-			),
+			publisher: Some(advert.hops.hops().iter().next().copied().unwrap_or(crate::Hop::UNKNOWN)),
 		})
 	}
 
@@ -1111,7 +1103,7 @@ where
 				// Two advertisements, so identity is the only link between them and
 				// UNKNOWN is no link at all: unrelated publishers all present the same
 				// one. Take the later as replacing the earlier.
-				Arrival::Separate => old != new || new == crate::Origin::UNKNOWN,
+				Arrival::Separate => old != new || new == crate::Hop::UNKNOWN,
 				// One advertisement, repeated on the stream that carries it. Continuity
 				// is the stream, not the identity, so an unchanged UNKNOWN stays put; a
 				// peer that never named itself would otherwise lose every subscription
@@ -1822,7 +1814,7 @@ mod tests {
 	/// What an unsolicited advertisement means to a subscriber on `version` whose peer
 	/// declared `solicit`.
 	fn unsolicited_is_a_violation(solicit: Option<bool>, version: Version) -> bool {
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let session = crate::lite::test_transport::SinkSession::new(Default::default());
 		let peer_setup = peer::PeerSetup::default();
 		peer_setup.set(peer::Peer {
@@ -1838,7 +1830,7 @@ mod tests {
 			Control::new(None, false),
 			None,
 			peer_setup,
-			crate::Origin::new(1).unwrap(),
+			crate::Hop::new(1).unwrap(),
 			None,
 			version,
 			tasks,
@@ -1891,7 +1883,7 @@ mod tests {
 	/// so sending it asks for a prefix that matches nothing there.
 	#[tokio::test]
 	async fn a_rooted_subscriber_asks_for_its_scope_not_its_root() {
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let scoped = origin
 			.with_root("rootns")
 			.and_then(|rooted| rooted.scope(&[crate::Path::new("cam")]))
@@ -1908,7 +1900,7 @@ mod tests {
 			Control::new(None, false),
 			None,
 			peer::PeerSetup::default(),
-			crate::Origin::new(1).unwrap(),
+			crate::Hop::new(1).unwrap(),
 			None,
 			Version::Draft16,
 			tasks,
@@ -1962,7 +1954,7 @@ mod tests {
 	async fn a_rooted_subscriber_mounts_a_reply_under_its_root_once() {
 		const VERSION: Version = Version::Draft18;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let consumer = origin.consume();
 		let scoped = origin
 			.with_root("rootns")
@@ -1982,7 +1974,7 @@ mod tests {
 			Control::new(None, false),
 			None,
 			peer_setup,
-			crate::Origin::new(1).unwrap(),
+			crate::Hop::new(1).unwrap(),
 			None,
 			VERSION,
 			tasks,
@@ -2110,11 +2102,11 @@ mod tests {
 		let subscriber = Subscriber::new(
 			TestRuntime::new(),
 			crate::lite::test_transport::SinkSession::new(Default::default()),
-			crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce(),
+			crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce(),
 			Control::new(None, false),
 			None,
 			peer::PeerSetup::default(),
-			crate::Origin::new(1).unwrap(),
+			crate::Hop::new(1).unwrap(),
 			None,
 			Version::Draft19,
 			tasks,
@@ -2264,11 +2256,11 @@ mod tests {
 		let mut subscriber = Subscriber::new(
 			TestRuntime::new(),
 			session,
-			crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce(),
+			crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce(),
 			Control::new(None, false),
 			None,
 			peer::PeerSetup::default(),
-			crate::Origin::new(1).unwrap(),
+			crate::Hop::new(1).unwrap(),
 			None,
 			VERSION,
 			tasks,
@@ -2320,11 +2312,11 @@ mod tests {
 		let mut subscriber = Subscriber::new(
 			TestRuntime::new(),
 			session,
-			crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce(),
+			crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce(),
 			Control::new(None, false),
 			None,
 			peer::PeerSetup::default(),
-			crate::Origin::new(1).unwrap(),
+			crate::Hop::new(1).unwrap(),
 			None,
 			VERSION,
 			tasks,
@@ -2425,11 +2417,11 @@ mod tests {
 		let mut subscriber = Subscriber::new(
 			TestRuntime::new(),
 			adapter,
-			crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce(),
+			crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce(),
 			control,
 			None,
 			peer::PeerSetup::default(),
-			crate::Origin::new(1).unwrap(),
+			crate::Hop::new(1).unwrap(),
 			None,
 			VERSION,
 			tasks,
@@ -2540,11 +2532,11 @@ mod tests {
 		let mut subscriber = Subscriber::new(
 			TestRuntime::new(),
 			session,
-			crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce(),
+			crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce(),
 			Control::new(None, false),
 			None,
 			peer::PeerSetup::default(),
-			crate::Origin::new(1).unwrap(),
+			crate::Hop::new(1).unwrap(),
 			None,
 			version,
 			tasks,
@@ -2630,15 +2622,15 @@ mod tests {
 
 	/// moq-transport carries no hop ids, so a peer's broadcasts are normally
 	/// attributed to a random per-connection origin. An identity assigned via
-	/// `Client::with_peer_origin` pins it, so sessions dialing the same relay
+	/// `Client::with_peer_hop` pins it, so sessions dialing the same relay
 	/// resolve to one recognizable route, and a reconnect splices rather than
 	/// replacing.
 	#[tokio::test]
 	async fn assigned_peer_origin_attributes_announces() {
 		let session = crate::lite::test_transport::SinkSession::new(Default::default());
-		let assigned = crate::Origin::new(777).unwrap();
+		let assigned = crate::Hop::new(777).unwrap();
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let consumer = origin.consume();
 		let (tasks, _task_set) = crate::util::TaskSet::new();
 		let mut subscriber = Subscriber::new(
@@ -2648,7 +2640,7 @@ mod tests {
 			Control::new(None, false),
 			Some(assigned),
 			peer::PeerSetup::default(),
-			crate::Origin::new(1).unwrap(),
+			crate::Hop::new(1).unwrap(),
 			None,
 			Version::Draft14,
 			tasks,
@@ -2677,20 +2669,20 @@ mod tests {
 	#[tokio::test]
 	async fn reflected_announce_does_not_evict_the_source_we_publish() {
 		let session = crate::lite::test_transport::SinkSession::new(Default::default());
-		let peer = crate::Origin::new(777).unwrap();
-		let self_origin = crate::Origin::new(1).unwrap();
+		let peer = crate::Hop::new(777).unwrap();
+		let self_hop = crate::Hop::new(1).unwrap();
 
-		let origin = crate::origin::Info::new(self_origin).produce();
+		let origin = crate::origin::Info::new(self_hop).produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
 		// The publish direction: an origin handle scoped to the peer, which is what
-		// `Client::with_peer_origin` hands the publisher. Holding its announce stream
+		// `Client::with_peer_hop` hands the publisher. Holding its announce stream
 		// is what records that the peer has been offered these paths.
 		let mut publishing = consumer.clone().excluding(peer).announced();
 
 		// What we are publishing to the peer: a real upstream, announced.
-		let upstream = crate::OriginList::try_from(vec![crate::Origin::new(7).unwrap()]).unwrap();
+		let upstream = crate::Hops::try_from(vec![crate::Hop::new(7).unwrap()]).unwrap();
 		let _source = origin
 			.create_broadcast(
 				"room/host",
@@ -2715,7 +2707,7 @@ mod tests {
 			Control::new(None, false),
 			Some(peer),
 			peer::PeerSetup::default(),
-			self_origin,
+			self_hop,
 			None,
 			Version::Draft14,
 			tasks,
@@ -2743,10 +2735,10 @@ mod tests {
 	/// must not cost us it.
 	#[tokio::test]
 	async fn reconnecting_peer_joins_the_front_it_replaces() {
-		let peer = crate::Origin::new(777).unwrap();
-		let self_origin = crate::Origin::new(1).unwrap();
+		let peer = crate::Hop::new(777).unwrap();
+		let self_hop = crate::Hop::new(1).unwrap();
 
-		let origin = crate::origin::Info::new(self_origin).produce();
+		let origin = crate::origin::Info::new(self_hop).produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -2760,7 +2752,7 @@ mod tests {
 				Control::new(None, false),
 				Some(peer),
 				peer::PeerSetup::default(),
-				self_origin,
+				self_hop,
 				None,
 				Version::Draft14,
 				tasks,
@@ -2789,13 +2781,13 @@ mod tests {
 	}
 
 	fn cluster_subscriber(
-		self_origin: crate::Origin,
+		self_hop: crate::Hop,
 	) -> (
 		Subscriber<crate::lite::test_transport::SinkSession, TestRuntime>,
 		crate::origin::Producer,
 	) {
 		let session = crate::lite::test_transport::SinkSession::new(Default::default());
-		let origin = crate::origin::Info::new(self_origin).produce();
+		let origin = crate::origin::Info::new(self_hop).produce();
 		let (tasks, task_set) = crate::util::TaskSet::new();
 		// The set only drains announce-serving tasks; the tests here drive the model
 		// directly, so leaking it keeps the handles alive without a spawner.
@@ -2808,7 +2800,7 @@ mod tests {
 			Control::new(None, false),
 			None,
 			peer::PeerSetup::default(),
-			self_origin,
+			self_hop,
 			None,
 			Version::Draft19,
 			tasks,
@@ -2818,11 +2810,8 @@ mod tests {
 	}
 
 	fn hop_path(ids: &[u64]) -> cluster::HopPath {
-		let hops = ids
-			.iter()
-			.map(|&id| crate::Origin::new(id).unwrap())
-			.collect::<Vec<_>>();
-		cluster::HopPath::new(crate::OriginList::try_from(hops).unwrap())
+		let hops = ids.iter().map(|&id| crate::Hop::new(id).unwrap()).collect::<Vec<_>>();
+		cluster::HopPath::new(crate::Hops::try_from(hops).unwrap())
 	}
 
 	/// A negotiated advertisement carries the whole path and its accumulated cost, and
@@ -2830,11 +2819,11 @@ mod tests {
 	/// upstream value ranks last rather than wrapping to best).
 	#[tokio::test]
 	async fn cluster_advert_becomes_a_route_with_the_link_charged() {
-		let (subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (subscriber, origin) = cluster_subscriber(crate::Hop::new(1).unwrap());
 		let consumer = origin.consume();
 
 		let peer = cluster::Peer {
-			origin: Some(crate::Origin::new(9).unwrap()),
+			origin: Some(crate::Hop::new(9).unwrap()),
 			cost: Some(3),
 		};
 		let advert = cluster::Advert {
@@ -2849,7 +2838,7 @@ mod tests {
 		);
 		assert_eq!(advertised.route.hops, hop_path(&[7, 9]).hops().clone());
 		assert!(advertised.route.announce);
-		assert_eq!(advertised.publisher, Some(crate::Origin::new(7).unwrap()));
+		assert_eq!(advertised.publisher, Some(crate::Hop::new(7).unwrap()));
 
 		let mut subscriber = subscriber;
 		subscriber
@@ -2868,9 +2857,9 @@ mod tests {
 	/// back to ourselves. Hop ID 0 identifies nothing, so it is never a loop.
 	#[test]
 	fn cluster_advert_loop_is_discarded() {
-		let (subscriber, _origin) = cluster_subscriber(crate::Origin::new(5).unwrap());
+		let (subscriber, _origin) = cluster_subscriber(crate::Hop::new(5).unwrap());
 		let peer = cluster::Peer {
-			origin: Some(crate::Origin::new(9).unwrap()),
+			origin: Some(crate::Hop::new(9).unwrap()),
 			cost: None,
 		};
 
@@ -2891,9 +2880,9 @@ mod tests {
 	/// hop count and degenerates to shortest-path routing.
 	#[test]
 	fn unpriced_link_costs_one() {
-		let (subscriber, _origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (subscriber, _origin) = cluster_subscriber(crate::Hop::new(1).unwrap());
 		let peer = cluster::Peer {
-			origin: Some(crate::Origin::new(9).unwrap()),
+			origin: Some(crate::Hop::new(9).unwrap()),
 			cost: None,
 		};
 		let advert = cluster::Advert {
@@ -2904,7 +2893,7 @@ mod tests {
 
 		// Zero is meaningful and distinct from absent: a free link adds nothing.
 		let free = cluster::Peer {
-			origin: Some(crate::Origin::new(9).unwrap()),
+			origin: Some(crate::Hop::new(9).unwrap()),
 			cost: Some(0),
 		};
 		assert_eq!(subscriber.route(Some(&advert), &free).unwrap().route.cost.warm, 2);
@@ -2922,7 +2911,7 @@ mod tests {
 	async fn a_lost_namespace_stream_closes_the_broadcast() {
 		const VERSION: Version = Version::Draft18;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let consumer = origin.consume();
 
 		// The peer answers, advertises one namespace, then the stream ends without ever
@@ -2941,7 +2930,7 @@ mod tests {
 			Control::new(None, false),
 			None,
 			peer_setup,
-			crate::Origin::new(1).unwrap(),
+			crate::Hop::new(1).unwrap(),
 			None,
 			VERSION,
 			tasks,
@@ -2965,7 +2954,7 @@ mod tests {
 	/// said the namespace is gone, so a later create at the path is new content.
 	#[tokio::test(start_paused = true)]
 	async fn an_explicit_namespace_done_closes_the_broadcast() {
-		let (mut subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (mut subscriber, origin) = cluster_subscriber(crate::Hop::new(1).unwrap());
 		let consumer = origin.consume();
 
 		let path = crate::Path::new("room/host").to_owned();
@@ -3000,7 +2989,7 @@ mod tests {
 			.unwrap();
 		let script = log.writes.lock().unwrap().clone();
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let consumer = origin.consume();
 		let session = crate::lite::test_transport::ScriptedSession::eof(script);
 		let (tasks, task_set) = crate::util::TaskSet::new();
@@ -3012,7 +3001,7 @@ mod tests {
 			Control::new(None, false),
 			None,
 			peer::PeerSetup::default(),
-			crate::Origin::new(1).unwrap(),
+			crate::Hop::new(1).unwrap(),
 			None,
 			VERSION,
 			tasks,
@@ -3047,7 +3036,7 @@ mod tests {
 	async fn a_broken_publish_namespace_stream_closes_the_broadcast() {
 		const VERSION: Version = Version::Draft19;
 
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let consumer = origin.consume();
 
 		// The peer sends something that does not belong on this stream, ending it with an
@@ -3067,7 +3056,7 @@ mod tests {
 			Control::new(None, false),
 			None,
 			peer::PeerSetup::default(),
-			crate::Origin::new(1).unwrap(),
+			crate::Hop::new(1).unwrap(),
 			None,
 			VERSION,
 			tasks,
@@ -3103,7 +3092,7 @@ mod tests {
 	/// what the origin sees.
 	#[tokio::test(start_paused = true)]
 	async fn the_last_owner_out_decides_the_detach() {
-		let (mut subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (mut subscriber, origin) = cluster_subscriber(crate::Hop::new(1).unwrap());
 		let consumer = origin.consume();
 		let path = crate::Path::new("room/host").to_owned();
 		let peer = cluster::Peer::default();
@@ -3136,7 +3125,7 @@ mod tests {
 	/// advertise a paid upstream as the cheapest route in the mesh.
 	#[test]
 	fn a_pathless_advert_still_pays_for_its_link() {
-		let (unpriced, _origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (unpriced, _origin) = cluster_subscriber(crate::Hop::new(1).unwrap());
 		let peer = cluster::Peer::default();
 
 		// Nothing priced this direction, so it ranks by hop count.
@@ -3153,7 +3142,7 @@ mod tests {
 		assert_eq!(unpriced.route(None, &priced_peer).unwrap().route.cost.warm, 4);
 
 		// Local policy still wins over what the peer declared.
-		let (mut priced, _origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (mut priced, _origin) = cluster_subscriber(crate::Hop::new(1).unwrap());
 		priced.cost = Some(6);
 		assert_eq!(priced.route(None, &priced_peer).unwrap().route.cost.warm, 6);
 	}
@@ -3163,7 +3152,7 @@ mod tests {
 	/// it, since that content is not interchangeable.
 	#[tokio::test]
 	async fn cluster_update_replaces_in_place() {
-		let (mut subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (mut subscriber, origin) = cluster_subscriber(crate::Hop::new(1).unwrap());
 		let consumer = origin.consume();
 		let path = crate::Path::new("room/host").to_owned();
 
@@ -3173,7 +3162,7 @@ mod tests {
 			.with_announce(true);
 		let first = Advertised {
 			route: first,
-			publisher: Some(crate::Origin::new(7).unwrap()),
+			publisher: Some(crate::Hop::new(7).unwrap()),
 		};
 		subscriber.start_announce(path.clone(), first).unwrap();
 		tokio::time::sleep(Duration::from_millis(1)).await;
@@ -3186,7 +3175,7 @@ mod tests {
 			.with_announce(true);
 		let rerouted = Advertised {
 			route: rerouted,
-			publisher: Some(crate::Origin::new(7).unwrap()),
+			publisher: Some(crate::Hop::new(7).unwrap()),
 		};
 		subscriber.update_announce(path.clone(), rerouted).unwrap();
 		tokio::time::sleep(Duration::from_millis(1)).await;
@@ -3209,7 +3198,7 @@ mod tests {
 	/// still reference the path.
 	#[tokio::test]
 	async fn cluster_publisher_change_replaces_the_source() {
-		let (mut subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (mut subscriber, origin) = cluster_subscriber(crate::Hop::new(1).unwrap());
 		let consumer = origin.consume();
 		let path = crate::Path::new("room/host").to_owned();
 
@@ -3218,7 +3207,7 @@ mod tests {
 			.with_announce(true);
 		let first = Advertised {
 			route: first,
-			publisher: Some(crate::Origin::new(7).unwrap()),
+			publisher: Some(crate::Hop::new(7).unwrap()),
 		};
 		subscriber.start_announce(path.clone(), first).unwrap();
 		tokio::time::sleep(Duration::from_millis(1)).await;
@@ -3229,7 +3218,7 @@ mod tests {
 			.with_announce(true);
 		let taken_over = Advertised {
 			route: taken_over,
-			publisher: Some(crate::Origin::new(8).unwrap()),
+			publisher: Some(crate::Hop::new(8).unwrap()),
 		};
 		subscriber.update_announce(path.clone(), taken_over).unwrap();
 		tokio::time::sleep(Duration::from_millis(1)).await;
@@ -3246,23 +3235,23 @@ mod tests {
 	}
 
 	/// Regression: a publisher that declares no identity of its own contributes
-	/// `Origin::UNKNOWN` as the first hop, which identifies nothing. A repeat NAMESPACE
+	/// `Hop::UNKNOWN` as the first hop, which identifies nothing. A repeat NAMESPACE
 	/// is still the same advertisement being repriced (the expected update, and how a
 	/// relay signals that it started carrying the namespace), so the source and every
 	/// live subscription on it must survive. Reading the repeat as a new publisher
 	/// detached the source milliseconds after SUBSCRIBE went out.
 	#[tokio::test(start_paused = true)]
 	async fn anonymous_publisher_survives_a_repricing_update() {
-		let (mut subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (mut subscriber, origin) = cluster_subscriber(crate::Hop::new(1).unwrap());
 		let consumer = origin.consume();
 		let path = crate::Path::new("room/host").to_owned();
 		// A free link, so the route cost is exactly what the peer advertised.
 		let peer = cluster::Peer {
-			origin: Some(crate::Origin::new(9).unwrap()),
+			origin: Some(crate::Hop::new(9).unwrap()),
 			cost: Some(0),
 		};
 		let hops = cluster::HopPath::new(
-			crate::OriginList::try_from(vec![crate::Origin::UNKNOWN, crate::Origin::new(9).unwrap()]).unwrap(),
+			crate::Hops::try_from(vec![crate::Hop::UNKNOWN, crate::Hop::new(9).unwrap()]).unwrap(),
 		);
 
 		let advertised = subscriber
@@ -3276,7 +3265,7 @@ mod tests {
 			.expect("route");
 		assert_eq!(
 			advertised.publisher,
-			Some(crate::Origin::UNKNOWN),
+			Some(crate::Hop::UNKNOWN),
 			"an anonymous publisher has no identity to carry",
 		);
 		subscriber.start_announce(path.clone(), advertised).unwrap();
@@ -3313,19 +3302,19 @@ mod tests {
 	}
 
 	/// Two *separate* advertisements have nothing linking them but the publisher, and
-	/// `Origin::UNKNOWN` links nothing: any number of unrelated publishers present it.
+	/// `Hop::UNKNOWN` links nothing: any number of unrelated publishers present it.
 	/// So the later one replaces the earlier, unlike the repeat above.
 	#[tokio::test(start_paused = true)]
 	async fn separate_anonymous_adverts_replace_the_source() {
-		let (mut subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (mut subscriber, origin) = cluster_subscriber(crate::Hop::new(1).unwrap());
 		let consumer = origin.consume();
 		let path = crate::Path::new("room/host").to_owned();
 		let peer = cluster::Peer {
-			origin: Some(crate::Origin::new(9).unwrap()),
+			origin: Some(crate::Hop::new(9).unwrap()),
 			cost: None,
 		};
 		let hops = cluster::HopPath::new(
-			crate::OriginList::try_from(vec![crate::Origin::UNKNOWN, crate::Origin::new(9).unwrap()]).unwrap(),
+			crate::Hops::try_from(vec![crate::Hop::UNKNOWN, crate::Hop::new(9).unwrap()]).unwrap(),
 		);
 		let advert = cluster::Advert { hops, cost: 0 };
 
@@ -3357,7 +3346,7 @@ mod tests {
 	/// as a subscriber is resolving a track through it.
 	#[tokio::test]
 	async fn pathless_adverts_never_replace_the_source() {
-		let (mut subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (mut subscriber, origin) = cluster_subscriber(crate::Hop::new(1).unwrap());
 		let consumer = origin.consume();
 		let path = crate::Path::new("room/host").to_owned();
 		let peer = cluster::Peer::default();
@@ -3391,12 +3380,12 @@ mod tests {
 	/// would leave subscriptions on a path the peer no longer offers.
 	#[tokio::test]
 	async fn reflected_replacement_retracts_the_route() {
-		let self_origin = crate::Origin::new(5).unwrap();
-		let (mut subscriber, origin) = cluster_subscriber(self_origin);
+		let self_hop = crate::Hop::new(5).unwrap();
+		let (mut subscriber, origin) = cluster_subscriber(self_hop);
 		let consumer = origin.consume();
 		let path = crate::Path::new("room/host").to_owned();
 		let peer = cluster::Peer {
-			origin: Some(crate::Origin::new(9).unwrap()),
+			origin: Some(crate::Hop::new(9).unwrap()),
 			cost: None,
 		};
 
@@ -3458,7 +3447,7 @@ mod tests {
 	/// Build a subscriber whose peer replays `updates` on one PUBLISH_NAMESPACE stream,
 	/// with the advertisement already attached.
 	async fn reflected_harness(
-		self_origin: crate::Origin,
+		self_hop: crate::Hop,
 		request_id: RequestId,
 		peer: &cluster::Peer,
 		attached: &cluster::Advert,
@@ -3471,7 +3460,7 @@ mod tests {
 		const VERSION: Version = Version::Draft19;
 		let script = publish_namespace_updates(request_id, "room/host", updates).await;
 		let session = crate::lite::test_transport::ScriptedSession::new(script);
-		let origin = crate::origin::Info::new(self_origin).produce();
+		let origin = crate::origin::Info::new(self_hop).produce();
 		let consumer = origin.consume();
 		let (tasks, task_set) = crate::util::TaskSet::new();
 		// The tests drive the loop directly, so nothing spawns; leaking keeps the
@@ -3485,7 +3474,7 @@ mod tests {
 			Control::new(None, false),
 			None,
 			peer::PeerSetup::default(),
-			self_origin,
+			self_hop,
 			None,
 			VERSION,
 			tasks,
@@ -3504,7 +3493,7 @@ mod tests {
 
 	fn peer_9() -> cluster::Peer {
 		cluster::Peer {
-			origin: Some(crate::Origin::new(9).unwrap()),
+			origin: Some(crate::Hop::new(9).unwrap()),
 			cost: None,
 		}
 	}
@@ -3530,13 +3519,13 @@ mod tests {
 	/// sibling shares it, which the draft answers with "discard", not PROTOCOL_VIOLATION.
 	#[tokio::test]
 	async fn a_reflected_update_detaches_but_keeps_the_stream() {
-		let self_origin = crate::Origin::new(5).unwrap();
+		let self_hop = crate::Hop::new(5).unwrap();
 		let request_id = RequestId(1);
 		let peer = peer_9();
 		let (clean, looped) = clean_and_looped();
 
 		let (mut subscriber, consumer, mut stream) =
-			reflected_harness(self_origin, request_id, &peer, &clean, &[Some(looped)]).await;
+			reflected_harness(self_hop, request_id, &peer, &clean, &[Some(looped)]).await;
 
 		let path = crate::Path::new("room/host").to_owned();
 		let mut attached = true;
@@ -3572,13 +3561,13 @@ mod tests {
 	/// reason the stream stays open.
 	#[tokio::test]
 	async fn a_clean_update_after_a_reflection_reattaches() {
-		let self_origin = crate::Origin::new(5).unwrap();
+		let self_hop = crate::Hop::new(5).unwrap();
 		let request_id = RequestId(1);
 		let peer = peer_9();
 		let (clean, looped) = clean_and_looped();
 
 		let (mut subscriber, consumer, mut stream) = reflected_harness(
-			self_origin,
+			self_hop,
 			request_id,
 			&peer,
 			&clean,
@@ -3620,7 +3609,7 @@ mod tests {
 	/// session keeps running).
 	#[tokio::test]
 	async fn namespace_stream_close_releases_live_paths() {
-		let (mut subscriber, origin) = cluster_subscriber(crate::Origin::new(1).unwrap());
+		let (mut subscriber, origin) = cluster_subscriber(crate::Hop::new(1).unwrap());
 		let consumer = origin.consume();
 		let peer = cluster::Peer::default();
 
@@ -3653,7 +3642,7 @@ mod tests {
 		// An open gate, so the rejection actually reaches the wire.
 		let gate = kio::Producer::new(true);
 		let session = crate::lite::test_transport::SinkSession::gated_bi(gate.consume());
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let consumer = origin.consume();
 		let (tasks, task_set) = crate::util::TaskSet::new();
 		std::mem::forget(task_set);
@@ -3665,7 +3654,7 @@ mod tests {
 			Control::new(None, false),
 			None,
 			peer::PeerSetup::default(),
-			crate::Origin::new(1).unwrap(),
+			crate::Hop::new(1).unwrap(),
 			None,
 			Version::Draft19,
 			tasks,

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -2823,7 +2823,7 @@ mod tests {
 		let consumer = origin.consume();
 
 		let peer = cluster::Peer {
-			origin: Some(crate::Hop::new(9).unwrap()),
+			hop: Some(crate::Hop::new(9).unwrap()),
 			cost: Some(3),
 		};
 		let advert = cluster::Advert {
@@ -2859,7 +2859,7 @@ mod tests {
 	fn cluster_advert_loop_is_discarded() {
 		let (subscriber, _origin) = cluster_subscriber(crate::Hop::new(5).unwrap());
 		let peer = cluster::Peer {
-			origin: Some(crate::Hop::new(9).unwrap()),
+			hop: Some(crate::Hop::new(9).unwrap()),
 			cost: None,
 		};
 
@@ -2882,7 +2882,7 @@ mod tests {
 	fn unpriced_link_costs_one() {
 		let (subscriber, _origin) = cluster_subscriber(crate::Hop::new(1).unwrap());
 		let peer = cluster::Peer {
-			origin: Some(crate::Hop::new(9).unwrap()),
+			hop: Some(crate::Hop::new(9).unwrap()),
 			cost: None,
 		};
 		let advert = cluster::Advert {
@@ -2893,7 +2893,7 @@ mod tests {
 
 		// Zero is meaningful and distinct from absent: a free link adds nothing.
 		let free = cluster::Peer {
-			origin: Some(crate::Hop::new(9).unwrap()),
+			hop: Some(crate::Hop::new(9).unwrap()),
 			cost: Some(0),
 		};
 		assert_eq!(subscriber.route(Some(&advert), &free).unwrap().route.cost.warm, 2);
@@ -3136,7 +3136,7 @@ mod tests {
 
 		// A peer that declared its egress price is charged it, extension or not.
 		let priced_peer = cluster::Peer {
-			origin: None,
+			hop: None,
 			cost: Some(4),
 		};
 		assert_eq!(unpriced.route(None, &priced_peer).unwrap().route.cost.warm, 4);
@@ -3247,7 +3247,7 @@ mod tests {
 		let path = crate::Path::new("room/host").to_owned();
 		// A free link, so the route cost is exactly what the peer advertised.
 		let peer = cluster::Peer {
-			origin: Some(crate::Hop::new(9).unwrap()),
+			hop: Some(crate::Hop::new(9).unwrap()),
 			cost: Some(0),
 		};
 		let hops = cluster::HopPath::new(
@@ -3310,7 +3310,7 @@ mod tests {
 		let consumer = origin.consume();
 		let path = crate::Path::new("room/host").to_owned();
 		let peer = cluster::Peer {
-			origin: Some(crate::Hop::new(9).unwrap()),
+			hop: Some(crate::Hop::new(9).unwrap()),
 			cost: None,
 		};
 		let hops = cluster::HopPath::new(
@@ -3385,7 +3385,7 @@ mod tests {
 		let consumer = origin.consume();
 		let path = crate::Path::new("room/host").to_owned();
 		let peer = cluster::Peer {
-			origin: Some(crate::Hop::new(9).unwrap()),
+			hop: Some(crate::Hop::new(9).unwrap()),
 			cost: None,
 		};
 
@@ -3493,7 +3493,7 @@ mod tests {
 
 	fn peer_9() -> cluster::Peer {
 		cluster::Peer {
-			origin: Some(crate::Hop::new(9).unwrap()),
+			hop: Some(crate::Hop::new(9).unwrap()),
 			cost: None,
 		}
 	}

--- a/rs/moq-net/src/lite/announce.rs
+++ b/rs/moq-net/src/lite/announce.rs
@@ -39,11 +39,7 @@ pub enum AnnounceBroadcast<'a> {
 	/// ANNOUNCE_START (lite-06) / active (older): a broadcast is now available.
 	/// Carries the path suffix, the hop chain, and (lite-06+) the warm and cold
 	/// route costs, and assigns the next announce id.
-	Active {
-		suffix: Path<'a>,
-		hops: Hops,
-		cost: Cost,
-	},
+	Active { suffix: Path<'a>, hops: Hops, cost: Cost },
 	/// Pre-lite-06: a broadcast is no longer available, retracted by path.
 	Ended { suffix: Path<'a>, hops: Hops },
 	/// ANNOUNCE_END (lite-06+): a broadcast is no longer available, retracted by
@@ -242,7 +238,7 @@ pub struct AnnounceRequest<'a> {
 	// Lite04/05 only: if non-zero, the publisher SHOULD skip announces whose hop IDs
 	// contain this value. Not on the wire elsewhere, so the value set here is ignored
 	// when encoding for another version and decodes as zero; lite-06 carries the
-	// identity session-wide in the SETUP Origin parameter instead.
+	// identity session-wide in the SETUP Hop parameter instead.
 	pub exclude_hop: u64,
 }
 
@@ -340,14 +336,14 @@ impl Message for AnnounceInit<'_> {
 /// Sent by the publisher as the first message on an announce stream, before any
 /// individual Announce messages. Lite05+ only; the successor to [`AnnounceInit`].
 ///
-/// `origin` is the responder's session origin id. In Lite05 the publisher no
+/// `hop` is the responder's session Hop ID. In Lite05 the publisher no
 /// longer stamps it onto each Announce's hop chain; the subscriber appends it on
 /// receipt instead. `active` is the number of currently-active broadcasts the
 /// publisher sends as the initial set immediately after this message, letting the
 /// receiver block until the initial set has arrived.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AnnounceOk {
-	pub origin: Hop,
+	pub hop: Hop,
 	pub active: u64,
 }
 
@@ -357,9 +353,9 @@ impl Message for AnnounceOk {
 			return Err(DecodeError::Version);
 		}
 
-		let origin = Hop::decode(r, version)?;
+		let hop = Hop::decode(r, version)?;
 		let active = u64::decode(r, version)?;
-		Ok(Self { origin, active })
+		Ok(Self { hop, active })
 	}
 
 	fn encode_msg<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
@@ -367,7 +363,7 @@ impl Message for AnnounceOk {
 			return Err(EncodeError::Version);
 		}
 
-		self.origin.encode(w, version)?;
+		self.hop.encode(w, version)?;
 		self.active.encode(w, version)
 	}
 }
@@ -440,7 +436,7 @@ mod tests {
 	#[test]
 	fn announce_ok_round_trip() {
 		let msg = AnnounceOk {
-			origin: Hop::new(42).unwrap(),
+			hop: Hop::new(42).unwrap(),
 			active: 3,
 		};
 		assert_eq!(round_trip(&msg), msg);
@@ -449,7 +445,7 @@ mod tests {
 	#[test]
 	fn announce_ok_zero_active() {
 		let msg = AnnounceOk {
-			origin: Hop::new(7).unwrap(),
+			hop: Hop::new(7).unwrap(),
 			active: 0,
 		};
 		assert_eq!(round_trip(&msg), msg);
@@ -635,7 +631,7 @@ mod tests {
 	#[test]
 	fn announce_ok_rejects_old_versions() {
 		let msg = AnnounceOk {
-			origin: Hop::new(1).unwrap(),
+			hop: Hop::new(1).unwrap(),
 			active: 0,
 		};
 		let mut buf = bytes::BytesMut::new();
@@ -650,7 +646,7 @@ mod tests {
 		// Encode a well-formed message then patch the origin to 0 on the wire.
 		let mut buf = bytes::BytesMut::new();
 		AnnounceOk {
-			origin: Hop::new(1).unwrap(),
+			hop: Hop::new(1).unwrap(),
 			active: 0,
 		}
 		.encode(&mut buf, Version::Lite05)
@@ -662,7 +658,7 @@ mod tests {
 		patched[1] = 0x00;
 		let mut slice = &patched[..];
 		let got = AnnounceOk::decode(&mut slice, Version::Lite05).unwrap();
-		assert_eq!(got.origin.id(), 0);
+		assert_eq!(got.hop.id(), 0);
 		assert_eq!(got.active, 0);
 	}
 }

--- a/rs/moq-net/src/lite/announce.rs
+++ b/rs/moq-net/src/lite/announce.rs
@@ -596,7 +596,7 @@ mod tests {
 		}
 	}
 
-	// Lite04/05 carry the subscriber's origin id so the publisher can skip reflected
+	// Lite04/05 carry the subscriber's Hop ID so the publisher can skip reflected
 	// announces before they hit the wire.
 	#[test]
 	fn announce_request_carries_exclude_hop_on_lite05() {
@@ -651,7 +651,7 @@ mod tests {
 		}
 		.encode(&mut buf, Version::Lite05)
 		.unwrap();
-		// origin id 1 sits right after the size prefix; rewrite it to 0.
+		// Hop ID 1 sits right after the size prefix; rewrite it to 0.
 		let bytes = &buf[..];
 		let mut patched = bytes.to_vec();
 		// size(1 byte) | origin varint(1 byte = 0x01) | active varint(1 byte)

--- a/rs/moq-net/src/lite/announce.rs
+++ b/rs/moq-net/src/lite/announce.rs
@@ -1,7 +1,7 @@
 use bytes::{Buf, BufMut};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
-use crate::{Origin, OriginList, Path, broadcast::Cost, coding::*};
+use crate::{Hop, Hops, Path, broadcast::Cost, coding::*};
 
 use super::{Message, Version};
 
@@ -41,11 +41,11 @@ pub enum AnnounceBroadcast<'a> {
 	/// route costs, and assigns the next announce id.
 	Active {
 		suffix: Path<'a>,
-		hops: OriginList,
+		hops: Hops,
 		cost: Cost,
 	},
 	/// Pre-lite-06: a broadcast is no longer available, retracted by path.
-	Ended { suffix: Path<'a>, hops: OriginList },
+	Ended { suffix: Path<'a>, hops: Hops },
 	/// ANNOUNCE_END (lite-06+): a broadcast is no longer available, retracted by
 	/// announce id. The id is retired; referencing it again is a protocol violation.
 	EndedId { id: u64 },
@@ -54,7 +54,7 @@ pub enum AnnounceBroadcast<'a> {
 	/// The id stays live.
 	///
 	/// Only ever received: we advertise a replacement as an `EndedId` + `Active` pair.
-	Restart { id: u64, hops: OriginList, cost: Cost },
+	Restart { id: u64, hops: Hops, cost: Cost },
 }
 
 impl Encode<Version> for Cost {
@@ -149,7 +149,7 @@ impl Decode<Version> for AnnounceBroadcast<'_> {
 			let msg = match typ {
 				ANNOUNCE_START => Self::Active {
 					suffix: Path::decode(&mut body, version)?,
-					hops: OriginList::decode(&mut body, version)?,
+					hops: Hops::decode(&mut body, version)?,
 					cost: Cost::decode(&mut body, version)?,
 				},
 				ANNOUNCE_END => Self::EndedId {
@@ -157,7 +157,7 @@ impl Decode<Version> for AnnounceBroadcast<'_> {
 				},
 				ANNOUNCE_RESTART => Self::Restart {
 					id: u64::decode(&mut body, version)?,
-					hops: OriginList::decode(&mut body, version)?,
+					hops: Hops::decode(&mut body, version)?,
 					cost: Cost::decode(&mut body, version)?,
 				},
 				_ => return Err(DecodeError::InvalidMessage(typ)),
@@ -189,18 +189,18 @@ impl AnnounceBroadcast<'_> {
 
 		let suffix = Path::decode(r, version)?;
 		let hops = match version {
-			Version::Lite01 | Version::Lite02 => OriginList::new(),
+			Version::Lite01 | Version::Lite02 => Hops::new(),
 			Version::Lite03 => {
 				// Lite03 sends only a hop count, not individual ids. Fill with UNKNOWN placeholders.
 				// push() enforces MAX_HOPS and `?` lifts the overflow to DecodeError::BoundsExceeded.
 				let count = u64::decode(r, version)? as usize;
-				let mut list = OriginList::new();
+				let mut list = Hops::new();
 				for _ in 0..count {
-					list.push(Origin::UNKNOWN)?;
+					list.push(Hop::UNKNOWN)?;
 				}
 				list
 			}
-			_ => OriginList::decode(r, version)?,
+			_ => Hops::decode(r, version)?,
 		};
 
 		Ok(match status {
@@ -225,7 +225,7 @@ impl AnnounceBroadcast<'_> {
 	}
 }
 
-fn encode_hops<W: bytes::BufMut>(w: &mut W, version: Version, hops: &OriginList) -> Result<(), EncodeError> {
+fn encode_hops<W: bytes::BufMut>(w: &mut W, version: Version, hops: &Hops) -> Result<(), EncodeError> {
 	match version {
 		Version::Lite01 | Version::Lite02 => Ok(()),
 		Version::Lite03 => (hops.len() as u64).encode(w, version),
@@ -347,7 +347,7 @@ impl Message for AnnounceInit<'_> {
 /// receiver block until the initial set has arrived.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct AnnounceOk {
-	pub origin: Origin,
+	pub origin: Hop,
 	pub active: u64,
 }
 
@@ -357,7 +357,7 @@ impl Message for AnnounceOk {
 			return Err(DecodeError::Version);
 		}
 
-		let origin = Origin::decode(r, version)?;
+		let origin = Hop::decode(r, version)?;
 		let active = u64::decode(r, version)?;
 		Ok(Self { origin, active })
 	}
@@ -383,7 +383,7 @@ mod tests {
 		let mut buf = bytes::BytesMut::new();
 		AnnounceBroadcast::Active {
 			suffix: Path::new("foo/bar"),
-			hops: OriginList::new(),
+			hops: Hops::new(),
 			cost: Cost::default(),
 		}
 		.encode(&mut buf, version)
@@ -440,7 +440,7 @@ mod tests {
 	#[test]
 	fn announce_ok_round_trip() {
 		let msg = AnnounceOk {
-			origin: Origin::new(42).unwrap(),
+			origin: Hop::new(42).unwrap(),
 			active: 3,
 		};
 		assert_eq!(round_trip(&msg), msg);
@@ -449,7 +449,7 @@ mod tests {
 	#[test]
 	fn announce_ok_zero_active() {
 		let msg = AnnounceOk {
-			origin: Origin::new(7).unwrap(),
+			origin: Hop::new(7).unwrap(),
 			active: 0,
 		};
 		assert_eq!(round_trip(&msg), msg);
@@ -479,8 +479,8 @@ mod tests {
 
 	#[test]
 	fn announce_broadcast_round_trip_on_lite05() {
-		let mut hops = OriginList::new();
-		hops.push(Origin::new(7).unwrap()).unwrap();
+		let mut hops = Hops::new();
+		hops.push(Hop::new(7).unwrap()).unwrap();
 		let msg = AnnounceBroadcast::Active {
 			suffix: Path::new("room/cam"),
 			hops: hops.clone(),
@@ -490,15 +490,15 @@ mod tests {
 
 		let ended = AnnounceBroadcast::Ended {
 			suffix: Path::new("room/cam"),
-			hops: OriginList::new(),
+			hops: Hops::new(),
 		};
 		assert_eq!(broadcast_round_trip(&ended, Version::Lite05), ended);
 	}
 
 	#[test]
 	fn announce_broadcast_round_trip_on_lite06() {
-		let mut hops = OriginList::new();
-		hops.push(Origin::new(7).unwrap()).unwrap();
+		let mut hops = Hops::new();
+		hops.push(Hop::new(7).unwrap()).unwrap();
 
 		// Asymmetric on purpose: the two magnitudes travel independently, so a
 		// swapped or shared encode would round-trip a symmetric pair unnoticed.
@@ -529,7 +529,7 @@ mod tests {
 		assert!(matches!(
 			AnnounceBroadcast::Restart {
 				id: 1,
-				hops: OriginList::new(),
+				hops: Hops::new(),
 				cost: Cost::default()
 			}
 			.encode(&mut buf, Version::Lite05),
@@ -538,7 +538,7 @@ mod tests {
 		assert!(matches!(
 			AnnounceBroadcast::Ended {
 				suffix: Path::new("room/cam"),
-				hops: OriginList::new()
+				hops: Hops::new()
 			}
 			.encode(&mut buf, Version::Lite06Wip),
 			Err(EncodeError::Version)
@@ -553,7 +553,7 @@ mod tests {
 	fn route_cost_is_dropped_before_lite06() {
 		let msg = AnnounceBroadcast::Active {
 			suffix: Path::new("room/cam"),
-			hops: OriginList::new(),
+			hops: Hops::new(),
 			cost: Cost { warm: 9, cold: 9 },
 		};
 		let got = broadcast_round_trip(&msg, Version::Lite05);
@@ -561,7 +561,7 @@ mod tests {
 			got,
 			AnnounceBroadcast::Active {
 				suffix: Path::new("room/cam"),
-				hops: OriginList::new(),
+				hops: Hops::new(),
 				cost: Cost::UNKNOWN,
 			}
 		);
@@ -635,7 +635,7 @@ mod tests {
 	#[test]
 	fn announce_ok_rejects_old_versions() {
 		let msg = AnnounceOk {
-			origin: Origin::new(1).unwrap(),
+			origin: Hop::new(1).unwrap(),
 			active: 0,
 		};
 		let mut buf = bytes::BytesMut::new();
@@ -650,7 +650,7 @@ mod tests {
 		// Encode a well-formed message then patch the origin to 0 on the wire.
 		let mut buf = bytes::BytesMut::new();
 		AnnounceOk {
-			origin: Origin::new(1).unwrap(),
+			origin: Hop::new(1).unwrap(),
 			active: 0,
 		}
 		.encode(&mut buf, Version::Lite05)

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -9,7 +9,7 @@ use std::{
 use web_transport_trait::Stats;
 
 use crate::{
-	AsPath, Error, Origin, OriginList,
+	AsPath, Error, Hop, Hops,
 	coding::{Encode, Stream, Writer},
 	lite::{
 		self,
@@ -41,7 +41,7 @@ struct WatchedRoute {
 /// message; one that matches is not.
 #[derive(Clone)]
 struct SentRoute {
-	hops: OriginList,
+	hops: Hops,
 	cost: crate::broadcast::Cost,
 	/// Whether this is the route we actually serve from (the table's first
 	/// entry) rather than a standby selected because the serving chain flows
@@ -65,24 +65,24 @@ pub(super) struct PublisherConfig<S: crate::transport::poll::Session, R: crate::
 	/// Receive-side GOAWAY signal: recorded when the peer's Goaway stream arrives.
 	pub goaway: crate::goaway::Protocol,
 	/// The origin (hop) id assigned to the peer, used whenever the peer doesn't
-	/// declare one itself. See `Client::with_peer_origin`.
-	pub peer_origin: Option<Origin>,
+	/// declare one itself. See `Client::with_peer_hop`.
+	pub peer_hop: Option<Hop>,
 }
 
 /// Context shared by every control-stream child.
 struct Shared<S: crate::transport::poll::Session> {
 	session: S,
 	origin: origin::Consumer,
-	self_origin: Origin,
+	self_hop: Hop,
 	// The peer's SETUP, read for the origin id it declared. Used to serve the
 	// peer from a source whose chain excludes them, keeping the data plane on
 	// the same split-horizon rule as the announces we send them.
 	peer_setup: super::PeerSetup,
-	// The identity assigned to the peer by the caller (`Client::with_peer_origin`, or
+	// The identity assigned to the peer by the caller (`Client::with_peer_hop`, or
 	// the per-session default a server hands every request), standing in wherever the
 	// peer declines to declare one. Backs both the announce filter and the serving
 	// origin, so a peer that names itself nowhere on the wire is still split-horizoned.
-	peer_origin: Option<Origin>,
+	peer_hop: Option<Hop>,
 	// The excluded origin handle, resolved once: the peer sends exactly one
 	// SETUP, so its declared id never changes for the session.
 	serving: std::sync::OnceLock<origin::Consumer>,
@@ -144,10 +144,10 @@ impl<S: crate::transport::poll::Session> Shared<S> {
 		}
 		// Pre-SETUP versions never declare an id, so only the assigned one applies.
 		let declared = match self.version.has_setup_stream() {
-			true => ready!(self.peer_setup.poll_origin(waiter)),
+			true => ready!(self.peer_setup.poll_hop(waiter)),
 			false => None,
 		};
-		let origin = match declared.or(self.peer_origin) {
+		let origin = match declared.or(self.peer_hop) {
 			Some(peer) => self.origin.clone().excluding(peer),
 			None => self.origin.clone(),
 		};
@@ -174,15 +174,15 @@ impl<S: crate::transport::poll::Session, R: crate::runtime::Runtime> Publisher<S
 		// Identity stamped onto outbound announce hops. Derived from the
 		// origin we're consuming so it matches the local relay identity
 		// across every session, required for cross-session loop detection.
-		let self_origin = *config.origin;
+		let self_hop = *config.origin;
 		let accept = config.session.clone();
 		Self {
 			shared: Arc::new(Shared {
 				session: config.session,
 				origin: config.origin,
-				self_origin,
+				self_hop,
 				peer_setup: config.peer_setup,
-				peer_origin: config.peer_origin,
+				peer_hop: config.peer_hop,
 				serving: std::sync::OnceLock::new(),
 				priority: Default::default(),
 				version: config.version,
@@ -234,11 +234,11 @@ impl<S: crate::transport::poll::Session, R: crate::runtime::Runtime> Publisher<S
 		origin: &origin::Consumer,
 		announced: &mut announce::Consumer,
 		prefix: impl AsPath,
-		self_origin: Origin,
+		self_hop: Hop,
 		exclude_hop: u64,
 		version: Version,
 	) -> Result<(), Error> {
-		let mut run = AnnounceRun::new(runtime, prefix.as_path().to_owned(), exclude_hop, self_origin, version);
+		let mut run = AnnounceRun::new(runtime, prefix.as_path().to_owned(), exclude_hop, self_hop, version);
 		kio::wait(|waiter| run.poll(stream, origin, announced, waiter)).await
 	}
 }
@@ -531,8 +531,8 @@ impl<S: crate::transport::poll::Session, R: crate::runtime::Runtime> AnnounceSer
 					// announce stream; lite-06+ reads the session-wide SETUP Origin
 					// parameter, the same identity the subscribe path excludes. A peer that
 					// declares nothing falls back to the identity the caller assigned it
-					// (`with_peer_origin`), if any.
-					let assigned = self.shared.peer_origin.map(|origin| origin.id()).unwrap_or(0);
+					// (`with_peer_hop`), if any.
+					let assigned = self.shared.peer_hop.map(|origin| origin.id()).unwrap_or(0);
 					if self.shared.version.has_exclude_hop() {
 						let exclude_hop = match interest.exclude_hop {
 							0 => assigned,
@@ -546,8 +546,8 @@ impl<S: crate::transport::poll::Session, R: crate::runtime::Runtime> AnnounceSer
 					}
 				}
 				AnnounceState::ExcludeHop { prefix } => {
-					let assigned = self.shared.peer_origin.map(|origin| origin.id()).unwrap_or(0);
-					let exclude_hop = ready!(self.shared.peer_setup.poll_origin(waiter))
+					let assigned = self.shared.peer_hop.map(|origin| origin.id()).unwrap_or(0);
+					let exclude_hop = ready!(self.shared.peer_setup.poll_hop(waiter))
 						.map(|origin| origin.id())
 						.unwrap_or(assigned);
 					let prefix = prefix.clone();
@@ -586,7 +586,7 @@ impl<S: crate::transport::poll::Session, R: crate::runtime::Runtime> AnnounceSer
 		// Register the split-horizon peer on the announce cursor too. The origin
 		// model uses this exposure to park a reflected copy before it can replace
 		// the source we are currently advertising to that peer.
-		let origin = match Origin::new(exclude_hop) {
+		let origin = match Hop::new(exclude_hop) {
 			Ok(peer) => origin.excluding(peer),
 			Err(_) => origin,
 		};
@@ -595,7 +595,7 @@ impl<S: crate::transport::poll::Session, R: crate::runtime::Runtime> AnnounceSer
 			self.runtime.clone(),
 			prefix,
 			exclude_hop,
-			self.shared.self_origin,
+			self.shared.self_hop,
 			self.shared.version,
 		);
 		self.state = AnnounceState::Run { origin, announced, run };
@@ -623,7 +623,7 @@ struct AnnounceRun<R: crate::runtime::Runtime> {
 	runtime: R,
 	prefix: crate::PathOwned,
 	exclude_hop: u64,
-	self_origin: Origin,
+	self_hop: Hop,
 	version: Version,
 	// Lite06+: announce ids. Every `active` we send implicitly assigns the next
 	// per-stream ordinal, and `ended` references the id instead of repeating the
@@ -656,11 +656,11 @@ enum AnnouncePhase {
 }
 
 impl<R: crate::runtime::Runtime> AnnounceRun<R> {
-	fn new(runtime: R, prefix: crate::PathOwned, exclude_hop: u64, self_origin: Origin, version: Version) -> Self {
+	fn new(runtime: R, prefix: crate::PathOwned, exclude_hop: u64, self_hop: Hop, version: Version) -> Self {
 		Self {
 			prefix,
 			exclude_hop,
-			self_origin,
+			self_hop,
 			version,
 			next_announce_id: 0,
 			announce_ids: HashMap::new(),
@@ -700,7 +700,7 @@ impl<R: crate::runtime::Runtime> AnnounceRun<R> {
 						let selected = select_route(
 							&broadcast.routes(),
 							&broadcast.demand(),
-							self.self_origin,
+							self.self_hop,
 							self.exclude_hop,
 							self.version,
 							&absolute,
@@ -756,7 +756,7 @@ impl<R: crate::runtime::Runtime> AnnounceRun<R> {
 							let Some(route) = select_route(
 								&routes,
 								&demand,
-								self.self_origin,
+								self.self_hop,
 								self.exclude_hop,
 								self.version,
 								&absolute,
@@ -779,7 +779,7 @@ impl<R: crate::runtime::Runtime> AnnounceRun<R> {
 				// Report our origin id (stamped onto hops by the receiver, not us)
 				// and the count of initial announces that follow immediately.
 				let ok = lite::AnnounceOk {
-					origin: self.self_origin,
+					origin: self.self_hop,
 					active: initial.len() as u64,
 				};
 				stream.writer.buffer(&ok)?;
@@ -938,7 +938,7 @@ impl<R: crate::runtime::Runtime> AnnounceRun<R> {
 							let Some(route) = select_route(
 								&routes,
 								&demand,
-								self.self_origin,
+								self.self_hop,
 								self.exclude_hop,
 								self.version,
 								&absolute,
@@ -982,7 +982,7 @@ impl<R: crate::runtime::Runtime> AnnounceRun<R> {
 								// An ended announce doesn't need hops; the receiver matches on path only.
 								stream.writer.buffer(&lite::AnnounceBroadcast::Ended {
 									suffix,
-									hops: OriginList::new(),
+									hops: Hops::new(),
 								})?;
 							}
 						}
@@ -1005,7 +1005,7 @@ impl<R: crate::runtime::Runtime> AnnounceRun<R> {
 					let hops = select_route(
 						&routes,
 						&entry.demand,
-						self.self_origin,
+						self.self_hop,
 						self.exclude_hop,
 						self.version,
 						&absolute,
@@ -1075,7 +1075,7 @@ impl<R: crate::runtime::Runtime> AnnounceRun<R> {
 							} else {
 								stream.writer.buffer(&lite::AnnounceBroadcast::Ended {
 									suffix,
-									hops: OriginList::new(),
+									hops: Hops::new(),
 								})?;
 							}
 						}
@@ -1114,22 +1114,22 @@ impl<R: crate::runtime::Runtime> AnnounceRun<R> {
 fn select_route(
 	routes: &[crate::broadcast::Route],
 	demand: &crate::broadcast::Demand,
-	self_origin: Origin,
+	self_hop: Hop,
 	exclude_hop: u64,
 	version: Version,
 	absolute: &crate::Path,
 ) -> Option<SentRoute> {
 	let exclude = match exclude_hop {
-		0 => Origin::UNKNOWN,
-		id => Origin::new(id).unwrap_or(Origin::UNKNOWN),
+		0 => Hop::UNKNOWN,
+		id => Hop::new(id).unwrap_or(Hop::UNKNOWN),
 	};
 
-	for (route, serving) in crate::broadcast::advertisable_routes(routes, self_origin, exclude) {
+	for (route, serving) in crate::broadcast::advertisable_routes(routes, self_hop, exclude) {
 		let mut hops = route.hops.clone();
 		// Lite05+ moves the self-stamp to the receiver, which appends our id (reported
 		// once via AnnounceOk) on receipt. Older versions stamp it here, dropping if the
 		// chain is full.
-		if !version.has_announce_ok() && hops.push(self_origin).is_err() {
+		if !version.has_announce_ok() && hops.push(self_hop).is_err() {
 			tracing::warn!(broadcast = %absolute, "dropping announce; hop chain at MAX_HOPS (possible loop)");
 			continue;
 		}
@@ -1989,8 +1989,8 @@ mod announce_test {
 	/// The original publisher stamped on every harness route: content identity is
 	/// keyed on the first hop, so a route change that should ride through as a
 	/// restart must keep it.
-	fn pub_hops() -> OriginList {
-		OriginList::try_from(vec![Origin::new(9).unwrap()]).unwrap()
+	fn pub_hops() -> Hops {
+		Hops::try_from(vec![Hop::new(9).unwrap()]).unwrap()
 	}
 
 	/// A cursor over the captured announce-stream bytes, decoding messages
@@ -2117,7 +2117,7 @@ mod announce_test {
 	/// against it, optionally with a viewer already attached (so the initial
 	/// announce goes out warm, at cost zero).
 	async fn harness(demand: bool) -> (Harness, Option<track::Consumer>) {
-		let origin = Origin::new(1).unwrap().produce();
+		let origin = Hop::new(1).unwrap().produce();
 		let source = origin
 			.create_broadcast(
 				"cam",
@@ -2139,14 +2139,14 @@ mod announce_test {
 		};
 		let task = tokio::spawn(async move {
 			let mut announced = consumer.announced();
-			let self_origin = *consumer;
+			let self_hop = *consumer;
 			Publisher::run_announce(
 				TestRuntime::new(),
 				&mut stream,
 				&consumer,
 				&mut announced,
 				"",
-				self_origin,
+				self_hop,
 				0,
 				VERSION,
 			)
@@ -2289,7 +2289,7 @@ mod announce_test {
 
 		// An upstream failover mid-linger: a new chain with the same first hop
 		// (the same original publisher reached another way).
-		let hops = OriginList::try_from(vec![Origin::new(9).unwrap(), Origin::new(12).unwrap()]).unwrap();
+		let hops = Hops::try_from(vec![Hop::new(9).unwrap(), Hop::new(12).unwrap()]).unwrap();
 		h.source
 			.set_route(
 				crate::broadcast::Route::new()
@@ -2348,14 +2348,14 @@ mod announce_test {
 		};
 		let task = tokio::spawn(async move {
 			let mut announced = consumer.announced();
-			let self_origin = *consumer;
+			let self_hop = *consumer;
 			Publisher::run_announce(
 				TestRuntime::new(),
 				&mut stream,
 				&consumer,
 				&mut announced,
 				"",
-				self_origin,
+				self_hop,
 				exclude_hop,
 				VERSION,
 			)
@@ -2370,12 +2370,12 @@ mod announce_test {
 	/// since serving this peer means opening a fresh ingest.
 	#[tokio::test(start_paused = true)]
 	async fn excluded_peer_receives_the_standby() {
-		let peer = Origin::new(33).unwrap();
-		let origin = Origin::new(1).unwrap().produce();
+		let peer = Hop::new(33).unwrap();
+		let origin = Hop::new(1).unwrap().produce();
 
 		// Active: free, but its chain flows through the peer. Standby: the same
 		// publisher reached directly, at its cold cost.
-		let tainted = OriginList::try_from(vec![Origin::new(9).unwrap(), peer]).unwrap();
+		let tainted = Hops::try_from(vec![Hop::new(9).unwrap(), peer]).unwrap();
 		let _a = origin
 			.create_broadcast(
 				"cam",
@@ -2434,11 +2434,11 @@ mod announce_test {
 	/// the advertised route, so the failover is invisible to the peer.
 	#[tokio::test(start_paused = true)]
 	async fn standby_attach_announces_to_excluded_peer() {
-		let peer = Origin::new(33).unwrap();
-		let origin = Origin::new(1).unwrap().produce();
+		let peer = Hop::new(33).unwrap();
+		let origin = Hop::new(1).unwrap().produce();
 
 		// The active route: the broadcast as carried via the peer itself.
-		let via_peer = OriginList::try_from(vec![Origin::new(9).unwrap(), peer]).unwrap();
+		let via_peer = Hops::try_from(vec![Hop::new(9).unwrap(), peer]).unwrap();
 		let source_a = origin
 			.create_broadcast(
 				"cam",
@@ -2485,8 +2485,8 @@ mod announce_test {
 	/// standby remains), and swinging back out re-announces fresh.
 	#[tokio::test(start_paused = true)]
 	async fn retracts_when_route_swings_through_peer() {
-		let peer = Origin::new(33).unwrap();
-		let origin = Origin::new(1).unwrap().produce();
+		let peer = Hop::new(33).unwrap();
+		let origin = Hop::new(1).unwrap().produce();
 		let mut source = origin
 			.create_broadcast(
 				"cam",
@@ -2508,7 +2508,7 @@ mod announce_test {
 
 		// The same publisher, now reached through the peer: nothing left to
 		// advertise to them.
-		let through_peer = OriginList::try_from(vec![Origin::new(9).unwrap(), peer]).unwrap();
+		let through_peer = Hops::try_from(vec![Hop::new(9).unwrap(), peer]).unwrap();
 		source
 			.set_route(
 				crate::broadcast::Route::new()
@@ -3725,11 +3725,11 @@ mod tests {
 	/// it, which is the loop the announce filter exists to prevent.
 	#[tokio::test(start_paused = true)]
 	async fn serving_origin_falls_back_to_the_assigned_identity() {
-		let assigned = crate::Origin::new(777).unwrap();
-		let upstream = crate::Origin::new(778).unwrap();
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let assigned = crate::Hop::new(777).unwrap();
+		let upstream = crate::Hop::new(778).unwrap();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 
-		let mut echoed_hops = OriginList::new();
+		let mut echoed_hops = Hops::new();
 		echoed_hops.push(assigned).unwrap();
 		let _echoed = origin
 			.create_broadcast(
@@ -3740,7 +3740,7 @@ mod tests {
 			)
 			.unwrap();
 
-		let mut local_hops = OriginList::new();
+		let mut local_hops = Hops::new();
 		local_hops.push(upstream).unwrap();
 		let _local = origin
 			.create_broadcast(
@@ -3764,7 +3764,7 @@ mod tests {
 			version: Version::Lite06Wip,
 			peer_setup,
 			goaway,
-			peer_origin: Some(assigned),
+			peer_hop: Some(assigned),
 		});
 
 		let serving = kio::wait(|waiter| publisher.shared.poll_serving_origin(waiter)).await;
@@ -3781,15 +3781,15 @@ mod tests {
 	/// Lite01/02 send the initial active set as ANNOUNCE_INIT. It must apply the
 	/// same per-peer route selection as the live loop: a broadcast whose only
 	/// route flows through the excluded hop (here the peer's assigned identity,
-	/// `Client::with_peer_origin`) is filtered from the initial set too.
+	/// `Client::with_peer_hop`) is filtered from the initial set too.
 	#[tokio::test]
 	async fn announce_init_applies_route_selection() {
-		let assigned = crate::Origin::new(777).unwrap();
-		let clean_publisher = crate::Origin::new(778).unwrap();
-		let self_origin = crate::Origin::new(1).unwrap();
-		let origin = crate::origin::Info::new(self_origin).produce();
+		let assigned = crate::Hop::new(777).unwrap();
+		let clean_publisher = crate::Hop::new(778).unwrap();
+		let self_hop = crate::Hop::new(1).unwrap();
+		let origin = crate::origin::Info::new(self_hop).produce();
 
-		let mut tainted_hops = OriginList::new();
+		let mut tainted_hops = Hops::new();
 		tainted_hops.push(assigned).unwrap();
 		let _tainted = origin
 			.create_broadcast(
@@ -3800,7 +3800,7 @@ mod tests {
 			)
 			.unwrap();
 
-		let mut clean_hops = OriginList::new();
+		let mut clean_hops = Hops::new();
 		clean_hops.push(clean_publisher).unwrap();
 		let _clean = origin
 			.create_broadcast(
@@ -3825,7 +3825,7 @@ mod tests {
 			&consumer,
 			&mut announced,
 			crate::Path::new(""),
-			self_origin,
+			self_hop,
 			assigned.id(),
 			Version::Lite01,
 		));
@@ -3864,7 +3864,7 @@ mod tests {
 		stream: Stream<SinkSession, Version>,
 		version: Version,
 	) -> ProbeServe<SinkSession, TestRuntime> {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let (_, goaway) = crate::goaway::Handle::new(true);
 		let publisher = Publisher::new(PublisherConfig {
 			runtime: TestRuntime::new(),
@@ -3873,7 +3873,7 @@ mod tests {
 			version,
 			peer_setup: crate::lite::PeerSetup::default(),
 			goaway,
-			peer_origin: None,
+			peer_hop: None,
 		});
 		ProbeServe::new(publisher.shared.clone(), publisher.runtime.clone(), stream)
 	}

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -776,10 +776,10 @@ impl<R: crate::runtime::Runtime> AnnounceRun<R> {
 					}
 				}
 
-				// Report our origin id (stamped onto hops by the receiver, not us)
+				// Report our Hop ID (stamped onto hops by the receiver, not us)
 				// and the count of initial announces that follow immediately.
 				let ok = lite::AnnounceOk {
-					origin: self.self_hop,
+					hop: self.self_hop,
 					active: initial.len() as u64,
 				};
 				stream.writer.buffer(&ok)?;

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -60,7 +60,7 @@ pub(super) struct PublisherConfig<S: crate::transport::poll::Session, R: crate::
 	pub origin: origin::Consumer,
 	pub version: Version,
 	/// The peer's SETUP (lite-05+), shared with the subscriber half that reads
-	/// it. Carries the peer's declared origin id for split-horizon serving.
+	/// it. Carries the peer's declared Hop ID for split-horizon serving.
 	pub peer_setup: super::PeerSetup,
 	/// Receive-side GOAWAY signal: recorded when the peer's Goaway stream arrives.
 	pub goaway: crate::goaway::Protocol,
@@ -3719,7 +3719,7 @@ mod tests {
 	/// The tokio-backed test runtime, matching the fake transport.
 	type TestRuntime = crate::runtime::tokio_test::Tokio<SinkSession>;
 
-	/// A peer that declares no origin in its SETUP is split-horizoned by the identity
+	/// A peer that declares no Hop ID in its SETUP is split-horizoned by the identity
 	/// the caller assigned it, on the data plane and not just the announce filter.
 	/// Otherwise it can subscribe its way back to content that already flowed through
 	/// it, which is the loop the announce filter exists to prevent.

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -74,7 +74,7 @@ struct Shared<S: crate::transport::poll::Session> {
 	session: S,
 	origin: origin::Consumer,
 	self_hop: Hop,
-	// The peer's SETUP, read for the origin id it declared. Used to serve the
+	// The peer's SETUP, read for the Hop ID it declared. Used to serve the
 	// peer from a source whose chain excludes them, keeping the data plane on
 	// the same split-horizon rule as the announces we send them.
 	peer_setup: super::PeerSetup,
@@ -497,7 +497,7 @@ struct AnnounceServe<S: crate::transport::poll::Session, R: crate::runtime::Runt
 enum AnnounceState<R: crate::runtime::Runtime> {
 	/// Reading the ANNOUNCE_REQUEST.
 	Decode,
-	/// Waiting on the peer's SETUP for the session-wide excluded origin
+	/// Waiting on the peer's SETUP for the session-wide excluded Hop ID
 	/// (lite-05, whose wire carries no per-stream exclude_hop).
 	ExcludeHop { prefix: crate::PathOwned },
 	/// Streaming announce updates.
@@ -528,11 +528,11 @@ impl<S: crate::transport::poll::Session, R: crate::runtime::Runtime> AnnounceSer
 					let prefix = interest.prefix.to_owned();
 
 					// The identity whose routes we filter out. Lite-04/05 carry it per
-					// announce stream; lite-06+ reads the session-wide SETUP Origin
+					// announce stream; lite-06+ reads the session-wide SETUP Hop
 					// parameter, the same identity the subscribe path excludes. A peer that
 					// declares nothing falls back to the identity the caller assigned it
 					// (`with_peer_hop`), if any.
-					let assigned = self.shared.peer_hop.map(|origin| origin.id()).unwrap_or(0);
+					let assigned = self.shared.peer_hop.map(|hop| hop.id()).unwrap_or(0);
 					if self.shared.version.has_exclude_hop() {
 						let exclude_hop = match interest.exclude_hop {
 							0 => assigned,
@@ -3752,7 +3752,7 @@ mod tests {
 		// Broadcast visibility is deferred until the executor ticks.
 		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
 
-		// A SETUP that declares no origin of its own, so only the assigned one applies.
+		// A SETUP that declares no Hop ID of its own, so only the assigned one applies.
 		let peer_setup = crate::lite::PeerSetup::default();
 		peer_setup.set(crate::lite::Setup::default());
 		let (_, goaway) = crate::goaway::Handle::new(true);

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -120,18 +120,18 @@ where
 		_ => Some(recv_bw),
 	};
 
-	// Declare our origin (hop) id in SETUP so the peer can serve our
-	// subscriptions from a route that does not flow through us. Taken from the
-	// caller's real handles before the empty-half defaulting below, since those
-	// placeholders carry throwaway ids that never appear in a hop chain. The
-	// publish identity is what we stamp onto forwarded announcements, so it
-	// wins when both halves are wired (they share it in practice).
-	if our_setup.origin.is_none() {
-		our_setup.origin = publish
+	// Declare our Hop ID in SETUP so the peer can serve our subscriptions from a
+	// route that does not flow through us. Taken from the caller's real handles
+	// before the empty-half defaulting below, since those placeholders carry
+	// throwaway ids that never appear in a hop chain. The publish identity is what
+	// we stamp onto forwarded announcements, so it wins when both halves are wired
+	// (they share it in practice).
+	if our_setup.hop.is_none() {
+		our_setup.hop = publish
 			.as_deref()
 			.or(subscribe.as_deref())
 			.copied()
-			.filter(|origin| origin.id() != 0);
+			.filter(|hop| hop.id() != 0);
 	}
 
 	// Always run both loops so inbound control (Subscribe/Announce/Probe/Goaway)

--- a/rs/moq-net/src/lite/session.rs
+++ b/rs/moq-net/src/lite/session.rs
@@ -1,6 +1,6 @@
 use crate::origin;
 use crate::{
-	Error, Origin, SessionError, bandwidth,
+	Error, Hop, SessionError, bandwidth,
 	coding::{Reader, Stream, Writer},
 	lite::SessionInfo,
 };
@@ -71,8 +71,8 @@ pub struct Config<S: crate::transport::poll::Session, R: crate::runtime::Runtime
 	pub subscribe: Option<origin::Producer>,
 
 	/// The origin (hop) id assigned to the peer, used whenever the peer doesn't
-	/// declare one itself. See `Client::with_peer_origin`.
-	pub peer_origin: Option<Origin>,
+	/// declare one itself. See `Client::with_peer_hop`.
+	pub peer_hop: Option<Hop>,
 
 	/// The version of the protocol to use.
 	pub version: Version,
@@ -102,7 +102,7 @@ where
 		setup_stream,
 		publish,
 		subscribe,
-		peer_origin,
+		peer_hop,
 		version,
 		mut our_setup,
 		peer_setup,
@@ -139,8 +139,8 @@ where
 	// An unset half gets an empty origin: an empty publish origin announces nothing
 	// (and answers the peer's announce-interest with an empty set), and an empty
 	// subscribe origin issues no ANNOUNCE_PLEASE.
-	let publish = publish.unwrap_or_else(|| origin::Producer::empty(Origin::random()).consume());
-	let subscribe = subscribe.unwrap_or_else(|| origin::Producer::empty(Origin::random()));
+	let publish = publish.unwrap_or_else(|| origin::Producer::empty(Hop::random()).consume());
+	let subscribe = subscribe.unwrap_or_else(|| origin::Producer::empty(Hop::random()));
 
 	// Publisher and Subscriber each derive their identity from their own
 	// attached origin (publish.info / subscribe.info). This is what gets
@@ -172,7 +172,7 @@ where
 		version,
 		peer_setup: peer_setup.clone(),
 		goaway: goaway.clone(),
-		peer_origin,
+		peer_hop,
 	});
 	let subscriber = Subscriber::new(SubscriberConfig {
 		session: session.clone(),
@@ -180,7 +180,7 @@ where
 		recv_bandwidth: recv_bw_for_sub,
 		version,
 		peer_setup,
-		peer_origin,
+		peer_hop,
 		// Local policy for what pulling from this peer costs. Set only when we
 		// configured a price; otherwise the subscriber charges what the peer declared
 		// for its own egress.

--- a/rs/moq-net/src/lite/setup.rs
+++ b/rs/moq-net/src/lite/setup.rs
@@ -13,8 +13,8 @@ const PARAM_PATH: u64 = 0x2;
 const PARAM_ROLE: u64 = 0x3;
 /// Setup Parameter id for the link cost the dialer assigns to this connection.
 const PARAM_COST: u64 = 0x4;
-/// Setup Parameter id for the endpoint's origin (hop) id.
-const PARAM_ORIGIN: u64 = 0x5;
+/// Setup Parameter id for the endpoint's Hop ID.
+const PARAM_HOP: u64 = 0x5;
 
 /// The cost of crossing a link that neither end priced.
 ///
@@ -176,12 +176,12 @@ pub struct Setup {
 	/// Directional: it prices the sender's own egress, so both ends declare their own
 	/// and the two need not match. `None` means the default cost of 1.
 	pub cost: Option<u64>,
-	/// This endpoint's origin (hop) id, the identity it stamps onto forwarded
+	/// This endpoint's Hop ID, the identity it stamps onto forwarded
 	/// announcements. The peer uses it to serve this endpoint's subscriptions from
 	/// a route that does not flow through it (the same split horizon the announce
 	/// filter applies). `None` when the endpoint has no meaningful identity (a
 	/// leaf that never forwards); a wire value of 0 decodes as `None`.
-	pub origin: Option<crate::Hop>,
+	pub hop: Option<crate::Hop>,
 }
 
 impl Message for Setup {
@@ -207,16 +207,14 @@ impl Message for Setup {
 		let cost = params.get_varint(PARAM_COST)?;
 		// 0 is legal on the wire but carries no identity (it can't be excluded),
 		// so it decodes as "not declared" rather than an error.
-		let origin = params
-			.get_varint(PARAM_ORIGIN)?
-			.and_then(|id| crate::Hop::new(id).ok());
+		let hop = params.get_varint(PARAM_HOP)?.and_then(|id| crate::Hop::new(id).ok());
 
 		Ok(Self {
 			probe,
 			path,
 			role,
 			cost,
-			origin,
+			hop,
 		})
 	}
 
@@ -241,8 +239,8 @@ impl Message for Setup {
 		if let Some(cost) = self.cost {
 			params.set_varint(PARAM_COST, cost);
 		}
-		if let Some(origin) = self.origin {
-			params.set_varint(PARAM_ORIGIN, origin.id());
+		if let Some(hop) = self.hop {
+			params.set_varint(PARAM_HOP, hop.id());
 		}
 
 		params.encode(w, version)
@@ -274,10 +272,10 @@ impl PeerSetup {
 		self.poll_get(waiter, |setup| setup.cost)
 	}
 
-	/// Poll for the [`Hop`](crate::Hop) id the peer declared in its SETUP `Origin`
+	/// Poll for the [`Hop`](crate::Hop) id the peer declared in its SETUP `Hop`
 	/// parameter. `None` when it declared none: a leaf with no identity worth excluding.
 	pub fn poll_hop(&self, waiter: &kio::Waiter) -> std::task::Poll<Option<crate::Hop>> {
-		self.poll_get(waiter, |setup| setup.origin)
+		self.poll_get(waiter, |setup| setup.hop)
 	}
 
 	/// Poll for a field of the peer's SETUP.
@@ -376,9 +374,9 @@ mod tests {
 	}
 
 	#[test]
-	fn origin_round_trip() {
+	fn hop_round_trip() {
 		let msg = Setup {
-			origin: Some(crate::Hop::new(42).unwrap()),
+			hop: Some(crate::Hop::new(42).unwrap()),
 			..Default::default()
 		};
 		assert_eq!(round_trip(&msg), msg);
@@ -387,12 +385,12 @@ mod tests {
 	// A declared id of 0 carries no identity (it cannot be excluded), so it
 	// decodes as absent rather than erroring.
 	#[test]
-	fn origin_zero_decodes_as_none() {
+	fn hop_zero_decodes_as_none() {
 		use crate::coding::Encode;
 
 		let version = Version::Lite05;
 		let mut params = Parameters::default();
-		params.set_varint(super::PARAM_ORIGIN, 0);
+		params.set_varint(super::PARAM_HOP, 0);
 		let mut body = bytes::BytesMut::new();
 		params.encode(&mut body, version).unwrap();
 		// Frame the body with the Message Length prefix `Setup::decode` expects.
@@ -401,7 +399,7 @@ mod tests {
 		buf.extend_from_slice(&body);
 		let mut slice = &buf[..];
 		let got = Setup::decode(&mut slice, version).unwrap();
-		assert_eq!(got.origin, None);
+		assert_eq!(got.hop, None);
 	}
 
 	#[test]

--- a/rs/moq-net/src/lite/setup.rs
+++ b/rs/moq-net/src/lite/setup.rs
@@ -181,7 +181,7 @@ pub struct Setup {
 	/// a route that does not flow through it (the same split horizon the announce
 	/// filter applies). `None` when the endpoint has no meaningful identity (a
 	/// leaf that never forwards); a wire value of 0 decodes as `None`.
-	pub origin: Option<crate::Origin>,
+	pub origin: Option<crate::Hop>,
 }
 
 impl Message for Setup {
@@ -209,7 +209,7 @@ impl Message for Setup {
 		// so it decodes as "not declared" rather than an error.
 		let origin = params
 			.get_varint(PARAM_ORIGIN)?
-			.and_then(|id| crate::Origin::new(id).ok());
+			.and_then(|id| crate::Hop::new(id).ok());
 
 		Ok(Self {
 			probe,
@@ -274,9 +274,9 @@ impl PeerSetup {
 		self.poll_get(waiter, |setup| setup.cost)
 	}
 
-	/// Poll for the origin (hop) id the peer declared in its SETUP. `None` when it
-	/// declared none: a leaf with no identity worth excluding.
-	pub fn poll_origin(&self, waiter: &kio::Waiter) -> std::task::Poll<Option<crate::Origin>> {
+	/// Poll for the [`Hop`](crate::Hop) id the peer declared in its SETUP `Origin`
+	/// parameter. `None` when it declared none: a leaf with no identity worth excluding.
+	pub fn poll_hop(&self, waiter: &kio::Waiter) -> std::task::Poll<Option<crate::Hop>> {
 		self.poll_get(waiter, |setup| setup.origin)
 	}
 
@@ -378,7 +378,7 @@ mod tests {
 	#[test]
 	fn origin_round_trip() {
 		let msg = Setup {
-			origin: Some(crate::Origin::new(42).unwrap()),
+			origin: Some(crate::Hop::new(42).unwrap()),
 			..Default::default()
 		};
 		assert_eq!(round_trip(&msg), msg);

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -47,7 +47,7 @@ pub(super) struct Subscriber<S: crate::transport::poll::Session> {
 
 	origin: origin::Producer,
 	recv_bandwidth: Option<bandwidth::Producer>,
-	// Session-level origin id shared with the Publisher. Used to drop reflected
+	// Session-level Hop ID shared with the Publisher. Used to drop reflected
 	// announces: any incoming announce whose hop chain already passed through us
 	// has looped, so it is neither used as a route nor forwarded. On lite-04/05
 	// we also ask the peer to filter them out (AnnounceRequest.exclude_hop) so
@@ -68,7 +68,7 @@ pub(super) struct Subscriber<S: crate::transport::poll::Session> {
 	session_hop: crate::Hop,
 	// The identity assigned to the peer by the caller (`Client::with_peer_hop`,
 	// or the per-session default a server hands every request), standing in wherever
-	// the peer declines to declare one (an AnnounceOk reporting origin id 0).
+	// the peer declines to declare one (an AnnounceOk reporting Hop ID 0).
 	peer_hop: Option<crate::Hop>,
 	subscribes: Lock<HashMap<u64, TrackEntry>>,
 	next_id: Arc<atomic::AtomicU64>,
@@ -247,7 +247,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		// This link's price, added to the wire cost; the pre-charge value is kept
 		// on the route so the origin's handover gate can tell a warm peer apart.
 		link_cost: u64,
-		// Lite05+: the announce sender's origin id (from AnnounceOk). The sender no
+		// Lite05+: the announce sender's Hop ID (from AnnounceOk). The sender no
 		// longer stamps itself onto the chain, so we append it here to reconstruct
 		// the full `[src...sender]` chain Lite04 stored. None for older versions,
 		// where the sender already appended itself.
@@ -388,7 +388,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		// The route cost off the wire and this link's price. See `start_announce`.
 		cost: crate::broadcast::Cost,
 		link_cost: u64,
-		// Lite05+: the announce sender's origin id (from AnnounceOk), appended here to
+		// Lite05+: the announce sender's Hop ID (from AnnounceOk), appended here to
 		// rebuild the full chain since the sender no longer stamps itself. None for older
 		// versions. See `start_announce`.
 		responder_origin: Option<crate::Hop>,
@@ -1171,7 +1171,7 @@ impl<S: crate::transport::poll::Session> AnnouncePrefix<S> {
 					};
 				}
 				PrefixState::ReadOk { stream } => {
-					// Lite05+: the publisher reports its own origin id, which we stamp onto
+					// Lite05+: the publisher reports its own Hop ID, which we stamp onto
 					// every received Announce's hop chain since it no longer does so itself.
 					// Its `active` count marks where the initial set ends; nothing here needs
 					// that boundary, so it is read and dropped. Callers that must not race an
@@ -2022,7 +2022,7 @@ mod tests {
 			going_away: Default::default(),
 		});
 
-		// The sender reports origin 0, so it takes the assigned identity, and its chain
+		// The sender reports Hop ID 0, so it takes the assigned identity, and its chain
 		// already carries that identity: the route came back through it.
 		let mut hops = crate::Hops::new();
 		hops.push(assigned).unwrap();
@@ -2088,7 +2088,7 @@ mod tests {
 		assert_eq!(hops, vec![assigned]);
 	}
 
-	/// A peer with no assigned identity is attributed the reserved origin 0
+	/// A peer with no assigned identity is attributed the reserved Hop ID 0
 	/// (UNKNOWN). This layer never mints one of its own: whether an anonymous peer
 	/// gets an identity, and whether two of its sessions share it, is the caller's
 	/// policy, and a minted id here would be indistinguishable from a declared one.

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -1180,9 +1180,9 @@ impl<S: crate::transport::poll::Session> AnnouncePrefix<S> {
 					let ok = ready!(stream.reader.poll_decode::<lite::AnnounceOk>(&mut cx))?;
 					// A peer may legally report id 0 (no identity). When the caller assigned
 					// it one, stand that in so the route isn't loop-blind.
-					let origin = match ok.origin.id() {
-						0 => self.subscriber.peer_hop.unwrap_or(ok.origin),
-						_ => ok.origin,
+					let origin = match ok.hop.id() {
+						0 => self.subscriber.peer_hop.unwrap_or(ok.hop),
+						_ => ok.hop,
 					};
 					let PrefixState::ReadOk { stream } = std::mem::replace(&mut self.state, PrefixState::Open) else {
 						unreachable!()

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -31,8 +31,8 @@ pub(super) struct SubscriberConfig<S: crate::transport::poll::Session> {
 	/// stream is read; the probe stream waits on it before opening.
 	pub peer_setup: super::PeerSetup,
 	/// The origin (hop) id assigned to the peer, used whenever the peer doesn't
-	/// declare one itself. See `Client::with_peer_origin`.
-	pub peer_origin: Option<crate::Origin>,
+	/// declare one itself. See `Client::with_peer_hop`.
+	pub peer_hop: Option<crate::Hop>,
 	/// Local policy for what pulling from this peer costs, overriding whatever it
 	/// declared in its SETUP. `None` charges the peer's declared price.
 	pub cost: Option<u64>,
@@ -52,24 +52,24 @@ pub(super) struct Subscriber<S: crate::transport::poll::Session> {
 	// has looped, so it is neither used as a route nor forwarded. On lite-04/05
 	// we also ask the peer to filter them out (AnnounceRequest.exclude_hop) so
 	// they never hit the wire, but this check is what makes it correct.
-	self_origin: crate::Origin,
+	self_hop: crate::Hop,
 	// The origin stamped into the hop chain of broadcasts from versions that
 	// don't carry real hop ids on the wire (Lite01/02/03), and into the
 	// placeholder entries Lite03 sends in place of real ids.
 	//
-	// This is the peer's assigned identity (`peer_origin`) when the caller gave
+	// This is the peer's assigned identity (`peer_hop`) when the caller gave
 	// it one, which also makes the route recognizable across sessions. Otherwise
-	// it is `Origin::UNKNOWN` (0), the reserved "no identity" value.
+	// it is `Hop::UNKNOWN` (0), the reserved "no identity" value.
 	//
 	// Assigning one is the caller's call, not this layer's: a server gives every
 	// accepted session a fresh id so its routes are at least distinguishable from
 	// another session's, while a client only assigns one it knows out of band. Either
 	// way the peer never learns the id, so only we can exclude it for loop detection.
-	session_origin: crate::Origin,
-	// The identity assigned to the peer by the caller (`Client::with_peer_origin`,
+	session_hop: crate::Hop,
+	// The identity assigned to the peer by the caller (`Client::with_peer_hop`,
 	// or the per-session default a server hands every request), standing in wherever
 	// the peer declines to declare one (an AnnounceOk reporting origin id 0).
-	peer_origin: Option<crate::Origin>,
+	peer_hop: Option<crate::Hop>,
 	subscribes: Lock<HashMap<u64, TrackEntry>>,
 	next_id: Arc<atomic::AtomicU64>,
 	version: Version,
@@ -97,14 +97,14 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		// origin we publish into so it matches the relay identity across
 		// every session sharing that origin, required for cross-session
 		// loop detection.
-		let self_origin = *config.origin;
+		let self_hop = *config.origin;
 		Self {
 			session: config.session,
 			origin: config.origin,
 			recv_bandwidth: config.recv_bandwidth,
-			self_origin,
-			session_origin: config.peer_origin.unwrap_or(crate::Origin::UNKNOWN),
-			peer_origin: config.peer_origin,
+			self_hop,
+			session_hop: config.peer_hop.unwrap_or(crate::Hop::UNKNOWN),
+			peer_hop: config.peer_hop,
 			subscribes: Default::default(),
 			next_id: Default::default(),
 			version: config.version,
@@ -239,7 +239,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 	fn start_announce(
 		&mut self,
 		path: PathOwned,
-		mut hops: crate::OriginList,
+		mut hops: crate::Hops,
 		// The route cost off the wire, i.e. as the peer advertised it.
 		// [`Cost::UNKNOWN`] before lite-06, leaving the hop chain as the only
 		// routing input as before.
@@ -251,7 +251,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		// longer stamps itself onto the chain, so we append it here to reconstruct
 		// the full `[src...sender]` chain Lite04 stored. None for older versions,
 		// where the sender already appended itself.
-		responder_origin: Option<crate::Origin>,
+		responder_origin: Option<crate::Hop>,
 		announced: &mut Announced,
 	) -> Result<bool, Error> {
 		// One current advertisement per path per stream. Test what the peer
@@ -269,7 +269,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 			// appending the sender again would name it twice. That is legal in a lite
 			// chain but a PROTOCOL_VIOLATION for an IETF peer we forward it to, so it
 			// must not enter the model at all. Zero names nobody, so it may repeat.
-			if responder != crate::Origin::UNKNOWN && hops.contains(&responder) {
+			if responder != crate::Hop::UNKNOWN && hops.contains(&responder) {
 				tracing::debug!(broadcast = %self.log_path(&path), "dropping announce reflected by its sender");
 				return Ok(false);
 			}
@@ -289,7 +289,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		// via AnnounceRequest.exclude_hop, but that is only an optimization:
 		// this is the authoritative cluster-loop check, and the only one on
 		// every other version.
-		if hops.contains(&self.self_origin) {
+		if hops.contains(&self.self_hop) {
 			tracing::debug!(broadcast = %self.log_path(&path), "dropping reflected announce");
 			return Ok(false);
 		}
@@ -302,7 +302,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		//
 		// The rewrite fails if the chain already names this session, which would put one
 		// id in it twice: a loop, and one a cluster receiver must close the session over.
-		if self.version_lacks_hops() && hops.replace_first(crate::Origin::UNKNOWN, self.session_origin).is_err() {
+		if self.version_lacks_hops() && hops.replace_first(crate::Hop::UNKNOWN, self.session_hop).is_err() {
 			tracing::debug!(broadcast = %self.log_path(&path), "dropping announce reflected by its session");
 			return Ok(false);
 		}
@@ -310,10 +310,10 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		// Guarantee at least one attributable hop for versions that did not provide
 		// one. Lite05 peers may legally advertise responder id 0; preserve it above
 		// rather than replacing it, even though that route stays loop-blind (the
-		// caller can assign an identity via `with_peer_origin`, substituted where
+		// caller can assign an identity via `with_peer_hop`, substituted where
 		// the AnnounceOk is read).
 		if hops.is_empty() {
-			hops.push(self.session_origin)
+			hops.push(self.session_hop)
 				.expect("an empty hop chain always has room for one entry, and repeats nothing");
 		}
 
@@ -322,7 +322,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		// The first hop of the reconstructed chain identifies the original
 		// publisher; a later restart advertising a different first hop is a new
 		// broadcast, not an alternate route to this one.
-		let publisher = hops.iter().next().copied().unwrap_or(self.session_origin);
+		let publisher = hops.iter().next().copied().unwrap_or(self.session_hop);
 
 		// Create this session's source feeding the origin-owned broadcast at the
 		// path. The first source creates and announces the broadcast; later sources
@@ -350,7 +350,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 	/// not win selection, however good the path it advertises looks.
 	fn announced_route(
 		&self,
-		hops: crate::OriginList,
+		hops: crate::Hops,
 		cost: crate::broadcast::Cost,
 		link_cost: u64,
 	) -> crate::broadcast::Route {
@@ -374,7 +374,7 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 	/// content on a new path: this session's route metadata updates in place,
 	/// in-flight tracks keep flowing, and the origin only hands over if the winner
 	/// changed. Consumers observe nothing. When the first hop differs, or is
-	/// [`Origin::UNKNOWN`](crate::Origin::UNKNOWN), the old route detaches gracefully
+	/// [`Hop::UNKNOWN`](crate::Hop::UNKNOWN), the old route detaches gracefully
 	/// and a fresh one attaches, so downstream sees a real Ended + Active.
 	/// The advertisement is already live, so this can attach a route even when the
 	/// original advertisement was declined locally.
@@ -384,25 +384,25 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 	fn restart_announce(
 		&mut self,
 		path: PathOwned,
-		mut hops: crate::OriginList,
+		mut hops: crate::Hops,
 		// The route cost off the wire and this link's price. See `start_announce`.
 		cost: crate::broadcast::Cost,
 		link_cost: u64,
 		// Lite05+: the announce sender's origin id (from AnnounceOk), appended here to
 		// rebuild the full chain since the sender no longer stamps itself. None for older
 		// versions. See `start_announce`.
-		responder_origin: Option<crate::Origin>,
+		responder_origin: Option<crate::Hop>,
 		announced: &mut Announced,
 	) -> Result<bool, Error> {
 		// Reflected loop (or a full chain): detach its route but keep the advertisement live.
 		let reflected = match responder_origin {
 			// A chain already naming the sender came back through it; see `start_announce`.
 			Some(responder) => {
-				(responder != crate::Origin::UNKNOWN && hops.contains(&responder))
+				(responder != crate::Hop::UNKNOWN && hops.contains(&responder))
 					|| hops.push(responder).is_err()
-					|| hops.contains(&self.self_origin)
+					|| hops.contains(&self.self_hop)
 			}
-			None => hops.contains(&self.self_origin),
+			None => hops.contains(&self.self_hop),
 		};
 		if reflected {
 			tracing::debug!(broadcast = %self.log_path(&path), "dropping reflected restart");
@@ -411,11 +411,11 @@ impl<S: crate::transport::poll::Session> Subscriber<S> {
 		}
 
 		tracing::debug!(broadcast = %self.log_path(&path), hops = hops.len(), "restart");
-		let publisher = hops.iter().next().copied().unwrap_or(self.session_origin);
+		let publisher = hops.iter().next().copied().unwrap_or(self.session_hop);
 		let metadata = self.announced_route(hops, cost, link_cost);
 
 		match announced.attached(&path) {
-			Some(entry) if entry.publisher != publisher || publisher == crate::Origin::UNKNOWN => {
+			Some(entry) if entry.publisher != publisher || publisher == crate::Hop::UNKNOWN => {
 				// A different original publisher, or no identity at all (UNKNOWN
 				// never proves continuity): a brand-new broadcast may have replaced
 				// the old one at this path. Detach gracefully (downstream unannounces
@@ -1099,7 +1099,7 @@ enum PrefixState<S: crate::transport::poll::Session> {
 	/// Waiting for the link cost (may block on the peer's SETUP).
 	Cost {
 		stream: Stream<S, Version>,
-		responder_origin: Option<crate::Origin>,
+		responder_origin: Option<crate::Hop>,
 	},
 	/// Lite01/02: reading the ANNOUNCE_INIT set.
 	ReadInit { stream: Stream<S, Version>, run: PrefixRun },
@@ -1109,7 +1109,7 @@ enum PrefixState<S: crate::transport::poll::Session> {
 
 /// The announce-decode loop's state, split out so the states above can share it.
 struct PrefixRun {
-	responder_origin: Option<crate::Origin>,
+	responder_origin: Option<crate::Hop>,
 	/// What we charge every announcement arriving on this stream. Resolved once:
 	/// it comes from the connect config or the peer's SETUP, neither of which
 	/// changes for the life of the session.
@@ -1153,7 +1153,7 @@ impl<S: crate::transport::poll::Session> AnnouncePrefix<S> {
 					// filter.
 					stream.writer.buffer(&lite::AnnounceRequest {
 						prefix: self.prefix.as_path(),
-						exclude_hop: self.subscriber.self_origin.id(),
+						exclude_hop: self.subscriber.self_hop.id(),
 					})?;
 					self.state = PrefixState::Send { stream };
 				}
@@ -1181,7 +1181,7 @@ impl<S: crate::transport::poll::Session> AnnouncePrefix<S> {
 					// A peer may legally report id 0 (no identity). When the caller assigned
 					// it one, stand that in so the route isn't loop-blind.
 					let origin = match ok.origin.id() {
-						0 => self.subscriber.peer_origin.unwrap_or(ok.origin),
+						0 => self.subscriber.peer_hop.unwrap_or(ok.origin),
 						_ => ok.origin,
 					};
 					let PrefixState::ReadOk { stream } = std::mem::replace(&mut self.state, PrefixState::Open) else {
@@ -1227,7 +1227,7 @@ impl<S: crate::transport::poll::Session> AnnouncePrefix<S> {
 						// model when this enters the origin via `create_broadcast`.
 						self.subscriber.start_announce(
 							path.clone(),
-							crate::OriginList::new(),
+							crate::Hops::new(),
 							crate::broadcast::Cost::UNKNOWN,
 							0,
 							run.responder_origin,
@@ -1353,14 +1353,14 @@ mod tests {
 		let gate = kio::Producer::new(false);
 		let session = SinkSession::gated_bi(gate.consume());
 
-		let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let subscriber = Subscriber::new(SubscriberConfig {
 			session: session.clone(),
 			origin,
 			recv_bandwidth: None,
 			version: VERSION,
 			peer_setup: Default::default(),
-			peer_origin: None,
+			peer_hop: None,
 			cost: None,
 			going_away: Default::default(),
 		});
@@ -1425,14 +1425,14 @@ mod tests {
 			// what was true at the instant it would.
 			let gate = kio::Producer::new(true);
 			let session = SinkSession::gated_bi(gate.consume());
-			let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+			let origin = origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 			let subscriber = Subscriber::new(SubscriberConfig {
 				session: session.clone(),
 				origin,
 				recv_bandwidth: None,
 				version,
 				peer_setup: Default::default(),
-				peer_origin: None,
+				peer_hop: None,
 				cost: None,
 				going_away: Default::default(),
 			});
@@ -1848,8 +1848,8 @@ mod tests {
 	/// wrong route.
 	#[tokio::test]
 	async fn a_double_announce_is_an_error_even_when_reflected() {
-		let assigned = crate::Origin::new(777).unwrap();
-		let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let assigned = crate::Hop::new(777).unwrap();
+		let origin = origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let mut subscriber = Subscriber::new(SubscriberConfig {
 			session: SinkSession::new(Default::default()),
 			origin,
@@ -1857,7 +1857,7 @@ mod tests {
 			version: VERSION,
 			peer_setup: Default::default(),
 			cost: None,
-			peer_origin: Some(assigned),
+			peer_hop: Some(assigned),
 			going_away: Default::default(),
 		});
 
@@ -1867,7 +1867,7 @@ mod tests {
 			subscriber
 				.start_announce(
 					path.clone(),
-					crate::OriginList::new(),
+					crate::Hops::new(),
 					crate::broadcast::Cost::default(),
 					0,
 					Some(assigned),
@@ -1877,7 +1877,7 @@ mod tests {
 		);
 
 		// The same path again, this time with a chain that names the sender.
-		let mut reflected = crate::OriginList::new();
+		let mut reflected = crate::Hops::new();
 		reflected.push(assigned).unwrap();
 		assert!(
 			matches!(
@@ -1903,8 +1903,8 @@ mod tests {
 	/// reach, where rewriting a placeholder hop would name this session twice.
 	#[tokio::test]
 	async fn every_declined_announce_is_recorded() {
-		let assigned = crate::Origin::new(777).unwrap();
-		let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let assigned = crate::Hop::new(777).unwrap();
+		let origin = origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let mut subscriber = Subscriber::new(SubscriberConfig {
 			session: SinkSession::new(Default::default()),
 			origin,
@@ -1914,7 +1914,7 @@ mod tests {
 			version: Version::Lite03,
 			peer_setup: Default::default(),
 			cost: None,
-			peer_origin: Some(assigned),
+			peer_hop: Some(assigned),
 			going_away: Default::default(),
 		});
 
@@ -1923,7 +1923,7 @@ mod tests {
 
 		// A chain whose placeholder cannot be rewritten: this session's id is already in it,
 		// so writing it over the placeholder would name it twice.
-		let hops = crate::OriginList::try_from(vec![crate::Origin::UNKNOWN, assigned]).unwrap();
+		let hops = crate::Hops::try_from(vec![crate::Hop::UNKNOWN, assigned]).unwrap();
 		assert!(
 			!subscriber
 				.start_announce(
@@ -1939,8 +1939,8 @@ mod tests {
 		);
 
 		// Declined, but still the peer's advertisement at that path.
-		let mut fresh = crate::OriginList::new();
-		fresh.push(crate::Origin::new(7).unwrap()).unwrap();
+		let mut fresh = crate::Hops::new();
+		fresh.push(crate::Hop::new(7).unwrap()).unwrap();
 		assert!(
 			matches!(
 				subscriber.start_announce(path, fresh, crate::broadcast::Cost::default(), 0, None, &mut announced),
@@ -1953,8 +1953,8 @@ mod tests {
 	/// A dropped announce still holds its path until the peer retracts it.
 	#[tokio::test]
 	async fn a_dropped_announce_still_holds_its_path() {
-		let assigned = crate::Origin::new(777).unwrap();
-		let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let assigned = crate::Hop::new(777).unwrap();
+		let origin = origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let consumer = origin.consume();
 		let mut subscriber = Subscriber::new(SubscriberConfig {
 			session: SinkSession::new(Default::default()),
@@ -1963,13 +1963,13 @@ mod tests {
 			version: VERSION,
 			peer_setup: Default::default(),
 			cost: None,
-			peer_origin: Some(assigned),
+			peer_hop: Some(assigned),
 			going_away: Default::default(),
 		});
 
 		let path = Path::new("room/host").to_owned();
 		let mut announced = Announced::default();
-		let mut reflected = crate::OriginList::new();
+		let mut reflected = crate::Hops::new();
 		reflected.push(assigned).unwrap();
 		assert!(
 			!subscriber
@@ -1986,8 +1986,8 @@ mod tests {
 		);
 		assert!(consumer.get_broadcast("room/host").is_none());
 
-		let mut hops = crate::OriginList::new();
-		hops.push(crate::Origin::new(7).unwrap()).unwrap();
+		let mut hops = crate::Hops::new();
+		hops.push(crate::Hop::new(7).unwrap()).unwrap();
 		let err = subscriber
 			.start_announce(
 				path,
@@ -2007,9 +2007,9 @@ mod tests {
 	/// to, so the route must never enter the model carrying it.
 	#[tokio::test]
 	async fn an_announce_reflected_by_its_sender_is_dropped() {
-		let assigned = crate::Origin::new(777).unwrap();
+		let assigned = crate::Hop::new(777).unwrap();
 
-		let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let consumer = origin.consume();
 		let mut subscriber = Subscriber::new(SubscriberConfig {
 			session: SinkSession::new(Default::default()),
@@ -2018,13 +2018,13 @@ mod tests {
 			version: VERSION,
 			peer_setup: Default::default(),
 			cost: None,
-			peer_origin: Some(assigned),
+			peer_hop: Some(assigned),
 			going_away: Default::default(),
 		});
 
 		// The sender reports origin 0, so it takes the assigned identity, and its chain
 		// already carries that identity: the route came back through it.
-		let mut hops = crate::OriginList::new();
+		let mut hops = crate::Hops::new();
 		hops.push(assigned).unwrap();
 
 		let mut announced = Announced::default();
@@ -2045,14 +2045,14 @@ mod tests {
 	}
 
 	/// A peer that declares no identity gets attributed the origin the caller
-	/// assigned it (`Client::with_peer_origin`), so every session dialing the same
+	/// assigned it (`Client::with_peer_hop`), so every session dialing the same
 	/// relay yields one recognizable hop instead of a random id per connection.
 	#[tokio::test]
 	async fn assigned_peer_origin_attributes_announces() {
 		let session = SinkSession::new(Default::default());
-		let assigned = crate::Origin::new(777).unwrap();
+		let assigned = crate::Hop::new(777).unwrap();
 
-		let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let consumer = origin.consume();
 		let mut subscriber = Subscriber::new(SubscriberConfig {
 			session,
@@ -2060,7 +2060,7 @@ mod tests {
 			recv_bandwidth: None,
 			version: VERSION,
 			peer_setup: Default::default(),
-			peer_origin: Some(assigned),
+			peer_hop: Some(assigned),
 			cost: None,
 			going_away: Default::default(),
 		});
@@ -2071,7 +2071,7 @@ mod tests {
 		let accepted = subscriber
 			.start_announce(
 				Path::new("room/host").to_owned(),
-				crate::OriginList::new(),
+				crate::Hops::new(),
 				crate::broadcast::Cost::UNKNOWN,
 				0,
 				None,
@@ -2100,7 +2100,7 @@ mod tests {
 		subscriber
 			.start_announce(
 				Path::new("room/host").to_owned(),
-				crate::OriginList::new(),
+				crate::Hops::new(),
 				crate::broadcast::Cost::UNKNOWN,
 				0,
 				None,
@@ -2111,11 +2111,11 @@ mod tests {
 
 		let broadcast = consumer.get_broadcast("room/host").unwrap();
 		let hops: Vec<_> = broadcast.routes()[0].hops.iter().copied().collect();
-		assert_eq!(hops, vec![crate::Origin::UNKNOWN]);
+		assert_eq!(hops, vec![crate::Hop::UNKNOWN]);
 	}
 
 	fn restart_subscriber(session: SinkSession) -> (Subscriber<SinkSession>, crate::origin::Consumer) {
-		let origin = origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let consumer = origin.consume();
 		let subscriber = Subscriber::new(SubscriberConfig {
 			session,
@@ -2124,7 +2124,7 @@ mod tests {
 			version: VERSION,
 			peer_setup: Default::default(),
 			cost: None,
-			peer_origin: None,
+			peer_hop: None,
 			going_away: Default::default(),
 		});
 		(subscriber, consumer)
@@ -2143,10 +2143,10 @@ mod tests {
 		subscriber
 			.start_announce(
 				path.clone(),
-				crate::OriginList::new(),
+				crate::Hops::new(),
 				crate::broadcast::Cost::UNKNOWN,
 				0,
-				Some(crate::Origin::UNKNOWN),
+				Some(crate::Hop::UNKNOWN),
 				&mut announced,
 			)
 			.unwrap();
@@ -2156,10 +2156,10 @@ mod tests {
 		subscriber
 			.restart_announce(
 				path,
-				crate::OriginList::new(),
+				crate::Hops::new(),
 				crate::broadcast::Cost::UNKNOWN,
 				0,
-				Some(crate::Origin::UNKNOWN),
+				Some(crate::Hop::UNKNOWN),
 				&mut announced,
 			)
 			.unwrap();
@@ -2177,14 +2177,14 @@ mod tests {
 	#[tokio::test]
 	async fn known_publisher_restart_updates_in_place() {
 		let (mut subscriber, consumer) = restart_subscriber(SinkSession::new(Default::default()));
-		let publisher = crate::Origin::new(7).unwrap();
+		let publisher = crate::Hop::new(7).unwrap();
 
 		let mut announced = Announced::default();
 		let path = Path::new("room/host").to_owned();
 		subscriber
 			.start_announce(
 				path.clone(),
-				crate::OriginList::new(),
+				crate::Hops::new(),
 				crate::broadcast::Cost::UNKNOWN,
 				0,
 				Some(publisher),
@@ -2197,7 +2197,7 @@ mod tests {
 		subscriber
 			.restart_announce(
 				path,
-				crate::OriginList::new(),
+				crate::Hops::new(),
 				crate::broadcast::Cost::new(5),
 				0,
 				Some(publisher),
@@ -2221,7 +2221,7 @@ mod tests {
 	/// to the session (outliving the stream) would leak the announcement instead.
 	#[tokio::test(start_paused = true)]
 	async fn a_lost_announce_stream_closes_the_broadcast() {
-		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let origin = crate::origin::Info::new(crate::Hop::new(1).unwrap()).produce();
 		let consumer = origin.consume();
 		let mut subscriber = Subscriber::new(SubscriberConfig {
 			session: SinkSession::new(Default::default()),
@@ -2230,12 +2230,12 @@ mod tests {
 			version: VERSION,
 			peer_setup: Default::default(),
 			cost: None,
-			peer_origin: None,
+			peer_hop: None,
 			going_away: Default::default(),
 		});
 
 		let path = Path::new("room/host").to_owned();
-		let hops = crate::OriginList::try_from(vec![crate::Origin::new(7).unwrap()]).unwrap();
+		let hops = crate::Hops::try_from(vec![crate::Hop::new(7).unwrap()]).unwrap();
 		let mut announced = Announced::default();
 		subscriber
 			.start_announce(
@@ -2260,7 +2260,7 @@ mod tests {
 		);
 
 		// An explicit retraction closes it the same way.
-		let hops = crate::OriginList::try_from(vec![crate::Origin::new(7).unwrap()]).unwrap();
+		let hops = crate::Hops::try_from(vec![crate::Hop::new(7).unwrap()]).unwrap();
 		let mut announced = Announced::default();
 		subscriber
 			.start_announce(
@@ -2400,11 +2400,11 @@ impl Announced {
 /// alternate route to the same broadcast from a brand-new broadcast.
 struct AnnouncedRoute {
 	source: crate::model::broadcast::SourceGuard,
-	publisher: crate::Origin,
+	publisher: crate::Hop,
 }
 
 impl AnnouncedRoute {
-	fn new(source: crate::broadcast::Producer, publisher: crate::Origin) -> Self {
+	fn new(source: crate::broadcast::Producer, publisher: crate::Hop) -> Self {
 		Self {
 			source: crate::model::broadcast::SourceGuard::new(source),
 			publisher,

--- a/rs/moq-net/src/lite/version.rs
+++ b/rs/moq-net/src/lite/version.rs
@@ -114,7 +114,7 @@ impl Version {
 	/// The receiver's own reflected-announce check drops those announces anyway (and
 	/// catches loops of any length, not just the two-hop case), so lite-06 drops the
 	/// field and keeps the check. Lite-06 also declares the same identity session-wide
-	/// in the SETUP `Origin` parameter, which filters announcements and subscriptions
+	/// in the SETUP `Hop` parameter, which filters announcements and subscriptions
 	/// alike rather than one announce stream.
 	///
 	/// Unlike the gates above, this lists the versions that *have* the field: it was

--- a/rs/moq-net/src/lite/version.rs
+++ b/rs/moq-net/src/lite/version.rs
@@ -108,7 +108,7 @@ impl Version {
 	}
 
 	/// Whether ANNOUNCE_REQUEST carries the Exclude Hop field: the subscriber's own
-	/// origin id, which the publisher uses to skip announces whose hop chain already
+	/// Hop ID, which the publisher uses to skip announces whose hop chain already
 	/// passed through the subscriber. Present in lite-04 and lite-05 only.
 	///
 	/// The receiver's own reflected-announce check drops those announces anyway (and

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -17,7 +17,7 @@ use std::{
 
 use crate::Error;
 
-use super::{Origin, OriginList, Requests, WeakCache};
+use super::{Hop, Hops, Requests, WeakCache};
 
 /// A collection of media tracks that can be published and subscribed to.
 ///
@@ -190,9 +190,9 @@ impl From<u64> for Cost {
 #[non_exhaustive]
 pub struct Route {
 	/// The chain of origins the broadcast has traversed, oldest first. Each relay
-	/// appends its own [`crate::Origin`] when forwarding; used for loop detection
+	/// appends its own [`crate::Hop`] when forwarding; used for loop detection
 	/// and as the selection tie-break.
-	pub hops: OriginList,
+	pub hops: Hops,
 
 	/// What pulling the broadcast via this route costs, accumulated per link:
 	/// lower wins, with ties broken by hop length, then a deterministic hash, and
@@ -249,13 +249,13 @@ impl Route {
 	///
 	/// Fails with [`crate::InvalidHop`] for a hop the wire would reject: one past the
 	/// chain's length cap, or one already in it, which is a loop.
-	pub fn with_hop(mut self, origin: super::Origin) -> Result<Self, super::InvalidHop> {
-		self.hops.push(origin)?;
+	pub fn with_hop(mut self, hop: super::Hop) -> Result<Self, super::InvalidHop> {
+		self.hops.push(hop)?;
 		Ok(self)
 	}
 
 	/// Replace the hop chain.
-	pub fn with_hops(mut self, hops: OriginList) -> Self {
+	pub fn with_hops(mut self, hops: Hops) -> Self {
 		self.hops = hops;
 		self
 	}
@@ -297,21 +297,21 @@ pub(crate) const COST_LINGER: Duration = Duration::from_secs(5);
 /// Callers take the first entry they can actually stamp themselves onto, since a chain
 /// already at `MAX_HOPS` has no room and almost certainly means a loop. Empty when
 /// every chain loops through the peer or us, or none is announced.
-/// [`Origin::UNKNOWN`] identifies nothing, so it excludes nothing and is never a loop.
+/// [`Hop::UNKNOWN`] identifies nothing, so it excludes nothing and is never a loop.
 pub(crate) fn advertisable_routes(
 	routes: &[Route],
-	self_origin: Origin,
-	exclude: Origin,
+	self_hop: Hop,
+	exclude: Hop,
 ) -> impl Iterator<Item = (&Route, bool)> {
 	routes.iter().enumerate().filter_map(move |(index, route)| {
 		// Offline routes are reachable by exact path but never advertised.
 		if !route.announce {
 			return None;
 		}
-		if exclude != Origin::UNKNOWN && route.hops.contains(&exclude) {
+		if exclude != Hop::UNKNOWN && route.hops.contains(&exclude) {
 			return None;
 		}
-		if self_origin != Origin::UNKNOWN && route.hops.contains(&self_origin) {
+		if self_hop != Hop::UNKNOWN && route.hops.contains(&self_hop) {
 			return None;
 		}
 		Some((route, index == 0))
@@ -1805,7 +1805,7 @@ mod test {
 		let mut consumer = producer.consume();
 		let mut dynamic = producer.dynamic();
 
-		let hops = crate::OriginList::try_from(vec![crate::Origin::new(7).unwrap()]).unwrap();
+		let hops = crate::Hops::try_from(vec![crate::Hop::new(7).unwrap()]).unwrap();
 		producer
 			.set_route(Route::new().with_hops(hops.clone()).with_cost(42).with_announce(true))
 			.unwrap();

--- a/rs/moq-net/src/model/mod.rs
+++ b/rs/moq-net/src/model/mod.rs
@@ -44,9 +44,9 @@ pub mod announce {
 	};
 }
 
-// Origin identity and the `Consume` conversion trait aren't part of a role
+// Hop identity and the `Consume` conversion trait aren't part of a role
 // module; keep them flat at the crate root.
-pub use origin_impl::{Consume, InvalidHop, InvalidOrigin, Origin, OriginList};
+pub use origin_impl::{Consume, Hop, Hops, InvalidHop};
 
 #[cfg(test)]
 pub(crate) use origin_impl::ProduceTest;

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -5128,17 +5128,10 @@ mod tests {
 
 		// Rewrites only the first placeholder, keeping the length the same.
 		assert!(list.replace_first(Hop::UNKNOWN, Hop::new(7).unwrap()).unwrap());
-		assert_eq!(
-			list.as_slice(),
-			&[Hop::new(7).unwrap(), Hop::UNKNOWN, Hop::UNKNOWN]
-		);
+		assert_eq!(list.as_slice(), &[Hop::new(7).unwrap(), Hop::UNKNOWN, Hop::UNKNOWN]);
 
 		// No match leaves the list untouched.
-		assert!(
-			!list
-				.replace_first(Hop::new(99).unwrap(), Hop::new(8).unwrap())
-				.unwrap()
-		);
+		assert!(!list.replace_first(Hop::new(99).unwrap(), Hop::new(8).unwrap()).unwrap());
 		assert_eq!(list.len(), 3);
 
 		// Writing in an id the chain already carries would name it twice, which is the
@@ -5157,14 +5150,8 @@ mod tests {
 
 		// Overwriting a slot with what it already holds is a no-op, not a duplicate: the
 		// entry being replaced is not a second occurrence of itself.
-		assert_eq!(
-			list.replace_first(Hop::new(7).unwrap(), Hop::new(7).unwrap()),
-			Ok(true)
-		);
-		assert_eq!(
-			list.as_slice(),
-			&[Hop::new(7).unwrap(), Hop::UNKNOWN, Hop::UNKNOWN]
-		);
+		assert_eq!(list.replace_first(Hop::new(7).unwrap(), Hop::new(7).unwrap()), Ok(true));
+		assert_eq!(list.as_slice(), &[Hop::new(7).unwrap(), Hop::UNKNOWN, Hop::UNKNOWN]);
 	}
 
 	#[test]
@@ -7461,13 +7448,7 @@ mod tests {
 		tokio::time::pause();
 
 		fn hops(ids: &[u64]) -> Hops {
-			Hops::try_from(
-				ids.iter()
-					.copied()
-					.map(|id| Hop::new(id).unwrap())
-					.collect::<Vec<_>>(),
-			)
-			.unwrap()
+			Hops::try_from(ids.iter().copied().map(|id| Hop::new(id).unwrap()).collect::<Vec<_>>()).unwrap()
 		}
 
 		// Resolve the advertised route for "test" after creating both sources in

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -27,8 +27,8 @@ use crate::{
 /// Names a *hop*, not an [`origin::Producer`](Producer): a relay's routing table is the
 /// origin, and this is the id it stamps into [`broadcast::Route::hops`] as an
 /// announcement passes through, so a receiver can spot its own id and reject a loop.
-/// Its own id lives in [`Info::id`]. The wire calls the SETUP parameter carrying it
-/// `Origin`, which is why the spec and this type disagree on the name.
+/// Its own id lives in [`Info::id`]; the SETUP parameter that carries it session-wide is
+/// `Hop` too.
 ///
 /// Local hops are built with [`Hop::new`] or [`Hop::random`], both of which guarantee a
 /// non-zero id so loop detection can work. Remote peers may still send `0`; it is legal

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -136,7 +136,7 @@ impl Default for Info {
 }
 
 impl Info {
-	/// Config for the given origin id with no byte target and the default idle expiry.
+	/// Config for the given Hop ID with no byte target and the default idle expiry.
 	pub fn new(id: Hop) -> Self {
 		Self { id, ..Self::default() }
 	}
@@ -163,7 +163,7 @@ impl Info {
 }
 
 impl From<Hop> for Info {
-	/// Config for the given origin id with the defaults of [`Info::new`].
+	/// Config for the given Hop ID with the defaults of [`Info::new`].
 	fn from(id: Hop) -> Self {
 		Self::new(id)
 	}
@@ -458,7 +458,7 @@ fn route_key(name: &Path, hops: &Hops) -> (usize, u64) {
 	(hops.len(), fnv_key(name, hops.iter().copied()))
 }
 
-/// FNV-1a over the broadcast name and a sequence of origin ids.
+/// FNV-1a over the broadcast name and a sequence of Hop IDs.
 ///
 /// FNV-1a, not the std hasher: its output is fixed across Rust versions and
 /// builds, which matters when nodes run mismatched binaries during a rolling
@@ -3346,7 +3346,7 @@ impl Consumer {
 	/// A clone that never serves the given peer its own data: broadcasts resolve
 	/// to a source whose hop chain excludes `peer`, matching what the announce
 	/// loop advertises to them. Sessions apply this once they learn the peer's
-	/// origin id.
+	/// Hop ID.
 	pub(crate) fn excluding(mut self, peer: Hop) -> Self {
 		self.exclude = Some(peer);
 		self
@@ -6830,7 +6830,7 @@ mod tests {
 	/// A local standby with the same original publisher joining a front that is
 	/// carrying the broadcast from a peer must splice the live subscription onto
 	/// the new source, never tear it down (#2473, e2e finding 2). Redundant
-	/// publishers sharing an origin id MUST produce the same tracks, so the
+	/// publishers sharing an Hop ID MUST produce the same tracks, so the
 	/// splice resumes seamlessly at the group boundary.
 	#[tokio::test]
 	async fn test_standby_join_splices_live_subscriber() {

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -22,49 +22,42 @@ use crate::{
 	util::{TaskSet, Tasks},
 };
 
-/// A relay origin, identified by a 62-bit varint on the wire.
+/// One relay's identity in a broadcast's hop chain: a 62-bit varint on the wire.
 ///
-/// Local origins are built with [`Origin::new`] or [`Origin::random`], both of
-/// which guarantee a non-zero id so loop detection can work. Remote peers may
-/// still send `0`; it is legal on the wire but cannot be used for loop detection.
+/// Names a *hop*, not an [`origin::Producer`](Producer): a relay's routing table is the
+/// origin, and this is the id it stamps into [`broadcast::Route::hops`] as an
+/// announcement passes through, so a receiver can spot its own id and reject a loop.
+/// Its own id lives in [`Info::id`]. The wire calls the SETUP parameter carrying it
+/// `Origin`, which is why the spec and this type disagree on the name.
+///
+/// Local hops are built with [`Hop::new`] or [`Hop::random`], both of which guarantee a
+/// non-zero id so loop detection can work. Remote peers may still send `0`; it is legal
+/// on the wire but cannot be used for loop detection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct Origin {
+pub struct Hop {
 	/// 62-bit identifier. Encoded as a QUIC varint on the wire.
 	id: u64,
 }
 
-/// Returned when a local origin id is zero or outside the 62-bit wire range.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[non_exhaustive]
-pub struct InvalidOrigin;
-
-impl fmt::Display for InvalidOrigin {
-	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-		write!(f, "local origin id must be non-zero and below 2^62")
-	}
-}
-
-impl std::error::Error for InvalidOrigin {}
-
-impl Origin {
+impl Hop {
 	/// Placeholder for hop entries whose actual id is not on the wire (Lite03).
 	/// Also used for remote peers that choose the legal but loop-blind id 0.
 	pub(crate) const UNKNOWN: Self = Self { id: 0 };
 
-	/// Build an origin from a stable id.
+	/// Build a hop from a stable id.
 	///
 	/// The id must be non-zero and fit in the 62-bit QUIC varint range. Wire
-	/// decode accepts remote id 0, but local origins should not use it because
+	/// decode accepts remote id 0, but a local hop should not use it because
 	/// downstream peers cannot exclude it for loop detection.
-	pub fn new(id: u64) -> Result<Self, InvalidOrigin> {
+	pub fn new(id: u64) -> Result<Self, InvalidHop> {
 		if id == 0 || id >= 1u64 << 62 {
-			return Err(InvalidOrigin);
+			return Err(InvalidHop::Range);
 		}
 		Ok(Self { id })
 	}
 
-	/// Generate a fresh origin with a random non-zero id. Use this for any
-	/// origin that does not need a stable identity across restarts.
+	/// Generate a fresh hop with a random non-zero id. Use this for any relay that
+	/// does not need a stable identity across restarts.
 	///
 	/// TEMPORARY: the wire format allows 62 bits, but older `@moq/lite` JS
 	/// clients decode `AnnounceInterest.exclude_hop` as a u53 (number) and
@@ -77,7 +70,7 @@ impl Origin {
 		Self { id }
 	}
 
-	/// Return the origin's wire id.
+	/// Return the hop's wire id.
 	pub fn id(self) -> u64 {
 		self.id
 	}
@@ -97,7 +90,7 @@ impl Origin {
 pub struct Info {
 	/// The origin's wire identity, appended to broadcast hop chains for loop
 	/// detection and shortest-path routing.
-	pub id: Origin,
+	pub id: Hop,
 
 	/// The cache pool broadcasts under this origin charge their groups into. It flows
 	/// down the ownership chain (origin -> broadcast -> track -> group): a track opens
@@ -134,7 +127,7 @@ impl Default for Info {
 	fn default() -> Self {
 		let pool = cache::Pool::new(cache::Config::default().with_expiry(cache::DEFAULT_EXPIRY));
 		Self {
-			id: Origin::UNKNOWN,
+			id: Hop::UNKNOWN,
 			pool,
 			cache_duration: Duration::MAX,
 			default_max_age: track::DEFAULT_MAX_AGE,
@@ -144,7 +137,7 @@ impl Default for Info {
 
 impl Info {
 	/// Config for the given origin id with no byte target and the default idle expiry.
-	pub fn new(id: Origin) -> Self {
+	pub fn new(id: Hop) -> Self {
 		Self { id, ..Self::default() }
 	}
 
@@ -169,28 +162,28 @@ impl Info {
 	}
 }
 
-impl From<Origin> for Info {
+impl From<Hop> for Info {
 	/// Config for the given origin id with the defaults of [`Info::new`].
-	fn from(id: Origin) -> Self {
+	fn from(id: Hop) -> Self {
 		Self::new(id)
 	}
 }
 
-impl TryFrom<u64> for Origin {
-	type Error = InvalidOrigin;
+impl TryFrom<u64> for Hop {
+	type Error = InvalidHop;
 
 	fn try_from(id: u64) -> Result<Self, Self::Error> {
 		Self::new(id)
 	}
 }
 
-impl fmt::Display for Origin {
+impl fmt::Display for Hop {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		self.id.fmt(f)
 	}
 }
 
-impl<V: Copy> Encode<V> for Origin
+impl<V: Copy> Encode<V> for Hop
 where
 	u64: Encode<V>,
 {
@@ -199,7 +192,7 @@ where
 	}
 }
 
-impl<V: Copy> Decode<V> for Origin
+impl<V: Copy> Decode<V> for Hop
 where
 	u64: Decode<V>,
 {
@@ -212,27 +205,31 @@ where
 	}
 }
 
-/// Maximum number of origins (hops) an [`OriginList`] can hold.
+/// Maximum number of hops a [`Hops`] chain can hold.
 ///
 /// Caps pathological or loop-induced announcements at a reasonable cluster
 /// diameter; appending past this limit returns [`InvalidHop::TooMany`] rather than
 /// silently truncating.
 pub(crate) const MAX_HOPS: usize = 32;
 
-/// Bounded, loop-free list of [`Origin`] entries: the hop chain of a broadcast.
+/// Bounded, loop-free list of [`Hop`] entries: the hop chain of a broadcast.
 ///
-/// Guarantees `len() <= MAX_HOPS` and that no non-zero [`Origin`] appears twice. Both
+/// Guarantees `len() <= MAX_HOPS` and that no non-zero [`Hop`] appears twice. Both
 /// are wire rules, and both hold wherever a list exists rather than only where one was
 /// parsed, so a chain that a conforming receiver would reject cannot be built and sent.
-/// Construct via [`OriginList::new`] + [`OriginList::push`], or fall back to the
-/// fallible [`TryFrom<Vec<Origin>>`].
+/// Construct via [`Hops::new`] + [`Hops::push`], or fall back to the
+/// fallible [`TryFrom<Vec<Hop>>`].
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct OriginList(Vec<Origin>);
+pub struct Hops(Vec<Hop>);
 
-/// Why an [`Origin`] cannot join an [`OriginList`].
+/// Why a [`Hop`] is not usable, on its own or as part of a [`Hops`] chain.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum InvalidHop {
+	/// The id is zero or outside the 62-bit wire range, so it cannot identify a local
+	/// hop. Only [`Hop::new`] returns this; a chain never holds one.
+	Range,
+
 	/// The list is already at its hop-count cap, which a real path never reaches and a
 	/// loop does.
 	TooMany,
@@ -246,8 +243,9 @@ pub enum InvalidHop {
 impl fmt::Display for InvalidHop {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
-			Self::TooMany => write!(f, "too many origins (max {MAX_HOPS})"),
-			Self::Duplicate => write!(f, "origin already in the hop chain"),
+			Self::Range => write!(f, "local hop id must be non-zero and below 2^62"),
+			Self::TooMany => write!(f, "too many hops (max {MAX_HOPS})"),
+			Self::Duplicate => write!(f, "hop already in the chain"),
 		}
 	}
 }
@@ -258,30 +256,30 @@ impl From<InvalidHop> for DecodeError {
 	fn from(err: InvalidHop) -> Self {
 		match err {
 			InvalidHop::TooMany => DecodeError::BoundsExceeded,
-			InvalidHop::Duplicate => DecodeError::InvalidValue,
+			InvalidHop::Range | InvalidHop::Duplicate => DecodeError::InvalidValue,
 		}
 	}
 }
 
-impl OriginList {
+impl Hops {
 	/// Create an empty list.
 	pub fn new() -> Self {
 		Self(Vec::new())
 	}
 
-	/// Append an [`Origin`], rejecting anything a conforming receiver would.
+	/// Append a [`Hop`], rejecting anything a conforming receiver would.
 	///
 	/// Fails with [`InvalidHop::TooMany`] once the list is full, and with
 	/// [`InvalidHop::Duplicate`] for an id already in the chain, which is a loop. The
 	/// reserved id 0 identifies nothing, so it may repeat.
-	pub fn push(&mut self, origin: Origin) -> Result<(), InvalidHop> {
+	pub fn push(&mut self, hop: Hop) -> Result<(), InvalidHop> {
 		if self.0.len() >= MAX_HOPS {
 			return Err(InvalidHop::TooMany);
 		}
-		if origin != Origin::UNKNOWN && self.0.contains(&origin) {
+		if hop != Hop::UNKNOWN && self.0.contains(&hop) {
 			return Err(InvalidHop::Duplicate);
 		}
-		self.0.push(origin);
+		self.0.push(hop);
 		Ok(())
 	}
 
@@ -292,12 +290,12 @@ impl OriginList {
 	/// `replacement` twice, which is the loop [`Self::push`] refuses to build. A `target`
 	/// that is not present changes nothing and so cannot duplicate anything, and the slot
 	/// being overwritten is not a duplicate of itself.
-	pub fn replace_first(&mut self, target: Origin, replacement: Origin) -> Result<bool, InvalidHop> {
+	pub fn replace_first(&mut self, target: Hop, replacement: Hop) -> Result<bool, InvalidHop> {
 		let Some(index) = self.0.iter().position(|entry| *entry == target) else {
 			return Ok(false);
 		};
 
-		if replacement != Origin::UNKNOWN
+		if replacement != Hop::UNKNOWN
 			&& self
 				.0
 				.iter()
@@ -311,9 +309,9 @@ impl OriginList {
 		Ok(true)
 	}
 
-	/// Returns true if any entry matches `origin`.
-	pub fn contains(&self, origin: &Origin) -> bool {
-		self.0.contains(origin)
+	/// Returns true if any entry matches `hop`.
+	pub fn contains(&self, hop: &Hop) -> bool {
+		self.0.contains(hop)
 	}
 
 	/// Number of entries currently in the list (always `<= MAX_HOPS`).
@@ -327,26 +325,26 @@ impl OriginList {
 	}
 
 	/// Iterate over the entries in hop order (oldest first).
-	pub fn iter(&self) -> std::slice::Iter<'_, Origin> {
+	pub fn iter(&self) -> std::slice::Iter<'_, Hop> {
 		self.0.iter()
 	}
 
 	/// Borrow the entries as a slice.
-	pub fn as_slice(&self) -> &[Origin] {
+	pub fn as_slice(&self) -> &[Hop] {
 		&self.0
 	}
 }
 
-impl TryFrom<Vec<Origin>> for OriginList {
+impl TryFrom<Vec<Hop>> for Hops {
 	type Error = InvalidHop;
 
-	fn try_from(v: Vec<Origin>) -> Result<Self, Self::Error> {
+	fn try_from(v: Vec<Hop>) -> Result<Self, Self::Error> {
 		if v.len() > MAX_HOPS {
 			return Err(InvalidHop::TooMany);
 		}
 		// MAX_HOPS is 32, so the quadratic scan is cheaper than allocating a set.
 		for (i, origin) in v.iter().enumerate() {
-			if *origin != Origin::UNKNOWN && v[i + 1..].contains(origin) {
+			if *origin != Hop::UNKNOWN && v[i + 1..].contains(origin) {
 				return Err(InvalidHop::Duplicate);
 			}
 		}
@@ -354,19 +352,19 @@ impl TryFrom<Vec<Origin>> for OriginList {
 	}
 }
 
-impl<'a> IntoIterator for &'a OriginList {
-	type Item = &'a Origin;
-	type IntoIter = std::slice::Iter<'a, Origin>;
+impl<'a> IntoIterator for &'a Hops {
+	type Item = &'a Hop;
+	type IntoIter = std::slice::Iter<'a, Hop>;
 
 	fn into_iter(self) -> Self::IntoIter {
 		self.iter()
 	}
 }
 
-impl<V: Copy> Encode<V> for OriginList
+impl<V: Copy> Encode<V> for Hops
 where
 	u64: Encode<V>,
-	Origin: Encode<V>,
+	Hop: Encode<V>,
 {
 	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: V) -> Result<(), EncodeError> {
 		(self.0.len() as u64).encode(w, version)?;
@@ -377,10 +375,10 @@ where
 	}
 }
 
-impl<V: Copy> Decode<V> for OriginList
+impl<V: Copy> Decode<V> for Hops
 where
 	u64: Decode<V>,
-	Origin: Decode<V>,
+	Hop: Decode<V>,
 {
 	fn decode<R: bytes::Buf>(r: &mut R, version: V) -> Result<Self, DecodeError> {
 		let count = u64::decode(r, version)? as usize;
@@ -391,7 +389,7 @@ where
 		// entering the model and being forwarded on to a receiver that must close on it.
 		let mut list = Self(Vec::with_capacity(count));
 		for _ in 0..count {
-			list.push(Origin::decode(r, version)?)?;
+			list.push(Hop::decode(r, version)?)?;
 		}
 		Ok(list)
 	}
@@ -456,7 +454,7 @@ pub(crate) const HANDOVER_HOLD: Duration = Duration::from_millis(500);
 /// on the same winner: the hops are forwarded unchanged, and the hash is
 /// build-stable. Mixing the name in spreads equal routes across different
 /// upstreams rather than funneling onto one.
-fn route_key(name: &Path, hops: &OriginList) -> (usize, u64) {
+fn route_key(name: &Path, hops: &Hops) -> (usize, u64) {
 	(hops.len(), fnv_key(name, hops.iter().copied()))
 }
 
@@ -472,7 +470,7 @@ fn route_key(name: &Path, hops: &OriginList) -> (usize, u64) {
 /// chain to pick among *routes*, and [`FrontState::handover_allowed`] hashes a
 /// single relay's origin to pick among *relays*. Mixing the name in spreads
 /// equal candidates across different winners rather than funneling onto one.
-fn fnv_key(name: &Path, origins: impl IntoIterator<Item = Origin>) -> u64 {
+fn fnv_key(name: &Path, hops: impl IntoIterator<Item = Hop>) -> u64 {
 	const SEED: u64 = 0x420C0DECB00B; // 420 C0DEC B00B
 	const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
 
@@ -480,8 +478,8 @@ fn fnv_key(name: &Path, origins: impl IntoIterator<Item = Origin>) -> u64 {
 	for &byte in name.as_str().as_bytes() {
 		hash = (hash ^ u64::from(byte)).wrapping_mul(FNV_PRIME);
 	}
-	for origin in origins {
-		for &byte in &origin.id().to_le_bytes() {
+	for hop in hops {
+		for &byte in &hop.id().to_le_bytes() {
 			hash = (hash ^ u64::from(byte)).wrapping_mul(FNV_PRIME);
 		}
 	}
@@ -599,7 +597,7 @@ struct AnnounceConsumerNotify {
 	/// [`Consumer::excluding`]). Every broadcast handed out registers an
 	/// [`ExclusionGuard`] for it, which is what tells the front it is exposed to that
 	/// peer even before they subscribe.
-	exclude: Option<Origin>,
+	exclude: Option<Hop>,
 }
 
 impl AnnounceConsumerNotify {
@@ -676,13 +674,13 @@ impl NotifyNode {
 /// front has already closed is inert.
 pub(crate) struct ExclusionGuard {
 	state: kio::Producer<FrontState>,
-	peer: Origin,
+	peer: Hop,
 }
 
 impl ExclusionGuard {
 	/// Register `peer` and return the guard that releases it, or `None` if the
 	/// front is closing (nothing left to keep off a route).
-	fn new(state: &kio::Producer<FrontState>, peer: Origin) -> Option<Arc<Self>> {
+	fn new(state: &kio::Producer<FrontState>, peer: Hop) -> Option<Arc<Self>> {
 		let mut s = state.write().ok()?;
 		if s.closed {
 			return None;
@@ -817,7 +815,7 @@ impl OriginNode {
 		}
 	}
 
-	fn resolve_broadcast(&self, rest: impl AsPath, exclude: Option<Origin>) -> Resolved {
+	fn resolve_broadcast(&self, rest: impl AsPath, exclude: Option<Hop>) -> Resolved {
 		let rest = rest.as_path();
 
 		if let Some((dir, rest)) = rest.next_part() {
@@ -1011,7 +1009,7 @@ pub struct Producer {
 	// Identity for this origin. Appended to broadcast hops when
 	// re-announcing so downstream relays can detect loops and prefer the
 	// shortest path.
-	info: Origin,
+	info: Hop,
 
 	// The roots of the tree that we are allowed to publish.
 	// A path of "" means we can publish anything.
@@ -1052,7 +1050,7 @@ pub struct Producer {
 }
 
 impl std::ops::Deref for Producer {
-	type Target = Origin;
+	type Target = Hop;
 
 	fn deref(&self) -> &Self::Target {
 		&self.info
@@ -1126,7 +1124,7 @@ impl Producer {
 	/// advertises no subscribe interest (its `allowed()` is empty, so the
 	/// subscriber issues no ANNOUNCE_PLEASE). Used to fill an unset session half
 	/// so both the publisher and subscriber loops still run.
-	pub(crate) fn empty(info: Origin) -> Self {
+	pub(crate) fn empty(info: Hop) -> Self {
 		// No allowed prefixes means no broadcast is ever created, so nothing will
 		// ever be queued on the detached submission handle.
 		let (tasks, _) = TaskSet::new();
@@ -1598,14 +1596,14 @@ struct FrontRoute {
 
 /// What a held re-parent is keyed by: the relay it would adopt.
 ///
-/// An anonymous relay ([`Origin::UNKNOWN`]) identifies nothing, so its route id
+/// An anonymous relay ([`Hop::UNKNOWN`]) identifies nothing, so its route id
 /// stands in: another anonymous route is another relay until proven otherwise,
 /// and a reconnecting anonymous relay restarts its wait, which is the price of
 /// withholding an identity.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum HoldKey {
 	/// The target's announcing relay, when it declared an identity.
-	Relay(Origin),
+	Relay(Hop),
 	/// The target route itself, when its relay is anonymous.
 	Route(u64),
 }
@@ -1630,7 +1628,7 @@ struct FrontState {
 	/// Absolute path of the broadcast, mixed into the route tie-break hash.
 	path: PathOwned,
 	/// The local origin's identity, the other half of the handover key gate.
-	self_origin: Origin,
+	self_hop: Hop,
 	/// Content identity: the original publisher (first hop) shared by every
 	/// attached source, or `None` for a broadcast produced locally (no hops).
 	/// Fixed for the front's lifetime; a source with a different first hop is new
@@ -1638,7 +1636,7 @@ struct FrontState {
 	/// it, when offline) rather than joining it (see [`attach_source`]). This is
 	/// the same rule the session layer applies to a restart whose first hop
 	/// changed.
-	publisher: Option<Origin>,
+	publisher: Option<Hop>,
 	/// The re-parent currently held down: which relay it targets and when the
 	/// wait started. Keyed to the target relay, so a candidate flapping between
 	/// two routes to the same relay (a reconnect under a fresh route id
@@ -1664,7 +1662,7 @@ struct FrontState {
 	/// back (moq-transport carries no hop ids) may re-advertise the path to us before
 	/// it ever subscribes. That reflection is otherwise indistinguishable from a rival
 	/// publisher, and this is what tells [`attach_source`] apart.
-	excluded: HashMap<Origin, usize>,
+	excluded: HashMap<Hop, usize>,
 	/// Set when `excluded` gained or lost a peer without a reselect. The guards
 	/// register and release under locks that cannot re-run selection or sync
 	/// the front, so the front task observes this flag and does both: a peer
@@ -1713,7 +1711,7 @@ impl FrontState {
 	/// the candidate chain and is filtered here, at any cycle length. Taints are
 	/// ignored: this pins one requester to one source rather than serving the
 	/// shared front.
-	fn dispatch(&self, exclude: Option<Origin>) -> Option<u64> {
+	fn dispatch(&self, exclude: Option<Hop>) -> Option<u64> {
 		self.pick(
 			|r| exclude.is_none_or(|origin| !r.route.hops.contains(&origin)),
 			Steer::Ignore,
@@ -1919,7 +1917,7 @@ impl FrontState {
 			.find(|r| r.id == id)
 			.and_then(|r| r.route.hops.iter().last().copied());
 		match relay {
-			Some(relay) if relay != Origin::UNKNOWN => HoldKey::Relay(relay),
+			Some(relay) if relay != Hop::UNKNOWN => HoldKey::Relay(relay),
 			_ => HoldKey::Route(id),
 		}
 	}
@@ -1935,7 +1933,7 @@ impl FrontState {
 	/// [`HANDOVER_HOLD`].
 	fn hold_deadline(&self, since: Instant) -> Option<Instant> {
 		let spread = (HANDOVER_HOLD / 2).as_millis() as u64;
-		let key = fnv_key(&self.path.as_path(), [self.self_origin]);
+		let key = fnv_key(&self.path.as_path(), [self.self_hop]);
 		since.checked_add(HANDOVER_HOLD + Duration::from_millis(key % spread.max(1)))
 	}
 
@@ -2004,7 +2002,7 @@ impl FrontState {
 		}
 
 		let theirs = (candidate.advertised.cold, fnv_key(&name, [peer]));
-		let ours = (incumbent.cost.cold, fnv_key(&name, [self.self_origin]));
+		let ours = (incumbent.cost.cold, fnv_key(&name, [self.self_hop]));
 		theirs < ours
 	}
 
@@ -2333,15 +2331,15 @@ struct AttachContext<'a> {
 
 /// Whether two hop entries prove the same endpoint.
 ///
-/// [`Origin::UNKNOWN`] identifies nothing: it is what a peer that declared no
+/// [`Hop::UNKNOWN`] identifies nothing: it is what a peer that declared no
 /// identity, or that does not speak the hops extension at all, contributes as a
 /// hop. Two such entries never match. As first hops, splicing the sources they
 /// name would cut one publisher's subscribers over to an unrelated publisher's
 /// content; as last hops, two anonymous relays would pass for one relay
 /// reconnecting and skip the handover safeguards. Every other id compares
 /// normally, including `None` for a locally produced broadcast with no hops.
-fn same_identity(a: Option<Origin>, b: Option<Origin>) -> bool {
-	if a == Some(Origin::UNKNOWN) || b == Some(Origin::UNKNOWN) {
+fn same_identity(a: Option<Hop>, b: Option<Hop>) -> bool {
+	if a == Some(Hop::UNKNOWN) || b == Some(Hop::UNKNOWN) {
 		return false;
 	}
 	a == b
@@ -2446,7 +2444,7 @@ fn attach_source(
 	let state = kio::Producer::new(FrontState {
 		pending: None,
 		path: ctx.full.clone(),
-		self_origin: ctx.origin.id,
+		self_hop: ctx.origin.id,
 		publisher,
 		next_route: 1,
 		excluded: HashMap::new(),
@@ -2947,7 +2945,7 @@ struct PendingBroadcast {
 /// [`Consumer::announced`]. Drop this handle (and every clone) to reject the
 /// requests still waiting to be served.
 pub struct Dynamic {
-	info: Origin,
+	hop: Hop,
 	root: PathOwned,
 	state: kio::Shared<OriginDynamicState>,
 }
@@ -2960,7 +2958,7 @@ impl Clone for Dynamic {
 		self.state.lock().requests.add_handler();
 
 		Self {
-			info: self.info,
+			hop: self.hop,
 			root: self.root.clone(),
 			state: self.state.clone(),
 		}
@@ -2968,15 +2966,15 @@ impl Clone for Dynamic {
 }
 
 impl Dynamic {
-	fn new(info: Origin, root: PathOwned, state: kio::Shared<OriginDynamicState>) -> Self {
+	fn new(hop: Hop, root: PathOwned, state: kio::Shared<OriginDynamicState>) -> Self {
 		state.lock().requests.add_handler();
 
-		Self { info, root, state }
+		Self { hop, root, state }
 	}
 
-	/// The origin this handler belongs to.
-	pub fn info(&self) -> &Origin {
-		&self.info
+	/// The id of the origin this handler belongs to.
+	pub fn hop(&self) -> Hop {
+		self.hop
 	}
 
 	/// Poll for the next requested broadcast, without blocking.
@@ -3298,7 +3296,7 @@ impl Consume<track::Consumer> for track::Consumer {
 #[derive(Clone)]
 pub struct Consumer {
 	// Identity of the origin this consumer was derived from.
-	info: Origin,
+	info: Hop,
 	nodes: OriginNodes,
 
 	// A prefix that is automatically stripped from all paths.
@@ -3316,11 +3314,11 @@ pub struct Consumer {
 	// Data-plane split horizon: broadcasts resolved through this handle are
 	// served from a source whose hop chain excludes this origin (the requesting
 	// peer). `None` (the default) serves from the active source as usual.
-	exclude: Option<Origin>,
+	exclude: Option<Hop>,
 }
 
 impl std::ops::Deref for Consumer {
-	type Target = Origin;
+	type Target = Hop;
 
 	fn deref(&self) -> &Self::Target {
 		&self.info
@@ -3329,7 +3327,7 @@ impl std::ops::Deref for Consumer {
 
 impl Consumer {
 	fn new(
-		info: Origin,
+		info: Hop,
 		root: PathOwned,
 		nodes: OriginNodes,
 		dynamic: kio::Shared<OriginDynamicState>,
@@ -3349,7 +3347,7 @@ impl Consumer {
 	/// to a source whose hop chain excludes `peer`, matching what the announce
 	/// loop advertises to them. Sessions apply this once they learn the peer's
 	/// origin id.
-	pub(crate) fn excluding(mut self, peer: Origin) -> Self {
+	pub(crate) fn excluding(mut self, peer: Hop) -> Self {
 		self.exclude = Some(peer);
 		self
 	}
@@ -3672,7 +3670,7 @@ impl AnnounceConsumer {
 		root: PathOwned,
 		nodes: OriginNodes,
 		stats: stats::Session,
-		exclude: Option<Origin>,
+		exclude: Option<Hop>,
 		dynamic: &kio::Shared<OriginDynamicState>,
 	) -> Self {
 		let state = kio::Producer::<OriginConsumerState>::default();
@@ -3832,7 +3830,7 @@ impl ProduceTest for Info {
 }
 
 #[cfg(test)]
-impl ProduceTest for Origin {
+impl ProduceTest for Hop {
 	fn produce(self) -> Producer {
 		Info::new(self).produce()
 	}
@@ -3919,22 +3917,22 @@ mod tests {
 	/// deterministic instead of hinging on a random id winning a hash comparison.
 	/// Starts searching above the small ids the tests use in hop chains, so the
 	/// result never collides with a hop (a looping chain trips a debug_assert).
-	fn origin_keyed(name: &str, peer: Origin, above: bool) -> Origin {
+	fn origin_keyed(name: &str, peer: Hop, above: bool) -> Hop {
 		let name = Path::new(name);
 		let peer_key = fnv_key(&name, [peer]);
 		(100u64..)
-			.map(|id| Origin::new(id).unwrap())
+			.map(|id| Hop::new(id).unwrap())
 			.find(|origin| (fnv_key(&name, [*origin]) > peer_key) == above)
 			.unwrap()
 	}
 
 	/// A front table for reselect tests: routes get ids in order, the first is
 	/// the incumbent.
-	fn front_state(self_origin: Origin, routes: Vec<broadcast::Route>) -> FrontState {
+	fn front_state(self_hop: Hop, routes: Vec<broadcast::Route>) -> FrontState {
 		let source = broadcast::Info::new().produce().consume();
 		FrontState {
 			path: Path::new("test").to_owned(),
-			self_origin,
+			self_hop,
 			publisher: routes.first().and_then(|r| r.hops.iter().next().copied()),
 			next_route: routes.len() as u64,
 			excluded: HashMap::new(),
@@ -3965,11 +3963,11 @@ mod tests {
 	fn warm_route(hops: &[u64], cold: u64, link: u64) -> broadcast::Route {
 		let hops = hops
 			.iter()
-			.map(|id| Origin::new(*id).unwrap_or(Origin::UNKNOWN))
+			.map(|id| Hop::new(*id).unwrap_or(Hop::UNKNOWN))
 			.collect::<Vec<_>>();
 		let advertised = broadcast::Cost { warm: 0, cold };
 		let mut route = announce()
-			.with_hops(OriginList::try_from(hops).unwrap())
+			.with_hops(Hops::try_from(hops).unwrap())
 			.with_cost(advertised.charged(link));
 		route.advertised = advertised;
 		route
@@ -3978,7 +3976,7 @@ mod tests {
 	/// A route as a relay that is *not* carrying announces it: its accumulated cost
 	/// forwarded undiscounted, so it is a plain forwarder rather than a warm sibling
 	/// and never trips the adoption hold-down.
-	fn forwarder_route(hops: OriginList, cost: u64) -> broadcast::Route {
+	fn forwarder_route(hops: Hops, cost: u64) -> broadcast::Route {
 		let advertised = broadcast::Cost::new(cost);
 		let mut route = announce().with_hops(hops).with_cost(advertised);
 		route.advertised = advertised;
@@ -3986,13 +3984,13 @@ mod tests {
 	}
 
 	/// A warm relay one hop past the publisher, on the standard test link.
-	fn sibling_route(peer: Origin, cold: u64) -> broadcast::Route {
+	fn sibling_route(peer: Hop, cold: u64) -> broadcast::Route {
 		warm_route(&[90, peer.id()], cold, SIBLING_LINK)
 	}
 
 	/// A route as the upstream announces it: priced, one hop.
 	fn upstream_route(cost: u64) -> broadcast::Route {
-		let hops = OriginList::try_from(vec![Origin::new(90).unwrap()]).unwrap();
+		let hops = Hops::try_from(vec![Hop::new(90).unwrap()]).unwrap();
 		announce().with_hops(hops).with_cost(cost)
 	}
 
@@ -4002,7 +4000,7 @@ mod tests {
 	/// below us.
 	#[test]
 	fn test_carrying_gate_keys() {
-		let peer = Origin::new(3).unwrap();
+		let peer = Hop::new(3).unwrap();
 
 		// We lose the key comparison: stay put while carrying, migrate when idle.
 		let mut lost = front_state(
@@ -4034,14 +4032,14 @@ mod tests {
 	/// cluster draft's "equal Hop IDs cannot be ordered").
 	#[test]
 	fn test_carrying_gate_anonymous_is_not_a_reconnect() {
-		let anon_hops = || OriginList::try_from(vec![Origin::new(90).unwrap(), Origin::UNKNOWN]).unwrap();
+		let anon_hops = || Hops::try_from(vec![Hop::new(90).unwrap(), Hop::UNKNOWN]).unwrap();
 		let incumbent = || forwarder_route(anon_hops(), 10);
 		let candidate = || warm_route(&[90, 0], 10, SIBLING_LINK);
 
 		// Equal cold roots fall through to the hash of the declared ids, ours
 		// against the candidate's 0. Keyed to lose, we must stay put.
 		let mut state = front_state(
-			origin_keyed("test", Origin::UNKNOWN, false),
+			origin_keyed("test", Hop::UNKNOWN, false),
 			vec![incumbent(), candidate()],
 		);
 		state.reselect_now(true);
@@ -4052,7 +4050,7 @@ mod tests {
 		);
 
 		// Both sides anonymous: the ranks tie exactly, and a tie never moves.
-		let mut state = front_state(Origin::UNKNOWN, vec![incumbent(), candidate()]);
+		let mut state = front_state(Hop::UNKNOWN, vec![incumbent(), candidate()]);
 		state.reselect_now(true);
 		assert_eq!(state.active, Some(0), "two anonymous relays cannot be ordered");
 	}
@@ -4074,7 +4072,7 @@ mod tests {
 			.map(|i| {
 				let next = ids[(i + 1) % 3];
 				let mut view = front_state(
-					Origin::new(ids[i]).unwrap(),
+					Hop::new(ids[i]).unwrap(),
 					// Our own upstream has worsened to cold 10; the advertisement we
 					// still hold from the next relay says cold 1.
 					vec![upstream_route(10), warm_route(&[90, next], 1, 1)],
@@ -4104,10 +4102,10 @@ mod tests {
 
 		let moved: Vec<bool> = (0..3)
 			.map(|i| {
-				let next = Origin::new(ids[(i + 1) % 3]).unwrap();
-				let hops = OriginList::try_from(vec![Origin::new(90).unwrap(), next]).unwrap();
+				let next = Hop::new(ids[(i + 1) % 3]).unwrap();
+				let hops = Hops::try_from(vec![Hop::new(90).unwrap(), next]).unwrap();
 				let mut view = front_state(
-					Origin::new(ids[i]).unwrap(),
+					Hop::new(ids[i]).unwrap(),
 					vec![upstream_route(10), forwarder_route(hops, 1)],
 				);
 				view.reselect(true, now);
@@ -4125,7 +4123,7 @@ mod tests {
 	/// passed and the candidate is still preferred, the handover happens.
 	#[test]
 	fn test_handover_hold_expires() {
-		let peer = Origin::new(3).unwrap();
+		let peer = Hop::new(3).unwrap();
 		let start = crate::model::clock::now();
 		let mut state = front_state(
 			origin_keyed("test", peer, false),
@@ -4162,7 +4160,7 @@ mod tests {
 	/// deadline every time rather than re-rolling it and drifting.
 	#[test]
 	fn test_handover_hold_spread_is_stable() {
-		let peer = Origin::new(3).unwrap();
+		let peer = Hop::new(3).unwrap();
 		let now = crate::model::clock::now();
 		let build = || {
 			front_state(
@@ -4173,8 +4171,8 @@ mod tests {
 		assert_eq!(build().hold_deadline(now), build().hold_deadline(now));
 
 		// Different relays land on different instants, which is the point.
-		let a = front_state(Origin::new(11).unwrap(), vec![upstream_route(10)]);
-		let b = front_state(Origin::new(12).unwrap(), vec![upstream_route(10)]);
+		let a = front_state(Hop::new(11).unwrap(), vec![upstream_route(10)]);
+		let b = front_state(Hop::new(12).unwrap(), vec![upstream_route(10)]);
 		assert_ne!(a.hold_deadline(now), b.hold_deadline(now));
 	}
 
@@ -4184,7 +4182,7 @@ mod tests {
 	/// re-parent at once off prices that have not landed yet.
 	#[test]
 	fn test_handover_hold_covers_a_drain() {
-		let peer = Origin::new(3).unwrap();
+		let peer = Hop::new(3).unwrap();
 		let now = crate::model::clock::now();
 		let mut state = front_state(
 			origin_keyed("test", peer, false),
@@ -4206,7 +4204,7 @@ mod tests {
 	/// moves that cannot close a loop, and repairs that must not wait, are exempt.
 	#[test]
 	fn test_handover_hold_ignores_moves_that_cannot_cycle() {
-		let peer = Origin::new(3).unwrap();
+		let peer = Hop::new(3).unwrap();
 		let now = crate::model::clock::now();
 		let keyed = || origin_keyed("test", peer, false);
 
@@ -4234,7 +4232,7 @@ mod tests {
 	/// a live route sits in the table.
 	#[test]
 	fn test_handover_hold_exempts_an_unannounced_incumbent() {
-		let peer = Origin::new(3).unwrap();
+		let peer = Hop::new(3).unwrap();
 		let now = crate::model::clock::now();
 		let offline = upstream_route(10).with_announce(false);
 		let mut state = front_state(origin_keyed("test", peer, false), vec![offline, sibling_route(peer, 4)]);
@@ -4254,7 +4252,7 @@ mod tests {
 	fn test_handover_hold_covers_anonymous_relays() {
 		let now = crate::model::clock::now();
 		let anon = |cold: u64| warm_route(&[90, 0], cold, SIBLING_LINK);
-		let mut state = front_state(Origin::new(7).unwrap(), vec![anon(10), anon(1)]);
+		let mut state = front_state(Hop::new(7).unwrap(), vec![anon(10), anon(1)]);
 
 		assert!(
 			state.reselect(true, now).is_some(),
@@ -4270,11 +4268,11 @@ mod tests {
 	#[test]
 	fn test_handover_hold_is_keyed_to_the_target() {
 		let start = crate::model::clock::now();
-		let relay_b = OriginList::try_from(vec![Origin::new(90).unwrap(), Origin::new(3).unwrap()]).unwrap();
-		let relay_c = OriginList::try_from(vec![Origin::new(90).unwrap(), Origin::new(4).unwrap()]).unwrap();
+		let relay_b = Hops::try_from(vec![Hop::new(90).unwrap(), Hop::new(3).unwrap()]).unwrap();
+		let relay_c = Hops::try_from(vec![Hop::new(90).unwrap(), Hop::new(4).unwrap()]).unwrap();
 
 		let mut state = front_state(
-			Origin::new(7).unwrap(),
+			Hop::new(7).unwrap(),
 			vec![upstream_route(10), forwarder_route(relay_b, 5)],
 		);
 		let deadline = state.reselect(true, start).expect("the hold must arm");
@@ -4320,7 +4318,7 @@ mod tests {
 	/// starts later rather than one that cannot happen.
 	#[test]
 	fn test_handover_hold_covers_an_idle_front() {
-		let peer = Origin::new(3).unwrap();
+		let peer = Hop::new(3).unwrap();
 		let now = crate::model::clock::now();
 		let mut state = front_state(
 			origin_keyed("test", peer, false),
@@ -4337,10 +4335,10 @@ mod tests {
 	/// not necessarily a publisher that never re-parents.
 	#[test]
 	fn test_handover_hold_covers_an_opaque_one_hop_peer() {
-		let peer = Origin::new(3).unwrap();
+		let peer = Hop::new(3).unwrap();
 		let now = crate::model::clock::now();
 		let opaque = announce()
-			.with_hops(OriginList::try_from(vec![peer]).unwrap())
+			.with_hops(Hops::try_from(vec![peer]).unwrap())
 			.with_cost(broadcast::Cost::UNKNOWN.charged(1));
 		let mut state = front_state(origin_keyed("test", peer, false), vec![upstream_route(10), opaque]);
 
@@ -4360,8 +4358,8 @@ mod tests {
 	/// its bytes take.
 	#[test]
 	fn test_a_tainted_incumbent_is_never_retained() {
-		let reader = Origin::new(5).unwrap();
-		let clean_peer = Origin::new(3).unwrap();
+		let reader = Hop::new(5).unwrap();
+		let clean_peer = Hop::new(3).unwrap();
 		let now = crate::model::clock::now();
 
 		// The incumbent runs through the reader and is cheaply rooted, so we outrank
@@ -4403,9 +4401,9 @@ mod tests {
 	/// and drops the very advertisement whose guard created the taint.
 	#[test]
 	fn test_taint_steer_keeps_the_announcement() {
-		let reader = Origin::new(5).unwrap();
+		let reader = Hop::new(5).unwrap();
 		let mut state = front_state(
-			Origin::new(7).unwrap(),
+			Hop::new(7).unwrap(),
 			vec![
 				warm_route(&[90, reader.id()], 1, 1),
 				upstream_route(10).with_announce(false),
@@ -4447,8 +4445,8 @@ mod tests {
 	/// left without a source.
 	#[test]
 	fn test_carrying_gate_symmetric_race() {
-		let a = Origin::new(1).unwrap();
-		let b = Origin::new(2).unwrap();
+		let a = Hop::new(1).unwrap();
+		let b = Hop::new(2).unwrap();
 
 		let mut a_view = front_state(a, vec![upstream_route(10), sibling_route(b, 10)]);
 		let mut b_view = front_state(b, vec![upstream_route(10), sibling_route(a, 10)]);
@@ -4469,7 +4467,7 @@ mod tests {
 	/// become the aggregation point either way the hash falls.
 	#[test]
 	fn test_carrying_gate_follows_the_cheaper_root() {
-		let peer = Origin::new(3).unwrap();
+		let peer = Hop::new(3).unwrap();
 
 		for above in [false, true] {
 			let mut state = front_state(
@@ -4490,7 +4488,7 @@ mod tests {
 	/// however the hash falls. It is the peer that has to come to us.
 	#[test]
 	fn test_carrying_gate_rejects_the_pricier_root() {
-		let peer = Origin::new(3).unwrap();
+		let peer = Hop::new(3).unwrap();
 
 		for above in [false, true] {
 			let mut state = front_state(
@@ -4511,7 +4509,7 @@ mod tests {
 	/// strictly above the relay we adopted and can never attract it back.
 	#[test]
 	fn test_carrying_gate_descends() {
-		let peer = Origin::new(3).unwrap();
+		let peer = Hop::new(3).unwrap();
 		let mut state = front_state(
 			origin_keyed("test", peer, false),
 			vec![upstream_route(10), sibling_route(peer, 4)],
@@ -4534,7 +4532,7 @@ mod tests {
 	/// front on a route that no longer exists.
 	#[test]
 	fn test_carrying_gate_reverts_when_the_parent_goes() {
-		let peer = Origin::new(3).unwrap();
+		let peer = Hop::new(3).unwrap();
 		let mut state = front_state(
 			origin_keyed("test", peer, false),
 			vec![upstream_route(10), sibling_route(peer, 4)],
@@ -4553,8 +4551,8 @@ mod tests {
 	/// cost existed.
 	#[test]
 	fn test_carrying_gate_unknown_cold_falls_back_to_the_hash() {
-		let a = Origin::new(1).unwrap();
-		let b = Origin::new(2).unwrap();
+		let a = Hop::new(1).unwrap();
+		let b = Hop::new(2).unwrap();
 		let unknown = broadcast::Cost::UNKNOWN.cold;
 
 		let mut a_view = front_state(a, vec![upstream_route(unknown), sibling_route(b, unknown)]);
@@ -4575,7 +4573,7 @@ mod tests {
 	/// peer that told us the least.
 	#[test]
 	fn test_carrying_gate_unknown_cold_ranks_last() {
-		let peer = Origin::new(3).unwrap();
+		let peer = Hop::new(3).unwrap();
 		let unknown = broadcast::Cost::UNKNOWN.cold;
 
 		for above in [false, true] {
@@ -4617,7 +4615,7 @@ mod tests {
 			"hop count must favor the wrong one"
 		);
 
-		let mut state = front_state(Origin::new(7).unwrap(), vec![shallow, deep]);
+		let mut state = front_state(Hop::new(7).unwrap(), vec![shallow, deep]);
 		state.reselect_now(true);
 		assert_eq!(state.active, Some(1), "hop count bypassed the cheaper-rooted warm copy");
 	}
@@ -4628,7 +4626,7 @@ mod tests {
 	/// and even when we would lose the key comparison.
 	#[test]
 	fn test_carrying_switches_to_benign_routes() {
-		let peer = Origin::new(3).unwrap();
+		let peer = Hop::new(3).unwrap();
 		let lost = origin_keyed("test", peer, false);
 
 		// A cheaper forwarder path: the relay advertised its accumulated cost.
@@ -4643,7 +4641,7 @@ mod tests {
 		);
 
 		// Directly from the original publisher: single-hop chain, advertised zero.
-		let direct = announce().with_hops(OriginList::try_from(vec![peer]).unwrap());
+		let direct = announce().with_hops(Hops::try_from(vec![peer]).unwrap());
 		let mut state = front_state(lost, vec![upstream_route(10), direct]);
 		state.reselect_now(true);
 		assert_eq!(
@@ -4669,7 +4667,7 @@ mod tests {
 	/// (the upstream retracted) is displaced regardless of the key comparison.
 	#[test]
 	fn test_carrying_gate_ignores_unannounced_incumbent() {
-		let peer = Origin::new(3).unwrap();
+		let peer = Hop::new(3).unwrap();
 		let unannounced = upstream_route(10).with_announce(false);
 		let mut state = front_state(
 			origin_keyed("test", peer, false),
@@ -4689,11 +4687,11 @@ mod tests {
 	/// of a sync target point at it.
 	#[test]
 	fn test_reflection_through_an_exposed_peer_cannot_take_over() {
-		let peer = Origin::new(42).unwrap();
-		let upstream = OriginList::try_from(vec![Origin::new(7).unwrap()]).unwrap();
-		let reflected = announce().with_hops(OriginList::try_from(vec![peer]).unwrap());
+		let peer = Hop::new(42).unwrap();
+		let upstream = Hops::try_from(vec![Hop::new(7).unwrap()]).unwrap();
+		let reflected = announce().with_hops(Hops::try_from(vec![peer]).unwrap());
 
-		let mut state = front_state(Origin::new(1).unwrap(), vec![announce().with_hops(upstream)]);
+		let mut state = front_state(Hop::new(1).unwrap(), vec![announce().with_hops(upstream)]);
 
 		// Nobody is exposed yet: a different publisher is free to take the path.
 		assert!(!state.taints_a_reader(&reflected));
@@ -4708,12 +4706,12 @@ mod tests {
 	/// publisher reaching us through some *other* peer still takes the path over.
 	#[test]
 	fn test_rival_publisher_through_another_peer_still_takes_over() {
-		let peer = Origin::new(42).unwrap();
-		let elsewhere = Origin::new(43).unwrap();
-		let upstream = OriginList::try_from(vec![Origin::new(7).unwrap()]).unwrap();
-		let rival = announce().with_hops(OriginList::try_from(vec![Origin::UNKNOWN, elsewhere]).unwrap());
+		let peer = Hop::new(42).unwrap();
+		let elsewhere = Hop::new(43).unwrap();
+		let upstream = Hops::try_from(vec![Hop::new(7).unwrap()]).unwrap();
+		let rival = announce().with_hops(Hops::try_from(vec![Hop::UNKNOWN, elsewhere]).unwrap());
 
-		let mut state = front_state(Origin::new(1).unwrap(), vec![announce().with_hops(upstream)]);
+		let mut state = front_state(Hop::new(1).unwrap(), vec![announce().with_hops(upstream)]);
 		*state.excluded.entry(peer).or_default() += 1;
 
 		assert!(!state.taints_a_reader(&rival), "only the peer we feed is a reflection");
@@ -4725,19 +4723,19 @@ mod tests {
 	/// opaque link (`Client::with_cost`) is what restores the intended order.
 	#[test]
 	fn test_opaque_peer_understates_its_depth() {
-		let us = Origin::new(1).unwrap();
+		let us = Hop::new(1).unwrap();
 
 		// Our own upstream, honestly described: two hops, charged per link.
 		let direct = || {
 			announce()
-				.with_hops(OriginList::try_from(vec![Origin::new(7).unwrap(), Origin::new(8).unwrap()]).unwrap())
+				.with_hops(Hops::try_from(vec![Hop::new(7).unwrap(), Hop::new(8).unwrap()]).unwrap())
 				.with_cost(2)
 		};
 		// The same content reached through an opaque relay, which is actually further
 		// away but advertises no chain at all, so it lands as one unpriced hop.
 		let opaque = |cost| {
 			announce()
-				.with_hops(OriginList::try_from(vec![Origin::new(42).unwrap()]).unwrap())
+				.with_hops(Hops::try_from(vec![Hop::new(42).unwrap()]).unwrap())
 				.with_cost(cost)
 		};
 
@@ -4814,7 +4812,7 @@ mod tests {
 		let registry = Registry::new(Config::new());
 		let ctx = registry.tier(Tier::default()).session("acme");
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let ingress = origin.clone().with_stats(ctx.clone());
 		let egress = origin.consume().with_stats(ctx.clone());
 
@@ -4917,7 +4915,7 @@ mod tests {
 		let registry = Registry::new(Config::new());
 		let ctx = registry.tier(Tier::default()).session("acme");
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let ingress = origin.clone().with_stats(ctx.clone());
 		let egress = origin.consume().with_stats(ctx.clone());
 
@@ -4975,7 +4973,7 @@ mod tests {
 		let registry = Registry::new(Config::new());
 		let ctx = registry.tier(Tier::default()).session("acme");
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let ingress = origin.clone().with_stats(ctx.clone());
 		let egress = origin.consume().with_stats(ctx.clone());
 
@@ -5043,7 +5041,7 @@ mod tests {
 		let registry = Registry::new(Config::new());
 		let ctx = registry.tier(Tier::default()).session("acme");
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let ingress = origin.clone().with_stats(ctx.clone());
 		let egress = origin.consume().with_stats(ctx.clone());
 
@@ -5081,25 +5079,25 @@ mod tests {
 
 	#[test]
 	fn origin_rejects_reserved_ids() {
-		assert!(Origin::new(0).is_err());
-		assert!(Origin::new(1u64 << 62).is_err());
-		assert_eq!(Origin::new(1).unwrap().id(), 1);
+		assert!(Hop::new(0).is_err());
+		assert!(Hop::new(1u64 << 62).is_err());
+		assert_eq!(Hop::new(1).unwrap().id(), 1);
 
 		let mut zero = [0u8].as_slice();
 		assert_eq!(
-			Origin::decode(&mut zero, crate::lite::Version::Lite05).unwrap(),
-			Origin::UNKNOWN
+			Hop::decode(&mut zero, crate::lite::Version::Lite05).unwrap(),
+			Hop::UNKNOWN
 		);
 	}
 
 	#[test]
 	fn origin_list_push_fails_at_limit() {
-		let mut list = OriginList::new();
+		let mut list = Hops::new();
 		for _ in 0..MAX_HOPS {
-			list.push(Origin::random()).unwrap();
+			list.push(Hop::random()).unwrap();
 		}
 		assert_eq!(list.len(), MAX_HOPS);
-		assert_eq!(list.push(Origin::random()), Err(InvalidHop::TooMany));
+		assert_eq!(list.push(Hop::random()), Err(InvalidHop::TooMany));
 	}
 
 	/// A chain that revisits a hop looped, and every receiver of one must close the
@@ -5107,38 +5105,38 @@ mod tests {
 	/// rule each place that constructs a chain has to remember.
 	#[test]
 	fn origin_list_push_rejects_a_repeat() {
-		let seven = Origin::new(7).unwrap();
-		let mut list = OriginList::new();
+		let seven = Hop::new(7).unwrap();
+		let mut list = Hops::new();
 		list.push(seven).unwrap();
-		list.push(Origin::new(9).unwrap()).unwrap();
+		list.push(Hop::new(9).unwrap()).unwrap();
 
 		assert_eq!(list.push(seven), Err(InvalidHop::Duplicate));
 		assert_eq!(list.len(), 2, "a refused push must not grow the chain");
 
 		// 0 identifies nothing, so two unknown hops are two hops, not a loop.
-		list.push(Origin::UNKNOWN).unwrap();
-		list.push(Origin::UNKNOWN).unwrap();
+		list.push(Hop::UNKNOWN).unwrap();
+		list.push(Hop::UNKNOWN).unwrap();
 		assert_eq!(list.len(), 4);
 	}
 
 	#[test]
 	fn origin_list_replace_first() {
-		let mut list = OriginList::new();
+		let mut list = Hops::new();
 		for _ in 0..3 {
-			list.push(Origin::UNKNOWN).unwrap();
+			list.push(Hop::UNKNOWN).unwrap();
 		}
 
 		// Rewrites only the first placeholder, keeping the length the same.
-		assert!(list.replace_first(Origin::UNKNOWN, Origin::new(7).unwrap()).unwrap());
+		assert!(list.replace_first(Hop::UNKNOWN, Hop::new(7).unwrap()).unwrap());
 		assert_eq!(
 			list.as_slice(),
-			&[Origin::new(7).unwrap(), Origin::UNKNOWN, Origin::UNKNOWN]
+			&[Hop::new(7).unwrap(), Hop::UNKNOWN, Hop::UNKNOWN]
 		);
 
 		// No match leaves the list untouched.
 		assert!(
 			!list
-				.replace_first(Origin::new(99).unwrap(), Origin::new(8).unwrap())
+				.replace_first(Hop::new(99).unwrap(), Hop::new(8).unwrap())
 				.unwrap()
 		);
 		assert_eq!(list.len(), 3);
@@ -5146,51 +5144,51 @@ mod tests {
 		// Writing in an id the chain already carries would name it twice, which is the
 		// loop `push` refuses; the rewrite has to refuse it for the same reason.
 		assert_eq!(
-			list.replace_first(Origin::UNKNOWN, Origin::new(7).unwrap()),
+			list.replace_first(Hop::UNKNOWN, Hop::new(7).unwrap()),
 			Err(InvalidHop::Duplicate)
 		);
 
 		// A target that is not there changes nothing, so it cannot duplicate anything,
 		// however many times the replacement already appears.
 		assert_eq!(
-			list.replace_first(Origin::new(99).unwrap(), Origin::new(7).unwrap()),
+			list.replace_first(Hop::new(99).unwrap(), Hop::new(7).unwrap()),
 			Ok(false)
 		);
 
 		// Overwriting a slot with what it already holds is a no-op, not a duplicate: the
 		// entry being replaced is not a second occurrence of itself.
 		assert_eq!(
-			list.replace_first(Origin::new(7).unwrap(), Origin::new(7).unwrap()),
+			list.replace_first(Hop::new(7).unwrap(), Hop::new(7).unwrap()),
 			Ok(true)
 		);
 		assert_eq!(
 			list.as_slice(),
-			&[Origin::new(7).unwrap(), Origin::UNKNOWN, Origin::UNKNOWN]
+			&[Hop::new(7).unwrap(), Hop::UNKNOWN, Hop::UNKNOWN]
 		);
 	}
 
 	#[test]
 	fn origin_list_try_from_vec_enforces_limit() {
-		let under: Vec<Origin> = (0..MAX_HOPS).map(|_| Origin::random()).collect();
-		assert!(OriginList::try_from(under).is_ok());
+		let under: Vec<Hop> = (0..MAX_HOPS).map(|_| Hop::random()).collect();
+		assert!(Hops::try_from(under).is_ok());
 
-		let over: Vec<Origin> = (0..MAX_HOPS + 1).map(|_| Origin::random()).collect();
-		assert_eq!(OriginList::try_from(over), Err(InvalidHop::TooMany));
+		let over: Vec<Hop> = (0..MAX_HOPS + 1).map(|_| Hop::random()).collect();
+		assert_eq!(Hops::try_from(over), Err(InvalidHop::TooMany));
 
 		// The other wire rule, on the path that skips `push` entirely.
-		let seven = Origin::new(7).unwrap();
+		let seven = Hop::new(7).unwrap();
 		assert_eq!(
-			OriginList::try_from(vec![seven, Origin::new(9).unwrap(), seven]),
+			Hops::try_from(vec![seven, Hop::new(9).unwrap(), seven]),
 			Err(InvalidHop::Duplicate)
 		);
-		assert!(OriginList::try_from(vec![Origin::UNKNOWN, seven, Origin::UNKNOWN]).is_ok());
+		assert!(Hops::try_from(vec![Hop::UNKNOWN, seven, Hop::UNKNOWN]).is_ok());
 	}
 
 	/// Exact lookups and eligible announcements land synchronously in
 	/// `create_broadcast`: no runtime, no driver poll.
 	#[test]
 	fn test_create_visible_without_driver() {
-		let (origin, _driver) = Producer::new(Info::new(Origin::random()));
+		let (origin, _driver) = Producer::new(Info::new(Hop::random()));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -5206,7 +5204,7 @@ mod tests {
 	async fn test_lifecycle_requires_driver() {
 		tokio::time::pause();
 
-		let (origin, driver) = Producer::new(Info::new(Origin::random()));
+		let (origin, driver) = Producer::new(Info::new(Hop::random()));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -5235,12 +5233,12 @@ mod tests {
 	/// interpret a stamp from another clock as an expired hold.
 	#[test]
 	fn test_pre_run_handover_uses_driver_clock() {
-		let (origin, driver) = Producer::new(Info::new(Origin::new(7).unwrap()));
+		let (origin, driver) = Producer::new(Info::new(Hop::new(7).unwrap()));
 		let consumer = origin.consume();
-		let publisher = Origin::new(90).unwrap();
-		let peer = Origin::new(3).unwrap();
-		let incumbent_hops = OriginList::try_from(vec![publisher]).unwrap();
-		let candidate_hops = OriginList::try_from(vec![publisher, peer]).unwrap();
+		let publisher = Hop::new(90).unwrap();
+		let peer = Hop::new(3).unwrap();
+		let incumbent_hops = Hops::try_from(vec![publisher]).unwrap();
+		let candidate_hops = Hops::try_from(vec![publisher, peer]).unwrap();
 
 		let _incumbent = origin
 			.create_broadcast("cam", announce().with_hops(incumbent_hops.clone()).with_cost(10))
@@ -5277,7 +5275,7 @@ mod tests {
 	async fn test_driver_drop_tears_down() {
 		tokio::time::pause();
 
-		let (origin, driver) = Producer::new(Info::new(Origin::random()));
+		let (origin, driver) = Producer::new(Info::new(Hop::random()));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -5324,7 +5322,7 @@ mod tests {
 	async fn test_driver_drop_rejects_handed_out_requests() {
 		tokio::time::pause();
 
-		let (origin, driver) = Producer::new(Info::new(Origin::random()));
+		let (origin, driver) = Producer::new(Info::new(Hop::random()));
 		let consumer = origin.consume();
 		let mut handler = origin.dynamic();
 
@@ -5345,7 +5343,7 @@ mod tests {
 	async fn test_driver_finishes_when_drained() {
 		tokio::time::pause();
 
-		let (origin, driver) = Producer::new(Info::new(Origin::random()));
+		let (origin, driver) = Producer::new(Info::new(Hop::random()));
 		let driver = tokio::spawn(driver.run(crate::runtime::tokio_test::Tokio::<()>::new()));
 
 		let mut source = origin.create_broadcast("cam", announce()).unwrap();
@@ -5368,7 +5366,7 @@ mod tests {
 	async fn test_create_after_dead_source_is_fresh() {
 		tokio::time::pause();
 
-		let (origin, _driver) = Producer::new(Info::new(Origin::random()));
+		let (origin, _driver) = Producer::new(Info::new(Hop::random()));
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -5392,7 +5390,7 @@ mod tests {
 	async fn test_announce() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		let mut consumer1 = origin.consume().announced();
 		consumer1.assert_next_wait();
@@ -5449,7 +5447,7 @@ mod tests {
 	async fn test_duplicate() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -5489,14 +5487,14 @@ mod tests {
 	async fn test_route_failover() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
 		// Both routes share the first hop (the original publisher): only
 		// interchangeable content may join as a standby.
-		let hops_a = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
-		let hops_b = OriginList::try_from(vec![Origin::new(1).unwrap(), Origin::new(3).unwrap()]).unwrap();
+		let hops_a = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
+		let hops_b = Hops::try_from(vec![Hop::new(1).unwrap(), Hop::new(3).unwrap()]).unwrap();
 
 		// The first source announces the broadcast.
 		let source_a = origin.create_broadcast("test", announce().with_hops(hops_a)).unwrap();
@@ -5564,12 +5562,12 @@ mod tests {
 	async fn test_route_failover_restores_every_track() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 
 		// Both routes share the first hop: interchangeable content.
-		let hops_a = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
-		let hops_b = OriginList::try_from(vec![Origin::new(1).unwrap(), Origin::new(3).unwrap()]).unwrap();
+		let hops_a = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
+		let hops_b = Hops::try_from(vec![Hop::new(1).unwrap(), Hop::new(3).unwrap()]).unwrap();
 
 		let source_a = origin.create_broadcast("test", announce().with_hops(hops_a)).unwrap();
 		let mut dynamic_a = source_a.dynamic();
@@ -5666,8 +5664,8 @@ mod tests {
 		producer.set_route(broadcast::Route::default()).unwrap();
 		assert!(consumer.route_changed().now_or_never().is_none());
 
-		let mut hops = OriginList::new();
-		hops.push(Origin::new(7).unwrap()).unwrap();
+		let mut hops = Hops::new();
+		hops.push(Hop::new(7).unwrap()).unwrap();
 		let route = broadcast::Route::new().with_hops(hops).with_cost(3);
 		producer.set_route(route.clone()).unwrap();
 		assert_eq!(consumer.route_changed().await.unwrap(), route);
@@ -5690,14 +5688,14 @@ mod tests {
 		// The takeover happens while a subscriber is live (carrying), so the local
 		// origin must win the handover key comparison against B's announcing hop
 		// (origin 3); a random id would flake on the hash.
-		let origin = Info::new(origin_keyed("test", Origin::new(3).unwrap(), true)).produce();
+		let origin = Info::new(origin_keyed("test", Hop::new(3).unwrap(), true)).produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
 		// Both routes share the first hop (the original publisher): only
 		// interchangeable content may join as a standby.
-		let hops_a = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
-		let hops_b = OriginList::try_from(vec![Origin::new(1).unwrap(), Origin::new(3).unwrap()]).unwrap();
+		let hops_a = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
+		let hops_b = Hops::try_from(vec![Hop::new(1).unwrap(), Hop::new(3).unwrap()]).unwrap();
 
 		// A (shorter chain) wins at equal cost.
 		let mut source_a = origin
@@ -5773,12 +5771,12 @@ mod tests {
 	async fn test_completed_track_survives_route_churn() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 
 		// Shared first hop, so B is a standby rather than a parked replacement.
-		let hops_a = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
-		let hops_b = OriginList::try_from(vec![Origin::new(1).unwrap(), Origin::new(3).unwrap()]).unwrap();
+		let hops_a = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
+		let hops_b = Hops::try_from(vec![Hop::new(1).unwrap(), Hop::new(3).unwrap()]).unwrap();
 
 		let source_a = origin.create_broadcast("test", announce().with_hops(hops_a)).unwrap();
 		let mut dynamic_a = source_a.dynamic();
@@ -5819,10 +5817,10 @@ mod tests {
 	async fn test_refused_track_aborts_instantly() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 
-		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let hops = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
 		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
 		let mut dynamic = source.dynamic();
 		settle().await;
@@ -5847,13 +5845,13 @@ mod tests {
 	async fn test_stale_rejection_does_not_abort_a_handover() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 
-		let publisher = Origin::new(1).unwrap();
-		let peer = Origin::new(5).unwrap();
-		let via_peer = OriginList::try_from(vec![publisher, peer]).unwrap();
-		let local = OriginList::try_from(vec![publisher]).unwrap();
+		let publisher = Hop::new(1).unwrap();
+		let peer = Hop::new(5).unwrap();
+		let via_peer = Hops::try_from(vec![publisher, peer]).unwrap();
+		let local = Hops::try_from(vec![publisher]).unwrap();
 
 		// The only route: dispatch parks on its pending info request.
 		let source_remote = origin
@@ -5891,13 +5889,13 @@ mod tests {
 	async fn test_route_handover() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
 		// Shared first hop, so the short route joins as an interchangeable source.
-		let hops_long = OriginList::try_from(vec![Origin::new(1).unwrap(), Origin::new(3).unwrap()]).unwrap();
-		let hops_short = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let hops_long = Hops::try_from(vec![Hop::new(1).unwrap(), Hop::new(3).unwrap()]).unwrap();
+		let hops_short = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
 
 		let source_a = origin
 			.create_broadcast("test", announce().with_hops(hops_long))
@@ -5953,11 +5951,11 @@ mod tests {
 	/// unannounce propagates promptly and a re-create is a fresh broadcast.
 	#[tokio::test(start_paused = true)]
 	async fn test_route_unannounce_immediate() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
-		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let hops = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
 		let mut source = origin
 			.create_broadcast("test", announce().with_hops(hops.clone()))
 			.unwrap();
@@ -5989,11 +5987,11 @@ mod tests {
 	/// it behind a stale route.
 	#[tokio::test(start_paused = true)]
 	async fn test_route_detach_immediate() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
-		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let hops = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
 		let source = origin
 			.create_broadcast("test", announce().with_hops(hops.clone()))
 			.unwrap();
@@ -6036,10 +6034,10 @@ mod tests {
 	/// re-requesting the track (and its info) every linger.
 	#[tokio::test(start_paused = true)]
 	async fn test_idle_track_releases_without_respinning() {
-		let origin = Info::new(Origin::random()).produce();
+		let origin = Info::new(Hop::random()).produce();
 		let consumer = origin.consume();
 
-		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let hops = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
 		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
 		let mut dynamic = source.dynamic();
 		settle().await;
@@ -6100,10 +6098,10 @@ mod tests {
 	/// doesn't re-request the track, and its `TRACK_INFO`, for every group.
 	#[tokio::test(start_paused = true)]
 	async fn test_back_to_back_fetches_reuse_the_track() {
-		let origin = Info::new(Origin::random()).produce();
+		let origin = Info::new(Hop::random()).produce();
 		let consumer = origin.consume();
 
-		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let hops = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
 		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
 		let mut dynamic = source.dynamic();
 		settle().await;
@@ -6151,7 +6149,7 @@ mod tests {
 	async fn test_announce_toggle() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -6199,7 +6197,7 @@ mod tests {
 	async fn test_announce_beats_offline() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -6231,13 +6229,13 @@ mod tests {
 	async fn test_better_source_no_churn() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let mut announced = origin.consume().announced();
 
 		// `a` carries two hops; `b` reaches the same publisher in one, so `b`
 		// wins dispatch when it joins.
-		let hops_a = OriginList::try_from(vec![Origin::new(1).unwrap(), Origin::new(3).unwrap()]).unwrap();
-		let hops_b = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let hops_a = Hops::try_from(vec![Hop::new(1).unwrap(), Hop::new(3).unwrap()]).unwrap();
+		let hops_b = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
 		let _a = origin.create_broadcast("test", announce().with_hops(hops_a)).unwrap();
 		settle().await;
 		let face = announced.assert_next_some("test");
@@ -6263,12 +6261,12 @@ mod tests {
 	async fn test_publisher_mismatch_replaces() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
-		let hops_a = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
-		let hops_b = OriginList::try_from(vec![Origin::new(2).unwrap()]).unwrap();
+		let hops_a = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
+		let hops_b = Hops::try_from(vec![Hop::new(2).unwrap()]).unwrap();
 
 		let mut source_a = origin
 			.create_broadcast("test", announce().with_hops(hops_a.clone()))
@@ -6306,12 +6304,12 @@ mod tests {
 	async fn test_displaced_publisher_reclaims_path_when_replacement_leaves() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
-		let hops_a = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
-		let hops_b = OriginList::try_from(vec![Origin::new(2).unwrap()]).unwrap();
+		let hops_a = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
+		let hops_b = Hops::try_from(vec![Hop::new(2).unwrap()]).unwrap();
 
 		// A announces and is live.
 		let mut source_a = origin
@@ -6357,12 +6355,12 @@ mod tests {
 	async fn test_reclaimed_publisher_can_still_replace_itself() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 
-		let hops_a = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
-		let hops_b = OriginList::try_from(vec![Origin::new(2).unwrap()]).unwrap();
-		let hops_c = OriginList::try_from(vec![Origin::new(3).unwrap()]).unwrap();
+		let hops_a = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
+		let hops_b = Hops::try_from(vec![Hop::new(2).unwrap()]).unwrap();
+		let hops_c = Hops::try_from(vec![Hop::new(3).unwrap()]).unwrap();
 
 		// Two sources sharing a publisher splice into one front.
 		let mut source_a1 = origin
@@ -6408,12 +6406,12 @@ mod tests {
 	async fn test_repricing_does_not_earn_a_takeover() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
-		let hops_a = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
-		let hops_b = OriginList::try_from(vec![Origin::new(2).unwrap()]).unwrap();
+		let hops_a = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
+		let hops_b = Hops::try_from(vec![Hop::new(2).unwrap()]).unwrap();
 
 		let mut source_a = origin
 			.create_broadcast("test", announce().with_hops(hops_a.clone()).with_cost(5))
@@ -6457,11 +6455,11 @@ mod tests {
 	async fn test_reconnect_wins_over_stale_route() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 
-		let publisher = Origin::new(1).unwrap();
-		let hops = OriginList::try_from(vec![publisher]).unwrap();
+		let publisher = Hop::new(1).unwrap();
+		let hops = Hops::try_from(vec![publisher]).unwrap();
 
 		// The original session, still attached: its QUIC connection has not been
 		// declared dead yet.
@@ -6498,10 +6496,10 @@ mod tests {
 	async fn test_carrying_reconnect_switches_immediately() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 
-		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let hops = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
 
 		let stale = origin
 			.create_broadcast("test", announce().with_hops(hops.clone()))
@@ -6544,12 +6542,12 @@ mod tests {
 	async fn test_offline_mismatch_never_evicts_a_live_front() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
-		let hops_live = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
-		let hops_cache = OriginList::try_from(vec![Origin::new(2).unwrap()]).unwrap();
+		let hops_live = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
+		let hops_cache = Hops::try_from(vec![Hop::new(2).unwrap()]).unwrap();
 
 		let mut live = origin
 			.create_broadcast("test", announce().with_hops(hops_live.clone()))
@@ -6601,14 +6599,14 @@ mod tests {
 	async fn test_dispatch_excludes_requester() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 
-		let peer = Origin::new(5).unwrap();
-		let publisher = Origin::new(1).unwrap();
+		let peer = Hop::new(5).unwrap();
+		let publisher = Hop::new(1).unwrap();
 		// The route through the peer is cheaper, so it is the active source.
-		let tainted = OriginList::try_from(vec![publisher, peer]).unwrap();
-		let clean = OriginList::try_from(vec![publisher]).unwrap();
+		let tainted = Hops::try_from(vec![publisher, peer]).unwrap();
+		let clean = Hops::try_from(vec![publisher]).unwrap();
 
 		let source_a = origin.create_broadcast("test", announce().with_hops(tainted)).unwrap();
 		let mut dynamic_a = source_a.dynamic();
@@ -6651,13 +6649,13 @@ mod tests {
 	async fn test_reader_taint_triggers_reselect() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 
-		let publisher = Origin::new(1).unwrap();
-		let peer = Origin::new(5).unwrap();
-		let via_peer = OriginList::try_from(vec![publisher, peer]).unwrap();
-		let clean = OriginList::try_from(vec![publisher]).unwrap();
+		let publisher = Hop::new(1).unwrap();
+		let peer = Hop::new(5).unwrap();
+		let via_peer = Hops::try_from(vec![publisher, peer]).unwrap();
+		let clean = Hops::try_from(vec![publisher]).unwrap();
 
 		// The via-peer route is cheaper, so it is the active source.
 		let _source_a = origin
@@ -6716,13 +6714,13 @@ mod tests {
 	async fn test_reader_taint_does_not_retract_the_announcement() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 
-		let publisher = Origin::new(1).unwrap();
-		let peer = Origin::new(5).unwrap();
-		let via_peer = OriginList::try_from(vec![publisher, peer]).unwrap();
-		let clean = OriginList::try_from(vec![publisher]).unwrap();
+		let publisher = Hop::new(1).unwrap();
+		let peer = Hop::new(5).unwrap();
+		let via_peer = Hops::try_from(vec![publisher, peer]).unwrap();
+		let clean = Hops::try_from(vec![publisher]).unwrap();
 
 		let source_a = origin
 			.create_broadcast("test", announce().with_hops(via_peer.clone()))
@@ -6771,12 +6769,12 @@ mod tests {
 	async fn test_unknown_publishers_do_not_splice() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
-		let unknown_a = OriginList::try_from(vec![Origin::UNKNOWN]).unwrap();
-		let unknown_b = OriginList::try_from(vec![Origin::UNKNOWN]).unwrap();
+		let unknown_a = Hops::try_from(vec![Hop::UNKNOWN]).unwrap();
+		let unknown_b = Hops::try_from(vec![Hop::UNKNOWN]).unwrap();
 
 		let mut source_a = origin
 			.create_broadcast("test", announce().with_hops(unknown_a.clone()))
@@ -6819,13 +6817,13 @@ mod tests {
 	async fn test_known_publishers_still_splice() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
-		let publisher = Origin::new(1).unwrap();
-		let hops_a = OriginList::try_from(vec![publisher]).unwrap();
-		let hops_b = OriginList::try_from(vec![publisher, Origin::new(3).unwrap()]).unwrap();
+		let publisher = Hop::new(1).unwrap();
+		let hops_a = Hops::try_from(vec![publisher]).unwrap();
+		let hops_b = Hops::try_from(vec![publisher, Hop::new(3).unwrap()]).unwrap();
 
 		let source_a = origin.create_broadcast("test", announce().with_hops(hops_a)).unwrap();
 		settle().await;
@@ -6851,13 +6849,13 @@ mod tests {
 	async fn test_standby_join_splices_live_subscriber() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 
-		let publisher = Origin::new(1).unwrap();
-		let peer = Origin::new(5).unwrap();
-		let via_peer = OriginList::try_from(vec![publisher, peer]).unwrap();
-		let local = OriginList::try_from(vec![publisher]).unwrap();
+		let publisher = Hop::new(1).unwrap();
+		let peer = Hop::new(5).unwrap();
+		let via_peer = Hops::try_from(vec![publisher, peer]).unwrap();
+		let local = Hops::try_from(vec![publisher]).unwrap();
 
 		// Carrying via the peer, with a live subscriber mid-stream.
 		let source_remote = origin
@@ -6898,13 +6896,13 @@ mod tests {
 	async fn test_standby_with_a_partial_track_list_splits_per_track() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 
-		let publisher = Origin::new(1).unwrap();
-		let peer = Origin::new(5).unwrap();
-		let via_peer = OriginList::try_from(vec![publisher, peer]).unwrap();
-		let local = OriginList::try_from(vec![publisher]).unwrap();
+		let publisher = Hop::new(1).unwrap();
+		let peer = Hop::new(5).unwrap();
+		let via_peer = Hops::try_from(vec![publisher, peer]).unwrap();
+		let local = Hops::try_from(vec![publisher]).unwrap();
 
 		// The incumbent carries both tracks, with live subscribers mid-stream.
 		let source_remote = origin
@@ -6979,13 +6977,13 @@ mod tests {
 	async fn test_standby_missing_track_keeps_incumbent() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 
-		let publisher = Origin::new(1).unwrap();
-		let peer = Origin::new(5).unwrap();
-		let via_peer = OriginList::try_from(vec![publisher, peer]).unwrap();
-		let local = OriginList::try_from(vec![publisher]).unwrap();
+		let publisher = Hop::new(1).unwrap();
+		let peer = Hop::new(5).unwrap();
+		let via_peer = Hops::try_from(vec![publisher, peer]).unwrap();
+		let local = Hops::try_from(vec![publisher]).unwrap();
 
 		// Carrying via the peer, with a live subscriber mid-stream.
 		let source_remote = origin
@@ -7042,7 +7040,7 @@ mod tests {
 	async fn test_unservable_track_retried_by_a_later_request() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 
 		let source = origin.create_broadcast("test", announce()).unwrap();
@@ -7076,10 +7074,10 @@ mod tests {
 	async fn test_track_dying_without_progress_aborts() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 
-		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let hops = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
 		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
 		let mut dynamic = source.dynamic();
 		settle().await;
@@ -7115,10 +7113,10 @@ mod tests {
 	async fn test_delivered_copy_death_survives_unrelated_wakes() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 
-		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let hops = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
 		let source = origin.create_broadcast("test", announce().with_hops(hops)).unwrap();
 		let mut dynamic = source.dynamic();
 		settle().await;
@@ -7160,13 +7158,13 @@ mod tests {
 	async fn test_per_track_fallback_respects_exclusion() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 
-		let publisher = Origin::new(1).unwrap();
-		let peer = Origin::new(5).unwrap();
-		let via_peer = OriginList::try_from(vec![publisher, peer]).unwrap();
-		let local = OriginList::try_from(vec![publisher]).unwrap();
+		let publisher = Hop::new(1).unwrap();
+		let peer = Hop::new(5).unwrap();
+		let via_peer = Hops::try_from(vec![publisher, peer]).unwrap();
+		let local = Hops::try_from(vec![publisher]).unwrap();
 
 		// The route through the peer has the track.
 		let source_tainted = origin
@@ -7203,13 +7201,13 @@ mod tests {
 	async fn test_exclusion_survives_failover_onto_a_tainted_route() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 
-		let publisher = Origin::new(1).unwrap();
-		let peer = Origin::new(5).unwrap();
-		let via_peer = OriginList::try_from(vec![publisher, peer]).unwrap();
-		let local = OriginList::try_from(vec![publisher]).unwrap();
+		let publisher = Hop::new(1).unwrap();
+		let peer = Hop::new(5).unwrap();
+		let via_peer = Hops::try_from(vec![publisher, peer]).unwrap();
+		let local = Hops::try_from(vec![publisher]).unwrap();
 
 		let source_tainted = origin
 			.create_broadcast("test", announce().with_hops(via_peer).with_cost(2))
@@ -7246,13 +7244,13 @@ mod tests {
 	async fn test_exclusion_holds_when_a_tainted_route_attaches_later() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 
-		let publisher = Origin::new(1).unwrap();
-		let peer = Origin::new(5).unwrap();
-		let local = OriginList::try_from(vec![publisher]).unwrap();
-		let via_peer = OriginList::try_from(vec![publisher, peer]).unwrap();
+		let publisher = Hop::new(1).unwrap();
+		let peer = Hop::new(5).unwrap();
+		let local = Hops::try_from(vec![publisher]).unwrap();
+		let via_peer = Hops::try_from(vec![publisher, peer]).unwrap();
 
 		// Only a clean route exists, so the peer legitimately gets the shared front.
 		// Priced above the route that arrives later, so the front genuinely prefers
@@ -7317,12 +7315,12 @@ mod tests {
 	async fn test_excluded_path_never_reaches_the_dynamic_handler() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 		let mut dynamic = origin.dynamic();
 
-		let peer = Origin::new(5).unwrap();
-		let tainted = OriginList::try_from(vec![Origin::new(1).unwrap(), peer]).unwrap();
+		let peer = Hop::new(5).unwrap();
+		let tainted = Hops::try_from(vec![Hop::new(1).unwrap(), peer]).unwrap();
 		let _source = origin.create_broadcast("test", announce().with_hops(tainted)).unwrap();
 		settle().await;
 		settle().await;
@@ -7352,7 +7350,7 @@ mod tests {
 	async fn test_dynamic_broadcast_named_by_the_requested_path() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let mut dynamic = origin.dynamic();
 
 		// A standalone broadcast, with no origin and no path of its own.
@@ -7391,7 +7389,7 @@ mod tests {
 	async fn test_rooted_cursor_names_broadcasts_relatively() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let _source = origin.create_broadcast("a/pub", announce()).unwrap();
 		settle().await;
 		settle().await;
@@ -7417,11 +7415,11 @@ mod tests {
 	async fn test_dispatch_all_tainted_unroutable() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 
-		let peer = Origin::new(5).unwrap();
-		let tainted = OriginList::try_from(vec![Origin::new(1).unwrap(), peer]).unwrap();
+		let peer = Hop::new(5).unwrap();
+		let tainted = Hops::try_from(vec![Hop::new(1).unwrap(), peer]).unwrap();
 		let _source = origin.create_broadcast("test", announce().with_hops(tainted)).unwrap();
 		settle().await;
 		settle().await;
@@ -7441,7 +7439,7 @@ mod tests {
 	async fn test_duplicate_reverse() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		let mut broadcast1 = origin.create_broadcast("test", announce()).unwrap();
 		let mut broadcast2 = origin.create_broadcast("test", announce()).unwrap();
@@ -7462,11 +7460,11 @@ mod tests {
 	async fn test_deterministic_tiebreak() {
 		tokio::time::pause();
 
-		fn hops(ids: &[u64]) -> OriginList {
-			OriginList::try_from(
+		fn hops(ids: &[u64]) -> Hops {
+			Hops::try_from(
 				ids.iter()
 					.copied()
-					.map(|id| Origin::new(id).unwrap())
+					.map(|id| Hop::new(id).unwrap())
 					.collect::<Vec<_>>(),
 			)
 			.unwrap()
@@ -7474,8 +7472,8 @@ mod tests {
 
 		// Resolve the advertised route for "test" after creating both sources in
 		// the given order.
-		async fn winner(first: &[u64], second: &[u64]) -> OriginList {
-			let origin = Origin::random().produce();
+		async fn winner(first: &[u64], second: &[u64]) -> Hops {
+			let origin = Hop::random().produce();
 			// Equal-cost forwarders: the ordering is what this test is about, so neither
 			// route is a warm sibling and the adoption hold-down never applies.
 			let _a = origin
@@ -7507,7 +7505,7 @@ mod tests {
 	// Names are zero-padded so lexicographic delivery order matches the loop index.
 	#[tokio::test]
 	async fn test_many_announces() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		let mut consumer = origin.consume().announced();
 		// Held for the duration: a dropped source unannounces immediately.
@@ -7525,7 +7523,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_many_announces_try() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		let mut consumer = origin.consume().announced();
 		// Held for the duration: a dropped source unannounces immediately.
@@ -7542,7 +7540,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_with_root_basic() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// Create a producer with root "/foo"
 		let foo_producer = origin.with_root("foo").expect("should create root");
@@ -7565,7 +7563,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_with_root_nested() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// Create nested roots
 		let foo_producer = origin.with_root("foo").expect("should create foo root");
@@ -7589,7 +7587,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_publish_scope_allows() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// Create a producer that can only publish to "allowed" paths
 		let limited_producer = origin
@@ -7616,7 +7614,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_publish_max_parts() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		let at_limit = (0..Path::MAX_PARTS)
 			.map(|i| i.to_string())
@@ -7637,7 +7635,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_publish_scope_empty() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// Creating a producer with no allowed paths should return None
 		assert!(origin.scope(&[]).is_none());
@@ -7645,7 +7643,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_consume_scope_filters() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		let mut consumer = origin.consume().announced();
 
@@ -7675,7 +7673,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_consume_scope_multiple_prefixes() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		let _broadcast1 = origin.create_broadcast("foo/test", announce()).unwrap();
 		let _broadcast2 = origin.create_broadcast("bar/test", announce()).unwrap();
@@ -7697,7 +7695,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_with_root_and_publish_scope() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// User connects to /foo root
 		let foo_producer = origin.with_root("foo").expect("should create foo root");
@@ -7738,7 +7736,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_with_root_and_consume_scope() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// Publish broadcasts
 		let _broadcast1 = origin.create_broadcast("foo/bar/test", announce()).unwrap();
@@ -7764,7 +7762,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_with_root_unauthorized() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// First limit the producer to specific paths
 		let limited_producer = origin
@@ -7783,7 +7781,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_wildcard_permission() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// Producer with root access (empty string means wildcard)
 		let root_producer = origin.clone();
@@ -7804,7 +7802,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_consume_broadcast_with_permissions() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		let _broadcast1 = origin.create_broadcast("allowed/test", announce()).unwrap();
 		let _broadcast2 = origin.create_broadcast("notallowed/test", announce()).unwrap();
@@ -7836,7 +7834,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_nested_paths_with_permissions() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// Create producer limited to "a/b/c"
 		let limited_producer = origin.scope(&["a/b/c".into()]).expect("should create limited producer");
@@ -7861,7 +7859,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_multiple_consumers_with_different_permissions() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// Publish to different paths
 		let _broadcast1 = origin.create_broadcast("foo/test", announce()).unwrap();
@@ -7902,7 +7900,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_select_with_empty_prefix() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// User with root "demo" allowed to subscribe to "worm-node" and "foobar"
 		let demo_producer = origin.with_root("demo").expect("should create demo root");
@@ -7938,7 +7936,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_select_narrowing_scope() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// User with root "demo" allowed to subscribe to "worm-node" and "foobar"
 		let demo_producer = origin.with_root("demo").expect("should create demo root");
@@ -7983,7 +7981,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_select_multiple_roots_with_empty_prefix() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// Producer with multiple allowed roots
 		let limited_producer = origin
@@ -8018,7 +8016,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_publish_scope_with_empty_prefix() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// Producer with specific allowed paths
 		let limited_producer = origin
@@ -8043,7 +8041,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_select_narrowing_to_deeper_path() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// Producer with broad permission
 		let limited_producer = origin.scope(&["org".into()]).expect("should create limited producer");
@@ -8084,7 +8082,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_select_with_non_matching_prefix() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// Producer with specific allowed paths
 		let limited_producer = origin
@@ -8102,7 +8100,7 @@ mod tests {
 	// with_root panics when String has trailing slash (AsPath for String skips normalization)
 	#[tokio::test]
 	async fn test_with_root_trailing_slash_consumer() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// Use an owned String so the trailing slash is NOT normalized away.
 		let prefix = "some_prefix/".to_string();
@@ -8116,7 +8114,7 @@ mod tests {
 	// Same issue but for the producer side of with_root
 	#[tokio::test]
 	async fn test_with_root_trailing_slash_producer() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// Use an owned String so the trailing slash is NOT normalized away.
 		let prefix = "some_prefix/".to_string();
@@ -8134,7 +8132,7 @@ mod tests {
 	async fn test_with_root_trailing_slash_unannounce() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		let prefix = "some_prefix/".to_string();
 		let mut consumer = origin.consume().with_root(prefix).unwrap().announced();
@@ -8153,7 +8151,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_select_maintains_access_with_wider_prefix() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// Setup: user with root "demo" allowed to subscribe to specific paths
 		let demo_producer = origin.with_root("demo").expect("should create demo root");
@@ -8199,7 +8197,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_duplicate_prefixes_deduped() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// scope with duplicate prefixes should work (deduped internally)
 		let producer = origin
@@ -8218,7 +8216,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_overlapping_prefixes_deduped() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// "demo" and "demo/foo". "demo/foo" is redundant, only "demo" should remain
 		let producer = origin
@@ -8238,7 +8236,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_overlapping_prefixes_no_duplicate_announcements() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		// Both "demo" and "demo/foo" are requested. Should only have one node
 		let producer = origin
@@ -8258,7 +8256,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_allowed_returns_deduped_prefixes() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		let producer = origin
 			.scope(&["demo".into(), "demo/foo".into(), "anon".into()])
@@ -8270,7 +8268,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_announced_broadcast_already_announced() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		let _broadcast = origin.create_broadcast("test", announce()).unwrap();
 		settle().await;
@@ -8284,7 +8282,7 @@ mod tests {
 	async fn test_announced_broadcast_delayed() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		let consumer = origin.consume();
 
@@ -8308,7 +8306,7 @@ mod tests {
 	async fn test_announced_broadcast_ignores_unrelated_paths() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		let consumer = origin.consume();
 
@@ -8335,7 +8333,7 @@ mod tests {
 	async fn test_announced_broadcast_skips_nested_paths() {
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		let consumer = origin.consume();
 
@@ -8360,7 +8358,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn test_announced_broadcast_disallowed() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let limited = origin
 			.consume()
 			.scope(&["allowed".into()])
@@ -8374,7 +8372,7 @@ mod tests {
 	async fn test_announced_broadcast_scope_too_narrow() {
 		// Consumer's scope is narrower than the requested path: asking for `foo` on a consumer
 		// limited to `foo/specific` can never resolve. Must return None, not loop forever.
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let limited = origin
 			.consume()
 			.scope(&["foo/specific".into()])
@@ -8396,7 +8394,7 @@ mod tests {
 		// announce + unannounce that the cursor hasn't observed yet collapses to nothing.
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let mut announced = origin.consume().announced();
 
 		let mut broadcast = origin.create_broadcast("test", announce()).unwrap();
@@ -8414,7 +8412,7 @@ mod tests {
 		// to a single Announce of the latest broadcast.
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let mut announced = origin.consume().announced();
 
 		let mut broadcast1 = origin.create_broadcast("test", announce()).unwrap();
@@ -8434,7 +8432,7 @@ mod tests {
 		// as two deliveries so the cursor learns the origin changed.
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let mut broadcast1 = origin.create_broadcast("test", announce()).unwrap();
 		settle().await;
 
@@ -8460,7 +8458,7 @@ mod tests {
 		// embedded announce was never observed.
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let mut broadcast1 = origin.create_broadcast("test", announce()).unwrap();
 		settle().await;
 
@@ -8487,7 +8485,7 @@ mod tests {
 		// require that churn doesn't accumulate across iterations.
 		tokio::time::pause();
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let mut announced = origin.consume().announced();
 
 		for _ in 0..1000 {
@@ -8517,7 +8515,7 @@ mod tests {
 	// still receives the active backlog.
 	#[tokio::test]
 	async fn test_consumer_clone_is_side_effect_free() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 
 		let _broadcast1 = origin.create_broadcast("test1", announce()).unwrap();
 		let _broadcast2 = origin.create_broadcast("test2", announce()).unwrap();
@@ -8558,7 +8556,7 @@ mod tests {
 	// With no Dynamic handler, an unannounced path resolves to Unroutable.
 	#[tokio::test]
 	async fn dynamic_request_unroutable_without_handler() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 		assert!(matches!(
 			consumer.request_broadcast("missing").await,
@@ -8570,7 +8568,7 @@ mod tests {
 	// never announced.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_served_not_announced() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -8607,7 +8605,7 @@ mod tests {
 	// Concurrent requests for the same queued path coalesce onto one handler request.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_coalesces() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -8634,7 +8632,7 @@ mod tests {
 	// instead of asking the handler again (no duplicate upstream subscription).
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_dedups_served() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -8659,7 +8657,7 @@ mod tests {
 	// Once a served broadcast closes, its cache entry is stale, so the next request re-serves.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_reserves_after_close() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -8685,7 +8683,7 @@ mod tests {
 	// unboundedly: the amortized GC on `accept` reclaims the stale entries left by closed ones.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_served_cache_bounded() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -8713,7 +8711,7 @@ mod tests {
 	// coalesces onto the in-flight request instead of queuing a duplicate.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_coalesces_after_handoff() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -8738,7 +8736,7 @@ mod tests {
 	// Dropping a handed-off request without accept/reject rejects every coalesced requester.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_dropped_after_handoff() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -8755,7 +8753,7 @@ mod tests {
 	// Rejecting a request resolves the requester with the error.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_rejected() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -8772,7 +8770,7 @@ mod tests {
 	// (a stale/clobbered entry would strand this request or panic the handler).
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_rerequest_after_reject() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -8793,7 +8791,7 @@ mod tests {
 	// resolving Unroutable.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_handler_dropped() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -8813,7 +8811,7 @@ mod tests {
 	// count to zero. The in-flight request must not be rejected as `Unroutable`.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_accept_after_handler_dropped() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -8832,7 +8830,7 @@ mod tests {
 	// A published broadcast wins over the dynamic fallback; no request is queued.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_request_prefers_announced() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let mut dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -8853,7 +8851,7 @@ mod tests {
 	// Cloning a handler and dropping the clone must not flip the count to zero.
 	#[tokio::test(start_paused = true)]
 	async fn dynamic_clone_keeps_alive() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let dynamic = origin.dynamic();
 		let consumer = origin.consume();
 
@@ -8894,7 +8892,7 @@ mod tests {
 
 		// Two hops beats one when the cheaper one is draining: the longer path is
 		// still the one that will still be there.
-		let hops = OriginList::try_from(vec![Origin::new(1).unwrap(), Origin::new(2).unwrap()]).unwrap();
+		let hops = Hops::try_from(vec![Hop::new(1).unwrap(), Hop::new(2).unwrap()]).unwrap();
 		let long = front(0, announce().with_hops(hops).with_cost(1));
 		assert!(route_order(&name, &draining) > route_order(&name, &long));
 	}
@@ -8904,7 +8902,7 @@ mod tests {
 	/// with nowhere else to go keeps being served by the draining route.
 	#[tokio::test(start_paused = true)]
 	async fn drain_migrates_best_route() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
@@ -8913,9 +8911,9 @@ mod tests {
 		// Two paths to the same content, so they share a first hop: a differing one
 		// would be a different publisher, and the front would park it as new content
 		// instead of attaching it as an alternate route.
-		let publisher = Origin::new(1).unwrap();
-		let hops_a = OriginList::try_from(vec![publisher, Origin::new(2).unwrap()]).unwrap();
-		let hops_b = OriginList::try_from(vec![publisher, Origin::new(3).unwrap()]).unwrap();
+		let publisher = Hop::new(1).unwrap();
+		let hops_a = Hops::try_from(vec![publisher, Hop::new(2).unwrap()]).unwrap();
+		let hops_b = Hops::try_from(vec![publisher, Hop::new(3).unwrap()]).unwrap();
 
 		// The source that will drain, and the pricier live fallback.
 		let source_a = origin.create_broadcast(&path, announce().with_hops(hops_a)).unwrap();
@@ -8960,12 +8958,12 @@ mod tests {
 	/// worth having.
 	#[tokio::test(start_paused = true)]
 	async fn drain_still_serves_when_it_is_the_only_route() {
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 		let mut announced = consumer.announced();
 
 		let path = PathOwned::from("lonely");
-		let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+		let hops = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
 		let source = origin.create_broadcast(&path, announce().with_hops(hops)).unwrap();
 		settle().await;
 		announced.assert_next_some("lonely");
@@ -9026,9 +9024,9 @@ mod tests {
 	#[test]
 	fn test_active_corpse_does_not_livelock_takeover() {
 		wedge_watchdog("active-corpse", 20, async {
-			let origin = Origin::random().produce();
+			let origin = Hop::random().produce();
 			let consumer = origin.consume();
-			let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+			let hops = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
 
 			// The healthy source: accepts the track and keeps the producer
 			// alive, so a later re-splice resolves synchronously from cache.
@@ -9097,7 +9095,7 @@ mod tests {
 			rng >> 33
 		};
 
-		let origin = Origin::random().produce();
+		let origin = Hop::random().produce();
 		let consumer = origin.consume();
 		let names: Vec<Arc<str>> = (0..8).map(|i| Arc::from(format!("t{i}"))).collect();
 
@@ -9118,7 +9116,7 @@ mod tests {
 					if sources.len() >= 3 {
 						continue;
 					}
-					let hops = OriginList::try_from(vec![Origin::new(1).unwrap()]).unwrap();
+					let hops = Hops::try_from(vec![Hop::new(1).unwrap()]).unwrap();
 					let route = announce().with_hops(hops).with_cost(next() % 4);
 					let Ok(source) = origin.create_broadcast("test", route) else {
 						continue;

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -27,7 +27,7 @@ use std::task::{Poll, ready};
 
 use crate::{Datagram, Error, Result, frame, group, track};
 
-use super::subscription::{Position, Subscription, min_some};
+use super::subscription::{Position, Subscription, max_some, min_some};
 
 /// One spliced source: a track bounded to a half-open range of positions.
 #[derive(Clone)]
@@ -76,29 +76,22 @@ impl Segment {
 /// preferences intersected with a segment's bounds.
 fn slice(prefs: &Subscription, start: Option<Position>, end: Option<Position>) -> Subscription {
 	// A segment's bounds and a subscription's are both half-open, so they intersect
-	// directly with no inclusive/exclusive conversion in between.
+	// directly with no inclusive/exclusive conversion in between. Both sides use the
+	// `_some` family: this is an intersection of two independent ranges, not an
+	// aggregate across subscribers, so an absent bound on either side is neutral rather
+	// than absorbing.
+	//
+	// For the start that means a takeover boundary becomes demand even for a live-edge
+	// subscriber, so the replacement resumes exactly where the dead route stopped and the
+	// splice loses nothing. The catch-up that buys is bounded by how far the boundary
+	// trails the replacement's live edge, which is failover max_age: a broadcast closes
+	// with its last source (there is no linger), so a takeover only happens between
+	// overlapping routes. A consumer that would rather skip even that much drops it
+	// downstream on its own max age budget, which is what `Duration::ZERO` means.
 	Subscription {
-		start: max_unbounded_start(prefs.start, start),
+		start: max_some(prefs.start, start),
 		end: min_some(prefs.end, end),
 		..prefs.clone()
-	}
-}
-
-/// The later of two optional start bounds, treating `None` as "the live edge" for the
-/// preference and "no lower bound" for the segment. Either way the other one wins.
-///
-/// A takeover boundary therefore becomes demand even for a live-edge subscriber, so the
-/// replacement resumes exactly where the dead route stopped and the splice loses nothing.
-/// The catch-up that buys is bounded by how far the boundary trails the replacement's live
-/// edge, which is failover max_age: a broadcast closes with its last source (there is no
-/// linger), so a takeover only happens between overlapping routes. A consumer that would
-/// rather skip even that much drops it downstream on its own max age budget, which is what
-/// [`std::time::Duration::ZERO`](std::time::Duration::ZERO) means.
-fn max_unbounded_start(prefs: Option<Position>, segment: Option<Position>) -> Option<Position> {
-	match (prefs, segment) {
-		(Some(a), Some(b)) => Some(a.max(b)),
-		(Some(a), None) | (None, Some(a)) => Some(a),
-		(None, None) => None,
 	}
 }
 

--- a/rs/moq-net/src/model/subscription.rs
+++ b/rs/moq-net/src/model/subscription.rs
@@ -223,7 +223,15 @@ impl Position {
 	}
 }
 
-/// The lower of two optional bounds, treating `None` as unbounded.
+// Combining two optional bounds comes in two families, and they disagree on what `None`
+// means. `_some` treats it as the neutral element (the other side wins), for intersecting
+// two ranges that each restrict independently. `_floored` / `_unbounded` treat it as
+// absorbing (the result is `None` too), for aggregating across subscribers, where one
+// subscriber asking for everything makes the aggregate everything. Picking the wrong
+// family silently narrows or widens what the publisher sends, so the suffix, not the
+// `min`/`max`, is the part to read.
+
+/// The lower of two optional bounds, `None` neutral. Pairs with [`max_some`].
 pub(super) fn min_some<T: Ord>(a: Option<T>, b: Option<T>) -> Option<T> {
 	match (a, b) {
 		(Some(a), Some(b)) => Some(a.min(b)),
@@ -232,9 +240,18 @@ pub(super) fn min_some<T: Ord>(a: Option<T>, b: Option<T>) -> Option<T> {
 	}
 }
 
-/// The lower of two optional floors, treating `None` as no floor (and therefore
-/// absorbing). The mirror of [`max_unbounded`]: both bounds only ever *restrict*, so a
-/// subscriber without one keeps the aggregate unrestricted.
+/// The higher of two optional bounds, `None` neutral. Pairs with [`min_some`].
+pub(super) fn max_some<T: Ord>(a: Option<T>, b: Option<T>) -> Option<T> {
+	match (a, b) {
+		(Some(a), Some(b)) => Some(a.max(b)),
+		(Some(a), None) | (None, Some(a)) => Some(a),
+		(None, None) => None,
+	}
+}
+
+/// The lower of two optional floors, `None` absorbing (no floor). The mirror of
+/// [`max_unbounded`]: both bounds only ever *restrict*, so a subscriber without one keeps
+/// the aggregate unrestricted.
 pub(super) fn min_floored<T: Ord>(a: Option<T>, b: Option<T>) -> Option<T> {
 	match (a, b) {
 		(Some(a), Some(b)) => Some(a.min(b)),
@@ -242,8 +259,7 @@ pub(super) fn min_floored<T: Ord>(a: Option<T>, b: Option<T>) -> Option<T> {
 	}
 }
 
-/// The higher of two optional bounds, treating `None` as unbounded (and therefore
-/// absorbing).
+/// The higher of two optional bounds, `None` absorbing (unbounded).
 pub(super) fn max_unbounded<T: Ord>(a: Option<T>, b: Option<T>) -> Option<T> {
 	match (a, b) {
 		(Some(a), Some(b)) => Some(a.max(b)),

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -100,7 +100,7 @@ impl Server {
 				role: None,
 				cost: None,
 				// Filled by `lite::start` from the attached origin handles.
-				origin: None,
+				hop: None,
 			}
 		} else {
 			lite::Setup::default()
@@ -171,7 +171,7 @@ impl Server {
 				(
 					client_setup.path.clone(),
 					client_setup.role,
-					client_setup.origin,
+					client_setup.hop,
 					Handshake::LiteSetup {
 						session,
 						version,
@@ -395,11 +395,7 @@ impl Server {
 			role: None,
 			// A moq-transport peer only has an identity if it negotiated the MoQ
 			// Cluster extension and declared a non-zero Hop ID.
-			origin: peer_setup
-				.declared
-				.cluster
-				.origin
-				.filter(|o| *o != crate::Hop::UNKNOWN),
+			origin: peer_setup.declared.cluster.origin.filter(|o| *o != crate::Hop::UNKNOWN),
 			assigned_hop: crate::Hop::random(),
 			inner: Some(RequestInner {
 				server: self.clone(),
@@ -947,7 +943,7 @@ mod tests {
 	}
 
 	/// Encode a lite-05 Setup Stream: the `DataType::Setup` tag then the SETUP message.
-	fn lite05_setup(path: Option<&str>, role: Option<Role>, origin: Option<Hop>) -> Vec<u8> {
+	fn lite05_setup(path: Option<&str>, role: Option<Role>, hop: Option<Hop>) -> Vec<u8> {
 		let v = lite::Version::Lite05;
 		let mut buf = Vec::new();
 		lite::DataType::Setup.encode(&mut buf, v).unwrap();
@@ -956,7 +952,7 @@ mod tests {
 			path: path.map(str::to_string),
 			role,
 			cost: None,
-			origin,
+			hop,
 		}
 		.encode(&mut buf, v)
 		.unwrap();

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -83,7 +83,7 @@ impl Server {
 		session: R::Transport,
 		version: lite::Version,
 		client_setup: Option<lite::Setup>,
-		peer_origin: Option<crate::Origin>,
+		peer_hop: Option<crate::Hop>,
 	) -> Result<Session, Error>
 	where
 		R: crate::runtime::Runtime + 'static,
@@ -112,7 +112,7 @@ impl Server {
 			setup_stream: None,
 			publish,
 			subscribe,
-			peer_origin,
+			peer_hop,
 			version,
 			our_setup,
 			peer_setup: client_setup,
@@ -214,7 +214,7 @@ impl Server {
 			path,
 			role,
 			origin,
-			assigned_origin: crate::Origin::random(),
+			assigned_hop: crate::Hop::random(),
 			inner: Some(RequestInner {
 				server: self.clone(),
 				runtime,
@@ -359,7 +359,7 @@ impl Server {
 			path,
 			role: None,
 			origin: None,
-			assigned_origin: crate::Origin::random(),
+			assigned_hop: crate::Hop::random(),
 			inner: Some(RequestInner {
 				server: self.clone(),
 				runtime,
@@ -399,8 +399,8 @@ impl Server {
 				.declared
 				.cluster
 				.origin
-				.filter(|o| *o != crate::Origin::UNKNOWN),
-			assigned_origin: crate::Origin::random(),
+				.filter(|o| *o != crate::Hop::UNKNOWN),
+			assigned_hop: crate::Hop::random(),
 			inner: Some(RequestInner {
 				server: self.clone(),
 				runtime,
@@ -424,11 +424,11 @@ impl Server {
 pub struct Request<S: crate::transport::poll::Session, R: crate::runtime::Runtime> {
 	path: Option<String>,
 	role: Option<Role>,
-	origin: Option<crate::Origin>,
+	origin: Option<crate::Hop>,
 	/// The identity this session's routes are stamped with when the peer declares none
 	/// on the wire. Fresh per request unless the caller overrides it
-	/// ([`Request::with_peer_origin`]).
-	assigned_origin: crate::Origin,
+	/// ([`Request::with_peer_hop`]).
+	assigned_hop: crate::Hop,
 	// Taken by `ok`/`close`; `Drop` rejects the handshake if neither ran.
 	inner: Option<RequestInner<S, R>>,
 }
@@ -474,7 +474,7 @@ trait Paused<R: crate::runtime::Runtime>: MaybeSend + MaybeSync {
 		self: Box<Self>,
 		server: Server,
 		runtime: R,
-		peer_origin: Option<crate::Origin>,
+		peer_hop: Option<crate::Hop>,
 	) -> crate::util::MaybeSendBox<'static, Result<Session, Error>>;
 
 	/// Reject the handshake, closing the transport with `err`'s wire code.
@@ -502,7 +502,7 @@ where
 		self: Box<Self>,
 		server: Server,
 		runtime: R,
-		peer_origin: Option<crate::Origin>,
+		peer_hop: Option<crate::Hop>,
 	) -> crate::util::MaybeSendBox<'static, Result<Session, Error>> {
 		use crate::util::MaybeBoxedExt as _;
 		async move {
@@ -523,7 +523,7 @@ where
 				client: false,
 				publish,
 				subscribe,
-				peer_origin,
+				peer_hop,
 				// Only the dialing side prices a link.
 				cost: None,
 				version,
@@ -574,7 +574,7 @@ where
 		self: Box<Self>,
 		server: Server,
 		runtime: R,
-		peer_origin: Option<crate::Origin>,
+		peer_hop: Option<crate::Hop>,
 	) -> crate::util::MaybeSendBox<'static, Result<Session, Error>> {
 		use crate::util::MaybeBoxedExt as _;
 		async move {
@@ -615,7 +615,7 @@ where
 						setup_stream: Some(stream),
 						publish,
 						subscribe,
-						peer_origin,
+						peer_hop,
 						version: v,
 						our_setup: lite::Setup::default(),
 						peer_setup: None,
@@ -637,7 +637,7 @@ where
 						client: false,
 						publish,
 						subscribe,
-						peer_origin,
+						peer_hop,
 						cost: None,
 						version: v,
 						path: None,
@@ -694,7 +694,7 @@ where
 	///
 	/// Self-declared, so treat it as a correlation hint rather than an
 	/// authenticated identity: authorize on the token or client certificate.
-	pub fn peer_origin(&self) -> Option<crate::Origin> {
+	pub fn peer_hop(&self) -> Option<crate::Hop> {
 		self.origin
 	}
 
@@ -715,7 +715,7 @@ where
 	/// per-session default.
 	///
 	/// Only for a peer whose identity the server has actually established, such as one
-	/// authenticated by mTLS or a token ([`crate::Client::with_peer_origin`] is the
+	/// authenticated by mTLS or a token ([`crate::Client::with_peer_hop`] is the
 	/// dialing-side equivalent). An identity the peer declares on the wire still wins.
 	///
 	/// Two sessions given the same origin are treated as one endpoint: routes learned
@@ -723,8 +723,8 @@ where
 	/// with the other's. That is the point when they really are one peer reconnecting or
 	/// running redundant links, and a bug otherwise. Derive it from the authenticated
 	/// identity, never from something coarser like the remote address.
-	pub fn with_peer_origin(mut self, origin: crate::Origin) -> Self {
-		self.assigned_origin = origin;
+	pub fn with_peer_hop(mut self, hop: crate::Hop) -> Self {
+		self.assigned_hop = hop;
 		self
 	}
 
@@ -744,7 +744,7 @@ where
 	/// The session's protocol machine is handed to the runtime given to
 	/// [`Server::accept_request`], so there is nothing else to drive.
 	pub async fn ok(mut self) -> Result<Session, Error> {
-		let peer_origin = Some(self.assigned_origin);
+		let peer_hop = Some(self.assigned_hop);
 		let RequestInner {
 			server,
 			runtime,
@@ -752,13 +752,13 @@ where
 		} = self.inner.take().expect("request already responded");
 
 		match handshake {
-			Handshake::LiteBare { session, version } => server.start_lite(runtime, session, version, None, peer_origin),
+			Handshake::LiteBare { session, version } => server.start_lite(runtime, session, version, None, peer_hop),
 			Handshake::LiteSetup {
 				session,
 				version,
 				client_setup,
-			} => server.start_lite(runtime, session, version, Some(client_setup), peer_origin),
-			Handshake::Boxed(paused) => paused.ok(server, runtime, peer_origin).await,
+			} => server.start_lite(runtime, session, version, Some(client_setup), peer_hop),
+			Handshake::Boxed(paused) => paused.ok(server, runtime, peer_hop).await,
 		}
 	}
 
@@ -794,7 +794,7 @@ impl<S: crate::transport::poll::Session, R: crate::runtime::Runtime> Drop for Re
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::Origin;
+	use crate::Hop;
 	use crate::model::ProduceTest;
 	use std::{
 		collections::VecDeque,
@@ -947,7 +947,7 @@ mod tests {
 	}
 
 	/// Encode a lite-05 Setup Stream: the `DataType::Setup` tag then the SETUP message.
-	fn lite05_setup(path: Option<&str>, role: Option<Role>, origin: Option<Origin>) -> Vec<u8> {
+	fn lite05_setup(path: Option<&str>, role: Option<Role>, origin: Option<Hop>) -> Vec<u8> {
 		let v = lite::Version::Lite05;
 		let mut buf = Vec::new();
 		lite::DataType::Setup.encode(&mut buf, v).unwrap();
@@ -1087,19 +1087,19 @@ mod tests {
 
 	#[tokio::test(start_paused = true)]
 	async fn accept_request_reads_lite05_peer_origin() {
-		let origin = Origin::new(42).unwrap();
+		let origin = Hop::new(42).unwrap();
 		let session = FakeSession::new(ALPN_LITE_05, [lite05_setup(None, None, Some(origin))]);
 		let request = Server::new()
 			.accept_request(crate::runtime::tokio_test::Tokio::new(), session)
 			.await
 			.unwrap();
-		assert_eq!(request.peer_origin(), Some(origin));
+		assert_eq!(request.peer_hop(), Some(origin));
 	}
 
 	#[tokio::test(start_paused = true)]
 	async fn anonymous_peer_origin_filters_routes_from_server_session() {
-		let other = Origin::new(778).unwrap();
-		let origin = crate::origin::Info::new(Origin::new(1).unwrap()).produce();
+		let other = Hop::new(778).unwrap();
+		let origin = crate::origin::Info::new(Hop::new(1).unwrap()).produce();
 
 		let gate = kio::Producer::new(true);
 		let transport = crate::lite::test_transport::SinkSession::gated_bi(gate.consume());
@@ -1109,7 +1109,7 @@ mod tests {
 			path: None,
 			role: None,
 			origin: None,
-			assigned_origin: Origin::random(),
+			assigned_hop: Hop::random(),
 			inner: Some(RequestInner {
 				server: Server::new().with_publisher(&origin),
 				runtime: crate::runtime::tokio_test::Tokio::new(),
@@ -1127,9 +1127,9 @@ mod tests {
 				})),
 			}),
 		};
-		let assigned = request.assigned_origin;
+		let assigned = request.assigned_hop;
 
-		let mut echoed_hops = crate::OriginList::new();
+		let mut echoed_hops = crate::Hops::new();
 		echoed_hops.push(assigned).unwrap();
 		let _echoed = origin
 			.create_broadcast(
@@ -1140,7 +1140,7 @@ mod tests {
 			)
 			.unwrap();
 
-		let mut local_hops = crate::OriginList::new();
+		let mut local_hops = crate::Hops::new();
 		local_hops.push(other).unwrap();
 		let _local = origin
 			.create_broadcast(

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -395,7 +395,7 @@ impl Server {
 			role: None,
 			// A moq-transport peer only has an identity if it negotiated the MoQ
 			// Cluster extension and declared a non-zero Hop ID.
-			origin: peer_setup.declared.cluster.origin.filter(|o| *o != crate::Hop::UNKNOWN),
+			origin: peer_setup.declared.cluster.hop.filter(|h| *h != crate::Hop::UNKNOWN),
 			assigned_hop: crate::Hop::random(),
 			inner: Some(RequestInner {
 				server: self.clone(),

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -682,7 +682,7 @@ where
 		self.role
 	}
 
-	/// The origin identity declared by the peer, when the negotiated protocol carries one.
+	/// The Hop ID declared by the peer, when the negotiated protocol carries one.
 	///
 	/// A moq-lite-05+ endpoint declares this when it attaches a publish or subscribe
 	/// origin; a `moqt-17`+ endpoint declares it via the MoQ Cluster extension. Older

--- a/rs/moq-net/tests/goaway.rs
+++ b/rs/moq-net/tests/goaway.rs
@@ -8,12 +8,12 @@ mod support;
 
 use std::time::Duration;
 
-use moq_net::{Origin, Version, goaway::Goaway};
+use moq_net::{Hop, Version, goaway::Goaway};
 use support::harness::{MockConnectOptions, MockPair, connect_mock};
 use support::mock::create_mock_session_pair;
 
 /// Build an origin producer, spawning its driver on the ambient runtime.
-fn produce_origin(origin: Origin) -> moq_net::origin::Producer {
+fn produce_origin(origin: Hop) -> moq_net::origin::Producer {
 	let (producer, driver) = moq_net::origin::Producer::new(moq_net::origin::Info::new(origin));
 	tokio::spawn(driver.run(support::harness::TokioRuntime::<()>::new()));
 	producer
@@ -317,7 +317,7 @@ async fn goaway_gates_new_subscribes_moq_lite_04() {
 		let version: Version = "moq-lite-04".parse().unwrap();
 
 		// Server publishes a broadcast with one live track.
-		let pub_origin = produce_origin(Origin::random());
+		let pub_origin = produce_origin(Hop::random());
 		let mut broadcast = pub_origin
 			.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("create broadcast");
@@ -332,7 +332,7 @@ async fn goaway_gates_new_subscribes_moq_lite_04() {
 		audio_group.finish().expect("finish group");
 
 		// Client consumes into its own origin.
-		let sub_origin = produce_origin(Origin::random());
+		let sub_origin = produce_origin(Hop::random());
 
 		let mut opts = MockConnectOptions::new(version);
 		opts.server_publish = Some(pub_origin.clone());
@@ -417,12 +417,12 @@ async fn goaway_gates_new_subscribes_moq_lite_04() {
 /// draining peer has no reason to send.
 async fn goaway_drains_routes(version: Version) {
 	tokio::time::timeout(TEST_TIMEOUT, async {
-		let pub_origin = produce_origin(Origin::random());
+		let pub_origin = produce_origin(Hop::random());
 		let _broadcast = pub_origin
 			.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("create broadcast");
 
-		let sub_origin = produce_origin(Origin::random());
+		let sub_origin = produce_origin(Hop::random());
 
 		let mut opts = MockConnectOptions::new(version);
 		opts.server_publish = Some(pub_origin.clone());

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -2097,7 +2097,7 @@ mod tests {
 		assert!(msg.contains("--cluster-mesh"), "missing --cluster-mesh in: {msg}");
 	}
 
-	/// A valid `cluster.id` is used verbatim as the relay's origin id, giving the
+	/// A valid `cluster.id` is used verbatim as the relay's Hop ID, giving the
 	/// node a stable identity across restarts.
 	#[tokio::test]
 	async fn cluster_id_sets_origin() {

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -10,7 +10,7 @@ use std::{
 
 use anyhow::Context;
 use moq_net::origin;
-use moq_net::{Origin, Path, stats::Tier};
+use moq_net::{Hop, Path, stats::Tier};
 use reqwest_middleware::ClientWithMiddleware;
 use tokio::task::AbortHandle;
 use tracing::Instrument as _;
@@ -664,8 +664,8 @@ impl Cluster {
 			Some(id) if id >= 1 << 62 => {
 				anyhow::bail!("--cluster-id must be below 2^62 (wire varint limit), got {id}")
 			}
-			Some(id) => Origin::new(id).expect("cluster id already validated"),
-			None => Origin::random(),
+			Some(id) => Hop::new(id).expect("cluster id already validated"),
+			None => Hop::random(),
 		};
 		#[allow(deprecated)]
 		if config.linger.is_some() {

--- a/rs/moq-relay/src/connection.rs
+++ b/rs/moq-relay/src/connection.rs
@@ -69,7 +69,7 @@ impl Connection {
 	/// Authenticates and serves this connection until it closes.
 	#[tracing::instrument("conn", skip_all, fields(id = self.id))]
 	pub async fn run(self) -> anyhow::Result<()> {
-		let peer_origin = self.request.peer_origin();
+		let peer_hop = self.request.peer_hop();
 		let token = match self.authenticate().await {
 			Ok(token) => token,
 			Err(err) => {
@@ -103,7 +103,7 @@ impl Connection {
 			request = request.with_subscriber(publish);
 		}
 		let session = request.ok().await?;
-		let _node_connection = peer_origin.map(|origin| self.cluster.nodes.connect_inbound(self.id, origin));
+		let _node_connection = peer_hop.map(|origin| self.cluster.nodes.connect_inbound(self.id, origin));
 
 		tracing::info!(version = %session.version(), %transport, "negotiated");
 

--- a/rs/moq-relay/src/internal.rs
+++ b/rs/moq-relay/src/internal.rs
@@ -210,9 +210,9 @@ async fn serve_metrics(State(state): State<InternalState>) -> Response {
 
 /// Cluster nodes currently visible through gossip or a direct outbound dial.
 ///
-/// Inbound connections appear only after their SETUP origin identity resolves
-/// to a unique `.internal/origins` node advertisement. Sessions without a
-/// unique match are omitted.
+/// Inbound connections appear only after their SETUP Hop ID resolves to a
+/// unique `.internal/origins` node advertisement. Sessions without a unique
+/// match are omitted.
 async fn serve_nodes(State(state): State<InternalState>) -> Json<crate::nodes::Snapshot> {
 	Json(state.nodes.map(|nodes| nodes.snapshot()).unwrap_or_default())
 }

--- a/rs/moq-relay/src/internal.rs
+++ b/rs/moq-relay/src/internal.rs
@@ -558,7 +558,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn nodes_endpoint_uses_the_attached_cluster_registry() {
-		let origin = moq_tokio::origin::spawn(moq_net::Origin::new(100).unwrap());
+		let origin = moq_tokio::origin::spawn(moq_net::Hop::new(100).unwrap());
 		let nodes = crate::nodes::Nodes::new(origin);
 		let _connection = nodes.connect_outbound(0, "https://relay-b.example/");
 		let state = InternalState {
@@ -577,14 +577,14 @@ mod tests {
 	#[tokio::test(start_paused = true)]
 	async fn metrics_render_exposition() {
 		use moq_net::stats::{Registry, Tier};
-		use moq_net::{Origin, Timestamp, broadcast};
+		use moq_net::{Hop, Timestamp, broadcast};
 
 		let stats = Registry::new(Default::default());
 
 		// Default-tier egress: an untagged local publisher writes, a tagged egress
 		// consumer reads it out, so publisher `bytes` advance on the default tier.
 		let default_ctx = stats.tier(Tier::default()).session("acme");
-		let pub_origin = moq_tokio::origin::spawn(Origin::random());
+		let pub_origin = moq_tokio::origin::spawn(Hop::random());
 		let egress = pub_origin.consume().with_stats(default_ctx.clone());
 		let mut announced = egress.announced();
 		let mut pub_source = pub_origin
@@ -595,7 +595,7 @@ mod tests {
 		// Named-tier ingress: a tagged ingress producer writes, so subscriber
 		// `bytes` advance on the regional tier.
 		let regional_ctx = stats.tier(Tier::new("region/sjc")).session("peer");
-		let sub_origin = moq_tokio::origin::spawn(Origin::random()).with_stats(regional_ctx.clone());
+		let sub_origin = moq_tokio::origin::spawn(Hop::random()).with_stats(regional_ctx.clone());
 		let mut sub_source = sub_origin
 			.create_broadcast("demo/x", broadcast::Route::announced())
 			.unwrap();

--- a/rs/moq-relay/src/nodes.rs
+++ b/rs/moq-relay/src/nodes.rs
@@ -51,9 +51,8 @@ pub(crate) struct Snapshot {
 pub(crate) struct Node {
 	/// Canonical URL advertised for the node.
 	pub node: String,
-	/// The node's [`Hop`](moq_net::Hop) id from its announcement, when available. Named
-	/// for the wire's `Origin` SETUP parameter, which is what this reports.
-	pub origin_id: Option<String>,
+	/// The node's [`Hop`](moq_net::Hop) id from its announcement, when available.
+	pub hop_id: Option<String>,
 	/// Selected route for the node's internal advertisement.
 	pub announced: Option<Announcement>,
 	/// Established direct connections to this node.
@@ -96,7 +95,7 @@ pub(crate) enum Direction {
 }
 
 struct NodeBuilder {
-	origin_id: Option<String>,
+	hop_id: Option<String>,
 	announced: Option<Announcement>,
 	connections: Vec<Connection>,
 }
@@ -107,7 +106,7 @@ struct Announced {
 	nodes: BTreeMap<String, NodeBuilder>,
 	/// Hop id to the single node advertising it, or `None` once more than one
 	/// does and the id no longer identifies a peer.
-	origins: HashMap<u64, Option<String>>,
+	hops: HashMap<u64, Option<String>>,
 }
 
 /// Removes a live connection from the topology view when its session ends.
@@ -177,13 +176,13 @@ impl Nodes {
 
 			let key = canonical_announced_node(update.path.as_str());
 			let route = broadcast.route();
-			let hop_ids = route.hops.iter().map(|origin| origin.id()).collect::<Vec<_>>();
+			let hop_ids = route.hops.iter().map(|hop| hop.id()).collect::<Vec<_>>();
 			// An advertisement with no hops never crossed a link, so it is our own.
-			let origin_id = hop_ids.first().copied().unwrap_or_else(|| self.origin.id());
+			let hop_id = hop_ids.first().copied().unwrap_or_else(|| self.origin.id());
 
 			scanned
-				.origins
-				.entry(origin_id)
+				.hops
+				.entry(hop_id)
 				.and_modify(|current| {
 					if current.as_deref() != Some(&key) {
 						*current = None;
@@ -194,10 +193,10 @@ impl Nodes {
 			scanned.nodes.insert(
 				key,
 				NodeBuilder {
-					origin_id: Some(origin_id.to_string()),
+					hop_id: Some(hop_id.to_string()),
 					announced: Some(Announcement {
 						hop_count: hop_ids.len(),
-						hops: hop_ids.into_iter().map(|origin| origin.to_string()).collect(),
+						hops: hop_ids.into_iter().map(|hop| hop.to_string()).collect(),
 						cost: route.cost.warm,
 						cold_cost: route.cost.cold,
 					}),
@@ -210,7 +209,7 @@ impl Nodes {
 	}
 
 	pub(crate) fn snapshot(&self) -> Snapshot {
-		let Announced { mut nodes, origins } = self.announced();
+		let Announced { mut nodes, hops } = self.announced();
 
 		let connections = self
 			.connections
@@ -222,15 +221,15 @@ impl Nodes {
 		for (&id, connection) in connections {
 			let key = match &connection.target {
 				ConnectionTarget::Node(node) => canonical_node(node),
-				ConnectionTarget::Hop(origin) => {
-					let Some(Some(node)) = origins.get(&origin.id()) else {
+				ConnectionTarget::Hop(hop) => {
+					let Some(Some(node)) = hops.get(&hop.id()) else {
 						continue;
 					};
 					node.clone()
 				}
 			};
 			let node = nodes.entry(key).or_insert_with(|| NodeBuilder {
-				origin_id: None,
+				hop_id: None,
 				announced: None,
 				connections: Vec::new(),
 			});
@@ -245,7 +244,7 @@ impl Nodes {
 				.into_iter()
 				.map(|(key, node)| Node {
 					node: key,
-					origin_id: node.origin_id,
+					hop_id: node.hop_id,
 					announced: node.announced,
 					connections: node.connections,
 				})
@@ -316,7 +315,7 @@ mod tests {
 		assert_eq!(snapshot.nodes.len(), 1);
 		let node = &snapshot.nodes[0];
 		assert_eq!(node.node, "https://relay-b.example/");
-		assert_eq!(node.origin_id.as_deref(), Some("9007199254740993"));
+		assert_eq!(node.hop_id.as_deref(), Some("9007199254740993"));
 		assert_eq!(node.announced.as_ref().unwrap().hops, vec!["9007199254740993"]);
 		assert_eq!(node.announced.as_ref().unwrap().hop_count, 1);
 		assert_eq!(node.announced.as_ref().unwrap().cost, 7);
@@ -329,7 +328,7 @@ mod tests {
 			serde_json::json!({
 				"nodes": [{
 					"node": "https://relay-b.example/",
-					"origin_id": "9007199254740993",
+					"hop_id": "9007199254740993",
 					"announced": { "hops": ["9007199254740993"], "hop_count": 1, "cost": 7, "cold_cost": 7 },
 					"connections": [
 						{ "id": 0, "direction": "outbound" },
@@ -403,7 +402,7 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn duplicate_origin_ids_do_not_resolve_inbound_connections() {
+	async fn duplicate_hop_ids_do_not_resolve_inbound_connections() {
 		let origin = moq_tokio::origin::spawn(Hop::new(100).unwrap());
 		let nodes = Nodes::new(origin.clone());
 		let _first = announced_node(&origin, "https://relay-b.example/", &[200], 1).await;

--- a/rs/moq-relay/src/nodes.rs
+++ b/rs/moq-relay/src/nodes.rs
@@ -9,7 +9,7 @@ use std::{
 	sync::{Arc, Mutex},
 };
 
-use moq_net::{Origin, origin};
+use moq_net::{Hop, origin};
 use serde::Serialize;
 
 /// Namespace containing the empty broadcasts used to advertise cluster nodes.
@@ -36,7 +36,7 @@ struct ConnectionRecord {
 #[derive(Clone)]
 enum ConnectionTarget {
 	Node(String),
-	Origin(Origin),
+	Hop(Hop),
 }
 
 /// The JSON document returned by the internal `/nodes` endpoint.
@@ -51,7 +51,8 @@ pub(crate) struct Snapshot {
 pub(crate) struct Node {
 	/// Canonical URL advertised for the node.
 	pub node: String,
-	/// Origin identity from the node's announcement, when available.
+	/// The node's [`Hop`](moq_net::Hop) id from its announcement, when available. Named
+	/// for the wire's `Origin` SETUP parameter, which is what this reports.
 	pub origin_id: Option<String>,
 	/// Selected route for the node's internal advertisement.
 	pub announced: Option<Announcement>,
@@ -62,7 +63,7 @@ pub(crate) struct Node {
 /// The selected route for a node advertisement.
 #[derive(Debug, Serialize)]
 pub(crate) struct Announcement {
-	/// Origin identities in traversal order, oldest first.
+	/// Hop ids in traversal order, oldest first.
 	pub hops: Vec<String>,
 	/// Number of hops in the selected route.
 	pub hop_count: usize,
@@ -104,7 +105,7 @@ struct NodeBuilder {
 #[derive(Default)]
 struct Announced {
 	nodes: BTreeMap<String, NodeBuilder>,
-	/// Origin id to the single node advertising it, or `None` once more than one
+	/// Hop id to the single node advertising it, or `None` once more than one
 	/// does and the id no longer identifies a peer.
 	origins: HashMap<u64, Option<String>>,
 }
@@ -140,8 +141,8 @@ impl Nodes {
 	///
 	/// `id` is the session's `conn` id from
 	/// [`Cluster::next_connection_id`](crate::Cluster::next_connection_id).
-	pub(crate) fn connect_inbound(&self, id: u64, origin: Origin) -> ConnectionGuard {
-		self.connect(id, Direction::Inbound, ConnectionTarget::Origin(origin))
+	pub(crate) fn connect_inbound(&self, id: u64, origin: Hop) -> ConnectionGuard {
+		self.connect(id, Direction::Inbound, ConnectionTarget::Hop(origin))
 	}
 
 	fn connect(&self, id: u64, direction: Direction, target: ConnectionTarget) -> ConnectionGuard {
@@ -221,7 +222,7 @@ impl Nodes {
 		for (&id, connection) in connections {
 			let key = match &connection.target {
 				ConnectionTarget::Node(node) => canonical_node(node),
-				ConnectionTarget::Origin(origin) => {
+				ConnectionTarget::Hop(origin) => {
 					let Some(Some(node)) = origins.get(&origin.id()) else {
 						continue;
 					};
@@ -275,7 +276,7 @@ fn canonical_announced_node(node: &str) -> String {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use moq_net::{Origin, OriginList, broadcast};
+	use moq_net::{Hop, Hops, broadcast};
 
 	async fn announced_node(
 		origin: &moq_net::origin::Producer,
@@ -283,9 +284,9 @@ mod tests {
 		hops: &[u64],
 		cost: u64,
 	) -> broadcast::Producer {
-		let hops = OriginList::try_from(
+		let hops = Hops::try_from(
 			hops.iter()
-				.map(|id| Origin::new(*id).expect("valid test origin"))
+				.map(|id| Hop::new(*id).expect("valid test origin"))
 				.collect::<Vec<_>>(),
 		)
 		.unwrap();
@@ -305,11 +306,11 @@ mod tests {
 	async fn snapshot_combines_announcements_and_live_connections() {
 		const REMOTE_ID: u64 = 9_007_199_254_740_993;
 
-		let origin = moq_tokio::origin::spawn(Origin::new(100).unwrap());
+		let origin = moq_tokio::origin::spawn(Hop::new(100).unwrap());
 		let nodes = Nodes::new(origin.clone());
 		let _remote = announced_node(&origin, "https://relay-b.example/", &[REMOTE_ID], 7).await;
 		let _outbound = nodes.connect_outbound(0, "https://relay-b.example/");
-		let _inbound = nodes.connect_inbound(1, Origin::new(REMOTE_ID).unwrap());
+		let _inbound = nodes.connect_inbound(1, Hop::new(REMOTE_ID).unwrap());
 
 		let snapshot = nodes.snapshot();
 		assert_eq!(snapshot.nodes.len(), 1);
@@ -341,16 +342,16 @@ mod tests {
 
 	#[tokio::test]
 	async fn snapshot_omits_unresolved_inbound_connections() {
-		let origin = moq_tokio::origin::spawn(Origin::new(100).unwrap());
+		let origin = moq_tokio::origin::spawn(Hop::new(100).unwrap());
 		let nodes = Nodes::new(origin);
-		let _inbound = nodes.connect_inbound(0, Origin::new(200).unwrap());
+		let _inbound = nodes.connect_inbound(0, Hop::new(200).unwrap());
 
 		assert!(nodes.snapshot().nodes.is_empty());
 	}
 
 	#[tokio::test]
 	async fn snapshot_stops_reporting_closed_outbound_connections() {
-		let origin = moq_tokio::origin::spawn(Origin::new(100).unwrap());
+		let origin = moq_tokio::origin::spawn(Hop::new(100).unwrap());
 		let nodes = Nodes::new(origin);
 		let connection = nodes.connect_outbound(0, "https://relay-b.example/");
 		assert_eq!(nodes.snapshot().nodes.len(), 1);
@@ -361,7 +362,7 @@ mod tests {
 
 	#[tokio::test]
 	async fn outbound_node_omits_credentials_from_url() {
-		let origin = moq_tokio::origin::spawn(Origin::new(100).unwrap());
+		let origin = moq_tokio::origin::spawn(Hop::new(100).unwrap());
 		let nodes = Nodes::new(origin);
 		let _connection = nodes.connect_outbound(0, "https://relay-b.example/?jwt=secret");
 
@@ -374,7 +375,7 @@ mod tests {
 	/// churned mid-request.
 	#[tokio::test(start_paused = true)]
 	async fn scan_skips_an_unannounce_queued_ahead_of_another_node() {
-		let origin = moq_tokio::origin::spawn(Origin::new(100).unwrap());
+		let origin = moq_tokio::origin::spawn(Hop::new(100).unwrap());
 		let nodes = Nodes::new(origin.clone());
 		let mut first = announced_node(&origin, "https://relay-a.example/", &[200], 1).await;
 		let _second = announced_node(&origin, "https://relay-b.example/", &[300], 1).await;
@@ -403,11 +404,11 @@ mod tests {
 
 	#[tokio::test]
 	async fn duplicate_origin_ids_do_not_resolve_inbound_connections() {
-		let origin = moq_tokio::origin::spawn(Origin::new(100).unwrap());
+		let origin = moq_tokio::origin::spawn(Hop::new(100).unwrap());
 		let nodes = Nodes::new(origin.clone());
 		let _first = announced_node(&origin, "https://relay-b.example/", &[200], 1).await;
 		let _second = announced_node(&origin, "https://relay-c.example/", &[200], 1).await;
-		let _inbound = nodes.connect_inbound(0, Origin::new(200).unwrap());
+		let _inbound = nodes.connect_inbound(0, Hop::new(200).unwrap());
 
 		let snapshot = nodes.snapshot();
 		assert_eq!(snapshot.nodes.len(), 2);

--- a/rs/moq-relay/src/uring.rs
+++ b/rs/moq-relay/src/uring.rs
@@ -680,7 +680,7 @@ async fn serve_connection(
 		}
 	};
 
-	let peer_origin = request.peer_origin();
+	let peer_hop = request.peer_hop();
 	let mut request = request.with_stats(grants.stats);
 	if let Some(subscribe) = grants.subscribe {
 		request = request.with_publisher(&subscribe);
@@ -689,7 +689,7 @@ async fn serve_connection(
 		request = request.with_subscriber(publish);
 	}
 	let session = request.ok().await?;
-	let node_connection = peer_origin.map(|origin| serve.cluster.nodes.connect_inbound(id, origin));
+	let node_connection = peer_hop.map(|origin| serve.cluster.nodes.connect_inbound(id, origin));
 
 	tracing::info!(id, version = %session.version(), transport = %moq_tokio::Transport::Quic, "negotiated");
 

--- a/rs/moq-relay/tests/auth_lifetime.rs
+++ b/rs/moq-relay/tests/auth_lifetime.rs
@@ -9,7 +9,7 @@ use std::{net::TcpListener, time::Duration};
 
 use moq_relay::{AuthConfig, Cluster, ClusterConfig, Connection, Web, WebConfig};
 use moq_token::{Algorithm, Key, KeyId};
-use moq_tokio::moq_net::{self, Origin};
+use moq_tokio::moq_net::{self, Hop};
 use wiremock::matchers::{method, path as path_matcher, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
@@ -175,7 +175,7 @@ fn room_url(scheme: &str, port: u16, key: &Key, claims: &moq_token::Claims) -> u
 /// Connect a publisher and a subscriber to `url` and prove one frame
 /// round-trips. Returns both sessions so the caller can watch them close.
 async fn connect_and_round_trip(url: &url::Url) -> (moq_tokio::Connection, moq_tokio::Connection) {
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -198,7 +198,7 @@ async fn connect_and_round_trip(url: &url::Url) -> (moq_tokio::Connection, moq_t
 	.expect("publisher connect timeout")
 	.expect("publisher connect failed");
 
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 	let sub_session = tokio::time::timeout(
 		TIMEOUT,

--- a/rs/moq-relay/tests/cluster_unknown.rs
+++ b/rs/moq-relay/tests/cluster_unknown.rs
@@ -1,10 +1,10 @@
 //! Regression for an external publisher whose protocol does not declare a Hop ID.
-//! The relay records that publisher as `Origin::UNKNOWN`; reflected cluster paths
+//! The relay records that publisher as `Hop::UNKNOWN`; reflected cluster paths
 //! must not replace it while gossiping around a redundant mesh.
 
 use std::{net::TcpListener, time::Duration};
 
-use moq_net::Origin;
+use moq_net::Hop;
 use moq_relay::{Config, PublicConfig, Relay};
 use url::Url;
 
@@ -82,7 +82,7 @@ impl Drop for Publisher {
 
 async fn publish_version(port: u16, version: &str) -> Publisher {
 	let url: Url = format!("tcp://127.0.0.1:{port}").parse().expect("parse url");
-	let origin = moq_tokio::origin::spawn(Origin::random());
+	let origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = origin
 		.create_broadcast(PATH, moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -133,7 +133,7 @@ async fn publish_unknown(port: u16) -> Publisher {
 /// broke rather than just "no frame".
 async fn read_first_frame(port: u16) -> Result<Vec<u8>, String> {
 	let url: Url = format!("tcp://127.0.0.1:{port}").parse().expect("parse url");
-	let origin = moq_tokio::origin::spawn(Origin::random());
+	let origin = moq_tokio::origin::spawn(Hop::random());
 	let consumer = origin.consume();
 	let session = tokio::time::timeout(TIMEOUT, client(None).with_subscriber(origin).connect(url).established())
 		.await
@@ -179,7 +179,7 @@ async fn read_first_frame(port: u16) -> Result<Vec<u8>, String> {
 
 async fn watch_announces(port: u16, window: Duration) -> Vec<(String, bool)> {
 	let url: Url = format!("tcp://127.0.0.1:{port}").parse().expect("parse url");
-	let origin = moq_tokio::origin::spawn(Origin::random());
+	let origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announced = origin.consume().announced();
 	let _session = tokio::time::timeout(TIMEOUT, client(None).with_subscriber(origin).connect(url).established())
 		.await

--- a/rs/moq-relay/tests/goaway_cluster.rs
+++ b/rs/moq-relay/tests/goaway_cluster.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeSet;
 use std::net::TcpListener;
 use std::time::Duration;
 
-use moq_net::Origin;
+use moq_net::Hop;
 use moq_relay::{AuthConfig, Cluster, ClusterConfig, Connection, PublicConfig};
 use url::Url;
 
@@ -95,7 +95,7 @@ fn drain_session_with_zero_timeout_closes_at_once() {
 async fn drain_session_with_zero_timeout_closes_at_once_inner() {
 	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
-	let origin = moq_tokio::origin::spawn(Origin::random());
+	let origin = moq_tokio::origin::spawn(Hop::random());
 	let (port, mut accepted, _handle) = spawn_upstream(origin);
 	wait_listening(port).await;
 
@@ -145,7 +145,7 @@ fn spawn_upstream(
 		let mut server = server.listen().await.expect("listen");
 		while let Some(request) = server.accept().await {
 			// Serve the shared origin bidirectionally, like a relay peer would.
-			let scratch = moq_tokio::origin::spawn(Origin::random());
+			let scratch = moq_tokio::origin::spawn(Hop::random());
 			let session = match request.with_publisher(&origin).with_subscriber(scratch).ok().await {
 				Ok(session) => session,
 				Err(err) => {
@@ -182,7 +182,7 @@ async fn cluster_migrates_on_upstream_goaway_inner() {
 
 	tokio::time::timeout(TEST_TIMEOUT, async {
 		// ── the shared "live" broadcast both siblings can serve ─────────
-		let upstream_origin = moq_tokio::origin::spawn(Origin::random());
+		let upstream_origin = moq_tokio::origin::spawn(Hop::random());
 		let mut broadcast = upstream_origin
 			.create_broadcast("cam", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("create broadcast");
@@ -369,7 +369,7 @@ async fn cluster_diamond_goaway_seamless_failover_inner() {
 	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
 	// ── TOP: origin server serving the same broadcast to both mids ──────
-	let top_origin = moq_tokio::origin::spawn(Origin::random());
+	let top_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = top_origin
 		.create_broadcast("diamond", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -388,7 +388,7 @@ async fn cluster_diamond_goaway_seamless_failover_inner() {
 		.expect("TOP accept channel closed");
 
 	// ── MID-A: mini-relay consuming TOP, serving BOTTOM, drains later ───
-	let mid_a_origin = moq_tokio::origin::spawn(Origin::random());
+	let mid_a_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut client_config = moq_tokio::connect::Config::default();
 	client_config.tls.insecure = Some(true);
 	// Short handover so the test observes the old session close quickly.
@@ -420,7 +420,7 @@ async fn cluster_diamond_goaway_seamless_failover_inner() {
 		.expect("MID-A accept channel closed");
 
 	// ── SUBSCRIBER: connects to BOTTOM ───────────────────────────────────
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut sub_client_config = moq_tokio::connect::Config::default();
 	sub_client_config.tls.insecure = Some(true);
 	let sub_client = sub_client_config
@@ -622,7 +622,7 @@ async fn collect_group(sub: &mut moq_net::track::Subscriber, seen: &mut BTreeSet
 async fn cluster_reconnects_on_empty_uri_goaway_inner() {
 	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
-	let upstream_origin = moq_tokio::origin::spawn(Origin::random());
+	let upstream_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = upstream_origin
 		.create_broadcast("cam", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -738,7 +738,7 @@ fn goaway_handover_is_enforced_while_the_replacement_dial_hangs() {
 async fn goaway_handover_is_enforced_while_the_replacement_dial_hangs_inner() {
 	let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
-	let upstream_origin = moq_tokio::origin::spawn(Origin::random());
+	let upstream_origin = moq_tokio::origin::spawn(Hop::random());
 	let (port, mut accepted, _handle) = spawn_upstream(upstream_origin);
 	wait_listening(port).await;
 

--- a/rs/moq-relay/tests/runtime_uring.rs
+++ b/rs/moq-relay/tests/runtime_uring.rs
@@ -11,7 +11,7 @@ use std::net::{SocketAddr, UdpSocket};
 use std::time::Duration;
 
 use moq_relay::{Config, PublicConfig, Relay};
-use moq_tokio::moq_net::{self, Origin};
+use moq_tokio::moq_net::{self, Hop};
 
 const TIMEOUT: Duration = Duration::from_secs(10);
 const WORKERS: u16 = 2;
@@ -135,7 +135,7 @@ async fn uring_workers_serve_webtransport_and_raw_quic() {
 	// ...and a raw-QUIC subscriber (moql, the native path).
 	let raw_url: url::Url = format!("moql://127.0.0.1:{port}/uring").parse().expect("parse url");
 
-	let origin = moq_tokio::origin::spawn(Origin::random());
+	let origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -151,7 +151,7 @@ async fn uring_workers_serve_webtransport_and_raw_quic() {
 	// Several subscribers of each flavor, spread over the steered workers.
 	let mut subscribers = Vec::new();
 	for url in [&wt_url, &raw_url, &wt_url, &raw_url] {
-		let origin = moq_tokio::origin::spawn(Origin::random());
+		let origin = moq_tokio::origin::spawn(Hop::random());
 		let announced = origin.consume().announced();
 		let connection = connect(client().with_subscriber(origin), url.clone()).await;
 		subscribers.push((connection, announced));
@@ -293,7 +293,7 @@ async fn an_mtls_client_authenticates_without_a_token() {
 	// unauthorized session establishes and is then closed, so merely
 	// connecting proves nothing.
 	let url: url::Url = format!("moql://127.0.0.1:{port}/mtls").parse().expect("parse url");
-	let origin = moq_tokio::origin::spawn(Origin::random());
+	let origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -305,7 +305,7 @@ async fn an_mtls_client_authenticates_without_a_token() {
 	group.finish().expect("finish group");
 	let publisher = connect(client().with_publisher(&origin), url.clone()).await;
 
-	let subscriber_origin = moq_tokio::origin::spawn(Origin::random());
+	let subscriber_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announced = subscriber_origin.consume().announced();
 	let subscriber = connect(client().with_subscriber(subscriber_origin), url).await;
 

--- a/rs/moq-relay/tests/runtime_workers.rs
+++ b/rs/moq-relay/tests/runtime_workers.rs
@@ -9,7 +9,7 @@ use std::net::{SocketAddr, UdpSocket};
 use std::time::Duration;
 
 use moq_relay::{Config, PublicConfig, Relay};
-use moq_tokio::moq_net::{self, Origin};
+use moq_tokio::moq_net::{self, Hop};
 
 const TIMEOUT: Duration = Duration::from_secs(10);
 const WORKERS: u16 = 4;
@@ -110,7 +110,7 @@ async fn workers_serve_quic_and_share_one_origin() {
 	let url: url::Url = format!("https://127.0.0.1:{port}/workers").parse().expect("parse url");
 
 	// ── publisher ───────────────────────────────────────────────────
-	let origin = moq_tokio::origin::spawn(Origin::random());
+	let origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -126,7 +126,7 @@ async fn workers_serve_quic_and_share_one_origin() {
 	// ── subscribers ─────────────────────────────────────────────────
 	let mut subscribers = Vec::new();
 	for _ in 0..WORKERS {
-		let origin = moq_tokio::origin::spawn(Origin::random());
+		let origin = moq_tokio::origin::spawn(Hop::random());
 		let announced = origin.consume().announced();
 		let connection = connect(client().with_subscriber(origin), url.clone()).await;
 		subscribers.push((connection, announced));

--- a/rs/moq-relay/tests/smoke.rs
+++ b/rs/moq-relay/tests/smoke.rs
@@ -10,7 +10,7 @@
 use std::{net::TcpListener, time::Duration};
 
 use moq_relay::{AuthConfig, Cluster, ClusterConfig, Config, Connection, PublicConfig, Relay, Web, WebConfig};
-use moq_tokio::moq_net::{self, Origin};
+use moq_tokio::moq_net::{self, Hop};
 
 const TIMEOUT: Duration = Duration::from_secs(10);
 
@@ -176,7 +176,7 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	let expected_version = newest_lite_version();
 
 	// ── publisher ───────────────────────────────────────────────────
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -199,7 +199,7 @@ async fn relay_websocket_round_trip_uses_newest_version() {
 	);
 
 	// ── subscriber ──────────────────────────────────────────────────
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 
 	let (_client, sub_connection) =
@@ -369,7 +369,7 @@ async fn relay_websocket_root_path_upgrades() {
 	let url: url::Url = format!("ws://127.0.0.1:{port}").parse().expect("parse url");
 
 	// ── publisher ───────────────────────────────────────────────────
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -389,7 +389,7 @@ async fn relay_websocket_root_path_upgrades() {
 	.expect("publisher connect failed (root-path WS upgrade)");
 
 	// ── subscriber ──────────────────────────────────────────────────
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 	let (_client, sub_connection) =
 		tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
@@ -436,7 +436,7 @@ async fn two_publish_only_clients_coexist() {
 	let url: url::Url = format!("ws://127.0.0.1:{port}/smoke").parse().expect("parse url");
 
 	// ── two publish-only publishers, each serving a distinct broadcast ──
-	let pub_a = moq_tokio::origin::spawn(Origin::random());
+	let pub_a = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast_a = pub_a
 		.create_broadcast("alpha", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast a");
@@ -447,7 +447,7 @@ async fn two_publish_only_clients_coexist() {
 		.write_frame(moq_net::Timestamp::ZERO, b"a".as_ref())
 		.expect("write frame a");
 
-	let pub_b = moq_tokio::origin::spawn(Origin::random());
+	let pub_b = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast_b = pub_b
 		.create_broadcast("beta", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast b");
@@ -474,7 +474,7 @@ async fn two_publish_only_clients_coexist() {
 	.expect("publisher b connect failed");
 
 	// ── one subscriber should see broadcasts from both publish-only clients ──
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 	let (_client, sub_connection) =
 		tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
@@ -594,7 +594,7 @@ async fn internal_tcp_round_trip() {
 	let expected_version = newest_lite_version();
 
 	// ── publisher ───────────────────────────────────────────────────
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -619,7 +619,7 @@ async fn internal_tcp_round_trip() {
 	);
 
 	// ── subscriber ──────────────────────────────────────────────────
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 	let (_client, sub_connection) =
 		tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
@@ -707,7 +707,7 @@ async fn internal_unix_round_trip() {
 	let expected_version = newest_lite_version();
 
 	// ── publisher ───────────────────────────────────────────────────
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -732,7 +732,7 @@ async fn internal_unix_round_trip() {
 	);
 
 	// ── subscriber ──────────────────────────────────────────────────
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 	let (_client, sub_connection) =
 		tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
@@ -795,7 +795,7 @@ fn path_versions() -> Vec<moq_net::Version> {
 /// whether the request path reached the server (it scopes the publisher's grant
 /// to that root).
 async fn path_round_trip(version: moq_net::Version, pub_url: url::Url, sub_url: url::Url, broadcast: &str) -> String {
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut bc = pub_origin
 		.create_broadcast(broadcast, moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -812,7 +812,7 @@ async fn path_round_trip(version: moq_net::Version, pub_url: url::Url, sub_url: 
 		.expect("publisher connect timeout")
 		.expect("publisher connect failed");
 
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 	let sub_client = client_version(Some(version)).with_subscriber(sub_origin);
 	let (_client, sub_connection) = tokio::time::timeout(TIMEOUT, connect_once(sub_client, sub_url))
@@ -980,7 +980,7 @@ async fn subscribe_only_public_rejects_publisher_role() {
 	let (port, handle) = spawn_subscribe_only_relay().await;
 	let url: url::Url = format!("tcp://127.0.0.1:{port}").parse().expect("parse url");
 
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 
 	// The lite-05 client resolves `connect()` optimistically, so it may return Ok
 	// before the relay's verdict lands. Either the connect fails outright, or the
@@ -1012,7 +1012,7 @@ async fn subscribe_only_public_accepts_subscriber_role() {
 	let (port, handle) = spawn_subscribe_only_relay().await;
 	let url: url::Url = format!("tcp://127.0.0.1:{port}").parse().expect("parse url");
 
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let (_client, connection) = tokio::time::timeout(TIMEOUT, connect_once(client().with_subscriber(sub_origin), url))
 		.await
 		.expect("subscriber connect timeout")
@@ -1068,7 +1068,7 @@ async fn publish_only_public_rejects_subscriber_role() {
 	let (port, handle) = spawn_publish_only_relay().await;
 	let url: url::Url = format!("tcp://127.0.0.1:{port}").parse().expect("parse url");
 
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 
 	// Like the publisher case, `connect()` may resolve optimistically; either it fails
 	// outright, or the session the relay hands back closes shortly after.

--- a/rs/moq-rtc/src/egress.rs
+++ b/rs/moq-rtc/src/egress.rs
@@ -300,7 +300,7 @@ pub fn dispatch(rtc: &mut str0m::Rtc, request: WriteRequest, wallclock: Instant)
 mod tests {
 	/// Build an origin producer, spawning its driver on the ambient runtime.
 	fn produce_origin() -> moq_net::origin::Producer {
-		let (producer, driver) = moq_net::origin::Producer::new(moq_net::Origin::random().into());
+		let (producer, driver) = moq_net::origin::Producer::new(moq_net::Hop::random().into());
 		if tokio::runtime::Handle::try_current().is_ok() {
 			tokio::spawn(driver.run(moq_tokio::runtime::Runtime::<()>::new()));
 		} else {

--- a/rs/moq-rtc/src/server/mod.rs
+++ b/rs/moq-rtc/src/server/mod.rs
@@ -295,7 +295,7 @@ pub(crate) async fn delete(State(server): State<Server>, Path(path): Path<String
 mod tests {
 	/// Build an origin producer, spawning its driver on the ambient runtime.
 	fn produce_origin() -> moq_net::origin::Producer {
-		let (producer, driver) = moq_net::origin::Producer::new(moq_net::Origin::random().into());
+		let (producer, driver) = moq_net::origin::Producer::new(moq_net::Hop::random().into());
 		if tokio::runtime::Handle::try_current().is_ok() {
 			tokio::spawn(driver.run(moq_tokio::runtime::Runtime::<()>::new()));
 		} else {

--- a/rs/moq-rtmp/src/dial.rs
+++ b/rs/moq-rtmp/src/dial.rs
@@ -535,7 +535,7 @@ mod tests {
 		let mut vframe = vec![0x17, 0x01, 0x00, 0x00, 0x00];
 		vframe.extend_from_slice(&[0, 0, 0, 5, 0x65, 0x88, 0x84, 0x21, 0x00]);
 
-		let server_origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let server_origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let mut broadcast = server_origin
 			.create_broadcast("live/cam0", broadcast::Route::new().with_announce(true))
 			.unwrap();
@@ -559,7 +559,7 @@ mod tests {
 		});
 
 		// Client: dial, connect(`live`), play(`cam0`), republish into our own origin.
-		let client_origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let client_origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let announced = client_origin.consume();
 		let pull_origin = client_origin.clone();
 		let pull = tokio::spawn(async move {

--- a/rs/moq-rtmp/src/server.rs
+++ b/rs/moq-rtmp/src/server.rs
@@ -1586,7 +1586,7 @@ mod tests {
 		vseq.extend_from_slice(&[0x01, 0x42, 0xc0, 0x1f, 0xff, 0xe1, 0x00, 0x04, 0x67, 0x42, 0xc0, 0x1f]);
 		vseq.extend_from_slice(&[0x01, 0x00, 0x04, 0x68, 0xce, 0x3c, 0x80]);
 
-		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let mut publisher = Publisher::new(&origin, "live/cam0", Some(Duration::from_secs(3))).unwrap();
 		publisher.push(flv::TAG_VIDEO, 0, &vseq).unwrap();
 
@@ -1616,7 +1616,7 @@ mod tests {
 		vframe.extend_from_slice(&[0, 0, 0, 5, 0x65, 0x88, 0x84, 0x21, 0x00]);
 
 		// Publish the broadcast at `live/cam0` by feeding synthetic FLV to the importer.
-		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let mut broadcast = origin
 			.create_broadcast("live/cam0", broadcast::Route::new().with_announce(true))
 			.unwrap();
@@ -1665,7 +1665,7 @@ mod tests {
 	async fn play_enhanced_codec_rejects_legacy_client() {
 		const VP9_KEYFRAME_320X240: &[u8] = &[0x82, 0x49, 0x83, 0x42, 0x20, 0x13, 0xf0, 0x0e, 0xf0, 0x00];
 
-		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let mut broadcast = origin
 			.create_broadcast("live/cam0", broadcast::Route::new().with_announce(true))
 			.unwrap();
@@ -1788,7 +1788,7 @@ mod tests {
 		let nalu = |b: u8| vec![0, 0, 0, 0, 0, 5, 0x65, b, 0x84, 0x21, 0x00];
 		let frames = multitrack_body(CODED_FRAMES, &[(0, nalu(0x88)), (1, nalu(0x99))]);
 
-		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let mut broadcast = origin
 			.create_broadcast("live/cam0", broadcast::Route::new().with_announce(true))
 			.unwrap();
@@ -1850,7 +1850,7 @@ mod tests {
 		let mut server = Server::bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
 		let addr = server.local_addr().unwrap();
 
-		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let consumer = origin.consume();
 
 		let stream = TcpStream::connect(addr).await.unwrap();

--- a/rs/moq-srt/src/dial.rs
+++ b/rs/moq-srt/src/dial.rs
@@ -138,7 +138,7 @@ impl Mode {
 mod tests {
 	/// Build an origin producer, spawning its driver on the ambient runtime.
 	fn produce_origin() -> moq_net::origin::Producer {
-		let (producer, driver) = moq_net::origin::Producer::new(moq_net::Origin::random().into());
+		let (producer, driver) = moq_net::origin::Producer::new(moq_net::Hop::random().into());
 		if tokio::runtime::Handle::try_current().is_ok() {
 			tokio::spawn(driver.run(moq_tokio::runtime::Runtime::<()>::new()));
 		} else {

--- a/rs/moq-srt/src/ts.rs
+++ b/rs/moq-srt/src/ts.rs
@@ -133,7 +133,7 @@ mod tests {
 
 	/// Build an origin producer, spawning its driver on the ambient runtime.
 	fn produce_origin() -> moq_net::origin::Producer {
-		let (producer, driver) = moq_net::origin::Producer::new(moq_net::Origin::random().into());
+		let (producer, driver) = moq_net::origin::Producer::new(moq_net::Hop::random().into());
 		if tokio::runtime::Handle::try_current().is_ok() {
 			tokio::spawn(driver.run(moq_tokio::runtime::Runtime::<()>::new()));
 		} else {

--- a/rs/moq-stats/src/aggregate.rs
+++ b/rs/moq-stats/src/aggregate.rs
@@ -336,7 +336,7 @@ fn terminate<V: Mergeable>(node: &mut Node<V>, changed: bool) -> bool {
 mod tests {
 	/// Build an origin producer, spawning its driver on the ambient runtime.
 	fn produce_origin() -> moq_net::origin::Producer {
-		let (producer, driver) = moq_net::origin::Producer::new(moq_net::Origin::random().into());
+		let (producer, driver) = moq_net::origin::Producer::new(moq_net::Hop::random().into());
 		if tokio::runtime::Handle::try_current().is_ok() {
 			tokio::spawn(driver.run(moq_tokio::runtime::Runtime::<()>::new()));
 		} else {

--- a/rs/moq-stats/src/consume.rs
+++ b/rs/moq-stats/src/consume.rs
@@ -103,7 +103,7 @@ impl SessionsConsumer {
 mod tests {
 	/// Build an origin producer, spawning its driver on the ambient runtime.
 	fn produce_origin() -> moq_net::origin::Producer {
-		let (producer, driver) = moq_net::origin::Producer::new(moq_net::Origin::random().into());
+		let (producer, driver) = moq_net::origin::Producer::new(moq_net::Hop::random().into());
 		if tokio::runtime::Handle::try_current().is_ok() {
 			tokio::spawn(driver.run(moq_tokio::runtime::Runtime::<()>::new()));
 		} else {

--- a/rs/moq-stats/src/produce.rs
+++ b/rs/moq-stats/src/produce.rs
@@ -878,7 +878,7 @@ fn advertised_path(prefix: &Path, group: &Path, node: Option<&str>) -> PathOwned
 mod tests {
 	/// Build an origin producer, spawning its driver on the ambient runtime.
 	fn produce_origin() -> moq_net::origin::Producer {
-		let (producer, driver) = moq_net::origin::Producer::new(moq_net::Origin::random().into());
+		let (producer, driver) = moq_net::origin::Producer::new(moq_net::Hop::random().into());
 		if tokio::runtime::Handle::try_current().is_ok() {
 			tokio::spawn(driver.run(moq_tokio::runtime::Runtime::<()>::new()));
 		} else {

--- a/rs/moq-tokio/CHANGELOG.md
+++ b/rs/moq-tokio/CHANGELOG.md
@@ -86,7 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- add Client::with_peer_origin for peers that declare no identity ([#2577](https://github.com/moq-dev/moq/pull/2577))
+- add Client::with_peer_hop for peers that declare no identity ([#2577](https://github.com/moq-dev/moq/pull/2577))
 
 ## [0.19.5](https://github.com/moq-dev/moq/compare/moq-native-v0.19.4...moq-native-v0.19.5) - 2026-07-31
 

--- a/rs/moq-tokio/examples/chat.rs
+++ b/rs/moq-tokio/examples/chat.rs
@@ -8,7 +8,7 @@ async fn main() -> anyhow::Result<()> {
 	moq_tokio::Log::new(tracing::Level::DEBUG).init()?;
 
 	// Create an origin that we can publish to and the session can consume from.
-	let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+	let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 
 	// Run the broadcast production and the session in parallel.
 	// This is a simple example of how you can concurrently run multiple tasks.

--- a/rs/moq-tokio/examples/clock.rs
+++ b/rs/moq-tokio/examples/clock.rs
@@ -59,7 +59,7 @@ async fn main() -> anyhow::Result<()> {
 
 	let track = config.track;
 
-	let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+	let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 
 	match config.role {
 		Command::Publish => {

--- a/rs/moq-tokio/src/client.rs
+++ b/rs/moq-tokio/src/client.rs
@@ -1,9 +1,53 @@
+//! Dialing peers: the [`Client`] and the [`Config`] it is built from.
+//!
+//! [`Config`] pairs the dial half of an endpoint ([`crate::connect::Config`]) with the
+//! QUIC settings ([`crate::quic::Config`]) a binary shares with its accept half. The
+//! accept side is [`crate::server`].
+
 #[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
 use crate::QuicBackend;
 use crate::{Addrs, Backoff, Connection, Error, GoawayConfig};
 #[cfg(all(feature = "websocket", any(feature = "noq", feature = "quinn", feature = "quiche")))]
 use std::future::Future;
 use url::Url;
+
+/// Everything a [`Client`] is built from.
+///
+/// Distinct from [`crate::connect::Config`], which is only the dial half of an endpoint:
+/// this pairs that half with the [`quic::Config`](crate::quic::Config) a binary shares
+/// between dialing and listening, because a `Client` needs both and neither owns the
+/// other. Grouping them here is what lets a future knob land as a field rather than as
+/// another [`Client::new`] parameter.
+///
+/// Most callers want the [`crate::connect::Config::init`] shorthand instead.
+#[derive(Clone, Debug, Default)]
+#[non_exhaustive]
+pub struct Config {
+	/// The dial side of the endpoint: where to connect and how to be trusted.
+	pub connect: crate::connect::Config,
+
+	/// QUIC socket and transport settings, shared with [`crate::Server`].
+	pub quic: crate::quic::Config,
+}
+
+impl Config {
+	/// Set the dial side, returning `self` for chaining.
+	pub fn with_connect(mut self, connect: crate::connect::Config) -> Self {
+		self.connect = connect;
+		self
+	}
+
+	/// Set the QUIC settings, returning `self` for chaining.
+	pub fn with_quic(mut self, quic: crate::quic::Config) -> Self {
+		self.quic = quic;
+		self
+	}
+
+	/// Build the [`Client`] this config describes.
+	pub fn init(self) -> crate::Result<Client> {
+		Client::new(self)
+	}
+}
 
 /// Client for establishing MoQ connections over QUIC, WebTransport, or WebSocket.
 ///
@@ -72,7 +116,7 @@ impl Client {
 		feature = "tcp",
 		feature = "uds"
 	)))]
-	pub fn new(_config: crate::connect::Config, _quic: crate::quic::Config) -> crate::Result<Self> {
+	pub fn new(_config: Config) -> crate::Result<Self> {
 		Err(Error::NoBackend(
 			"no backend compiled; enable noq, quinn, quiche, iroh, websocket, tcp, or uds feature",
 		))
@@ -88,7 +132,11 @@ impl Client {
 		feature = "tcp",
 		feature = "uds"
 	))]
-	pub fn new(config: crate::connect::Config, quic: crate::quic::Config) -> crate::Result<Self> {
+	pub fn new(config: Config) -> crate::Result<Self> {
+		let Config {
+			connect: config, quic, ..
+		} = config;
+
 		// Refuse here rather than in `init`, so a caller that skipped its own check
 		// can't reach a dial that quietly ignored half of what it was given.
 		let mut deprecated = config.deprecated();
@@ -826,7 +874,7 @@ mod tests {
 	#[test]
 	fn building_a_client_refuses_a_released_spelling() {
 		let config = Cli::config_from(["test", "--client-connect", "https://relay.example.com/anon"]);
-		let Err(err) = crate::Client::new(config, crate::quic::Config::default()) else {
+		let Err(err) = crate::client::Config::default().with_connect(config).init() else {
 			panic!("building a client must refuse a released spelling");
 		};
 		assert!(matches!(err, Error::Deprecated(_)), "{err}");

--- a/rs/moq-tokio/src/client.rs
+++ b/rs/moq-tokio/src/client.rs
@@ -223,9 +223,9 @@ impl Client {
 	}
 
 	/// Assign an origin (hop) id to the peers this client dials, used whenever a
-	/// peer doesn't declare one itself; see [`moq_net::Client::with_peer_origin`].
-	pub fn with_peer_origin(mut self, origin: moq_net::Origin) -> Self {
-		self.moq = self.moq.with_peer_origin(origin);
+	/// peer doesn't declare one itself; see [`moq_net::Client::with_peer_hop`].
+	pub fn with_peer_hop(mut self, hop: moq_net::Hop) -> Self {
+		self.moq = self.moq.with_peer_hop(hop);
 		self
 	}
 

--- a/rs/moq-tokio/src/connect.rs
+++ b/rs/moq-tokio/src/connect.rs
@@ -602,7 +602,10 @@ impl Config {
 
 	/// Build the [`crate::Client`] this config describes.
 	pub fn init(self, quic: crate::quic::Config) -> crate::Result<crate::Client> {
-		crate::Client::new(self, quic)
+		crate::client::Config::default()
+			.with_connect(self)
+			.with_quic(quic)
+			.init()
 	}
 
 	/// The local address a dial sends from, resolving the default.

--- a/rs/moq-tokio/src/deprecated.rs
+++ b/rs/moq-tokio/src/deprecated.rs
@@ -32,18 +32,22 @@ impl Deprecated {
 	/// `env` is the released variable, which is the half a rename usually misses:
 	/// a deployment configured through the environment never typed the flag, so a
 	/// message naming only the flag reads as unrelated to its problem.
-	pub(crate) fn flag(&mut self, old: &str, env: Option<&str>, new: &str) {
+	///
+	/// Public because a binary flattening these configs has renamed flags of its own
+	/// (`moq-cli` does), and they belong in the same message: a process that refuses
+	/// twice makes the caller fix one rename, rerun, and hit the next.
+	pub fn flag(&mut self, old: &str, env: Option<&str>, new: &str) {
 		self.entry(&Self::spelling(old, env), new, None);
 	}
 
 	/// Record a released flag whose replacement does not mean the same thing, with
 	/// a note saying how it differs.
-	pub(crate) fn changed(&mut self, old: &str, env: Option<&str>, new: &str, note: &str) {
+	pub fn changed(&mut self, old: &str, env: Option<&str>, new: &str, note: &str) {
 		self.entry(&Self::spelling(old, env), new, Some(note));
 	}
 
 	/// Record a released config-file key or table, which has no environment variable.
-	pub(crate) fn toml(&mut self, old: &str, new: &str, note: Option<&str>) {
+	pub fn toml(&mut self, old: &str, new: &str, note: Option<&str>) {
 		self.entry(old, new, note);
 	}
 

--- a/rs/moq-tokio/src/lib.rs
+++ b/rs/moq-tokio/src/lib.rs
@@ -27,7 +27,7 @@ compile_error!("a rustls QUIC backend requires a crypto provider: enable either 
 pub mod accept;
 pub use moq_sock::bind;
 pub mod cli;
-mod client;
+pub mod client;
 pub mod connect;
 mod connection;
 mod crypto;
@@ -57,7 +57,7 @@ pub mod runtime;
 	feature = "websocket",
 	feature = "tcp"
 ))]
-mod server;
+pub mod server;
 #[cfg(feature = "tcp")]
 pub mod tcp;
 pub mod tls;

--- a/rs/moq-tokio/src/origin.rs
+++ b/rs/moq-tokio/src/origin.rs
@@ -11,7 +11,7 @@
 /// Panics if called outside a tokio runtime.
 ///
 /// Accepts an [`Info`](moq_net::origin::Info) or a bare
-/// [`Origin`](moq_net::Origin) id (which uses the default config).
+/// [`Hop`](moq_net::Hop) id (which uses the default config).
 pub fn spawn(info: impl Into<moq_net::origin::Info>) -> moq_net::origin::Producer {
 	let (producer, driver) = moq_net::origin::Producer::new(info.into());
 	tokio::spawn(driver.run(crate::runtime::Runtime::<()>::new()));
@@ -26,7 +26,7 @@ mod tests {
 	/// reaches a consumer, and finishing it unannounces.
 	#[tokio::test]
 	async fn spawn_drives_the_origin() {
-		let origin = spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
+		let origin = spawn(moq_net::origin::Info::new(moq_net::Hop::random()));
 		let mut announced = origin.consume().announced();
 
 		let mut broadcast = origin
@@ -47,6 +47,6 @@ mod tests {
 	#[test]
 	#[should_panic(expected = "no reactor running")]
 	fn spawn_outside_runtime_panics() {
-		let _ = spawn(moq_net::origin::Info::new(moq_net::Origin::random()));
+		let _ = spawn(moq_net::origin::Info::new(moq_net::Hop::random()));
 	}
 }

--- a/rs/moq-tokio/src/server.rs
+++ b/rs/moq-tokio/src/server.rs
@@ -1339,7 +1339,7 @@ impl Request {
 		request_ref!(self, r => r.role())
 	}
 
-	/// The origin identity the peer declared in its SETUP (moq-lite-05+).
+	/// The Hop ID the peer declared in its SETUP (moq-lite-05+).
 	///
 	/// A peer declares this when it attaches a publish or subscribe origin.
 	/// Older versions and peers without one return `None`.

--- a/rs/moq-tokio/src/server.rs
+++ b/rs/moq-tokio/src/server.rs
@@ -1,3 +1,9 @@
+//! Accepting peers: the [`Server`], its [`Request`]s, and the [`Config`] it is built from.
+//!
+//! [`Config`] pairs the accept half of an endpoint ([`crate::listen::Config`]) with the
+//! QUIC settings ([`crate::quic::Config`]) a binary shares with its dial half. The dial
+//! side is [`crate::client`].
+
 use std::net;
 #[cfg(any(test, all(feature = "uds", unix)))]
 use std::path::PathBuf;
@@ -27,7 +33,7 @@ use futures::stream::StreamExt;
 impl crate::listen::Config {
 	/// Build the [`Server`] this config describes, binding its listeners.
 	pub fn init(self, quic: crate::quic::Config) -> crate::Result<Server> {
-		Server::new(self, quic)
+		Config::default().with_listen(self).with_quic(quic).init()
 	}
 
 	/// Build a server with only the `tcp`/`unix` listeners, leaving the QUIC
@@ -42,7 +48,7 @@ impl crate::listen::Config {
 	/// Distinct from clearing [`bind`](crate::listen::Config::bind), which still
 	/// opens the default QUIC listener when nothing else is configured.
 	pub fn init_streams(self) -> crate::Result<Server> {
-		Server::build(self, crate::quic::Config::default(), Parts::Streams)
+		Server::build(Config::default().with_listen(self), Parts::Streams)
 	}
 
 	/// Returns the configured versions, defaulting to all if none specified.
@@ -132,6 +138,44 @@ impl Parts {
 	}
 }
 
+/// Everything a [`Server`] is built from.
+///
+/// Distinct from [`crate::listen::Config`], which is only the accept half of an endpoint:
+/// this pairs that half with the [`quic::Config`](crate::quic::Config) a binary shares
+/// between listening and dialing, because a `Server` needs both and neither owns the
+/// other. Grouping them here is what lets a future knob land as a field rather than as
+/// another [`Server::new`] parameter. The mirror of [`crate::client::Config`].
+///
+/// Most callers want the [`crate::listen::Config::init`] shorthand instead.
+#[derive(Clone, Debug, Default)]
+#[non_exhaustive]
+pub struct Config {
+	/// The accept side of the endpoint: what to listen on and how to be trusted.
+	pub listen: crate::listen::Config,
+
+	/// QUIC socket and transport settings, shared with [`crate::Client`].
+	pub quic: crate::quic::Config,
+}
+
+impl Config {
+	/// Set the accept side, returning `self` for chaining.
+	pub fn with_listen(mut self, listen: crate::listen::Config) -> Self {
+		self.listen = listen;
+		self
+	}
+
+	/// Set the QUIC settings, returning `self` for chaining.
+	pub fn with_quic(mut self, quic: crate::quic::Config) -> Self {
+		self.quic = quic;
+		self
+	}
+
+	/// Build the [`Server`] this config describes.
+	pub fn init(self) -> crate::Result<Server> {
+		Server::new(self)
+	}
+}
+
 /// Server for accepting MoQ connections.
 ///
 /// Accepts QUIC (and optionally WebSocket), plus plaintext qmux over TCP
@@ -160,12 +204,16 @@ impl Server {
 	///
 	/// The stream (`tcp`/`unix`) listeners need a runtime, so they wait for
 	/// [`listen`](Self::listen).
-	pub fn new(config: crate::listen::Config, quic: crate::quic::Config) -> crate::Result<Self> {
-		Self::build(config, quic, Parts::All)
+	pub fn new(config: Config) -> crate::Result<Self> {
+		Self::build(config, Parts::All)
 	}
 
 	/// [`Self::new`], for a caller that opens only some of the config's listeners.
-	pub(crate) fn build(config: crate::listen::Config, quic: crate::quic::Config, parts: Parts) -> crate::Result<Self> {
+	pub(crate) fn build(config: Config, parts: Parts) -> crate::Result<Self> {
+		let Config {
+			listen: config, quic, ..
+		} = config;
+
 		// Refuse here rather than in `init`, so a caller that skipped its own check
 		// can't reach a listener that quietly ignored half of what it was given.
 		let mut deprecated = config.deprecated();
@@ -1351,7 +1399,10 @@ mod tests {
 	fn accept_health_covers_stream_listeners_before_they_bind() {
 		let mut config = crate::listen::Config::default();
 		config.tcp.bind = Some("127.0.0.1:0".parse().unwrap());
-		let server = Server::new(config, Default::default()).expect("stream-only server");
+		let server = Config::default()
+			.with_listen(config)
+			.init()
+			.expect("stream-only server");
 
 		let names: Vec<_> = server.accept_health().iter().map(|h| h.listener()).collect();
 		assert_eq!(names, vec!["tcp"], "the tcp listener must report before it binds");
@@ -1381,7 +1432,10 @@ mod tests {
 		let mut config = crate::listen::Config::default();
 		config.tcp.bind = Some(format!("127.0.0.1:{port}").parse().expect("parse addr"));
 		config.unix.bind = Some(occupied);
-		let server = Server::new(config, Default::default()).expect("stream-only server");
+		let server = Config::default()
+			.with_listen(config)
+			.init()
+			.expect("stream-only server");
 
 		assert!(server.listen().await.is_err(), "the unix bind must fail");
 		std::net::TcpListener::bind(("127.0.0.1", port)).expect("the tcp port must be free again");
@@ -1397,7 +1451,9 @@ mod tests {
 
 		let mut config = crate::listen::Config::default();
 		config.tcp.bind = Some(addr);
-		let listener = Server::new(config, Default::default())
+		let listener = Config::default()
+			.with_listen(config)
+			.init()
 			.expect("stream-only server")
 			.listen()
 			.await
@@ -1514,7 +1570,10 @@ mod tests {
 
 		let mut config = crate::listen::Config::default();
 		config.tcp.bind = Some(addr);
-		let server = Server::new(config, Default::default()).expect("stream-only server");
+		let server = Config::default()
+			.with_listen(config)
+			.init()
+			.expect("stream-only server");
 		let listener = server.listen().await.expect("listen");
 		assert!(tokio::net::TcpListener::bind(addr).await.is_err(), "listener is bound");
 
@@ -1534,7 +1593,7 @@ mod tests {
 		};
 
 		assert!(matches!(
-			Server::new(config, Default::default()),
+			Config::default().with_listen(config).init(),
 			Err(Error::NoBackend(_))
 		));
 	}

--- a/rs/moq-tokio/src/server.rs
+++ b/rs/moq-tokio/src/server.rs
@@ -1199,16 +1199,16 @@ impl Request {
 	}
 
 	/// Assign the identity this peer's routes are attributed to; see
-	/// [`moq_net::Request::with_peer_origin`]. Derive it from [`Self::peer_identity`],
+	/// [`moq_net::Request::with_peer_hop`]. Derive it from [`Self::peer_identity`],
 	/// never from something coarser.
-	pub fn with_peer_origin(self, origin: moq_net::Origin) -> Self {
+	pub fn with_peer_hop(self, hop: moq_net::Hop) -> Self {
 		let Request {
 			transport,
 			url,
 			identity,
 			kind,
 		} = self;
-		let kind = request_map!(kind, request => request.with_peer_origin(origin));
+		let kind = request_map!(kind, request => request.with_peer_hop(hop));
 		Request {
 			transport,
 			url,
@@ -1298,8 +1298,8 @@ impl Request {
 	///
 	/// Self-declared, so treat it as a correlation hint rather than an
 	/// authenticated identity: authorize on the token or client certificate.
-	pub fn peer_origin(&self) -> Option<moq_net::Origin> {
-		request_ref!(self, r => r.peer_origin())
+	pub fn peer_hop(&self) -> Option<moq_net::Hop> {
+		request_ref!(self, r => r.peer_hop())
 	}
 
 	/// The client certificate chain the peer presented, if any, validated
@@ -1421,7 +1421,7 @@ mod tests {
 		let path = PathBuf::from(format!("/tmp/moq-tokio-publish-{}.sock", std::process::id()));
 		let _ = std::fs::remove_file(&path);
 
-		let origin = crate::origin::spawn(moq_net::Origin::random());
+		let origin = crate::origin::spawn(moq_net::Hop::random());
 		let mut broadcast = origin
 			.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 			.expect("create broadcast");
@@ -1459,7 +1459,7 @@ mod tests {
 		const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 		let url: Url = format!("unix://{}", path.display()).parse().expect("parse url");
-		let subscriber = crate::origin::spawn(moq_net::Origin::random());
+		let subscriber = crate::origin::spawn(moq_net::Hop::random());
 		let mut announced = subscriber.consume().announced();
 		let client = crate::connect::Config::default()
 			.init(Default::default())

--- a/rs/moq-tokio/src/worker.rs
+++ b/rs/moq-tokio/src/worker.rs
@@ -489,8 +489,11 @@ fn run(
 
 	let built = {
 		let _guard = runtime.enter();
-		Server::build(listen, quic, crate::server::Parts::Shard(shard))
-			.and_then(|server| server.local_addr().map(|addr| (server, addr)))
+		Server::build(
+			crate::server::Config::default().with_listen(listen).with_quic(quic),
+			crate::server::Parts::Shard(shard),
+		)
+		.and_then(|server| server.local_addr().map(|addr| (server, addr)))
 	};
 
 	let (server, addr) = match built {

--- a/rs/moq-tokio/tests/alpn.rs
+++ b/rs/moq-tokio/tests/alpn.rs
@@ -24,7 +24,7 @@ async fn connect_with_version(version: &str) {
 	let addr = server.local_addr().expect("failed to get local addr");
 
 	// Provide a dummy origin so the MoQ handshake has something to negotiate.
-	let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+	let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 
 	// ── client ──────────────────────────────────────────────────────
 	let mut client_config = moq_tokio::connect::Config::default();
@@ -75,7 +75,7 @@ async fn connect_with_webtransport(version: Option<&str>) {
 	let mut server = server.listen().await.expect("failed to listen");
 	let addr = server.local_addr().expect("failed to get local addr");
 
-	let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+	let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 
 	// ── client ──────────────────────────────────────────────────────
 	let mut client_config = moq_tokio::connect::Config::default();

--- a/rs/moq-tokio/tests/backend.rs
+++ b/rs/moq-tokio/tests/backend.rs
@@ -4,7 +4,7 @@
 //! Each test is gated with `#[cfg(feature = "...")]` so it only compiles when the
 //! corresponding backend is enabled. Running `cargo test --all-features` exercises all.
 
-use moq_tokio::moq_net::{self, Origin};
+use moq_tokio::moq_net::{self, Hop};
 use std::time::Duration;
 
 const TIMEOUT: Duration = Duration::from_secs(10);
@@ -104,7 +104,7 @@ async fn connect_test(config: ConnectTest<'_>) {
 	} = config;
 
 	// ── publisher (server) ──────────────────────────────────────────
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -128,7 +128,7 @@ async fn connect_test(config: ConnectTest<'_>) {
 	let addr = server.local_addr().expect("failed to get local addr");
 
 	// ── subscriber (client) ─────────────────────────────────────────
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_tokio::connect::Config::default();
@@ -279,7 +279,7 @@ struct MtlsPaths {
 async fn mtls_test(scheme: &str, backend: moq_tokio::QuicBackend, reject: bool) {
 	let (_dir, paths) = generate_mtls_certs();
 
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 
 	let mut server_config = moq_tokio::listen::Config::default();
 	server_config.bind = Some("127.0.0.1:0".to_string());
@@ -466,7 +466,7 @@ async fn iroh_connect() {
 	use moq_tokio::iroh::EndpointConfig;
 
 	// ── publisher (server) ──────────────────────────────────────────
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -505,7 +505,7 @@ async fn iroh_connect() {
 	let mut server = server.listen().await.expect("failed to listen");
 
 	// ── subscriber (client) ─────────────────────────────────────────
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 
 	// Create client iroh endpoint

--- a/rs/moq-tokio/tests/broadcast.rs
+++ b/rs/moq-tokio/tests/broadcast.rs
@@ -8,7 +8,7 @@
 //! This covers raw QUIC (moqt://) and WebTransport (https://) transports,
 //! exercising every protocol version the library supports.
 
-use moq_tokio::moq_net::{self, Origin};
+use moq_tokio::moq_net::{self, Hop};
 use std::time::Duration;
 
 const TIMEOUT: Duration = Duration::from_secs(10);
@@ -23,7 +23,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 	let server_version: Option<moq_net::Version> = server_version.map(|v| v.parse().expect("invalid server version"));
 
 	// ── publisher (server) ──────────────────────────────────────────
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -48,7 +48,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 	let addr = server.local_addr().expect("failed to get local addr");
 
 	// ── subscriber (client) ─────────────────────────────────────────
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_tokio::connect::Config::default();
@@ -127,7 +127,7 @@ async fn broadcast_test(scheme: &str, client_version: Option<&str>, server_versi
 async fn lite05_timestamp_roundtrip(scheme: &str) {
 	use moq_tokio::moq_net::{Timescale, Timestamp};
 
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -166,7 +166,7 @@ async fn lite05_timestamp_roundtrip(scheme: &str) {
 	let mut server = server.listen().await.expect("failed to listen");
 	let addr = server.local_addr().expect("failed to get local addr");
 
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_tokio::connect::Config::default();
@@ -247,7 +247,7 @@ async fn broadcast_moq_lite_05_timestamps_webtransport() {
 async fn lite05_fetch_roundtrip(scheme: &str) {
 	use moq_tokio::moq_net::{Timescale, Timestamp};
 
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -284,7 +284,7 @@ async fn lite05_fetch_roundtrip(scheme: &str) {
 	let mut server = server.listen().await.expect("failed to listen");
 	let addr = server.local_addr().expect("failed to get local addr");
 
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_tokio::connect::Config::default();
@@ -376,7 +376,7 @@ async fn lite05_fetch_during_subscribe(scheme: &str) {
 		}
 	}
 
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -409,7 +409,7 @@ async fn lite05_fetch_during_subscribe(scheme: &str) {
 	let mut server = server.listen().await.expect("failed to listen");
 	let addr = server.local_addr().expect("failed to get local addr");
 
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_tokio::connect::Config::default();
@@ -497,7 +497,7 @@ async fn broadcast_moq_lite_05_fetch_during_subscribe_webtransport() {
 async fn broadcast_moq_lite_05_default_timescale() {
 	use moq_tokio::moq_net::Timescale;
 
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -517,7 +517,7 @@ async fn broadcast_moq_lite_05_default_timescale() {
 	let mut server = server.listen().await.expect("failed to listen");
 	let addr = server.local_addr().expect("local addr");
 
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_tokio::connect::Config::default();
@@ -592,7 +592,7 @@ async fn next_announce(announcements: &mut moq_net::announce::Consumer) -> moq_n
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_moq_lite_06_announce_lifecycle() {
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 
 	// Announced before the client connects, so it rides the initial set.
 	let mut first = pub_origin
@@ -607,7 +607,7 @@ async fn broadcast_moq_lite_06_announce_lifecycle() {
 	let mut server = server.listen().await.expect("failed to listen");
 	let addr = server.local_addr().expect("local addr");
 
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_tokio::connect::Config::default();
@@ -727,11 +727,11 @@ async fn broadcast_route_migration() {
 	// The original publisher's identity, shared by both routes: the first hop is
 	// the broadcast's content identity, so only same-first-hop routes are
 	// interchangeable enough to migrate across without a re-announce.
-	let publisher = Origin::new(0x42).unwrap();
+	let publisher = Hop::new(0x42).unwrap();
 
 	// ── publisher A: the preferred route (shorter hop chain) ────────
-	let origin_a = moq_tokio::origin::spawn(Origin::random());
-	let mut hops_a = moq_net::OriginList::new();
+	let origin_a = moq_tokio::origin::spawn(Hop::random());
+	let mut hops_a = moq_net::Hops::new();
 	hops_a.push(publisher).unwrap();
 	let mut broadcast_a = origin_a
 		.create_broadcast(
@@ -751,10 +751,10 @@ async fn broadcast_route_migration() {
 	}
 
 	// ── publisher B: the standby, carrying an extra hop so A wins ───
-	let origin_b = moq_tokio::origin::spawn(Origin::random());
-	let mut hops_b = moq_net::OriginList::new();
+	let origin_b = moq_tokio::origin::spawn(Hop::random());
+	let mut hops_b = moq_net::Hops::new();
 	hops_b.push(publisher).unwrap();
-	hops_b.push(Origin::new(0x1234).unwrap()).unwrap();
+	hops_b.push(Hop::new(0x1234).unwrap()).unwrap();
 	let mut broadcast_b = origin_b
 		.create_broadcast(
 			"test",
@@ -809,7 +809,7 @@ async fn broadcast_route_migration() {
 	});
 
 	// ── one subscriber origin fed by both sessions ───────────────────
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 
 	let connect = |port: u16, sub: moq_net::origin::Producer| {
@@ -893,12 +893,12 @@ async fn route_reannounce_test(version: Option<&str>) {
 	let version: Option<moq_net::Version> = version.map(|v| v.parse().expect("invalid version"));
 
 	// ── publisher (server) ──────────────────────────────────────────
-	let origin = moq_tokio::origin::spawn(Origin::random());
+	let origin = moq_tokio::origin::spawn(Hop::random());
 	// The original publisher: the first hop of every advertised chain. Keeping
 	// it stable across the update is what makes the restart an in-place route
 	// change rather than a broadcast replacement.
-	let publisher_hop = Origin::new(0x4444).unwrap();
-	let mut initial_hops = moq_net::OriginList::new();
+	let publisher_hop = Hop::new(0x4444).unwrap();
+	let mut initial_hops = moq_net::Hops::new();
 	initial_hops.push(publisher_hop).unwrap();
 	let mut producer = origin
 		.create_broadcast(
@@ -938,7 +938,7 @@ async fn route_reannounce_test(version: Option<&str>) {
 	});
 
 	// ── subscriber (client) ─────────────────────────────────────────
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_tokio::connect::Config::default();
@@ -974,9 +974,9 @@ async fn route_reannounce_test(version: Option<&str>) {
 
 	// The publisher re-advertises: the same original publisher, reached through
 	// a new intermediate relay.
-	let mut hops = moq_net::OriginList::new();
+	let mut hops = moq_net::Hops::new();
 	hops.push(publisher_hop).unwrap();
-	hops.push(Origin::new(0x5555).unwrap()).unwrap();
+	hops.push(Hop::new(0x5555).unwrap()).unwrap();
 	route_producer
 		.set_route(moq_net::broadcast::Route::new().with_hops(hops).with_announce(true))
 		.expect("update route");
@@ -1036,9 +1036,9 @@ async fn route_replaced_test(version: Option<&str>) {
 	let version: Option<moq_net::Version> = version.map(|v| v.parse().expect("invalid version"));
 
 	// ── publisher (server) ──────────────────────────────────────────
-	let origin = moq_tokio::origin::spawn(Origin::random());
-	let mut hops_a = moq_net::OriginList::new();
-	hops_a.push(Origin::new(0x1111).unwrap()).unwrap();
+	let origin = moq_tokio::origin::spawn(Hop::random());
+	let mut hops_a = moq_net::Hops::new();
+	hops_a.push(Hop::new(0x1111).unwrap()).unwrap();
 	let mut producer = origin
 		.create_broadcast(
 			"test",
@@ -1074,7 +1074,7 @@ async fn route_replaced_test(version: Option<&str>) {
 	});
 
 	// ── subscriber (client) ─────────────────────────────────────────
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_tokio::connect::Config::default();
@@ -1101,8 +1101,8 @@ async fn route_replaced_test(version: Option<&str>) {
 	assert_eq!(read_payloads(&mut sub, 1).await, ["g0"]);
 
 	// A different first hop: a different original publisher took the path over.
-	let mut hops_b = moq_net::OriginList::new();
-	hops_b.push(Origin::new(0x2222).unwrap()).unwrap();
+	let mut hops_b = moq_net::Hops::new();
+	hops_b.push(Hop::new(0x2222).unwrap()).unwrap();
 	route_producer
 		.set_route(moq_net::broadcast::Route::new().with_hops(hops_b).with_announce(true))
 		.expect("update route");
@@ -1334,7 +1334,7 @@ async fn max_age_test(version: &str) -> Duration {
 	let version: moq_net::Version = version.parse().expect("invalid version");
 
 	// ── publisher (server) ──────────────────────────────────────────
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -1362,7 +1362,7 @@ async fn max_age_test(version: &str) -> Duration {
 	// The origin the session writes remote broadcasts into decides the window for
 	// tracks whose protocol can't carry the publisher's.
 	let sub_origin =
-		moq_tokio::origin::spawn(moq_net::origin::Info::new(Origin::random()).with_default_max_age(MAX_AGE_DEFAULT));
+		moq_tokio::origin::spawn(moq_net::origin::Info::new(Hop::random()).with_default_max_age(MAX_AGE_DEFAULT));
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_tokio::connect::Config::default();
@@ -1611,10 +1611,10 @@ async fn broadcast_webtransport_negotiate_client_all_server_transport_19() {
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_websocket() {
-	use moq_tokio::moq_net::Origin;
+	use moq_tokio::moq_net::Hop;
 
 	// ── publisher (server) ──────────────────────────────────────────
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -1643,7 +1643,7 @@ async fn broadcast_websocket() {
 	let mut server = server.listen().await.expect("failed to listen");
 
 	// ── subscriber (client) ─────────────────────────────────────────
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_tokio::connect::Config::default();
@@ -1723,10 +1723,10 @@ async fn broadcast_websocket() {
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_websocket_fallback() {
-	use moq_tokio::moq_net::Origin;
+	use moq_tokio::moq_net::Hop;
 
 	// ── publisher (server) ──────────────────────────────────────────
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -1755,7 +1755,7 @@ async fn broadcast_websocket_fallback() {
 	let mut server = server.listen().await.expect("failed to listen");
 
 	// ── subscriber (client) ─────────────────────────────────────────
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_tokio::connect::Config::default();
@@ -1849,7 +1849,7 @@ const NEWEST_LITE: &str = "moq-lite-05";
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_websocket_uses_newest_version() {
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -1875,7 +1875,7 @@ async fn broadcast_websocket_uses_newest_version() {
 		.with_websocket(ws_listener);
 	let mut server = server.listen().await.expect("failed to listen");
 
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut client_config = moq_tokio::connect::Config::default();
 	client_config.tls.insecure = Some(true);
 	client_config.websocket.delay = Duration::ZERO.into();
@@ -1920,7 +1920,7 @@ async fn broadcast_websocket_uses_newest_version() {
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_race_quic_wins() {
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -1949,7 +1949,7 @@ async fn broadcast_race_quic_wins() {
 		.with_websocket(ws_listener);
 	let mut server = server.listen().await.expect("failed to listen");
 
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut client_config = moq_tokio::connect::Config::default();
 	client_config.tls.insecure = Some(true);
 	// Zero head start: QUIC has to win on its own merit, not by penalising WS.
@@ -2005,7 +2005,7 @@ async fn broadcast_race_quic_wins() {
 async fn quic_driver_task_inherits_connection_span() {
 	use tracing::Instrument;
 
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -2024,7 +2024,7 @@ async fn quic_driver_task_inherits_connection_span() {
 	let mut server = server.listen().await.expect("failed to listen");
 	let addr = server.local_addr().expect("failed to get local addr");
 
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_tokio::connect::Config::default();
@@ -2126,7 +2126,7 @@ async fn quic_driver_task_inherits_connection_span() {
 /// consumer.
 #[tokio::test]
 async fn resubscribe_keeps_flowing_moq_lite_03() {
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -2146,7 +2146,7 @@ async fn resubscribe_keeps_flowing_moq_lite_03() {
 	let mut server = server.listen().await.expect("failed to listen");
 	let addr = server.local_addr().expect("server addr");
 
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_tokio::connect::Config::default();
@@ -2258,7 +2258,7 @@ fn active_viewers(registry: &moq_net::stats::Registry) -> u64 {
 /// viewer nobody is watching (chained through relays, one phantom per hop).
 #[tokio::test]
 async fn idle_subscription_releases_the_viewer_count() {
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -2281,7 +2281,7 @@ async fn idle_subscription_releases_the_viewer_count() {
 	let registry = moq_net::stats::Registry::new(moq_net::stats::Config::new());
 	let stats = registry.tier(moq_net::stats::Tier::default()).session("");
 
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_tokio::connect::Config::default();
@@ -2483,7 +2483,7 @@ async fn one_shot_connect_surfaces_the_session_close() {
 	// close each session as soon as it lands.
 	let accepts = Arc::new(AtomicUsize::new(0));
 	let server_accepts = accepts.clone();
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let server_handle = tokio::spawn(async move {
 		while let Some(request) = server.accept().await {
 			server_accepts.fetch_add(1, Ordering::SeqCst);
@@ -2535,7 +2535,7 @@ async fn a_dead_session_unannounces_while_the_reconnect_retries() {
 	let (mut server, addr) = test_server().await;
 	let url: url::Url = format!("https://localhost:{}", addr.port()).parse().unwrap();
 
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let _broadcast = pub_origin
 		.create_broadcast("live", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("create broadcast");
@@ -2553,7 +2553,7 @@ async fn a_dead_session_unannounces_while_the_reconnect_retries() {
 		Ok::<_, anyhow::Error>(())
 	});
 
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_tokio::connect::Config::default();
@@ -2594,10 +2594,10 @@ async fn a_dead_session_unannounces_while_the_reconnect_retries() {
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn announce_interest_unauthorized_keeps_session_alive() {
-	use moq_tokio::moq_net::Origin;
+	use moq_tokio::moq_net::Hop;
 
 	// ── publisher (server): only allowed to announce under "allowed" ──
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("allowed/test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -2617,7 +2617,7 @@ async fn announce_interest_unauthorized_keeps_session_alive() {
 
 	// ── subscriber (client): interested in both "allowed" and "denied" ──
 	// "denied" is disjoint from the publisher's scope, so its announce stream is FINed.
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let consume = sub_origin
 		.scope(&["allowed".into(), "denied".into()])
 		.expect("failed to scope consume origin");
@@ -2672,10 +2672,10 @@ async fn announce_interest_unauthorized_keeps_session_alive() {
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn publish_only_client_to_subscribe_only_server() {
-	use moq_tokio::moq_net::Origin;
+	use moq_tokio::moq_net::Hop;
 
 	// ── subscriber (server): interested in both "allowed" and "denied" ──
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let consume = sub_origin
 		.scope(&["allowed".into(), "denied".into()])
 		.expect("failed to scope consume origin");
@@ -2733,7 +2733,7 @@ async fn publish_only_client_to_subscribe_only_server() {
 	});
 
 	// ── publisher (client): only allowed to serve under "allowed" ──
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("allowed/test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -2806,7 +2806,7 @@ async fn goaway_test(scheme: &str, version: &str, expect_wire_timeout: bool) {
 	let version: moq_net::Version = version.parse().expect("invalid version");
 
 	// ── publisher (server) ──────────────────────────────────────────
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut broadcast = pub_origin
 		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
 		.expect("failed to create broadcast");
@@ -2828,7 +2828,7 @@ async fn goaway_test(scheme: &str, version: &str, expect_wire_timeout: bool) {
 	let addr = server.local_addr().expect("failed to get local addr");
 
 	// ── subscriber (client) ─────────────────────────────────────────
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let mut announcements = sub_origin.consume().announced();
 
 	let mut client_config = moq_tokio::connect::Config::default();
@@ -2954,7 +2954,7 @@ async fn goaway_moq_transport_19_quic() {
 async fn goaway_timeout_force_close_moq_transport_19_quic() {
 	let version: moq_net::Version = "moq-transport-19".parse().unwrap();
 
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 
 	let mut server_config = moq_tokio::listen::Config::default();
 	server_config.bind = Some("[::]:0".to_string());
@@ -2983,7 +2983,7 @@ async fn goaway_timeout_force_close_moq_transport_19_quic() {
 		Ok::<_, anyhow::Error>(())
 	});
 
-	let sub_origin = moq_tokio::origin::spawn(Origin::random());
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
 	let (_client, connection) = tokio::time::timeout(TIMEOUT, connect_once(client.with_subscriber(sub_origin), url))
 		.await
 		.expect("client connect timed out")
@@ -3041,7 +3041,7 @@ async fn zero_initial_backoff_still_gives_up_on_a_flapping_peer() {
 	let (mut server, addr) = test_server().await;
 	let url: url::Url = format!("https://localhost:{}", addr.port()).parse().unwrap();
 
-	let pub_origin = moq_tokio::origin::spawn(Origin::random());
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
 	let server_handle = tokio::spawn(async move {
 		// Accept and immediately sever, over and over.
 		while let Some(request) = server.accept().await {

--- a/rs/moq-transcode/examples/transcode.rs
+++ b/rs/moq-transcode/examples/transcode.rs
@@ -41,8 +41,8 @@ async fn main() -> anyhow::Result<()> {
 
 	// Publish the derivative through one origin and consume the source through
 	// another, over a single auto-reconnecting session.
-	let publish = moq_tokio::origin::spawn(moq_net::Origin::random());
-	let remote = moq_tokio::origin::spawn(moq_net::Origin::random());
+	let publish = moq_tokio::origin::spawn(moq_net::Hop::random());
+	let remote = moq_tokio::origin::spawn(moq_net::Hop::random());
 
 	let client = moq_tokio::connect::Config::default().init(Default::default())?;
 	let session = client

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -585,7 +585,7 @@ mod tests {
 		// The passthrough reference (`..`) resolves against the output broadcast's path, so
 		// the output must be minted through an origin: a standalone producer has no path, and
 		// `..` from it would escape, failing the catalog read below.
-		let origin = moq_tokio::origin::spawn(moq_net::Origin::random());
+		let origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let output = origin
 			.create_broadcast("room/transcode", moq_net::broadcast::Route::new())
 			.unwrap();

--- a/rs/moq-uring/benches/session_lite.rs
+++ b/rs/moq-uring/benches/session_lite.rs
@@ -135,8 +135,8 @@ mod linux {
 			let mut worker = Worker::new(Config::default()).expect("worker");
 			let handle = worker.handle();
 
-			let (pub_origin, pub_driver) = origin::Producer::new(origin::Info::new(moq_net::Origin::random()));
-			let (sub_origin, sub_driver) = origin::Producer::new(origin::Info::new(moq_net::Origin::random()));
+			let (pub_origin, pub_driver) = origin::Producer::new(origin::Info::new(moq_net::Hop::random()));
+			let (sub_origin, sub_driver) = origin::Producer::new(origin::Info::new(moq_net::Hop::random()));
 			let origins = std::thread::spawn(move || {
 				let rt = tokio::runtime::Builder::new_current_thread()
 					.enable_time()

--- a/rs/moq-uring/tests/session.rs
+++ b/rs/moq-uring/tests/session.rs
@@ -44,8 +44,8 @@ fn lite_session_over_the_worker() {
 	let handle = worker.handle();
 
 	// The model and its origins, driven on a tokio thread (see module docs).
-	let (pub_origin, pub_driver) = origin::Producer::new(origin::Info::new(moq_net::Origin::random()));
-	let (sub_origin, sub_driver) = origin::Producer::new(origin::Info::new(moq_net::Origin::random()));
+	let (pub_origin, pub_driver) = origin::Producer::new(origin::Info::new(moq_net::Hop::random()));
+	let (sub_origin, sub_driver) = origin::Producer::new(origin::Info::new(moq_net::Hop::random()));
 	let origins = std::thread::spawn(move || {
 		let rt = tokio::runtime::Builder::new_current_thread()
 			.enable_time()
@@ -162,9 +162,9 @@ fn two_lite_sessions_share_the_server_socket() {
 	let Some(mut worker) = worker() else { return };
 	let handle = worker.handle();
 
-	let (pub_origin, pub_driver) = origin::Producer::new(origin::Info::new(moq_net::Origin::random()));
-	let (sub_a, sub_a_driver) = origin::Producer::new(origin::Info::new(moq_net::Origin::random()));
-	let (sub_b, sub_b_driver) = origin::Producer::new(origin::Info::new(moq_net::Origin::random()));
+	let (pub_origin, pub_driver) = origin::Producer::new(origin::Info::new(moq_net::Hop::random()));
+	let (sub_a, sub_a_driver) = origin::Producer::new(origin::Info::new(moq_net::Hop::random()));
+	let (sub_b, sub_b_driver) = origin::Producer::new(origin::Info::new(moq_net::Hop::random()));
 	let origins = std::thread::spawn(move || {
 		let rt = tokio::runtime::Builder::new_current_thread()
 			.enable_time()

--- a/rs/moq-uring/tests/web.rs
+++ b/rs/moq-uring/tests/web.rs
@@ -210,7 +210,7 @@ fn lite_session_over_webtransport() {
 	let handle = worker.handle();
 	let certs = support::certs().expect("certificates");
 
-	let (pub_origin, pub_driver) = origin::Producer::new(origin::Info::new(moq_net::Origin::random()));
+	let (pub_origin, pub_driver) = origin::Producer::new(origin::Info::new(moq_net::Hop::random()));
 	let origins = std::thread::spawn(move || {
 		let rt = tokio::runtime::Builder::new_current_thread()
 			.enable_time()
@@ -235,7 +235,7 @@ fn lite_session_over_webtransport() {
 	let client = quinn_client(format!("https://{addr}/"), |session| {
 		Box::pin(async move {
 			assert_eq!(session.protocol(), Some(PROTO), "negotiated subprotocol");
-			let (sub_origin, sub_driver) = origin::Producer::new(origin::Info::new(moq_net::Origin::random()));
+			let (sub_origin, sub_driver) = origin::Producer::new(origin::Info::new(moq_net::Hop::random()));
 			let driver = tokio::spawn(sub_driver.run(moq_tokio::runtime::Runtime::<()>::new()));
 
 			let moq = moq_net::Client::new()

--- a/rs/moq-video/src/decode/consumer.rs
+++ b/rs/moq-video/src/decode/consumer.rs
@@ -88,7 +88,7 @@ impl Consumer {
 mod tests {
 	/// Build an origin producer, spawning its driver on the ambient runtime.
 	fn produce_origin() -> moq_net::origin::Producer {
-		let (producer, driver) = moq_net::origin::Producer::new(moq_net::Origin::random().into());
+		let (producer, driver) = moq_net::origin::Producer::new(moq_net::Hop::random().into());
 		if tokio::runtime::Handle::try_current().is_ok() {
 			tokio::spawn(driver.run(moq_tokio::runtime::Runtime::<()>::new()));
 		} else {

--- a/rs/moq-wasm/src/lib.rs
+++ b/rs/moq-wasm/src/lib.rs
@@ -74,7 +74,7 @@ impl Session {
 	async fn handshake(transport: transport::Session) -> Result<Session, JsValue> {
 		// Wire a subscribe origin so the session has somewhere to insert the
 		// broadcasts the remote announces; keep a consumer to read them.
-		let (origin, origin_driver) = moq_net::origin::Producer::new(moq_net::Origin::random().into());
+		let (origin, origin_driver) = moq_net::origin::Producer::new(moq_net::Hop::random().into());
 		web_async::spawn(origin_driver.run(runtime::Runtime));
 		let consumer = origin.consume();
 		let client = moq_net::Client::new().with_subscriber(origin);


### PR DESCRIPTION
Started as a review of the API delta between `dev` and `main`, and turned into fixing what the review found. The delta itself is healthy: 464 public signatures removed against 1243 added, and every removal has a named replacement. No lost capability.

What it did surface was a naming collision and three smaller shape problems.

## `Origin` meant two unrelated things

`moq_net` exported both from the crate root. `origin::Producer` / `origin::Consumer` are a routing table: the broadcasts a peer can serve. `Origin` was the 62-bit id one relay stamps into a broadcast's hop chain so a receiver can spot its own id and reject a loop.

The docs had already lost the thread. `doc/lib/rs/index.md` told you to "wire an `Origin` into the client" while linking `struct.Origin.html` — the id, which isn't something you can wire anywhere.

The chain was also already half-renamed: `InvalidHop`, `MAX_HOPS`, `Route::hops`, and `with_hop` all said *hop*; only the type they were about didn't. So:

- `Origin` → `Hop`, `OriginList` → `Hops`
- `Client::with_peer_origin` and `Request::{with_peer_origin, peer_origin}` → `with_peer_hop` / `peer_hop`, in both `moq-net` and `moq-tokio`
- `InvalidOrigin` folds into `InvalidHop::Range` — two error types for one domain bought nothing, and `InvalidHop` was already `#[non_exhaustive]`
- `origin::Dynamic::info` returned the id while every other `info()` in the crate returns an `Info`; it's `hop()` now
- js/net's `hop.ts` gets the same treatment, where the collision was worse: `index.ts` re-exports the routing table as `Origin`, so the package had a `hop.ts` whose main export was named after a different module

Then, in a second pass, the three places users actually read:

- **moq-lite SETUP parameter 0x5 is `Hop`, not `Origin`.** Its value was already spelled `Hop ID` in the same table. The ID and encoding are untouched — this is editorial within **moq-lite-06, which is unpublished** (`Lite06Wip`), so the changelog entry that added it is corrected in place rather than gaining a "renamed from" note nobody should need. `AnnounceOk` followed too; the draft has called that field `Hop ID` all along and only the structs lagged.
- **`moq-relay`'s `GET /nodes` reports `hop_id`.** Straight rename, no shim: the endpoint's own docs say don't build on it.
- **`moq --origin` is `--hop`** (`MOQ_ORIGIN` → `MOQ_HOP`). The only *released* spelling of the three, so it takes the path the `--client-*` renames took: old flag stays hidden in the parser, and a process that passes it is refused with the migration rather than started on a setting it would not honor. That needed `Deprecated`'s recorders to go public — they were `pub(crate)`, so an external binary could consume a `Deprecated` but never contribute to one, and `moq-cli` flattening these configs is exactly the case that has to.

## Three smaller shapes

**`MoqError::Unsupported` was overloaded.** `track::Subscriber::ordered` consumes the subscriber, so mixing arrival-order and sequence-order reads is a compile error in Rust. A foreign binding can't express that, so `MoqTrackConsumer` commits on first read and refused the other cursor with `Unsupported` — the same error a caller gets when a feature genuinely isn't available. A binding couldn't tell "MoQ can't do this here" from "you held it wrong", and the two want opposite responses. `Unsupported` now means only the former; `AlreadyCommitted` names the latter and points at the fix.

**`Client::new` / `Server::new` took two positional configs**, so the next knob is either a third parameter or a breaking change. `client::Config { connect, quic }` and `server::Config { listen, quic }` group them without touching how a binary parses them — `quic::Config` is shared between both directions, so neither endpoint config can own the other. `connect::Config::init(quic)` is unchanged and still the way nearly every caller builds one.

**`resume.rs` had a private `max_unbounded_start`** that was `_some` behavior under a `_unbounded` name — the exact inversion a reader would assume. Combining optional bounds comes in two families that disagree on what `None` means, and picking the wrong one silently narrows or widens what the publisher sends. Now `max_some`, next to `min_some`, with the two families spelled out. Internal only.

## Not changed

`cluster.md`'s "origin identity" and the cluster draft's `RELAY_HOPS` are about the content's *origin publisher*, a genuinely different concept. `Role::from_origins` is about the publish/subscribe origin handles. `origin::Producer` still has a private field named `info` holding a `Hop`; untangling it means touching a dozen sites where `info` is also a local for the real `Info`, and the public surface reads correctly now.

## Verification

`nix develop` was deadlocked on a shared eval-cache SQLite lock held by another worktree, so **`just check` / `just test` did not run end to end.** Equivalent tools ran directly against the same nix-store `rust 1.95.0`:

- clippy `-D warnings`, 20 packages — clean
- `cargo nextest` on moq-net/moq-tokio/moq-cli/moq-relay — **1695 passed**
- `cargo fmt`, `biome check` — clean
- `tsc --noEmit` + `bun test` on `@moq/net` — 604 pass, 0 fail
- `kramdown-rfc` + `xml2rfc --preptool` on `draft-lcurley-moq-lite` — valid

Uncovered versus a real `just check`: the moq-doc build, the wasm and feature-gated selections, publint, remark, taplo. **CI is the gate on those.**

## Cross-package sync

`js/net` and `doc/` move with `moq-net`; the draft moves with the wire. Nothing crosses the FFI as a type (`MoqRoute.hops` is raw `u64`), so no bindings regenerate — only `go/wrapper` gains the `ErrAlreadyCommitted` sentinel, and the generated `go/ffi` picks the variant up on its next build. Interop (`just test smoke-full`) not run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 5)
