### PR TITLE
feat(moq-net): add moq-transport draft-20 (moqt-20)

### DIFF
--- a/doc/concept/layer/moq-lite.md
+++ b/doc/concept/layer/moq-lite.md
@@ -168,7 +168,7 @@ But if a publisher needs a feature, then the subscriber needs it too, so you can
 - **No Request IDs**: A bidirectional stream for each request to avoid HoLB. (NOTE: likely to be upstreamed into moq-transport)
 - **No Push**: A subscriber must explicitly subscribe to each track.
 - **Single-group FETCH only (lite-05+)**: Fetch one complete group by sequence. Ranges and joining fetches are not supported.
-- **No Joining Fetch**: Subscriptions start at the latest group, not the latest frame. On `moqt-20`, which replaced the joining fetch with a fill, we ask for the current group as a fill so playback starts on a group boundary. We serve an incoming fill as ordinary subgroups rather than opening a fetch stream, so a backfill never blocks the live edge behind it, and we accept a fill fetch stream from a peer that opens one, limited to the single group we asked for.
+- **No Joining Fetch**: Subscriptions start at the latest group, not the latest frame. On `moqt-20`, which replaced the joining fetch with a fill, we ask for the current group directly with a relative Location Filter and request no fill, so a group is never split across two streams. We serve a fill a peer asks us for as ordinary subgroups rather than opening a fetch stream, so a backfill never blocks the live edge behind it. We do not read an incoming fetch stream: having requested no fill, one would duplicate a group the subscription is already delivering.
 - **No sub-groups**: SVC layers should be separate tracks.
 - **No gaps**: Makes life much easier for the relay and every application.
 - **No object properties**: Encode your metadata into the frame payload.

--- a/doc/concept/layer/moq-lite.md
+++ b/doc/concept/layer/moq-lite.md
@@ -168,7 +168,7 @@ But if a publisher needs a feature, then the subscriber needs it too, so you can
 - **No Request IDs**: A bidirectional stream for each request to avoid HoLB. (NOTE: likely to be upstreamed into moq-transport)
 - **No Push**: A subscriber must explicitly subscribe to each track.
 - **Single-group FETCH only (lite-05+)**: Fetch one complete group by sequence. Ranges and joining fetches are not supported.
-- **No Joining Fetch**: Subscriptions start at the latest group, not the latest frame. On `moqt-20`, which replaced the joining fetch with a fill, we ask for the current group directly with a relative Location Filter and request no fill, so a group is never split across two streams. We serve a fill a peer asks us for as ordinary subgroups rather than opening a fetch stream, so a backfill never blocks the live edge behind it. We do not read an incoming fetch stream: having requested no fill, one would duplicate a group the subscription is already delivering.
+- **No Joining Fetch, and no fill**: Subscriptions start at the latest group, not the latest frame. `moqt-20` replaced the joining fetch with a fill, which we do not support in either direction. We ask for the current group directly with a relative Location Filter, so a group is never split across two streams; a fetch is capped at the largest published object, so it cannot deliver a group that is still being written. A fill a peer asks us for is parsed and ignored, and an incoming fetch stream is refused.
 - **No sub-groups**: SVC layers should be separate tracks.
 - **No gaps**: Makes life much easier for the relay and every application.
 - **No object properties**: Encode your metadata into the frame payload.

--- a/doc/concept/layer/moq-lite.md
+++ b/doc/concept/layer/moq-lite.md
@@ -168,11 +168,11 @@ But if a publisher needs a feature, then the subscriber needs it too, so you can
 - **No Request IDs**: A bidirectional stream for each request to avoid HoLB. (NOTE: likely to be upstreamed into moq-transport)
 - **No Push**: A subscriber must explicitly subscribe to each track.
 - **Single-group FETCH only (lite-05+)**: Fetch one complete group by sequence. Ranges and joining fetches are not supported.
-- **No Joining Fetch, and no fill**: Subscriptions start at the latest group, not the latest frame. `moqt-20` replaced the joining fetch with a fill, which we do not support in either direction. We ask for the current group directly with a relative Location Filter, so a group is never split across two streams; a fetch is capped at the largest published object, so it cannot deliver a group that is still being written. A fill a peer asks us for is parsed and ignored, and an incoming fetch stream is refused.
+- **No Joining Fetch, and single-group fills only**: Subscriptions start at the latest group, not the latest frame. `moqt-20` replaced the joining fetch with a fill. As a publisher we serve a fill whose range resolves to a single group, straight from the group cache and capped at the largest published object, which covers `moqt-20`'s own current-group join (a Next Object subscription plus a `StartGroup=1` fill); a fill spanning several groups is refused by resetting its fetch stream. As a subscriber we request no fill: we ask for the current group directly with a relative Location Filter instead, and refuse an incoming fetch stream because it answers no request of ours. Against a strict publisher, which only delivers objects published after the subscription, that degrades the join to the next group boundary.
 - **No sub-groups**: SVC layers should be separate tracks.
 - **No gaps**: Makes life much easier for the relay and every application.
 - **No object properties**: Encode your metadata into the frame payload.
-- **Group granularity**: A subscription starts and ends on a group. A `moq-transport` Location Filter can narrow a range to an object, but we widen it back to whole groups, so a filter that starts or ends mid-group gets the entire group.
+- **Group granularity, object-trimmed**: A subscription starts and ends on a group. A `moq-transport` Location Filter can narrow a range to an object, and delivery honors that: the start group is served from the requested object and the end group up to it. The subscription itself still spans whole groups.
 - **No pausing**: Unsubscribe if you don't want a track.
 - **No binary names**: Uses UTF-8 strings instead of arrays of byte arrays.
 

--- a/doc/concept/layer/moq-lite.md
+++ b/doc/concept/layer/moq-lite.md
@@ -168,7 +168,7 @@ But if a publisher needs a feature, then the subscriber needs it too, so you can
 - **No Request IDs**: A bidirectional stream for each request to avoid HoLB. (NOTE: likely to be upstreamed into moq-transport)
 - **No Push**: A subscriber must explicitly subscribe to each track.
 - **Single-group FETCH only (lite-05+)**: Fetch one complete group by sequence. Ranges and joining fetches are not supported.
-- **No Joining Fetch**: Subscriptions start at the latest group, not the latest frame.
+- **No Joining Fetch**: Subscriptions start at the latest group, not the latest frame. On `moqt-20`, which replaced the joining fetch with a fill, we ask for the current group as a fill so playback starts on a group boundary. We serve an incoming fill as ordinary subgroups rather than opening a fetch stream, so a backfill never blocks the live edge behind it, and we accept a fill fetch stream from a peer that opens one, limited to the single group we asked for.
 - **No sub-groups**: SVC layers should be separate tracks.
 - **No gaps**: Makes life much easier for the relay and every application.
 - **No object properties**: Encode your metadata into the frame payload.

--- a/doc/concept/layer/moq-lite.md
+++ b/doc/concept/layer/moq-lite.md
@@ -172,6 +172,7 @@ But if a publisher needs a feature, then the subscriber needs it too, so you can
 - **No sub-groups**: SVC layers should be separate tracks.
 - **No gaps**: Makes life much easier for the relay and every application.
 - **No object properties**: Encode your metadata into the frame payload.
+- **Group granularity**: A subscription starts and ends on a group. A `moq-transport` Location Filter can narrow a range to an object, but we widen it back to whole groups, so a filter that starts or ends mid-group gets the entire group.
 - **No pausing**: Unsubscribe if you don't want a track.
 - **No binary names**: Uses UTF-8 strings instead of arrays of byte arrays.
 

--- a/js/net/src/connection/accept.ts
+++ b/js/net/src/connection/accept.ts
@@ -30,6 +30,9 @@ export async function accept(transport: WebTransport, url: URL, props?: AcceptPr
 
 	const discovery = props?.discovery ?? true;
 
+	if (protocol === Ietf.ALPN.DRAFT_20) {
+		return acceptAlpn(transport, url, Ietf.Version.DRAFT_20, discovery);
+	}
 	if (protocol === Ietf.ALPN.DRAFT_19) {
 		return acceptAlpn(transport, url, Ietf.Version.DRAFT_19, discovery);
 	} else if (protocol === Ietf.ALPN.DRAFT_18) {

--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -196,13 +196,15 @@ async function connectTransport(url: URL, session: WebTransport, discovery: bool
 	// Choose setup encoding based on negotiated WebTransport protocol (if any).
 	let setupVersion: Ietf.Version;
 	const modernVersion =
-		protocol === Ietf.ALPN.DRAFT_19
-			? Ietf.Version.DRAFT_19
-			: protocol === Ietf.ALPN.DRAFT_18
-				? Ietf.Version.DRAFT_18
-				: protocol === Ietf.ALPN.DRAFT_17
-					? Ietf.Version.DRAFT_17
-					: undefined;
+		protocol === Ietf.ALPN.DRAFT_20
+			? Ietf.Version.DRAFT_20
+			: protocol === Ietf.ALPN.DRAFT_19
+				? Ietf.Version.DRAFT_19
+				: protocol === Ietf.ALPN.DRAFT_18
+					? Ietf.Version.DRAFT_18
+					: protocol === Ietf.ALPN.DRAFT_17
+						? Ietf.Version.DRAFT_17
+						: undefined;
 	if (modernVersion !== undefined) {
 		return await handshakeAlpn(url, session, modernVersion, discovery);
 	} else if (protocol === Ietf.ALPN.DRAFT_16) {
@@ -367,6 +369,7 @@ async function connectWebTransport(
 			Lite.ALPN_04,
 			Lite.ALPN_03,
 			Lite.ALPN,
+			Ietf.ALPN.DRAFT_20,
 			Ietf.ALPN.DRAFT_19,
 			Ietf.ALPN.DRAFT_18,
 			Ietf.ALPN.DRAFT_17,

--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -449,6 +449,7 @@ async function connectWebSocket(url: URL, delay: number, cancel: Promise<void>):
 		[Lite.ALPN_04]: null,
 		[Lite.ALPN_03]: null,
 		[Lite.ALPN]: null,
+		[Ietf.ALPN.DRAFT_20]: "qmux-01",
 		[Ietf.ALPN.DRAFT_18]: "qmux-01",
 		[Ietf.ALPN.DRAFT_17]: null,
 		[Ietf.ALPN.DRAFT_16]: null,

--- a/js/net/src/ietf/filter.test.ts
+++ b/js/net/src/ietf/filter.test.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "bun:test";
+import * as Filter from "./filter.ts";
+import { Version } from "./version.ts";
+
+const OLD = Version.DRAFT_19;
+const NEW = Version.DRAFT_20;
+
+function roundTrip(filter: Filter.Filter, version: typeof OLD | typeof NEW): Filter.Filter {
+	return Filter.decode(Filter.encode(filter, version), version);
+}
+
+test("draft-20 selects the meaning by field count", () => {
+	expect([...Filter.encode({ kind: "nextObject" }, NEW)]).toEqual([0x00, 0x00]);
+	expect([...Filter.encode({ kind: "relative", groups: 0n }, NEW)]).toEqual([0x00]);
+	expect([...Filter.encode({ kind: "relative", groups: 1n }, NEW)]).toEqual([0x01]);
+	expect([...Filter.encode({ kind: "absolute", startGroup: 7n, startObject: 3n }, NEW)]).toEqual([0x07, 0x03]);
+	// End is a delta from the start group, not an absolute group id.
+	expect([...Filter.encode({ kind: "absolute", startGroup: 7n, startObject: 3n, endGroup: 9n }, NEW)]).toEqual([
+		0x07, 0x03, 0x02,
+	]);
+});
+
+test("draft-20 round trips", () => {
+	const filters: Filter.Filter[] = [
+		{ kind: "unfiltered" },
+		{ kind: "nextObject" },
+		{ kind: "relative", groups: 0n },
+		{ kind: "relative", groups: 5n },
+		{ kind: "absolute", startGroup: 12n, startObject: 0n, endGroup: undefined },
+		{ kind: "absolute", startGroup: 12n, startObject: 4n, endGroup: 20n },
+	];
+	for (const filter of filters) {
+		expect(roundTrip(filter, NEW)).toEqual(filter);
+	}
+});
+
+// An open ended absolute {0, 0} is defined as equivalent to unfiltered, so it must not
+// collide with the two-zero-field spelling of Next Object.
+test("draft-20 absolute origin is unfiltered", () => {
+	const origin: Filter.Filter = { kind: "absolute", startGroup: 0n, startObject: 0n };
+	expect(Filter.encode(origin, NEW).length).toBe(0);
+	expect(roundTrip(origin, NEW)).toEqual({ kind: "unfiltered" });
+});
+
+test("draft-19 uses tags", () => {
+	expect([...Filter.encode({ kind: "nextObject" }, OLD)]).toEqual([0x02]);
+	expect([...Filter.encode({ kind: "relative", groups: 0n }, OLD)]).toEqual([0x01]);
+
+	const filters: Filter.Filter[] = [
+		{ kind: "nextObject" },
+		{ kind: "relative", groups: 0n },
+		{ kind: "absolute", startGroup: 12n, startObject: 4n, endGroup: undefined },
+		{ kind: "absolute", startGroup: 12n, startObject: 4n, endGroup: 20n },
+	];
+	for (const filter of filters) {
+		expect(roundTrip(filter, OLD)).toEqual(filter);
+	}
+});
+
+// Draft-19 has a tag per case and none of them mean "two groups back", so refuse rather
+// than silently sending a nearby filter the peer would honor.
+test("draft-19 cannot name a relative group", () => {
+	expect(() => Filter.encode({ kind: "relative", groups: 2n }, OLD)).toThrow();
+});
+
+test("rejects a backwards range", () => {
+	for (const version of [OLD, NEW] as const) {
+		expect(() =>
+			Filter.encode({ kind: "absolute", startGroup: 9n, startObject: 0n, endGroup: 4n }, version),
+		).toThrow();
+	}
+});
+
+test("rejects too many fields", () => {
+	expect(() => Filter.decode(new Uint8Array([0, 0, 0, 0, 0]), NEW)).toThrow();
+});
+
+// The canonical current-group join: an empty subscription filter paired with a fill that
+// starts one group back.
+test("fill encodes the current group join", () => {
+	const encoded = Filter.encodeFill({ kind: "relative", groups: 1n }, NEW);
+	// count=1, type=0x21, len=1, StartGroup=1
+	expect([...encoded]).toEqual([0x01, 0x21, 0x01, 0x01]);
+	expect(Filter.decodeFill(encoded, NEW)).toEqual({ kind: "relative", groups: 1n });
+});
+
+test("fill round trips", () => {
+	const filters: Filter.Filter[] = [
+		{ kind: "unfiltered" },
+		{ kind: "relative", groups: 3n },
+		{ kind: "absolute", startGroup: 4n, startObject: 0n, endGroup: 9n },
+	];
+	for (const filter of filters) {
+		expect(Filter.decodeFill(Filter.encodeFill(filter, NEW), NEW)).toEqual(filter);
+	}
+});
+
+// A parameter the draft does not allow inside the scope is a violation, not something to
+// skip past.
+test("fill rejects a disallowed parameter", () => {
+	// count=1, type=0x10 (FORWARD), value=0
+	expect(() => Filter.decodeFill(new Uint8Array([0x01, 0x10, 0x00]), NEW)).toThrow();
+});
+
+// An allowed parameter we ignore still has to be consumed, or the keys after it desync.
+// Parity decides how many bytes that is.
+test("fill skips allowed parameters it ignores", () => {
+	// count=2, 0x20 (even, one varint) = 42, delta 1 -> 0x21 (odd, length prefixed)
+	const encoded = new Uint8Array([0x02, 0x20, 0x2a, 0x01, 0x01, 0x02]);
+	expect(Filter.decodeFill(encoded, NEW)).toEqual({ kind: "relative", groups: 2n });
+});

--- a/js/net/src/ietf/filter.test.ts
+++ b/js/net/src/ietf/filter.test.ts
@@ -71,6 +71,39 @@ test("rejects a backwards range", () => {
 	}
 });
 
+// The fourth field bounds the last object in the end group. Dropping it on decode would
+// let a publisher deliver past the Location the subscriber asked for.
+test("draft-20 keeps the end object", () => {
+	const bounded: Filter.Filter = {
+		kind: "absolute",
+		startGroup: 7n,
+		startObject: 3n,
+		endGroup: 9n,
+		endObject: 4n,
+	};
+	expect([...Filter.encode(bounded, NEW)]).toEqual([0x07, 0x03, 0x02, 0x04]);
+	expect(roundTrip(bounded, NEW)).toEqual(bounded);
+
+	// Three fields leave the end group whole, which is a different filter.
+	const whole: Filter.Filter = { kind: "absolute", startGroup: 7n, startObject: 3n, endGroup: 9n };
+	expect([...Filter.encode(whole, NEW)]).toEqual([0x07, 0x03, 0x02]);
+});
+
+// Draft-19's AbsoluteRange ends on a group, so an object bound cannot be expressed.
+test("draft-19 cannot bound the end object", () => {
+	expect(() =>
+		Filter.encode({ kind: "absolute", startGroup: 7n, startObject: 0n, endGroup: 9n, endObject: 4n }, OLD),
+	).toThrow();
+});
+
+// OBJECTID_FILTER has an even id but is written with an explicit Length, so parity would
+// read its length byte as the whole value and desync everything after it.
+test("fill skips a length-prefixed range filter", () => {
+	// count=2, 0x26 len=3 AABBCC, delta 1 -> 0x27 len=1 DD
+	const encoded = new Uint8Array([0x02, 0x26, 0x03, 0xaa, 0xbb, 0xcc, 0x01, 0x01, 0xdd]);
+	expect(Filter.decodeFill(encoded, NEW)).toEqual({ kind: "unfiltered" });
+});
+
 test("rejects too many fields", () => {
 	expect(() => Filter.decode(new Uint8Array([0, 0, 0, 0, 0]), NEW)).toThrow();
 });

--- a/js/net/src/ietf/filter.test.ts
+++ b/js/net/src/ietf/filter.test.ts
@@ -137,6 +137,26 @@ test("fill rejects a disallowed parameter", () => {
 
 // An allowed parameter we ignore still has to be consumed, or the keys after it desync.
 // Parity decides how many bytes that is.
+// Draft-17 replaced QUIC's varint with a leading-1-bits one. They agree below 64, so a
+// wrong codec is invisible until group or object ids grow past that, and then Rust and JS
+// stop understanding each other's filters.
+test("draft-20 uses leading-ones varints above 63", () => {
+	// 128 is 0x80_80 with leading ones, and 0x40_80 with the QUIC form.
+	expect([...Filter.encode({ kind: "relative", groups: 128n }, NEW)]).toEqual([0x80, 0x80]);
+	expect(roundTrip({ kind: "relative", groups: 128n }, NEW)).toEqual({ kind: "relative", groups: 128n });
+
+	const wide: Filter.Filter = { kind: "absolute", startGroup: 300n, startObject: 64n };
+	expect(roundTrip(wide, NEW)).toEqual({ ...wide, endGroup: undefined, endObject: undefined });
+});
+
+// A uint8 parameter is one raw byte, so a priority of 128 or more would be read as a
+// multi-byte varint prefix and swallow the parameter after it.
+test("fill skips a uint8 parameter whose value has a leading one", () => {
+	// count=2, 0x20 (uint8) = 0x80, delta 1 -> 0x21 len=1 StartGroup=1
+	const encoded = new Uint8Array([0x02, 0x20, 0x80, 0x01, 0x01, 0x01]);
+	expect(Filter.decodeFill(encoded, NEW)).toEqual({ kind: "relative", groups: 1n });
+});
+
 test("fill skips allowed parameters it ignores", () => {
 	// count=2, 0x20 (even, one varint) = 42, delta 1 -> 0x21 (odd, length prefixed)
 	const encoded = new Uint8Array([0x02, 0x20, 0x2a, 0x01, 0x01, 0x02]);

--- a/js/net/src/ietf/filter.ts
+++ b/js/net/src/ietf/filter.ts
@@ -1,0 +1,273 @@
+/**
+ * The Location Filter carried by SUBSCRIBE, and draft-20's fill request.
+ *
+ * @module
+ */
+
+import * as Varint from "../varint.ts";
+import { type IetfVersion, Version } from "./version.ts";
+
+/** Which Objects a subscription delivers. */
+export type Filter =
+	/** Every Object in the track, encoded by omitting the parameter. */
+	| { kind: "unfiltered" }
+	/** The next Object after the live edge, which can begin mid-group. */
+	| { kind: "nextObject" }
+	/**
+	 * The given number of groups back from the next group, always open ended.
+	 * Zero is the next group and one is the current one.
+	 */
+	| { kind: "relative"; groups: bigint }
+	/** An absolute range, ending after `endGroup` (inclusive) when one is set. */
+	| { kind: "absolute"; startGroup: bigint; startObject: bigint; endGroup?: bigint };
+
+/** The tagged Filter Type of draft-19 and earlier. */
+const TAG_NEXT_GROUP = 0x1n;
+const TAG_LARGEST_OBJECT = 0x2n;
+const TAG_ABSOLUTE_START = 0x3n;
+const TAG_ABSOLUTE_RANGE = 0x4n;
+
+/**
+ * Whether this is draft-20 or newer.
+ *
+ * Draft-20 replaced the Filter Type tag with up to four optional varints, where the number
+ * present selects the meaning.
+ */
+export function isDraft20(version: IetfVersion): boolean {
+	return version === Version.DRAFT_20;
+}
+
+function concat(parts: Uint8Array[]): Uint8Array {
+	const total = parts.reduce((n, p) => n + p.length, 0);
+	const out = new Uint8Array(total);
+	let offset = 0;
+	for (const part of parts) {
+		out.set(part, offset);
+		offset += part.length;
+	}
+	return out;
+}
+
+function endDelta(startGroup: bigint, endGroup: bigint): bigint {
+	if (endGroup < startGroup) {
+		throw new Error(`filter range runs backwards: ${startGroup} > ${endGroup}`);
+	}
+	return endGroup - startGroup;
+}
+
+/** Encode a filter as its raw parameter value. Unfiltered encodes to zero bytes. */
+export function encode(filter: Filter, version: IetfVersion): Uint8Array {
+	return isDraft20(version) ? encodeFields(filter) : encodeTag(filter);
+}
+
+function encodeFields(filter: Filter): Uint8Array {
+	switch (filter.kind) {
+		case "unfiltered":
+			return new Uint8Array();
+		case "nextObject":
+			return concat([Varint.encode(0n), Varint.encode(0n)]);
+		case "relative":
+			return Varint.encode(filter.groups);
+		case "absolute": {
+			// An open ended absolute {0, 0} is defined as equivalent to unfiltered, so it
+			// normalizes rather than colliding with the two-zero-field nextObject spelling.
+			if (filter.startGroup === 0n && filter.startObject === 0n && filter.endGroup === undefined) {
+				return new Uint8Array();
+			}
+			const parts = [Varint.encode(filter.startGroup), Varint.encode(filter.startObject)];
+			if (filter.endGroup !== undefined) {
+				parts.push(Varint.encode(endDelta(filter.startGroup, filter.endGroup)));
+			}
+			return concat(parts);
+		}
+	}
+}
+
+function encodeTag(filter: Filter): Uint8Array {
+	switch (filter.kind) {
+		case "unfiltered":
+			// No tag means "everything", which only the absolute spelling can say.
+			return concat([Varint.encode(TAG_ABSOLUTE_START), Varint.encode(0n), Varint.encode(0n)]);
+		case "nextObject":
+			return Varint.encode(TAG_LARGEST_OBJECT);
+		case "relative":
+			if (filter.groups !== 0n) {
+				// Only draft-20 can name a start further back than the next group without
+				// knowing Largest Object, so there is no honest tag to fall back to.
+				throw new Error(`relative filter ${filter.groups} needs draft-20`);
+			}
+			return Varint.encode(TAG_NEXT_GROUP);
+		case "absolute": {
+			const parts = [
+				Varint.encode(filter.endGroup === undefined ? TAG_ABSOLUTE_START : TAG_ABSOLUTE_RANGE),
+				Varint.encode(filter.startGroup),
+				Varint.encode(filter.startObject),
+			];
+			if (filter.endGroup !== undefined) {
+				parts.push(Varint.encode(endDelta(filter.startGroup, filter.endGroup)));
+			}
+			return concat(parts);
+		}
+	}
+}
+
+/** Decode a filter from its raw parameter value. */
+export function decode(data: Uint8Array, version: IetfVersion): Filter {
+	return isDraft20(version) ? decodeFields(data) : decodeTag(data);
+}
+
+function decodeFields(data: Uint8Array): Filter {
+	const fields: bigint[] = [];
+	let rest = data;
+	while (rest.length > 0) {
+		if (fields.length === 4) {
+			throw new Error("too many fields in LOCATION_FILTER");
+		}
+		const [value, next] = Varint.decodeBigInt(rest);
+		fields.push(value);
+		rest = next;
+	}
+
+	switch (fields.length) {
+		case 0:
+			return { kind: "unfiltered" };
+		case 1:
+			return { kind: "relative", groups: fields[0] };
+		default: {
+			const [startGroup, startObject] = fields;
+			// Two zeroes is the Next Object spelling; anything else is an absolute start.
+			if (fields.length === 2 && startGroup === 0n && startObject === 0n) {
+				return { kind: "nextObject" };
+			}
+			// The fourth field is End Object. We deliver whole groups, so the end group is
+			// all we act on, but it still has to parse or the value is not consumed.
+			const endGroup = fields.length >= 3 ? startGroup + fields[2] : undefined;
+			return { kind: "absolute", startGroup, startObject, endGroup };
+		}
+	}
+}
+
+function decodeTag(data: Uint8Array): Filter {
+	const [tag, afterTag] = Varint.decodeBigInt(data);
+
+	const readLocation = (buf: Uint8Array): [bigint, bigint, Uint8Array] => {
+		const [group, afterGroup] = Varint.decodeBigInt(buf);
+		const [object, rest] = Varint.decodeBigInt(afterGroup);
+		return [group, object, rest];
+	};
+
+	switch (tag) {
+		case TAG_NEXT_GROUP:
+			expectEmpty(afterTag);
+			return { kind: "relative", groups: 0n };
+		case TAG_LARGEST_OBJECT:
+			expectEmpty(afterTag);
+			return { kind: "nextObject" };
+		case TAG_ABSOLUTE_START: {
+			const [startGroup, startObject, rest] = readLocation(afterTag);
+			expectEmpty(rest);
+			return { kind: "absolute", startGroup, startObject };
+		}
+		case TAG_ABSOLUTE_RANGE: {
+			const [startGroup, startObject, afterLocation] = readLocation(afterTag);
+			const [delta, rest] = Varint.decodeBigInt(afterLocation);
+			expectEmpty(rest);
+			return { kind: "absolute", startGroup, startObject, endGroup: startGroup + delta };
+		}
+		default:
+			throw new Error(`unsupported filter type: ${tag}`);
+	}
+}
+
+function expectEmpty(rest: Uint8Array): void {
+	if (rest.length !== 0) {
+		throw new Error("trailing bytes in LOCATION_FILTER");
+	}
+}
+
+/** LOCATION_FILTER, the only parameter we act on inside a fill. */
+const FILL_LOCATION_FILTER = 0x21n;
+
+/**
+ * The parameters draft-20 allows inside FILL_PARAMETERS. Anything else is a protocol
+ * violation rather than something to skip.
+ */
+const FILL_ALLOWED = new Set([
+	0x0an, // FILL_TIMEOUT
+	0x20n, // SUBSCRIBER_PRIORITY
+	FILL_LOCATION_FILTER,
+	0x22n, // GROUP_ORDER
+	0x25n, // SUBGROUP_FILTER
+	0x26n, // OBJECTID_FILTER
+	0x27n, // PRIORITY_FILTER
+	0x28n, // OBJECT_PROPERTY_FILTER
+]);
+
+/**
+ * Encode FILL_PARAMETERS, whose presence is what requests a backfill.
+ *
+ * The value is a nested parameter scope, encoded like a message's parameters.
+ */
+export function encodeFill(filter: Filter, version: IetfVersion): Uint8Array {
+	if (filter.kind === "unfiltered") {
+		// An empty scope fills the whole track up to Largest Object.
+		return Varint.encode(0n);
+	}
+	return concat([
+		Varint.encode(1n),
+		// The first type in a scope is not delta encoded, so this is the raw id.
+		Varint.encode(FILL_LOCATION_FILTER),
+		encodeLengthPrefixed(encode(filter, version)),
+	]);
+}
+
+/** Decode FILL_PARAMETERS, returning the range it asks to fill. */
+export function decodeFill(data: Uint8Array, version: IetfVersion): Filter {
+	const [count, afterCount] = Varint.decodeBigInt(data);
+	if (count > 64n) {
+		throw new Error("too many parameters in FILL_PARAMETERS");
+	}
+
+	let rest = afterCount;
+	let filter: Filter | undefined;
+	let prev = 0n;
+	for (let i = 0n; i < count; i++) {
+		const [delta, afterType] = Varint.decodeBigInt(rest);
+		const key = i === 0n ? delta : prev + delta;
+		prev = key;
+		rest = afterType;
+
+		if (!FILL_ALLOWED.has(key)) {
+			throw new Error(`parameter ${key} is not allowed inside FILL_PARAMETERS`);
+		}
+
+		// The rest are parameters we do not act on, but their bytes still have to be
+		// consumed or the remaining keys desync. Key-Value-Pair parity says how: an even
+		// type carries a single varint, an odd type a length-prefixed byte string.
+		if (key % 2n === 0n) {
+			[, rest] = Varint.decodeBigInt(rest);
+			continue;
+		}
+
+		const [length, afterLength] = Varint.decodeBigInt(rest);
+		const value = afterLength.slice(0, Number(length));
+		rest = afterLength.slice(Number(length));
+
+		if (key === FILL_LOCATION_FILTER) {
+			if (filter !== undefined) {
+				throw new Error("duplicate LOCATION_FILTER inside FILL_PARAMETERS");
+			}
+			filter = decode(value, version);
+		}
+	}
+
+	if (rest.length !== 0) {
+		throw new Error("trailing bytes in FILL_PARAMETERS");
+	}
+
+	return filter ?? { kind: "unfiltered" };
+}
+
+function encodeLengthPrefixed(value: Uint8Array): Uint8Array {
+	return concat([Varint.encode(BigInt(value.length)), value]);
+}

--- a/js/net/src/ietf/filter.ts
+++ b/js/net/src/ietf/filter.ts
@@ -18,8 +18,11 @@ export type Filter =
 	 * Zero is the next group and one is the current one.
 	 */
 	| { kind: "relative"; groups: bigint }
-	/** An absolute range, ending after `endGroup` (inclusive) when one is set. */
-	| { kind: "absolute"; startGroup: bigint; startObject: bigint; endGroup?: bigint };
+	/**
+	 * An absolute range. `endGroup` is the last group, inclusive; `endObject` further bounds
+	 * the last object in it, and its absence includes the whole end group.
+	 */
+	| { kind: "absolute"; startGroup: bigint; startObject: bigint; endGroup?: bigint; endObject?: bigint };
 
 /** The tagged Filter Type of draft-19 and earlier. */
 const TAG_NEXT_GROUP = 0x1n;
@@ -77,6 +80,9 @@ function encodeFields(filter: Filter): Uint8Array {
 			const parts = [Varint.encode(filter.startGroup), Varint.encode(filter.startObject)];
 			if (filter.endGroup !== undefined) {
 				parts.push(Varint.encode(endDelta(filter.startGroup, filter.endGroup)));
+				if (filter.endObject !== undefined) {
+					parts.push(Varint.encode(filter.endObject));
+				}
 			}
 			return concat(parts);
 		}
@@ -98,6 +104,11 @@ function encodeTag(filter: Filter): Uint8Array {
 			}
 			return Varint.encode(TAG_NEXT_GROUP);
 		case "absolute": {
+			// Draft-19's AbsoluteRange ends on a group, so an object-bounded range has no
+			// spelling. Refuse rather than widen the range the caller asked for.
+			if (filter.endObject !== undefined) {
+				throw new Error("an object-bounded range needs draft-20");
+			}
 			const parts = [
 				Varint.encode(filter.endGroup === undefined ? TAG_ABSOLUTE_START : TAG_ABSOLUTE_RANGE),
 				Varint.encode(filter.startGroup),
@@ -139,10 +150,9 @@ function decodeFields(data: Uint8Array): Filter {
 			if (fields.length === 2 && startGroup === 0n && startObject === 0n) {
 				return { kind: "nextObject" };
 			}
-			// The fourth field is End Object. We deliver whole groups, so the end group is
-			// all we act on, but it still has to parse or the value is not consumed.
 			const endGroup = fields.length >= 3 ? startGroup + fields[2] : undefined;
-			return { kind: "absolute", startGroup, startObject, endGroup };
+			const endObject = fields.length === 4 ? fields[3] : undefined;
+			return { kind: "absolute", startGroup, startObject, endGroup, endObject };
 		}
 	}
 }
@@ -192,15 +202,23 @@ const FILL_LOCATION_FILTER = 0x21n;
  * The parameters draft-20 allows inside FILL_PARAMETERS. Anything else is a protocol
  * violation rather than something to skip.
  */
-const FILL_ALLOWED = new Set([
-	0x0an, // FILL_TIMEOUT
-	0x20n, // SUBSCRIBER_PRIORITY
-	FILL_LOCATION_FILTER,
-	0x22n, // GROUP_ORDER
-	0x25n, // SUBGROUP_FILTER
-	0x26n, // OBJECTID_FILTER
-	0x27n, // PRIORITY_FILTER
-	0x28n, // OBJECT_PROPERTY_FILTER
+/**
+ * Maps each to whether it carries a length prefix.
+ *
+ * The Key-Value-Pair rule keys the framing off the id's parity, but the Range Filters
+ * (0x25-0x28) are written with an explicit `Length` field despite two of them having even
+ * ids. Their own definition wins, so the framing is tabulated rather than derived: reading
+ * 0x26 or 0x28 as a bare varint would desync every parameter after it.
+ */
+const FILL_ALLOWED = new Map<bigint, boolean>([
+	[0x0an, false], // FILL_TIMEOUT, a varint
+	[0x20n, false], // SUBSCRIBER_PRIORITY, a uint8 varint
+	[FILL_LOCATION_FILTER, true],
+	[0x22n, false], // GROUP_ORDER, a uint8 varint
+	[0x25n, true], // SUBGROUP_FILTER
+	[0x26n, true], // OBJECTID_FILTER, length prefixed despite an even id
+	[0x27n, true], // PRIORITY_FILTER
+	[0x28n, true], // OBJECT_PROPERTY_FILTER, likewise
 ]);
 
 /**
@@ -237,19 +255,22 @@ export function decodeFill(data: Uint8Array, version: IetfVersion): Filter {
 		prev = key;
 		rest = afterType;
 
-		if (!FILL_ALLOWED.has(key)) {
+		const lengthPrefixed = FILL_ALLOWED.get(key);
+		if (lengthPrefixed === undefined) {
 			throw new Error(`parameter ${key} is not allowed inside FILL_PARAMETERS`);
 		}
 
 		// The rest are parameters we do not act on, but their bytes still have to be
-		// consumed or the remaining keys desync. Key-Value-Pair parity says how: an even
-		// type carries a single varint, an odd type a length-prefixed byte string.
-		if (key % 2n === 0n) {
+		// consumed or the remaining keys desync.
+		if (!lengthPrefixed) {
 			[, rest] = Varint.decodeBigInt(rest);
 			continue;
 		}
 
 		const [length, afterLength] = Varint.decodeBigInt(rest);
+		if (BigInt(afterLength.length) < length) {
+			throw new Error("truncated value inside FILL_PARAMETERS");
+		}
 		const value = afterLength.slice(0, Number(length));
 		rest = afterLength.slice(Number(length));
 

--- a/js/net/src/ietf/filter.ts
+++ b/js/net/src/ietf/filter.ts
@@ -40,6 +40,23 @@ export function isDraft20(version: IetfVersion): boolean {
 	return version === Version.DRAFT_20;
 }
 
+/**
+ * Draft-17 replaced QUIC's two-bit-length varint with a leading-1-bits one. The two agree
+ * below 64 and diverge above it, so getting this wrong is invisible until group or object
+ * ids grow past that.
+ */
+function usesLeadingOnes(version: IetfVersion): boolean {
+	return version !== Version.DRAFT_14 && version !== Version.DRAFT_15 && version !== Version.DRAFT_16;
+}
+
+function varint(v: bigint, version: IetfVersion): Uint8Array {
+	return usesLeadingOnes(version) ? Varint.encodeLeadingOnes(v) : Varint.encode(v);
+}
+
+function unvarint(buf: Uint8Array, version: IetfVersion): [bigint, Uint8Array] {
+	return usesLeadingOnes(version) ? Varint.decodeLeadingOnes(buf) : Varint.decodeBigInt(buf);
+}
+
 function concat(parts: Uint8Array[]): Uint8Array {
 	const total = parts.reduce((n, p) => n + p.length, 0);
 	const out = new Uint8Array(total);
@@ -60,28 +77,28 @@ function endDelta(startGroup: bigint, endGroup: bigint): bigint {
 
 /** Encode a filter as its raw parameter value. Unfiltered encodes to zero bytes. */
 export function encode(filter: Filter, version: IetfVersion): Uint8Array {
-	return isDraft20(version) ? encodeFields(filter) : encodeTag(filter);
+	return isDraft20(version) ? encodeFields(filter, version) : encodeTag(filter, version);
 }
 
-function encodeFields(filter: Filter): Uint8Array {
+function encodeFields(filter: Filter, version: IetfVersion): Uint8Array {
 	switch (filter.kind) {
 		case "unfiltered":
 			return new Uint8Array();
 		case "nextObject":
-			return concat([Varint.encode(0n), Varint.encode(0n)]);
+			return concat([varint(0n, version), varint(0n, version)]);
 		case "relative":
-			return Varint.encode(filter.groups);
+			return varint(filter.groups, version);
 		case "absolute": {
 			// An open ended absolute {0, 0} is defined as equivalent to unfiltered, so it
 			// normalizes rather than colliding with the two-zero-field nextObject spelling.
 			if (filter.startGroup === 0n && filter.startObject === 0n && filter.endGroup === undefined) {
 				return new Uint8Array();
 			}
-			const parts = [Varint.encode(filter.startGroup), Varint.encode(filter.startObject)];
+			const parts = [varint(filter.startGroup, version), varint(filter.startObject, version)];
 			if (filter.endGroup !== undefined) {
-				parts.push(Varint.encode(endDelta(filter.startGroup, filter.endGroup)));
+				parts.push(varint(endDelta(filter.startGroup, filter.endGroup), version));
 				if (filter.endObject !== undefined) {
-					parts.push(Varint.encode(filter.endObject));
+					parts.push(varint(filter.endObject, version));
 				}
 			}
 			return concat(parts);
@@ -89,20 +106,20 @@ function encodeFields(filter: Filter): Uint8Array {
 	}
 }
 
-function encodeTag(filter: Filter): Uint8Array {
+function encodeTag(filter: Filter, version: IetfVersion): Uint8Array {
 	switch (filter.kind) {
 		case "unfiltered":
 			// No tag means "everything", which only the absolute spelling can say.
-			return concat([Varint.encode(TAG_ABSOLUTE_START), Varint.encode(0n), Varint.encode(0n)]);
+			return concat([varint(TAG_ABSOLUTE_START, version), varint(0n, version), varint(0n, version)]);
 		case "nextObject":
-			return Varint.encode(TAG_LARGEST_OBJECT);
+			return varint(TAG_LARGEST_OBJECT, version);
 		case "relative":
 			if (filter.groups !== 0n) {
 				// Only draft-20 can name a start further back than the next group without
 				// knowing Largest Object, so there is no honest tag to fall back to.
 				throw new Error(`relative filter ${filter.groups} needs draft-20`);
 			}
-			return Varint.encode(TAG_NEXT_GROUP);
+			return varint(TAG_NEXT_GROUP, version);
 		case "absolute": {
 			// Draft-19's AbsoluteRange ends on a group, so an object-bounded range has no
 			// spelling. Refuse rather than widen the range the caller asked for.
@@ -110,12 +127,12 @@ function encodeTag(filter: Filter): Uint8Array {
 				throw new Error("an object-bounded range needs draft-20");
 			}
 			const parts = [
-				Varint.encode(filter.endGroup === undefined ? TAG_ABSOLUTE_START : TAG_ABSOLUTE_RANGE),
-				Varint.encode(filter.startGroup),
-				Varint.encode(filter.startObject),
+				varint(filter.endGroup === undefined ? TAG_ABSOLUTE_START : TAG_ABSOLUTE_RANGE, version),
+				varint(filter.startGroup, version),
+				varint(filter.startObject, version),
 			];
 			if (filter.endGroup !== undefined) {
-				parts.push(Varint.encode(endDelta(filter.startGroup, filter.endGroup)));
+				parts.push(varint(endDelta(filter.startGroup, filter.endGroup), version));
 			}
 			return concat(parts);
 		}
@@ -124,17 +141,17 @@ function encodeTag(filter: Filter): Uint8Array {
 
 /** Decode a filter from its raw parameter value. */
 export function decode(data: Uint8Array, version: IetfVersion): Filter {
-	return isDraft20(version) ? decodeFields(data) : decodeTag(data);
+	return isDraft20(version) ? decodeFields(data, version) : decodeTag(data, version);
 }
 
-function decodeFields(data: Uint8Array): Filter {
+function decodeFields(data: Uint8Array, version: IetfVersion): Filter {
 	const fields: bigint[] = [];
 	let rest = data;
 	while (rest.length > 0) {
 		if (fields.length === 4) {
 			throw new Error("too many fields in LOCATION_FILTER");
 		}
-		const [value, next] = Varint.decodeBigInt(rest);
+		const [value, next] = unvarint(rest, version);
 		fields.push(value);
 		rest = next;
 	}
@@ -157,12 +174,12 @@ function decodeFields(data: Uint8Array): Filter {
 	}
 }
 
-function decodeTag(data: Uint8Array): Filter {
-	const [tag, afterTag] = Varint.decodeBigInt(data);
+function decodeTag(data: Uint8Array, version: IetfVersion): Filter {
+	const [tag, afterTag] = unvarint(data, version);
 
 	const readLocation = (buf: Uint8Array): [bigint, bigint, Uint8Array] => {
-		const [group, afterGroup] = Varint.decodeBigInt(buf);
-		const [object, rest] = Varint.decodeBigInt(afterGroup);
+		const [group, afterGroup] = unvarint(buf, version);
+		const [object, rest] = unvarint(afterGroup, version);
 		return [group, object, rest];
 	};
 
@@ -180,7 +197,7 @@ function decodeTag(data: Uint8Array): Filter {
 		}
 		case TAG_ABSOLUTE_RANGE: {
 			const [startGroup, startObject, afterLocation] = readLocation(afterTag);
-			const [delta, rest] = Varint.decodeBigInt(afterLocation);
+			const [delta, rest] = unvarint(afterLocation, version);
 			expectEmpty(rest);
 			return { kind: "absolute", startGroup, startObject, endGroup: startGroup + delta };
 		}
@@ -199,8 +216,13 @@ function expectEmpty(rest: Uint8Array): void {
 const FILL_LOCATION_FILTER = 0x21n;
 
 /**
- * The parameters draft-20 allows inside FILL_PARAMETERS. Anything else is a protocol
- * violation rather than something to skip.
+ * The parameters draft-20 allows inside FILL_PARAMETERS, and how each frames its value.
+ *
+ * Tabulated rather than derived, because neither shortcut is right. The Key-Value-Pair rule
+ * keys framing off the id's parity, but the Range Filters (0x25-0x28) carry an explicit
+ * Length despite two of them having even ids. And a uint8 parameter is one raw byte rather
+ * than a varint, so reading it as one misparses any value with a leading 1-bit. Either
+ * mistake desyncs every parameter after it.
  */
 /**
  * Maps each to whether it carries a length prefix.
@@ -210,15 +232,17 @@ const FILL_LOCATION_FILTER = 0x21n;
  * ids. Their own definition wins, so the framing is tabulated rather than derived: reading
  * 0x26 or 0x28 as a bare varint would desync every parameter after it.
  */
-const FILL_ALLOWED = new Map<bigint, boolean>([
-	[0x0an, false], // FILL_TIMEOUT, a varint
-	[0x20n, false], // SUBSCRIBER_PRIORITY, a uint8 varint
-	[FILL_LOCATION_FILTER, true],
-	[0x22n, false], // GROUP_ORDER, a uint8 varint
-	[0x25n, true], // SUBGROUP_FILTER
-	[0x26n, true], // OBJECTID_FILTER, length prefixed despite an even id
-	[0x27n, true], // PRIORITY_FILTER
-	[0x28n, true], // OBJECT_PROPERTY_FILTER, likewise
+type Framing = "byte" | "varint" | "bytes";
+
+const FILL_ALLOWED = new Map<bigint, Framing>([
+	[0x0an, "varint"], // FILL_TIMEOUT
+	[0x20n, "byte"], // SUBSCRIBER_PRIORITY, a uint8
+	[FILL_LOCATION_FILTER, "bytes"],
+	[0x22n, "byte"], // GROUP_ORDER, a uint8
+	[0x25n, "bytes"], // SUBGROUP_FILTER
+	[0x26n, "bytes"], // OBJECTID_FILTER, length prefixed despite an even id
+	[0x27n, "bytes"], // PRIORITY_FILTER
+	[0x28n, "bytes"], // OBJECT_PROPERTY_FILTER, likewise
 ]);
 
 /**
@@ -229,19 +253,19 @@ const FILL_ALLOWED = new Map<bigint, boolean>([
 export function encodeFill(filter: Filter, version: IetfVersion): Uint8Array {
 	if (filter.kind === "unfiltered") {
 		// An empty scope fills the whole track up to Largest Object.
-		return Varint.encode(0n);
+		return varint(0n, version);
 	}
 	return concat([
-		Varint.encode(1n),
+		varint(1n, version),
 		// The first type in a scope is not delta encoded, so this is the raw id.
-		Varint.encode(FILL_LOCATION_FILTER),
-		encodeLengthPrefixed(encode(filter, version)),
+		varint(FILL_LOCATION_FILTER, version),
+		encodeLengthPrefixed(encode(filter, version), version),
 	]);
 }
 
 /** Decode FILL_PARAMETERS, returning the range it asks to fill. */
 export function decodeFill(data: Uint8Array, version: IetfVersion): Filter {
-	const [count, afterCount] = Varint.decodeBigInt(data);
+	const [count, afterCount] = unvarint(data, version);
 	if (count > 64n) {
 		throw new Error("too many parameters in FILL_PARAMETERS");
 	}
@@ -250,24 +274,29 @@ export function decodeFill(data: Uint8Array, version: IetfVersion): Filter {
 	let filter: Filter | undefined;
 	let prev = 0n;
 	for (let i = 0n; i < count; i++) {
-		const [delta, afterType] = Varint.decodeBigInt(rest);
+		const [delta, afterType] = unvarint(rest, version);
 		const key = i === 0n ? delta : prev + delta;
 		prev = key;
 		rest = afterType;
 
-		const lengthPrefixed = FILL_ALLOWED.get(key);
-		if (lengthPrefixed === undefined) {
+		const framing = FILL_ALLOWED.get(key);
+		if (framing === undefined) {
 			throw new Error(`parameter ${key} is not allowed inside FILL_PARAMETERS`);
 		}
 
 		// The rest are parameters we do not act on, but their bytes still have to be
 		// consumed or the remaining keys desync.
-		if (!lengthPrefixed) {
-			[, rest] = Varint.decodeBigInt(rest);
+		if (framing === "varint") {
+			[, rest] = unvarint(rest, version);
+			continue;
+		}
+		if (framing === "byte") {
+			if (rest.length < 1) throw new Error("truncated value inside FILL_PARAMETERS");
+			rest = rest.slice(1);
 			continue;
 		}
 
-		const [length, afterLength] = Varint.decodeBigInt(rest);
+		const [length, afterLength] = unvarint(rest, version);
 		if (BigInt(afterLength.length) < length) {
 			throw new Error("truncated value inside FILL_PARAMETERS");
 		}
@@ -289,6 +318,6 @@ export function decodeFill(data: Uint8Array, version: IetfVersion): Filter {
 	return filter ?? { kind: "unfiltered" };
 }
 
-function encodeLengthPrefixed(value: Uint8Array): Uint8Array {
-	return concat([Varint.encode(BigInt(value.length)), value]);
+function encodeLengthPrefixed(value: Uint8Array, version: IetfVersion): Uint8Array {
+	return concat([varint(BigInt(value.length), version), value]);
 }

--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -1386,6 +1386,43 @@ test("Frame object time: draft-15 uses absolute property types", async () => {
 	expect(decoded.timestamp?.scale).toBe(Timescale.MILLI);
 });
 
+// FIRST_OBJECT says the stream carries the subgroup from its first published object. It is
+// the only signal that a group arrived with its head missing, so the value has to survive
+// decode rather than being stripped along with the bit.
+test("group flags round-trip firstObject", async () => {
+	const makeGroup = (firstObject: boolean) =>
+		new Group({
+			trackAlias: 7n,
+			groupId: 3,
+			subGroupId: 0,
+			publisherPriority: 0,
+			flags: {
+				hasExtensions: false,
+				hasSubgroup: false,
+				hasSubgroupObject: false,
+				hasEnd: true,
+				hasPriority: true,
+				firstObject,
+			},
+		});
+
+	for (const version of [Version.DRAFT_18, Version.DRAFT_19, Version.DRAFT_20]) {
+		for (const firstObject of [true, false]) {
+			const encoded = await encodeVersioned(makeGroup(firstObject), version);
+			const decoded = await decodeVersioned(encoded, Group.decode, version);
+			expect(decoded.flags.firstObject).toBe(firstObject);
+		}
+	}
+
+	// The bit arrived in draft-18. Earlier drafts carry no such signal, so a group there is
+	// taken at its word rather than read as starting partway through.
+	for (const version of [Version.DRAFT_15, Version.DRAFT_16, Version.DRAFT_17]) {
+		const encoded = await encodeVersioned(makeGroup(false), version);
+		const decoded = await decodeVersioned(encoded, Group.decode, version);
+		expect(decoded.flags.firstObject).toBe(true);
+	}
+});
+
 test("Frame object time: draft-16 starts delta property types", async () => {
 	const flags: GroupFlags = {
 		hasExtensions: true,

--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -100,7 +100,10 @@ test("Message Parameters: uint8 wire encoding changes in draft 17", async () => 
 	}
 });
 
-test("Message Parameters: Location loses its length prefix in draft 17", async () => {
+test("Message Parameters: Location keeps its length prefix on every draft", async () => {
+	// 0x09 is odd, so the Key-Value-Pair rule gives the value a Length on every draft;
+	// only the inner varint format differs (QUIC-style before draft-17, leading-ones
+	// after). These bytes are pinned against the Rust codec's wire vectors.
 	const params = new Parameters();
 	params.largest = { groupId: 255n, objectId: 128n };
 
@@ -118,6 +121,7 @@ test("Message Parameters: Location loses its length prefix in draft 17", async (
 		const expected = new Uint8Array([
 			0x01, // parameter count
 			0x09, // LARGEST_OBJECT
+			0x04, // byte-string length
 			0x80,
 			0xff, // leading-ones varint 255
 			0x80,

--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -87,7 +87,7 @@ test("Message Parameters: uint8 wire encoding changes in draft 17", async () => 
 		0xff, // QUIC varint 255
 	]);
 
-	for (const version of [Version.DRAFT_17, Version.DRAFT_18, Version.DRAFT_19]) {
+	for (const version of [Version.DRAFT_17, Version.DRAFT_18, Version.DRAFT_19, Version.DRAFT_20]) {
 		const expected = new Uint8Array([
 			0x01, // parameter count
 			0x20, // SUBSCRIBER_PRIORITY
@@ -114,7 +114,7 @@ test("Message Parameters: Location loses its length prefix in draft 17", async (
 		0x80, // QUIC varint 128
 	]);
 
-	for (const version of [Version.DRAFT_17, Version.DRAFT_18, Version.DRAFT_19]) {
+	for (const version of [Version.DRAFT_17, Version.DRAFT_18, Version.DRAFT_19, Version.DRAFT_20]) {
 		const expected = new Uint8Array([
 			0x01, // parameter count
 			0x09, // LARGEST_OBJECT
@@ -158,7 +158,7 @@ test("Message Parameters: Location preserves full uint64 values in draft 17", as
 
 	expect(params.largest).toEqual(largest);
 
-	for (const version of [Version.DRAFT_17, Version.DRAFT_18, Version.DRAFT_19]) {
+	for (const version of [Version.DRAFT_17, Version.DRAFT_18, Version.DRAFT_19, Version.DRAFT_20]) {
 		const encoded = await encodeVersioned(params, version);
 		const decoded = await decodeVersioned(encoded, Parameters.decode, version);
 		expect(decoded.largest).toEqual(largest);

--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -1333,6 +1333,7 @@ test("Group: draft-18 sets FIRST_OBJECT bit, draft-17 does not", async () => {
 				hasSubgroupObject: false,
 				hasEnd: true,
 				hasPriority: true,
+				firstObject: true,
 			},
 		});
 
@@ -1361,6 +1362,7 @@ test("Frame object time: draft-15 uses absolute property types", async () => {
 		hasSubgroupObject: false,
 		hasEnd: true,
 		hasPriority: true,
+		firstObject: true,
 	};
 	const timestamp = new Timestamp(96_000, Timescale.MILLI);
 	const frame = new Frame({ payload: new Uint8Array([0xaa]), timestamp });
@@ -1391,6 +1393,7 @@ test("Frame object time: draft-16 starts delta property types", async () => {
 		hasSubgroupObject: false,
 		hasEnd: true,
 		hasPriority: true,
+		firstObject: true,
 	};
 	const timestamp = new Timestamp(96_000, Timescale.MILLI);
 	const frame = new Frame({ payload: new Uint8Array([0xaa]), timestamp });

--- a/js/net/src/ietf/object.ts
+++ b/js/net/src/ietf/object.ts
@@ -143,9 +143,13 @@ export interface GroupFlags {
 	// v15: whether priority is present in the header.
 	// When false (0x30 base), priority inherits from the control message.
 	hasPriority: boolean;
-	// draft-18+: whether this stream carries the subgroup from its first published object.
-	// A subgroup that starts partway through has a hole at the front, which moq-lite cannot
-	// represent. Always true on the drafts that predate the bit, where there is no signal.
+	/**
+	 * Whether this stream carries the subgroup from its first published object.
+	 *
+	 * A subgroup that starts partway through has a hole at the front, which moq-lite cannot
+	 * represent. Always true on the drafts that predate the FIRST_OBJECT bit (before
+	 * draft-18), where there is no such signal to read.
+	 */
 	firstObject: boolean;
 }
 

--- a/js/net/src/ietf/object.ts
+++ b/js/net/src/ietf/object.ts
@@ -143,6 +143,10 @@ export interface GroupFlags {
 	// v15: whether priority is present in the header.
 	// When false (0x30 base), priority inherits from the control message.
 	hasPriority: boolean;
+	// draft-18+: whether this stream carries the subgroup from its first published object.
+	// A subgroup that starts partway through has a hole at the front, which moq-lite cannot
+	// represent. Always true on the drafts that predate the bit, where there is no signal.
+	firstObject: boolean;
 }
 
 /**
@@ -195,7 +199,7 @@ export class Group {
 		if (this.flags.hasEnd) {
 			id |= 0x08;
 		}
-		if (hasFirstObjectBit(version)) {
+		if (this.flags.firstObject && hasFirstObjectBit(version)) {
 			id |= FIRST_OBJECT_BIT;
 		}
 		await w.u53(id);
@@ -211,8 +215,12 @@ export class Group {
 
 	static async decode(r: Reader, version: IetfVersion): Promise<Group> {
 		const raw = await r.u53();
-		// Strip the draft-18 FIRST_OBJECT bit before the range check.
-		const id = hasFirstObjectBit(version) ? raw & ~FIRST_OBJECT_BIT : raw;
+		// Strip the draft-18 FIRST_OBJECT bit before the range check, but keep the value:
+		// it is the only signal that a subgroup starts partway through. Drafts that predate
+		// it carry no such signal, so they are taken at their word.
+		const legacy = !hasFirstObjectBit(version);
+		const firstObject = legacy || (raw & FIRST_OBJECT_BIT) !== 0;
+		const id = legacy ? raw : raw & ~FIRST_OBJECT_BIT;
 
 		let hasPriority: boolean;
 		let baseId: number;
@@ -232,6 +240,7 @@ export class Group {
 			hasSubgroup: (baseId & 0x04) !== 0,
 			hasEnd: (baseId & 0x08) !== 0,
 			hasPriority,
+			firstObject,
 		};
 
 		const trackAlias = await r.u62();
@@ -286,9 +295,13 @@ export class Frame {
 		timescale: Timescale | undefined,
 		version = r.version,
 	): Promise<Frame> {
+		// The first object's delta is its absolute Object ID; every later one is the prior ID
+		// plus the delta plus one. moq-lite groups start at object 0 and never skip one, so
+		// a sequential group is a zero delta throughout, and any other value means the group
+		// either starts partway through or has a gap that would renumber the frames after it.
 		const delta = await r.u53();
 		if (delta !== 0) {
-			throw new Error(`object ID delta is not supported: ${delta}`);
+			throw new Error(`object IDs must start at 0 and increment by 1, got a delta of ${delta}`);
 		}
 
 		let timestamp: Timestamp | undefined;

--- a/js/net/src/ietf/parameters.ts
+++ b/js/net/src/ietf/parameters.ts
@@ -482,8 +482,13 @@ export class Parameters {
 						const location = this.#locations.get(key);
 						if (location === undefined)
 							throw new Error(`invalid Location message parameter: ${key.toString()}`);
-						await w.u62(location.groupId);
-						await w.u62(location.objectId);
+						// LARGEST_OBJECT is an odd type, so the Key-Value-Pair rule gives it
+						// a Length on every draft: two varints inside the value.
+						const group = Varint.encodeLeadingOnes(location.groupId);
+						const object = Varint.encodeLeadingOnes(location.objectId);
+						await w.u53(group.length + object.length);
+						await w.write(group);
+						await w.write(object);
 						break;
 					}
 					case "bytes": {
@@ -555,8 +560,14 @@ export class Parameters {
 					params.vars.set(id, (await r.bool()) ? 1n : 0n);
 					break;
 				case "location": {
-					const groupId = await r.u62();
-					const objectId = await r.u62();
+					// LARGEST_OBJECT is an odd type, so the Key-Value-Pair rule gives it a
+					// Length on every draft: two varints inside the value.
+					const size = await r.u53();
+					const [groupId, objectData] = Varint.decodeLeadingOnes(await r.read(size));
+					const [objectId, trailing] = Varint.decodeLeadingOnes(objectData);
+					if (trailing.length !== 0) {
+						throw new Error("trailing bytes in message parameter Location");
+					}
 					params.#locations.set(id, { groupId, objectId });
 					break;
 				}

--- a/js/net/src/ietf/parameters.ts
+++ b/js/net/src/ietf/parameters.ts
@@ -192,6 +192,8 @@ export class SetupOptions {
 
 // Varint parameter IDs (even)
 const MSG_PARAM_DELIVERY_TIMEOUT = 0x02n;
+/// SUBGROUP_DELIVERY_TIMEOUT, alongside the per-object one above.
+const MSG_PARAM_SUBGROUP_DELIVERY_TIMEOUT = 0x06n;
 const MSG_PARAM_MAX_CACHE_DURATION = 0x04n;
 const MSG_PARAM_EXPIRES = 0x08n;
 const MSG_PARAM_PUBLISHER_PRIORITY = 0x0en;
@@ -218,6 +220,7 @@ type MessageLocation = { groupId: bigint; objectId: bigint };
 function getMessageParamKind(id: bigint): MessageParamKind {
 	switch (id) {
 		case MSG_PARAM_DELIVERY_TIMEOUT:
+		case MSG_PARAM_SUBGROUP_DELIVERY_TIMEOUT:
 		case MSG_PARAM_MAX_CACHE_DURATION:
 		case MSG_PARAM_EXPIRES:
 		case MSG_PARAM_ROUTE_COST:

--- a/js/net/src/ietf/parameters.ts
+++ b/js/net/src/ietf/parameters.ts
@@ -204,6 +204,11 @@ const MSG_PARAM_ROUTE_COST = 0x40b58n;
 // Bytes parameter IDs (odd)
 const MSG_PARAM_LARGEST_OBJECT = 0x09n;
 const MSG_PARAM_SUBSCRIPTION_FILTER = 0x21n;
+/// FILL_PARAMETERS, draft-20's request for a backfill.
+const MSG_PARAM_FILL_PARAMETERS = 0x23n;
+/// INCLUDE_PROPERTIES, draft-20's opt-out from Track Properties. Its own section calls the
+/// value a uint8, but 0x35 is odd, so the Key-Value-Pair rule length prefixes it.
+const MSG_PARAM_INCLUDE_PROPERTIES = 0x35n;
 /// HOP_PATH, from the MoQ Cluster extension. See `cluster.ts`.
 const MSG_PARAM_HOP_PATH = 0x40b57n;
 
@@ -226,6 +231,8 @@ function getMessageParamKind(id: bigint): MessageParamKind {
 		case MSG_PARAM_LARGEST_OBJECT:
 			return "location";
 		case MSG_PARAM_SUBSCRIPTION_FILTER:
+		case MSG_PARAM_FILL_PARAMETERS:
+		case MSG_PARAM_INCLUDE_PROPERTIES:
 		case MSG_PARAM_HOP_PATH:
 			return "bytes";
 		default:
@@ -336,15 +343,42 @@ export class Parameters {
 		this.#locations.set(MSG_PARAM_LARGEST_OBJECT, { ...v });
 	}
 
-	get subscriptionFilter(): number | undefined {
-		const data = this.bytes.get(MSG_PARAM_SUBSCRIPTION_FILTER);
-		if (!data || data.length === 0) return undefined;
-		// Filter type is a varint — for our purposes, the first byte suffices
-		return data[0];
+	/**
+	 * LOCATION_FILTER, as its raw parameter value.
+	 *
+	 * Raw because the encoding is version dependent: a Filter Type tag through draft-19, a
+	 * list of up to four varints from draft-20 on. See `filter.ts`.
+	 */
+	get subscriptionFilter(): Uint8Array | undefined {
+		return this.bytes.get(MSG_PARAM_SUBSCRIPTION_FILTER);
 	}
 
-	set subscriptionFilter(v: number) {
-		this.bytes.set(MSG_PARAM_SUBSCRIPTION_FILTER, new Uint8Array([v]));
+	set subscriptionFilter(v: Uint8Array) {
+		this.bytes.set(MSG_PARAM_SUBSCRIPTION_FILTER, v);
+	}
+
+	/** FILL_PARAMETERS: the draft-20 backfill request, as its raw parameter value. */
+	get fillParameters(): Uint8Array | undefined {
+		return this.bytes.get(MSG_PARAM_FILL_PARAMETERS);
+	}
+
+	set fillParameters(v: Uint8Array) {
+		this.bytes.set(MSG_PARAM_FILL_PARAMETERS, v);
+	}
+
+	/** INCLUDE_PROPERTIES: whether the peer wants Track Properties on the response. */
+	get includeProperties(): boolean | undefined {
+		const data = this.bytes.get(MSG_PARAM_INCLUDE_PROPERTIES);
+		if (!data) return undefined;
+		// The draft allows exactly 0 or 1; anything else is a protocol violation.
+		if (data.length !== 1 || data[0] > 1) {
+			throw new Error(`invalid INCLUDE_PROPERTIES value: ${data.join(",")}`);
+		}
+		return data[0] === 1;
+	}
+
+	set includeProperties(v: boolean) {
+		this.bytes.set(MSG_PARAM_INCLUDE_PROPERTIES, new Uint8Array([v ? 1 : 0]));
 	}
 
 	/** HOP_PATH: the hop chain an advertisement traversed, as its raw parameter value. */

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -292,6 +292,7 @@ export class Publisher {
 					hasSubgroupObject: false,
 					hasEnd: true,
 					hasPriority: true,
+					firstObject: true,
 				},
 			});
 

--- a/js/net/src/ietf/subscribe.ts
+++ b/js/net/src/ietf/subscribe.ts
@@ -1,6 +1,7 @@
 import type * as Path from "../path.ts";
 import type { Reader, Writer } from "../stream.ts";
 import type { Timescale } from "../time.ts";
+import * as Filter from "./filter.ts";
 import * as Message from "./message.ts";
 import * as Namespace from "./namespace.ts";
 import { Parameters } from "./parameters.ts";
@@ -55,7 +56,15 @@ export class Subscribe {
 			params.subscriberPriority = this.subscriberPriority;
 			params.groupOrder = GROUP_ORDER;
 			params.forward = true;
-			params.subscriptionFilter = 0x2; // LargestObject
+			// moq-lite joins a track at the start of the current group. A Location Filter
+			// cannot say that on its own: it only restricts which newly published Objects
+			// are forwarded, it never asks for ones already published. So the current group
+			// is requested as a fill, which is the draft's own recipe. Older drafts have no
+			// fill and still join mid-group, exactly as before.
+			params.subscriptionFilter = Filter.encode({ kind: "nextObject" }, version);
+			if (Filter.isDraft20(version)) {
+				params.fillParameters = Filter.encodeFill({ kind: "relative", groups: 1n }, version);
+			}
 			await params.encode(w, version);
 		}
 	}
@@ -117,9 +126,15 @@ export class Subscribe {
 			throw new Error(`unsupported forward value: ${forward}`);
 		}
 
-		const filterType = params.subscriptionFilter ?? 0x2;
-		if (filterType !== 0x1 && filterType !== 0x2) {
-			throw new Error(`unsupported filter type: ${filterType}`);
+		// Parsed to reject a malformed filter, then dropped: this side always serves from
+		// the live edge, so the range does not change what it sends.
+		const filter = params.subscriptionFilter;
+		if (filter !== undefined) {
+			Filter.decode(filter, version);
+		}
+		const fill = params.fillParameters;
+		if (fill !== undefined) {
+			Filter.decodeFill(fill, version);
 		}
 
 		return new Subscribe({ requestId, trackNamespace, trackName, subscriberPriority });

--- a/js/net/src/ietf/subscribe.ts
+++ b/js/net/src/ietf/subscribe.ts
@@ -56,15 +56,14 @@ export class Subscribe {
 			params.subscriberPriority = this.subscriberPriority;
 			params.groupOrder = GROUP_ORDER;
 			params.forward = true;
-			// moq-lite joins a track at the start of the current group. A Location Filter
-			// cannot say that on its own: it only restricts which newly published Objects
-			// are forwarded, it never asks for ones already published. So the current group
-			// is requested as a fill, which is the draft's own recipe. Older drafts have no
-			// fill and still join mid-group, exactly as before.
-			params.subscriptionFilter = Filter.encode({ kind: "nextObject" }, version);
-			if (Filter.isDraft20(version)) {
-				params.fillParameters = Filter.encodeFill({ kind: "relative", groups: 1n }, version);
-			}
+			// moq-lite joins a track at the start of the current group, which is a decodable
+			// point, and draft-20's relative form is the first that can name it without
+			// knowing Largest Object. No fill is requested: a fill is capped at Largest
+			// Object, so pairing one with a live subscription splits a single group across
+			// two streams, and the two cannot be reassembled into one group here.
+			params.subscriptionFilter = Filter.isDraft20(version)
+				? Filter.encode({ kind: "relative", groups: 1n }, version)
+				: Filter.encode({ kind: "nextObject" }, version);
 			await params.encode(w, version);
 		}
 	}

--- a/js/net/src/ietf/subscribe.ts
+++ b/js/net/src/ietf/subscribe.ts
@@ -58,9 +58,12 @@ export class Subscribe {
 			params.forward = true;
 			// moq-lite joins a track at the start of the current group, which is a decodable
 			// point, and draft-20's relative form is the first that can name it without
-			// knowing Largest Object. No fill is requested: a fill is capped at Largest
-			// Object, so pairing one with a live subscription splits a single group across
-			// two streams, and the two cannot be reassembled into one group here.
+			// knowing Largest Object. No fill is requested: the fill's fetch stream and the
+			// live subscription split the group across two streams, and this subscriber does
+			// not reassemble them into one group yet. A lenient publisher (like ours)
+			// replays the whole in-range group on the subscription instead; a strict one
+			// only delivers from the next published object, and that mid-group stream is
+			// dropped, degrading the join to the next group boundary.
 			params.subscriptionFilter = Filter.isDraft20(version)
 				? Filter.encode({ kind: "relative", groups: 1n }, version)
 				: Filter.encode({ kind: "nextObject" }, version);

--- a/js/net/src/ietf/version.ts
+++ b/js/net/src/ietf/version.ts
@@ -43,6 +43,12 @@ export const Version = {
 	 * https://www.ietf.org/archive/id/draft-ietf-moq-transport-19.txt
 	 */
 	DRAFT_19: 0xff000013,
+
+	/**
+	 * draft-ietf-moq-transport-20
+	 * https://www.ietf.org/archive/id/draft-ietf-moq-transport-20.txt
+	 */
+	DRAFT_20: 0xff000014,
 } as const;
 
 export type Version = (typeof Version)[keyof typeof Version];
@@ -55,6 +61,7 @@ export const ALPN = {
 	DRAFT_17: "moqt-17",
 	DRAFT_18: "moqt-18",
 	DRAFT_19: "moqt-19",
+	DRAFT_20: "moqt-20",
 } as const;
 
 /**
@@ -67,7 +74,8 @@ export type IetfVersion =
 	| typeof Version.DRAFT_16
 	| typeof Version.DRAFT_17
 	| typeof Version.DRAFT_18
-	| typeof Version.DRAFT_19;
+	| typeof Version.DRAFT_19
+	| typeof Version.DRAFT_20;
 
 const VERSION_NAMES: Record<number, string> = {
 	[Version.DRAFT_07]: "moq-transport-07",
@@ -77,6 +85,7 @@ const VERSION_NAMES: Record<number, string> = {
 	[Version.DRAFT_17]: "moq-transport-17",
 	[Version.DRAFT_18]: "moq-transport-18",
 	[Version.DRAFT_19]: "moq-transport-19",
+	[Version.DRAFT_20]: "moq-transport-20",
 };
 
 export function versionName(v: Version): string {

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -630,7 +630,7 @@ pub extern "C" fn moq_client_close(client: u32) -> i32 {
 ///
 /// By default every supported version is offered and the server picks one. Pass a
 /// subset to pin the negotiation, in the same spelling the CLI uses: `moq-lite-01`
-/// through `moq-lite-06-wip`, or `moq-transport-14` through `moq-transport-19`. An
+/// through `moq-lite-06-wip`, or `moq-transport-14` through `moq-transport-20`. An
 /// empty list restores the default.
 ///
 /// Returns zero on success, or a negative code if the handle is unknown or a version

--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -263,7 +263,7 @@ async fn connect_tls_override(
 /// moq-transport-18 and -19 require qmux-01, so we never pair them with qmux-00.
 /// This mirrors the policy in `js/net`'s `connect.ts`. Every other ALPN returns
 /// `&[]`, which qmux expands to every draft it knows about.
-const QMUX01_ONLY_ALPNS: &[&str] = &["moqt-18", "moqt-19"];
+const QMUX01_ONLY_ALPNS: &[&str] = &["moqt-18", "moqt-19", "moqt-20"];
 
 fn qmux_versions_for(alpn: &str) -> &'static [qmux::Version] {
 	if QMUX01_ONLY_ALPNS.contains(&alpn) {
@@ -595,7 +595,7 @@ mod tests {
 				.iter()
 				.map(|&a| moq_net::Version::from_alpn(a).map(|v| v.code()))
 				.collect::<Vec<_>>(),
-			vec![Some(0xff000012), Some(0xff000013)]
+			vec![Some(0xff000012), Some(0xff000013), Some(0xff000014)]
 		);
 		for &alpn in QMUX01_ONLY_ALPNS {
 			assert_eq!(qmux_versions_for(alpn), &[qmux::Version::QMux01]);

--- a/rs/moq-native/tests/alpn.rs
+++ b/rs/moq-native/tests/alpn.rs
@@ -169,6 +169,12 @@ async fn version_moq_transport_19() {
 	connect_with_version("moq-transport-19").await;
 }
 
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn version_moq_transport_20() {
+	connect_with_version("moq-transport-20").await;
+}
+
 // ── WebTransport: sub-protocol negotiation ──────────────────────────
 // Browser clients use WebTransport (h3 ALPN) and negotiate the MoQ
 // protocol version via sub-protocols in the HTTP CONNECT request.
@@ -231,4 +237,10 @@ async fn webtransport_moq_transport_18() {
 #[tokio::test]
 async fn webtransport_moq_transport_19() {
 	connect_with_webtransport(Some("moq-transport-19")).await;
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn webtransport_moq_transport_20() {
+	connect_with_webtransport(Some("moq-transport-20")).await;
 }

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -1188,6 +1188,12 @@ async fn broadcast_moq_transport_19() {
 	broadcast_test("moqt", Some("moq-transport-19"), Some("moq-transport-19")).await;
 }
 
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_moq_transport_20() {
+	broadcast_test("moqt", Some("moq-transport-20"), Some("moq-transport-20")).await;
+}
+
 // ── Raw QUIC – server supports all versions, client pins one ─────────
 
 #[tracing_test::traced_test]
@@ -1463,6 +1469,12 @@ async fn broadcast_webtransport_moq_transport_18() {
 #[tokio::test]
 async fn broadcast_webtransport_moq_transport_19() {
 	broadcast_test("https", Some("moq-transport-19"), Some("moq-transport-19")).await;
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_webtransport_moq_transport_20() {
+	broadcast_test("https", Some("moq-transport-20"), Some("moq-transport-20")).await;
 }
 
 // ── WebTransport – server supports all, client pins one ─────────────

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -1,6 +1,6 @@
 use crate::origin;
 use crate::{
-	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05,
+	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_20, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05,
 	ALPN_LITE_06_WIP, Consume, Driver, Error, NEGOTIATED, Session, Version, Versions,
 	coding::{self, Decode, Encode, Stream},
 	ietf, lite, setup, stats,
@@ -152,6 +152,31 @@ impl Client {
 		// If ALPN was used to negotiate the version, use the appropriate encoding.
 		// Default to IETF 14 if no ALPN was used and we'll negotiate the version later.
 		let (encoding, supported) = match session.protocol() {
+			Some(ALPN_20) => {
+				let v = self
+					.versions
+					.select(Version::Ietf(ietf::Version::Draft20))
+					.ok_or(Error::Version)?;
+
+				// Draft-17+: SETUP is exchanged by the connection driver.
+				let protocol = ietf::start(ietf::Config {
+					session: session.clone(),
+					setup: None,
+					request_id_max: None,
+					client: true,
+					publish: publish.clone(),
+					subscribe: subscribe.clone(),
+					peer_origin: self.peer_origin,
+					cost: self.cost,
+					version: ietf::Version::Draft20,
+					path: self.setup_path.clone(),
+					peer_setup_stream: None,
+					peer_declared: None,
+				})?;
+
+				tracing::debug!(version = ?v, "connected");
+				return Ok(Session::new(session, v, None, protocol));
+			}
 			Some(ALPN_19) => {
 				let v = self
 					.versions

--- a/rs/moq-net/src/fuzz.rs
+++ b/rs/moq-net/src/fuzz.rs
@@ -48,6 +48,7 @@ const IETF_VERSIONS: &[ietf::Version] = &[
 	ietf::Version::Draft17,
 	ietf::Version::Draft18,
 	ietf::Version::Draft19,
+	ietf::Version::Draft20,
 ];
 
 /// How many types [`lite_wire`] dispatches over.

--- a/rs/moq-net/src/ietf/filter.rs
+++ b/rs/moq-net/src/ietf/filter.rs
@@ -457,11 +457,10 @@ mod tests {
 /// Its presence is what asks for one. The value is a nested parameter scope describing the
 /// fill, of which the Location Filter is the part we act on.
 ///
-/// The draft delivers a fill on a separate unidirectional fetch stream. We deliver it as
-/// ordinary live subgroups instead, by lowering the subscription's floor to the start of
-/// the fill range, which avoids the head-of-line blocking a fetch stream imposes on
-/// everything queued behind it. The subscriber receives every Object it asked for, just
-/// never on the stream the draft says to watch.
+/// Fills are unsupported. This parses so a peer asking for one does not have its session
+/// torn down over an unknown parameter, but nothing is served in response: a fetch is
+/// capped at Largest Object, so it cannot deliver a group that is still being written, and
+/// answering on ordinary subgroups instead would look like support without being it.
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Fill {
 	/// The range to fill. [`Filter::Unfiltered`] means the whole track up to Largest Object.

--- a/rs/moq-net/src/ietf/filter.rs
+++ b/rs/moq-net/src/ietf/filter.rs
@@ -483,14 +483,18 @@ enum Framing {
 /// Its presence is what asks for one. The value is a nested parameter scope describing the
 /// fill, of which the Location Filter is the part we act on.
 ///
-/// Fills are unsupported. This parses so a peer asking for one does not have its session
-/// torn down over an unknown parameter, but nothing is served in response: a fetch is
-/// capped at Largest Object, so it cannot deliver a group that is still being written, and
-/// answering on ordinary subgroups instead would look like support without being it.
+/// The publisher serves a fill whose range resolves to a single group, straight from the
+/// model's group cache on a fetch stream. That covers the draft's own current-group join
+/// (a Next Object subscription plus a `StartGroup=1` fill). A range spanning several
+/// groups is refused by resetting the fetch stream, the draft's fill-failure signal,
+/// because multi-group fetch serialization depends on a negotiated group order we do not
+/// implement. We never request a fill ourselves; see `subscriber::subscribe_filter`.
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Fill {
-	/// The range to fill. [`Filter::Unfiltered`] means the whole track up to Largest Object.
-	pub filter: Filter,
+	/// The range to fill. `None` means the Location Filter was omitted, which inherits the
+	/// subscription's own filter; [`Filter::Unfiltered`] (a zero-length filter) means the
+	/// whole track up to Largest Object.
+	pub filter: Option<Filter>,
 }
 
 impl Fill {
@@ -523,10 +527,11 @@ impl Param for Fill {
 		let mut buf = Vec::new();
 
 		// A nested scope is encoded like a message's parameters: a count, then the KVPs.
-		// Unfiltered carries no filter, so the fill is the whole track and the scope is empty.
+		// An omitted filter inherits the subscription's, so the scope is empty. An explicit
+		// Unfiltered still encodes, as a zero-length filter meaning the whole track.
 		match self.filter {
-			Filter::Unfiltered => 0u64.encode(&mut buf, version)?,
-			filter => {
+			None => 0u64.encode(&mut buf, version)?,
+			Some(filter) => {
 				1u64.encode(&mut buf, version)?;
 				// The first type in a scope is not delta encoded, so this is the raw id.
 				Self::LOCATION_FILTER.encode(&mut buf, version)?;
@@ -588,9 +593,7 @@ impl Param for Fill {
 			return Err(DecodeError::TrailingBytes);
 		}
 
-		Ok(Self {
-			filter: filter.unwrap_or(Filter::Unfiltered),
-		})
+		Ok(Self { filter })
 	}
 }
 
@@ -612,13 +615,16 @@ mod fill_tests {
 	#[test]
 	fn round_trips() {
 		for filter in [
-			Filter::Unfiltered,
-			Filter::Relative(1),
-			Filter::Relative(3),
-			Filter::Absolute {
+			// An omitted filter (inherit the subscription's) and an explicit zero-length
+			// one (the whole track) are distinct spellings and must stay distinct.
+			None,
+			Some(Filter::Unfiltered),
+			Some(Filter::Relative(1)),
+			Some(Filter::Relative(3)),
+			Some(Filter::Absolute {
 				start: Location { group: 4, object: 0 },
 				end: Some(EndLocation { group: 9, object: None }),
-			},
+			}),
 		] {
 			assert_eq!(round_trip(Fill { filter }).filter, filter, "{filter:?}");
 		}
@@ -629,7 +635,7 @@ mod fill_tests {
 	#[test]
 	fn current_group_join() {
 		let fill = Fill {
-			filter: Filter::Relative(1),
+			filter: Some(Filter::Relative(1)),
 		};
 		let mut buf = Vec::new();
 		fill.param_encode(&mut buf, NEW).expect("encode");
@@ -669,7 +675,7 @@ mod fill_tests {
 		value.encode(&mut buf, NEW).unwrap();
 		let mut bytes = bytes::Bytes::from(buf);
 		let fill = Fill::param_decode(&mut bytes, NEW).expect("decode");
-		assert_eq!(fill.filter, Filter::Relative(1));
+		assert_eq!(fill.filter, Some(Filter::Relative(1)));
 	}
 
 	/// An allowed parameter we ignore still has to be consumed, or the keys after it
@@ -689,7 +695,7 @@ mod fill_tests {
 		value.encode(&mut buf, NEW).unwrap();
 		let mut bytes = bytes::Bytes::from(buf);
 		let fill = Fill::param_decode(&mut bytes, NEW).expect("decode");
-		assert_eq!(fill.filter, Filter::Unfiltered);
+		assert_eq!(fill.filter, None, "no Location Filter in the scope means inherit");
 	}
 
 	#[test]
@@ -705,6 +711,6 @@ mod fill_tests {
 		value.encode(&mut buf, NEW).unwrap();
 		let mut bytes = bytes::Bytes::from(buf);
 		let fill = Fill::param_decode(&mut bytes, NEW).expect("decode");
-		assert_eq!(fill.filter, Filter::Relative(2));
+		assert_eq!(fill.filter, Some(Filter::Relative(2)));
 	}
 }

--- a/rs/moq-net/src/ietf/filter.rs
+++ b/rs/moq-net/src/ietf/filter.rs
@@ -495,6 +495,12 @@ pub struct Fill {
 	/// subscription's own filter; [`Filter::Unfiltered`] (a zero-length filter) means the
 	/// whole track up to Largest Object.
 	pub filter: Option<Filter>,
+
+	/// Whether the scope carried a Range Filter (0x25-0x28). Those narrow which objects
+	/// pass, which we do not implement, and serving the unfiltered range instead would
+	/// deliver objects the peer excluded, so such a fill is refused rather than widened.
+	/// Never encoded; we send no range filters.
+	pub range_filters: bool,
 }
 
 impl Fill {
@@ -552,6 +558,7 @@ impl Param for Fill {
 		}
 
 		let mut filter = None;
+		let mut range_filters = false;
 		let mut prev = 0u64;
 		for i in 0..count {
 			let delta = u64::decode(&mut buf, version)?;
@@ -574,6 +581,10 @@ impl Param for Fill {
 				continue;
 			}
 
+			// A Range Filter changes which objects the fill may contain, so its presence
+			// is recorded even though its value is not interpreted.
+			range_filters |= (0x25..=0x28).contains(&key);
+
 			// The rest are parameters we do not act on, but their bytes still have to be
 			// consumed or the remaining keys desync.
 			match framing {
@@ -593,7 +604,7 @@ impl Param for Fill {
 			return Err(DecodeError::TrailingBytes);
 		}
 
-		Ok(Self { filter })
+		Ok(Self { filter, range_filters })
 	}
 }
 
@@ -626,7 +637,11 @@ mod fill_tests {
 				end: Some(EndLocation { group: 9, object: None }),
 			}),
 		] {
-			assert_eq!(round_trip(Fill { filter }).filter, filter, "{filter:?}");
+			let fill = Fill {
+				filter,
+				range_filters: false,
+			};
+			assert_eq!(round_trip(fill).filter, filter, "{filter:?}");
 		}
 	}
 
@@ -636,6 +651,7 @@ mod fill_tests {
 	fn current_group_join() {
 		let fill = Fill {
 			filter: Some(Filter::Relative(1)),
+			range_filters: false,
 		};
 		let mut buf = Vec::new();
 		fill.param_encode(&mut buf, NEW).expect("encode");
@@ -696,6 +712,7 @@ mod fill_tests {
 		let mut bytes = bytes::Bytes::from(buf);
 		let fill = Fill::param_decode(&mut bytes, NEW).expect("decode");
 		assert_eq!(fill.filter, None, "no Location Filter in the scope means inherit");
+		assert!(fill.range_filters, "a Range Filter's presence must be recorded");
 	}
 
 	#[test]

--- a/rs/moq-net/src/ietf/filter.rs
+++ b/rs/moq-net/src/ietf/filter.rs
@@ -318,6 +318,21 @@ mod tests {
 		);
 	}
 
+	/// Draft-17 replaced QUIC's varint with a leading-1-bits one. They agree below 64, so a
+	/// wrong codec stays invisible until group or object ids grow past that.
+	#[test]
+	fn draft20_uses_leading_ones_varints_above_63() {
+		// 128 is 0x80_80 with leading ones, and 0x40_80 with the QUIC form.
+		assert_eq!(value(Filter::Relative(128), NEW), vec![0x80, 0x80]);
+		assert_eq!(round_trip(Filter::Relative(128), NEW), Filter::Relative(128));
+
+		let wide = Filter::Absolute {
+			start: Location { group: 300, object: 64 },
+			end: None,
+		};
+		assert_eq!(round_trip(wide, NEW), wide);
+	}
+
 	/// The current group is what moq-lite means by joining a track, and draft-20 is the
 	/// first version that can name it without knowing Largest Object.
 	#[test]
@@ -452,6 +467,17 @@ mod tests {
 	}
 }
 
+/// How a parameter inside a FILL_PARAMETERS scope frames its value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Framing {
+	/// A single raw byte, which is what the draft's `uint8` parameters are.
+	Byte,
+	/// A variable-length integer.
+	Varint,
+	/// A length prefix followed by that many bytes.
+	Bytes,
+}
+
 /// The FILL_PARAMETERS parameter (0x23), draft-20's request for a backfill.
 ///
 /// Its presence is what asks for one. The value is a nested parameter scope describing the
@@ -471,23 +497,24 @@ impl Fill {
 	/// LOCATION_FILTER, the only nested parameter that changes what we deliver.
 	const LOCATION_FILTER: u64 = 0x21;
 
-	/// The parameters the draft allows inside FILL_PARAMETERS, and whether each carries a
-	/// length prefix. Anything absent from this table is a protocol violation rather than
-	/// something to skip.
+	/// The parameters the draft allows inside FILL_PARAMETERS, and how each frames its
+	/// value. Anything absent from this table is a protocol violation rather than something
+	/// to skip.
 	///
-	/// The Key-Value-Pair rule keys the framing off the id's parity, but the Range Filters
-	/// (0x25-0x28) are written with an explicit `Length` field despite two of them having
-	/// even ids. Their own definition wins, so the framing is tabulated here rather than
-	/// derived: reading 0x26 or 0x28 as a bare varint would desync every parameter after it.
-	const ALLOWED: &'static [(u64, bool)] = &[
-		(0x0A, false), // FILL_TIMEOUT, a varint
-		(0x20, false), // SUBSCRIBER_PRIORITY, a uint8 varint
-		(Self::LOCATION_FILTER, true),
-		(0x22, false), // GROUP_ORDER, a uint8 varint
-		(0x25, true),  // SUBGROUP_FILTER
-		(0x26, true),  // OBJECTID_FILTER, length prefixed despite an even id
-		(0x27, true),  // PRIORITY_FILTER
-		(0x28, true),  // OBJECT_PROPERTY_FILTER, likewise
+	/// The framing is tabulated rather than derived, because neither shortcut is right. The
+	/// Key-Value-Pair rule keys it off the id's parity, but the Range Filters (0x25-0x28)
+	/// carry an explicit `Length` despite two of them having even ids. And a `uint8`
+	/// parameter is one raw byte rather than a varint, so reading it as one misparses any
+	/// value with a leading 1-bit. Either mistake desyncs every parameter after it.
+	const ALLOWED: &'static [(u64, Framing)] = &[
+		(0x0A, Framing::Varint), // FILL_TIMEOUT
+		(0x20, Framing::Byte),   // SUBSCRIBER_PRIORITY, a uint8
+		(Self::LOCATION_FILTER, Framing::Bytes),
+		(0x22, Framing::Byte),  // GROUP_ORDER, a uint8
+		(0x25, Framing::Bytes), // SUBGROUP_FILTER
+		(0x26, Framing::Bytes), // OBJECTID_FILTER, length prefixed despite an even id
+		(0x27, Framing::Bytes), // PRIORITY_FILTER
+		(0x28, Framing::Bytes), // OBJECT_PROPERTY_FILTER, likewise
 	];
 }
 
@@ -530,7 +557,7 @@ impl Param for Fill {
 			};
 			prev = key;
 
-			let Some((_, length_prefixed)) = Self::ALLOWED.iter().find(|(id, _)| *id == key) else {
+			let Some((_, framing)) = Self::ALLOWED.iter().find(|(id, _)| *id == key) else {
 				return Err(DecodeError::InvalidValue);
 			};
 
@@ -544,12 +571,15 @@ impl Param for Fill {
 
 			// The rest are parameters we do not act on, but their bytes still have to be
 			// consumed or the remaining keys desync.
-			match length_prefixed {
-				true => {
+			match framing {
+				Framing::Bytes => {
 					Vec::<u8>::decode(&mut buf, version)?;
 				}
-				false => {
+				Framing::Varint => {
 					u64::decode(&mut buf, version)?;
+				}
+				Framing::Byte => {
+					u8::decode(&mut buf, version)?;
 				}
 			}
 		}
@@ -622,6 +652,24 @@ mod fill_tests {
 		value.encode(&mut buf, NEW).unwrap();
 		let mut bytes = bytes::Bytes::from(buf);
 		assert!(Fill::param_decode(&mut bytes, NEW).is_err());
+	}
+
+	/// A uint8 parameter is one raw byte, so a priority of 128 or more would be read as a
+	/// multi-byte varint prefix and swallow the parameter after it.
+	#[test]
+	fn skips_a_uint8_whose_value_has_a_leading_one() {
+		let mut value = Vec::new();
+		2u64.encode(&mut value, NEW).unwrap();
+		0x20u64.encode(&mut value, NEW).unwrap(); // SUBSCRIBER_PRIORITY
+		0x80u8.encode(&mut value, NEW).unwrap(); // a raw byte, not a varint
+		1u64.encode(&mut value, NEW).unwrap(); // delta to 0x21
+		Filter::Relative(1).param_encode(&mut value, NEW).unwrap();
+
+		let mut buf = Vec::new();
+		value.encode(&mut buf, NEW).unwrap();
+		let mut bytes = bytes::Bytes::from(buf);
+		let fill = Fill::param_decode(&mut bytes, NEW).expect("decode");
+		assert_eq!(fill.filter, Filter::Relative(1));
 	}
 
 	/// An allowed parameter we ignore still has to be consumed, or the keys after it

--- a/rs/moq-net/src/ietf/filter.rs
+++ b/rs/moq-net/src/ietf/filter.rs
@@ -1,0 +1,564 @@
+//! The Location Filter carried by SUBSCRIBE, PUBLISH and REQUEST_UPDATE.
+
+use bytes::Buf as _;
+
+use crate::coding::{Decode, DecodeError, Encode, EncodeError};
+
+use super::{Location, Param, Version};
+
+/// Which Objects a subscription delivers.
+///
+/// A subscriber has not learned Largest Object when it sends SUBSCRIBE, so the live-edge
+/// relative forms are the only ones it can name up front. [`Self::Absolute`] is for the
+/// cases where the caller already knows the group it wants.
+///
+/// The variants are the shapes the wire can actually express, so a range that no draft can
+/// encode (a relative start with an end) cannot be built. Ordering matches the wire: a
+/// relative start is always open ended.
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Filter {
+	/// Every Object in the track, encoded by omitting the parameter.
+	Unfiltered,
+
+	/// The next Object after the live edge: `{Largest.Group, Largest.Object + 1}`.
+	///
+	/// Delivery can begin mid-group, so a subscriber that needs a decodable start pairs
+	/// this with a fill (see [`super::Fill`]) or uses [`Self::Relative`] instead.
+	#[default]
+	NextObject,
+
+	/// Start the given number of groups back from the next group, always open ended.
+	///
+	/// `{Largest.Group + 1 - groups, 0}`, so 0 is the next group and 1 is the current one.
+	/// Only draft-20 can encode a value above 1; older drafts have a tag per case.
+	Relative(u64),
+
+	/// An absolute range, ending after group `end` (inclusive) when one is set.
+	Absolute {
+		/// The first Location to deliver.
+		start: Location,
+		/// The last group to deliver, inclusive. `None` leaves the range open ended.
+		end: Option<u64>,
+	},
+}
+
+/// The tagged Filter Type of draft-19 and earlier.
+mod tag {
+	pub const NEXT_GROUP: u64 = 0x1;
+	pub const LARGEST_OBJECT: u64 = 0x2;
+	pub const ABSOLUTE_START: u64 = 0x3;
+	pub const ABSOLUTE_RANGE: u64 = 0x4;
+}
+
+impl Filter {
+	/// Whether this is draft-20 or newer.
+	///
+	/// Draft-20 replaced the Filter Type tag with up to four optional varints, where the
+	/// number present selects the meaning, and added the parameters that ride alongside it.
+	pub(crate) fn is_draft20(version: Version) -> bool {
+		!matches!(
+			version,
+			Version::Draft14
+				| Version::Draft15
+				| Version::Draft16
+				| Version::Draft17
+				| Version::Draft18
+				| Version::Draft19
+		)
+	}
+
+	/// The absolute end group, given the start, or an error when the range runs backwards.
+	fn end_delta(start: u64, end: u64) -> Result<u64, EncodeError> {
+		end.checked_sub(start).ok_or(EncodeError::InvalidState)
+	}
+
+	/// Encode the draft-20 field list, without the enclosing length prefix.
+	fn encode_fields<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
+		match *self {
+			// Zero fields. The draft defines an open ended absolute {0, 0} as equivalent, so
+			// that spelling normalizes to this one rather than colliding with NextObject.
+			Self::Unfiltered => {}
+			Self::NextObject => {
+				0u64.encode(w, version)?;
+				0u64.encode(w, version)?;
+			}
+			Self::Relative(groups) => groups.encode(w, version)?,
+			Self::Absolute {
+				start: Location { group: 0, object: 0 },
+				end: None,
+			} => {}
+			Self::Absolute { start, end } => {
+				start.group.encode(w, version)?;
+				start.object.encode(w, version)?;
+				if let Some(end) = end {
+					Self::end_delta(start.group, end)?.encode(w, version)?;
+				}
+			}
+		}
+		Ok(())
+	}
+
+	/// Decode the draft-20 field list, which the caller has already delimited.
+	fn decode_fields<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		let mut fields = Vec::with_capacity(4);
+		while r.has_remaining() {
+			if fields.len() == 4 {
+				return Err(DecodeError::TrailingBytes);
+			}
+			fields.push(u64::decode(r, version)?);
+		}
+
+		Ok(match fields[..] {
+			[] => Self::Unfiltered,
+			[groups] => Self::Relative(groups),
+			// Two zeroes is the Next Object spelling; anything else is an absolute start.
+			[0, 0] => Self::NextObject,
+			[group, object] => Self::Absolute {
+				start: Location { group, object },
+				end: None,
+			},
+			// The fourth field is End Object. We deliver whole groups, so the end group is
+			// all we can act on; parsing it is still required or the peer's bytes desync.
+			[group, object, delta] | [group, object, delta, _] => Self::Absolute {
+				start: Location { group, object },
+				end: Some(group.checked_add(delta).ok_or(DecodeError::BoundsExceeded)?),
+			},
+			_ => unreachable!("capped at 4 fields above"),
+		})
+	}
+
+	/// Encode the draft-19 and earlier tag form, without the enclosing length prefix.
+	fn encode_tag<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
+		match *self {
+			// No tag means "everything", which only the absolute spelling can say.
+			Self::Unfiltered => {
+				tag::ABSOLUTE_START.encode(w, version)?;
+				Location::default().encode(w, version)?;
+			}
+			Self::NextObject => tag::LARGEST_OBJECT.encode(w, version)?,
+			Self::Relative(0) => tag::NEXT_GROUP.encode(w, version)?,
+			// Only draft-20 can name a start further back than the next group without
+			// knowing Largest Object, so there is no honest tag to fall back to.
+			Self::Relative(_) => return Err(EncodeError::Unsupported),
+			Self::Absolute { start, end: None } => {
+				tag::ABSOLUTE_START.encode(w, version)?;
+				start.encode(w, version)?;
+			}
+			Self::Absolute { start, end: Some(end) } => {
+				tag::ABSOLUTE_RANGE.encode(w, version)?;
+				start.encode(w, version)?;
+				Self::end_delta(start.group, end)?.encode(w, version)?;
+			}
+		}
+		Ok(())
+	}
+
+	/// Decode the draft-19 and earlier tag form.
+	fn decode_tag<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		Ok(match u64::decode(r, version)? {
+			tag::NEXT_GROUP => Self::Relative(0),
+			tag::LARGEST_OBJECT => Self::NextObject,
+			tag::ABSOLUTE_START => Self::Absolute {
+				start: Location::decode(r, version)?,
+				end: None,
+			},
+			tag::ABSOLUTE_RANGE => {
+				let start = Location::decode(r, version)?;
+				let delta = u64::decode(r, version)?;
+				Self::Absolute {
+					start,
+					end: Some(start.group.checked_add(delta).ok_or(DecodeError::BoundsExceeded)?),
+				}
+			}
+			_ => return Err(DecodeError::InvalidValue),
+		})
+	}
+}
+
+/// The inline form, used by draft-14 where the filter is message fields rather than a
+/// parameter. Later drafts go through [`Param`] instead.
+impl Encode<Version> for Filter {
+	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
+		self.encode_tag(w, version)
+	}
+}
+
+impl Decode<Version> for Filter {
+	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		Self::decode_tag(r, version)
+	}
+}
+
+impl Param for Filter {
+	/// An unfiltered subscription is the default, so it goes on the wire as an absent
+	/// parameter rather than an empty one.
+	fn param_present(&self) -> bool {
+		!matches!(self, Self::Unfiltered)
+	}
+
+	fn param_encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
+		let mut buf = Vec::new();
+
+		// Inner varints use the draft-15 leading-ones encoding on the drafts that predate
+		// the switch, matching the other length-prefixed parameters.
+		let sv = match version {
+			Version::Draft14 | Version::Draft15 | Version::Draft16 => Version::Draft15,
+			_ => version,
+		};
+
+		if Self::is_draft20(version) {
+			self.encode_fields(&mut buf, sv)?;
+		} else {
+			self.encode_tag(&mut buf, sv)?;
+		}
+
+		buf.encode(w, version)
+	}
+
+	fn param_decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		let data = Vec::<u8>::decode(r, version)?;
+		let mut buf = bytes::Bytes::from(data);
+		let sv = match version {
+			Version::Draft14 | Version::Draft15 | Version::Draft16 => Version::Draft15,
+			_ => version,
+		};
+
+		if Self::is_draft20(version) {
+			// The field count is what carries the meaning, so the value is consumed whole.
+			return Self::decode_fields(&mut buf, sv);
+		}
+
+		let filter = Self::decode_tag(&mut buf, sv)?;
+		if buf.has_remaining() {
+			return Err(DecodeError::TrailingBytes);
+		}
+		Ok(filter)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	const OLD: Version = Version::Draft19;
+	const NEW: Version = Version::Draft20;
+
+	fn round_trip(filter: Filter, version: Version) -> Filter {
+		let mut buf = Vec::new();
+		filter.param_encode(&mut buf, version).expect("encode");
+		let mut bytes = bytes::Bytes::from(buf);
+		let decoded = Filter::param_decode(&mut bytes, version).expect("decode");
+		assert!(!bytes.has_remaining(), "parameter left trailing bytes");
+		decoded
+	}
+
+	/// The value bytes, without the length prefix a parameter carries.
+	fn value(filter: Filter, version: Version) -> Vec<u8> {
+		let mut buf = Vec::new();
+		filter.param_encode(&mut buf, version).expect("encode");
+		let mut bytes = bytes::Bytes::from(buf);
+		Vec::<u8>::decode(&mut bytes, version).expect("length prefix")
+	}
+
+	#[test]
+	fn draft20_field_counts() {
+		// The number of fields present is what selects the meaning, so pin the bytes.
+		assert_eq!(value(Filter::NextObject, NEW), vec![0x00, 0x00]);
+		assert_eq!(value(Filter::Relative(0), NEW), vec![0x00]);
+		assert_eq!(value(Filter::Relative(1), NEW), vec![0x01]);
+		assert_eq!(
+			value(
+				Filter::Absolute {
+					start: Location { group: 7, object: 3 },
+					end: None
+				},
+				NEW
+			),
+			vec![0x07, 0x03]
+		);
+		// End is a delta from the start group, not an absolute group id.
+		assert_eq!(
+			value(
+				Filter::Absolute {
+					start: Location { group: 7, object: 3 },
+					end: Some(9)
+				},
+				NEW
+			),
+			vec![0x07, 0x03, 0x02]
+		);
+	}
+
+	/// The current group is what moq-lite means by joining a track, and draft-20 is the
+	/// first version that can name it without knowing Largest Object.
+	#[test]
+	fn draft20_names_the_current_group() {
+		assert_eq!(value(Filter::Relative(1), NEW), vec![0x01]);
+		assert_eq!(round_trip(Filter::Relative(1), NEW), Filter::Relative(1));
+	}
+
+	#[test]
+	fn draft20_round_trips() {
+		for filter in [
+			Filter::Unfiltered,
+			Filter::NextObject,
+			Filter::Relative(0),
+			Filter::Relative(5),
+			Filter::Absolute {
+				start: Location { group: 12, object: 0 },
+				end: None,
+			},
+			Filter::Absolute {
+				start: Location { group: 12, object: 4 },
+				end: Some(20),
+			},
+		] {
+			assert_eq!(round_trip(filter, NEW), filter, "{filter:?}");
+		}
+	}
+
+	/// Absolute {0, 0} open ended is defined as equivalent to unfiltered, so it must not
+	/// collide with the two-zero-field spelling of NextObject.
+	#[test]
+	fn draft20_absolute_origin_is_unfiltered() {
+		let origin = Filter::Absolute {
+			start: Location::default(),
+			end: None,
+		};
+		assert!(value(origin, NEW).is_empty());
+		assert_eq!(round_trip(origin, NEW), Filter::Unfiltered);
+		assert_ne!(value(origin, NEW), value(Filter::NextObject, NEW));
+	}
+
+	#[test]
+	fn draft19_uses_tags() {
+		assert_eq!(value(Filter::NextObject, OLD), vec![tag::LARGEST_OBJECT as u8]);
+		assert_eq!(value(Filter::Relative(0), OLD), vec![tag::NEXT_GROUP as u8]);
+		for filter in [
+			Filter::NextObject,
+			Filter::Relative(0),
+			Filter::Absolute {
+				start: Location { group: 12, object: 4 },
+				end: None,
+			},
+			Filter::Absolute {
+				start: Location { group: 12, object: 4 },
+				end: Some(20),
+			},
+		] {
+			assert_eq!(round_trip(filter, OLD), filter, "{filter:?}");
+		}
+	}
+
+	/// Draft-19 has a tag per case and none of them mean "two groups back", so refuse
+	/// rather than silently sending a nearby filter the peer would honor.
+	#[test]
+	fn draft19_cannot_name_a_relative_group() {
+		let mut buf = Vec::new();
+		assert!(Filter::Relative(2).param_encode(&mut buf, OLD).is_err());
+	}
+
+	#[test]
+	fn rejects_a_backwards_range() {
+		let backwards = Filter::Absolute {
+			start: Location { group: 9, object: 0 },
+			end: Some(4),
+		};
+		for version in [OLD, NEW] {
+			let mut buf = Vec::new();
+			assert!(backwards.param_encode(&mut buf, version).is_err(), "{version}");
+		}
+	}
+
+	#[test]
+	fn rejects_too_many_fields() {
+		let mut buf = Vec::new();
+		vec![0u8; 5].encode(&mut buf, NEW).expect("encode");
+		let mut bytes = bytes::Bytes::from(buf);
+		assert!(Filter::param_decode(&mut bytes, NEW).is_err());
+	}
+}
+
+/// The FILL_PARAMETERS parameter (0x23), draft-20's request for a backfill.
+///
+/// Its presence is what asks for one. The value is a nested parameter scope describing the
+/// fill, of which the Location Filter is the part we act on.
+///
+/// The draft delivers a fill on a separate unidirectional fetch stream. We deliver it as
+/// ordinary live subgroups instead, by lowering the subscription's floor to the start of
+/// the fill range, which avoids the head-of-line blocking a fetch stream imposes on
+/// everything queued behind it. The subscriber receives every Object it asked for, just
+/// never on the stream the draft says to watch.
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Fill {
+	/// The range to fill. [`Filter::Unfiltered`] means the whole track up to Largest Object.
+	pub filter: Filter,
+}
+
+impl Fill {
+	/// LOCATION_FILTER, the only nested parameter that changes what we deliver.
+	const LOCATION_FILTER: u64 = 0x21;
+
+	/// The parameters the draft allows inside FILL_PARAMETERS. Anything else is a
+	/// protocol violation rather than something to skip.
+	const ALLOWED: &'static [u64] = &[
+		0x0A, // FILL_TIMEOUT
+		0x20, // SUBSCRIBER_PRIORITY
+		Self::LOCATION_FILTER,
+		0x22, // GROUP_ORDER
+		0x25, // SUBGROUP_FILTER
+		0x26, // OBJECTID_FILTER
+		0x27, // PRIORITY_FILTER
+		0x28, // OBJECT_PROPERTY_FILTER
+	];
+}
+
+impl Param for Fill {
+	fn param_encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
+		let mut buf = Vec::new();
+
+		// A nested scope is encoded like a message's parameters: a count, then the KVPs.
+		// Unfiltered carries no filter, so the fill is the whole track and the scope is empty.
+		match self.filter {
+			Filter::Unfiltered => 0u64.encode(&mut buf, version)?,
+			filter => {
+				1u64.encode(&mut buf, version)?;
+				// The first type in a scope is not delta encoded, so this is the raw id.
+				Self::LOCATION_FILTER.encode(&mut buf, version)?;
+				filter.param_encode(&mut buf, version)?;
+			}
+		}
+
+		buf.encode(w, version)
+	}
+
+	fn param_decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		let data = Vec::<u8>::decode(r, version)?;
+		let mut buf = bytes::Bytes::from(data);
+
+		let count = u64::decode(&mut buf, version)?;
+		if count > 64 {
+			return Err(DecodeError::TooMany);
+		}
+
+		let mut filter = None;
+		let mut prev = 0u64;
+		for i in 0..count {
+			let delta = u64::decode(&mut buf, version)?;
+			let key = if i == 0 {
+				delta
+			} else {
+				prev.checked_add(delta).ok_or(DecodeError::BoundsExceeded)?
+			};
+			prev = key;
+
+			if !Self::ALLOWED.contains(&key) {
+				return Err(DecodeError::InvalidValue);
+			}
+
+			if key == Self::LOCATION_FILTER {
+				if filter.is_some() {
+					return Err(DecodeError::Duplicate);
+				}
+				filter = Some(Filter::param_decode(&mut buf, version)?);
+				continue;
+			}
+
+			// The rest are parameters we do not act on, but their bytes still have to be
+			// consumed or the remaining keys desync. Key-Value-Pair parity says how: an even
+			// type carries a single varint, an odd type a length-prefixed byte string.
+			if key % 2 == 0 {
+				u64::decode(&mut buf, version)?;
+			} else {
+				Vec::<u8>::decode(&mut buf, version)?;
+			}
+		}
+
+		if buf.has_remaining() {
+			return Err(DecodeError::TrailingBytes);
+		}
+
+		Ok(Self {
+			filter: filter.unwrap_or(Filter::Unfiltered),
+		})
+	}
+}
+
+#[cfg(test)]
+mod fill_tests {
+	use super::*;
+
+	const NEW: Version = Version::Draft20;
+
+	fn round_trip(fill: Fill) -> Fill {
+		let mut buf = Vec::new();
+		fill.param_encode(&mut buf, NEW).expect("encode");
+		let mut bytes = bytes::Bytes::from(buf);
+		let decoded = Fill::param_decode(&mut bytes, NEW).expect("decode");
+		assert!(!bytes.has_remaining());
+		decoded
+	}
+
+	#[test]
+	fn round_trips() {
+		for filter in [
+			Filter::Unfiltered,
+			Filter::Relative(1),
+			Filter::Relative(3),
+			Filter::Absolute {
+				start: Location { group: 4, object: 0 },
+				end: Some(9),
+			},
+		] {
+			assert_eq!(round_trip(Fill { filter }).filter, filter, "{filter:?}");
+		}
+	}
+
+	/// The canonical current-group join: an empty subscription filter paired with a fill
+	/// that starts one group back.
+	#[test]
+	fn current_group_join() {
+		let fill = Fill {
+			filter: Filter::Relative(1),
+		};
+		let mut buf = Vec::new();
+		fill.param_encode(&mut buf, NEW).expect("encode");
+		// count=1, type=0x21, len=1, StartGroup=1
+		let mut bytes = bytes::Bytes::from(buf);
+		let value = Vec::<u8>::decode(&mut bytes, NEW).expect("length prefix");
+		assert_eq!(value, vec![0x01, 0x21, 0x01, 0x01]);
+	}
+
+	/// A parameter the draft does not allow inside the scope is a violation, not something
+	/// to skip past.
+	#[test]
+	fn rejects_a_disallowed_parameter() {
+		let mut value = Vec::new();
+		1u64.encode(&mut value, NEW).unwrap();
+		0x10u64.encode(&mut value, NEW).unwrap(); // FORWARD, not allowed in a fill
+		0u64.encode(&mut value, NEW).unwrap();
+
+		let mut buf = Vec::new();
+		value.encode(&mut buf, NEW).unwrap();
+		let mut bytes = bytes::Bytes::from(buf);
+		assert!(Fill::param_decode(&mut bytes, NEW).is_err());
+	}
+
+	/// An allowed parameter we ignore still has to be consumed, or the keys after it
+	/// desync. Parity decides how many bytes that is.
+	#[test]
+	fn skips_allowed_parameters_it_ignores() {
+		let mut value = Vec::new();
+		2u64.encode(&mut value, NEW).unwrap();
+		0x20u64.encode(&mut value, NEW).unwrap(); // SUBSCRIBER_PRIORITY, even: one varint
+		42u64.encode(&mut value, NEW).unwrap();
+		1u64.encode(&mut value, NEW).unwrap(); // delta to 0x21, odd: length prefixed
+		Filter::Relative(2).param_encode(&mut value, NEW).unwrap();
+
+		let mut buf = Vec::new();
+		value.encode(&mut buf, NEW).unwrap();
+		let mut bytes = bytes::Bytes::from(buf);
+		let fill = Fill::param_decode(&mut bytes, NEW).expect("decode");
+		assert_eq!(fill.filter, Filter::Relative(2));
+	}
+}

--- a/rs/moq-net/src/ietf/filter.rs
+++ b/rs/moq-net/src/ietf/filter.rs
@@ -33,13 +33,22 @@ pub enum Filter {
 	/// Only draft-20 can encode a value above 1; older drafts have a tag per case.
 	Relative(u64),
 
-	/// An absolute range, ending after group `end` (inclusive) when one is set.
+	/// An absolute range, ending at `end` (inclusive) when one is set.
 	Absolute {
 		/// The first Location to deliver.
 		start: Location,
-		/// The last group to deliver, inclusive. `None` leaves the range open ended.
-		end: Option<u64>,
+		/// Where the range ends, inclusive. `None` leaves it open ended.
+		end: Option<EndLocation>,
 	},
+}
+
+/// The inclusive end of an absolute [`Filter`] range.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct EndLocation {
+	/// The last group to deliver, inclusive.
+	pub group: u64,
+	/// The last object in that group, inclusive. `None` includes the whole group.
+	pub object: Option<u64>,
 }
 
 /// The tagged Filter Type of draft-19 and earlier.
@@ -91,7 +100,10 @@ impl Filter {
 				start.group.encode(w, version)?;
 				start.object.encode(w, version)?;
 				if let Some(end) = end {
-					Self::end_delta(start.group, end)?.encode(w, version)?;
+					Self::end_delta(start.group, end.group)?.encode(w, version)?;
+					if let Some(object) = end.object {
+						object.encode(w, version)?;
+					}
 				}
 			}
 		}
@@ -117,11 +129,19 @@ impl Filter {
 				start: Location { group, object },
 				end: None,
 			},
-			// The fourth field is End Object. We deliver whole groups, so the end group is
-			// all we can act on; parsing it is still required or the peer's bytes desync.
-			[group, object, delta] | [group, object, delta, _] => Self::Absolute {
+			[group, object, delta] => Self::Absolute {
 				start: Location { group, object },
-				end: Some(group.checked_add(delta).ok_or(DecodeError::BoundsExceeded)?),
+				end: Some(EndLocation {
+					group: group.checked_add(delta).ok_or(DecodeError::BoundsExceeded)?,
+					object: None,
+				}),
+			},
+			[group, object, delta, end_object] => Self::Absolute {
+				start: Location { group, object },
+				end: Some(EndLocation {
+					group: group.checked_add(delta).ok_or(DecodeError::BoundsExceeded)?,
+					object: Some(end_object),
+				}),
 			},
 			_ => unreachable!("capped at 4 fields above"),
 		})
@@ -144,10 +164,16 @@ impl Filter {
 				tag::ABSOLUTE_START.encode(w, version)?;
 				start.encode(w, version)?;
 			}
+			// Draft-19's AbsoluteRange ends on a group, so an object-bounded range has no
+			// spelling. Refuse rather than widen the range the caller asked for.
+			Self::Absolute {
+				end: Some(EndLocation { object: Some(_), .. }),
+				..
+			} => return Err(EncodeError::Unsupported),
 			Self::Absolute { start, end: Some(end) } => {
 				tag::ABSOLUTE_RANGE.encode(w, version)?;
 				start.encode(w, version)?;
-				Self::end_delta(start.group, end)?.encode(w, version)?;
+				Self::end_delta(start.group, end.group)?.encode(w, version)?;
 			}
 		}
 		Ok(())
@@ -167,7 +193,10 @@ impl Filter {
 				let delta = u64::decode(r, version)?;
 				Self::Absolute {
 					start,
-					end: Some(start.group.checked_add(delta).ok_or(DecodeError::BoundsExceeded)?),
+					end: Some(EndLocation {
+						group: start.group.checked_add(delta).ok_or(DecodeError::BoundsExceeded)?,
+						object: None,
+					}),
 				}
 			}
 			_ => return Err(DecodeError::InvalidValue),
@@ -281,7 +310,7 @@ mod tests {
 			value(
 				Filter::Absolute {
 					start: Location { group: 7, object: 3 },
-					end: Some(9)
+					end: Some(EndLocation { group: 9, object: None })
 				},
 				NEW
 			),
@@ -310,7 +339,10 @@ mod tests {
 			},
 			Filter::Absolute {
 				start: Location { group: 12, object: 4 },
-				end: Some(20),
+				end: Some(EndLocation {
+					group: 20,
+					object: None,
+				}),
 			},
 		] {
 			assert_eq!(round_trip(filter, NEW), filter, "{filter:?}");
@@ -343,11 +375,52 @@ mod tests {
 			},
 			Filter::Absolute {
 				start: Location { group: 12, object: 4 },
-				end: Some(20),
+				end: Some(EndLocation {
+					group: 20,
+					object: None,
+				}),
 			},
 		] {
 			assert_eq!(round_trip(filter, OLD), filter, "{filter:?}");
 		}
+	}
+
+	/// The fourth field bounds the last object in the end group. Dropping it on decode
+	/// would let a publisher deliver past the Location the subscriber asked for.
+	#[test]
+	fn draft20_keeps_the_end_object() {
+		let bounded = Filter::Absolute {
+			start: Location { group: 7, object: 3 },
+			end: Some(EndLocation {
+				group: 9,
+				object: Some(4),
+			}),
+		};
+		assert_eq!(value(bounded, NEW), vec![0x07, 0x03, 0x02, 0x04]);
+		assert_eq!(round_trip(bounded, NEW), bounded);
+
+		// Three fields leave the end group whole, which is a different filter.
+		let whole = Filter::Absolute {
+			start: Location { group: 7, object: 3 },
+			end: Some(EndLocation { group: 9, object: None }),
+		};
+		assert_eq!(value(whole, NEW), vec![0x07, 0x03, 0x02]);
+		assert_ne!(round_trip(bounded, NEW), whole);
+	}
+
+	/// Draft-19's AbsoluteRange ends on a group, so an object bound cannot be expressed.
+	/// Widening the range silently would deliver objects the subscriber excluded.
+	#[test]
+	fn draft19_cannot_bound_the_end_object() {
+		let mut buf = Vec::new();
+		let bounded = Filter::Absolute {
+			start: Location { group: 7, object: 0 },
+			end: Some(EndLocation {
+				group: 9,
+				object: Some(4),
+			}),
+		};
+		assert!(bounded.param_encode(&mut buf, OLD).is_err());
 	}
 
 	/// Draft-19 has a tag per case and none of them mean "two groups back", so refuse
@@ -362,7 +435,7 @@ mod tests {
 	fn rejects_a_backwards_range() {
 		let backwards = Filter::Absolute {
 			start: Location { group: 9, object: 0 },
-			end: Some(4),
+			end: Some(EndLocation { group: 4, object: None }),
 		};
 		for version in [OLD, NEW] {
 			let mut buf = Vec::new();
@@ -399,17 +472,23 @@ impl Fill {
 	/// LOCATION_FILTER, the only nested parameter that changes what we deliver.
 	const LOCATION_FILTER: u64 = 0x21;
 
-	/// The parameters the draft allows inside FILL_PARAMETERS. Anything else is a
-	/// protocol violation rather than something to skip.
-	const ALLOWED: &'static [u64] = &[
-		0x0A, // FILL_TIMEOUT
-		0x20, // SUBSCRIBER_PRIORITY
-		Self::LOCATION_FILTER,
-		0x22, // GROUP_ORDER
-		0x25, // SUBGROUP_FILTER
-		0x26, // OBJECTID_FILTER
-		0x27, // PRIORITY_FILTER
-		0x28, // OBJECT_PROPERTY_FILTER
+	/// The parameters the draft allows inside FILL_PARAMETERS, and whether each carries a
+	/// length prefix. Anything absent from this table is a protocol violation rather than
+	/// something to skip.
+	///
+	/// The Key-Value-Pair rule keys the framing off the id's parity, but the Range Filters
+	/// (0x25-0x28) are written with an explicit `Length` field despite two of them having
+	/// even ids. Their own definition wins, so the framing is tabulated here rather than
+	/// derived: reading 0x26 or 0x28 as a bare varint would desync every parameter after it.
+	const ALLOWED: &'static [(u64, bool)] = &[
+		(0x0A, false), // FILL_TIMEOUT, a varint
+		(0x20, false), // SUBSCRIBER_PRIORITY, a uint8 varint
+		(Self::LOCATION_FILTER, true),
+		(0x22, false), // GROUP_ORDER, a uint8 varint
+		(0x25, true),  // SUBGROUP_FILTER
+		(0x26, true),  // OBJECTID_FILTER, length prefixed despite an even id
+		(0x27, true),  // PRIORITY_FILTER
+		(0x28, true),  // OBJECT_PROPERTY_FILTER, likewise
 	];
 }
 
@@ -452,9 +531,9 @@ impl Param for Fill {
 			};
 			prev = key;
 
-			if !Self::ALLOWED.contains(&key) {
+			let Some((_, length_prefixed)) = Self::ALLOWED.iter().find(|(id, _)| *id == key) else {
 				return Err(DecodeError::InvalidValue);
-			}
+			};
 
 			if key == Self::LOCATION_FILTER {
 				if filter.is_some() {
@@ -465,12 +544,14 @@ impl Param for Fill {
 			}
 
 			// The rest are parameters we do not act on, but their bytes still have to be
-			// consumed or the remaining keys desync. Key-Value-Pair parity says how: an even
-			// type carries a single varint, an odd type a length-prefixed byte string.
-			if key % 2 == 0 {
-				u64::decode(&mut buf, version)?;
-			} else {
-				Vec::<u8>::decode(&mut buf, version)?;
+			// consumed or the remaining keys desync.
+			match length_prefixed {
+				true => {
+					Vec::<u8>::decode(&mut buf, version)?;
+				}
+				false => {
+					u64::decode(&mut buf, version)?;
+				}
 			}
 		}
 
@@ -507,7 +588,7 @@ mod fill_tests {
 			Filter::Relative(3),
 			Filter::Absolute {
 				start: Location { group: 4, object: 0 },
-				end: Some(9),
+				end: Some(EndLocation { group: 9, object: None }),
 			},
 		] {
 			assert_eq!(round_trip(Fill { filter }).filter, filter, "{filter:?}");
@@ -545,7 +626,25 @@ mod fill_tests {
 	}
 
 	/// An allowed parameter we ignore still has to be consumed, or the keys after it
-	/// desync. Parity decides how many bytes that is.
+	/// desync. Its own definition decides how many bytes that is.
+	/// OBJECTID_FILTER has an even id but is written with an explicit Length, so parity
+	/// would read its length byte as the whole value and desync everything after it.
+	#[test]
+	fn skips_a_length_prefixed_range_filter() {
+		let mut value = Vec::new();
+		2u64.encode(&mut value, NEW).unwrap();
+		0x26u64.encode(&mut value, NEW).unwrap(); // OBJECTID_FILTER, length prefixed
+		vec![0xAAu8, 0xBB, 0xCC].encode(&mut value, NEW).unwrap();
+		1u64.encode(&mut value, NEW).unwrap(); // delta to 0x27
+		vec![0xDDu8].encode(&mut value, NEW).unwrap(); // PRIORITY_FILTER
+
+		let mut buf = Vec::new();
+		value.encode(&mut buf, NEW).unwrap();
+		let mut bytes = bytes::Bytes::from(buf);
+		let fill = Fill::param_decode(&mut bytes, NEW).expect("decode");
+		assert_eq!(fill.filter, Filter::Unfiltered);
+	}
+
 	#[test]
 	fn skips_allowed_parameters_it_ignores() {
 		let mut value = Vec::new();

--- a/rs/moq-net/src/ietf/group.rs
+++ b/rs/moq-net/src/ietf/group.rs
@@ -174,9 +174,11 @@ pub struct GroupFlags {
 	// When false (0x30 base), priority inherits from the control message.
 	pub has_priority: bool,
 
-	// draft-18+: whether this stream carries the subgroup from its first published object.
-	// A subgroup that starts partway through has a hole at the front, which moq-lite cannot
-	// represent. Always true on the drafts that predate the bit, where there is no signal.
+	/// Whether this stream carries the subgroup from its first published object.
+	///
+	/// A subgroup that starts partway through has a hole at the front, which moq-lite cannot
+	/// represent. Always true on the drafts that predate the FIRST_OBJECT bit (before
+	/// draft-18), where there is no such signal to read.
 	pub first_object: bool,
 }
 

--- a/rs/moq-net/src/ietf/group.rs
+++ b/rs/moq-net/src/ietf/group.rs
@@ -173,6 +173,11 @@ pub struct GroupFlags {
 	// v15: whether priority is present in the header.
 	// When false (0x30 base), priority inherits from the control message.
 	pub has_priority: bool,
+
+	// draft-18+: whether this stream carries the subgroup from its first published object.
+	// A subgroup that starts partway through has a hole at the front, which moq-lite cannot
+	// represent. Always true on the drafts that predate the bit, where there is no signal.
+	pub first_object: bool,
 }
 
 impl GroupFlags {
@@ -211,29 +216,29 @@ impl GroupFlags {
 		if self.has_end {
 			id |= 0x08;
 		}
-		// Draft-18+: set FIRST_OBJECT. moq-lite always starts subgroups at object 0
-		// and never has gaps, so this is unconditionally true on the publisher side.
-		if !matches!(
-			version,
-			Version::Draft14 | Version::Draft15 | Version::Draft16 | Version::Draft17
-		) {
+		// Draft-18+: moq-lite always starts subgroups at object 0 and never has gaps, so
+		// the publisher side sets this on everything it produces.
+		if self.first_object
+			&& !matches!(
+				version,
+				Version::Draft14 | Version::Draft15 | Version::Draft16 | Version::Draft17
+			) {
 			id |= Self::FIRST_OBJECT_BIT;
 		}
 		Ok(id)
 	}
 
 	pub fn decode(id: u64, version: Version) -> Result<Self, DecodeError> {
-		// Draft-18+ allows bit 0x40 (FIRST_OBJECT). Strip it before range check;
-		// moq-lite already assumes every subgroup starts at object 0, so the bit
-		// value carries no extra information for us.
-		let id = if matches!(
+		// Draft-18+ allows bit 0x40 (FIRST_OBJECT), which says the stream carries the
+		// subgroup from its first published object. Strip it before the range check, but
+		// keep the value: it is the only signal that a subgroup starts partway through.
+		// The drafts that predate it carry no such signal, so they are taken at their word.
+		let legacy = matches!(
 			version,
 			Version::Draft14 | Version::Draft15 | Version::Draft16 | Version::Draft17
-		) {
-			id
-		} else {
-			id & !Self::FIRST_OBJECT_BIT
-		};
+		);
+		let first_object = legacy || (id & Self::FIRST_OBJECT_BIT) != 0;
+		let id = if legacy { id } else { id & !Self::FIRST_OBJECT_BIT };
 
 		let (has_priority, base_id) = if (Self::START..=Self::END).contains(&id) {
 			(true, id)
@@ -253,6 +258,7 @@ impl GroupFlags {
 		}
 
 		Ok(Self {
+			first_object,
 			has_extensions,
 			has_subgroup,
 			has_subgroup_object,
@@ -270,6 +276,7 @@ impl Default for GroupFlags {
 			has_subgroup_object: false,
 			has_end: true,
 			has_priority: true,
+			first_object: true,
 		}
 	}
 }
@@ -616,6 +623,43 @@ mod tests {
 		assert!(GroupFlags::decode(v17 | GroupFlags::FIRST_OBJECT_BIT, Version::Draft17).is_err());
 	}
 
+	/// FIRST_OBJECT says the stream carries the subgroup from its first published object.
+	/// It is the only signal that a group arrived with its head missing, so the value has
+	/// to survive decode rather than being stripped with the bit.
+	#[test]
+	fn first_object_round_trips() {
+		for version in [Version::Draft18, Version::Draft19, Version::Draft20] {
+			for first_object in [true, false] {
+				let flags = GroupFlags {
+					first_object,
+					..Default::default()
+				};
+				let encoded = flags.encode(version).unwrap();
+				assert_eq!(
+					(encoded & GroupFlags::FIRST_OBJECT_BIT) != 0,
+					first_object,
+					"{version} {first_object}"
+				);
+				assert_eq!(GroupFlags::decode(encoded, version).unwrap().first_object, first_object);
+			}
+		}
+	}
+
+	/// The bit arrived in draft-18. Earlier drafts carry no such signal, so a group there
+	/// is taken at its word rather than read as starting partway through.
+	#[test]
+	fn older_drafts_have_no_first_object_signal() {
+		for version in [Version::Draft14, Version::Draft15, Version::Draft16, Version::Draft17] {
+			let flags = GroupFlags {
+				first_object: false,
+				..Default::default()
+			};
+			let encoded = flags.encode(version).unwrap();
+			assert_eq!(encoded & GroupFlags::FIRST_OBJECT_BIT, 0, "{version}");
+			assert!(GroupFlags::decode(encoded, version).unwrap().first_object, "{version}");
+		}
+	}
+
 	/// Draft-19 makes no changes to the subgroup header wire format, so the flags
 	/// byte must be byte-identical to draft-18 on both encode and decode.
 	#[test]
@@ -628,6 +672,7 @@ mod tests {
 				has_end: true,
 				has_subgroup_object: false,
 				has_priority: false,
+				first_object: true,
 			},
 		] {
 			let v18 = flags.encode(Version::Draft18).unwrap();

--- a/rs/moq-net/src/ietf/location.rs
+++ b/rs/moq-net/src/ietf/location.rs
@@ -2,7 +2,7 @@ use crate::coding::{Decode, DecodeError, Encode, EncodeError};
 
 use super::Version;
 
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Location {
 	pub group: u64,
 	pub object: u64,

--- a/rs/moq-net/src/ietf/mod.rs
+++ b/rs/moq-net/src/ietf/mod.rs
@@ -11,6 +11,7 @@ pub mod cluster;
 mod control;
 mod error;
 mod fetch;
+mod filter;
 mod goaway;
 mod group;
 mod location;
@@ -33,6 +34,7 @@ mod version;
 
 use control::Control;
 pub use fetch::*;
+pub use filter::*;
 pub use goaway::*;
 pub use group::*;
 pub use location::*;

--- a/rs/moq-net/src/ietf/parameters.rs
+++ b/rs/moq-net/src/ietf/parameters.rs
@@ -299,44 +299,37 @@ impl Param for u64 {
 	}
 }
 
+/// The varint format inside a length-prefixed Location value: the drafts before 17 pin it
+/// to the draft-15 encoding, matching the other length-prefixed parameters.
+fn location_inner_version(version: Version) -> Version {
+	match version {
+		Version::Draft14 | Version::Draft15 | Version::Draft16 => Version::Draft15,
+		_ => version,
+	}
+}
+
 impl Param for Location {
 	fn param_encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
-		match version {
-			Version::Draft14 | Version::Draft15 | Version::Draft16 => {
-				// Length-prefixed bytes containing two QUIC varints
-				let mut buf = Vec::new();
-				self.group.encode(&mut buf, Version::Draft15)?;
-				self.object.encode(&mut buf, Version::Draft15)?;
-				buf.encode(w, version)?;
-				Ok(())
-			}
-			_ => {
-				self.group.encode(w, version)?;
-				self.object.encode(w, version)?;
-				Ok(())
-			}
-		}
+		// LARGEST_OBJECT (0x09) is an odd type, so the Key-Value-Pair rule gives it a
+		// Length on every draft: two varints inside a length-prefixed value.
+		let sv = location_inner_version(version);
+		let mut buf = Vec::new();
+		self.group.encode(&mut buf, sv)?;
+		self.object.encode(&mut buf, sv)?;
+		buf.encode(w, version)?;
+		Ok(())
 	}
 
 	fn param_decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
-		match version {
-			Version::Draft14 | Version::Draft15 | Version::Draft16 => {
-				// Length-prefixed bytes containing two QUIC varints
-				let data = Vec::<u8>::decode(r, version)?;
-				let mut buf = bytes::Bytes::from(data);
-				let group = u64::decode(&mut buf, Version::Draft15)?;
-				let object = u64::decode(&mut buf, Version::Draft15)?;
-				if buf.has_remaining() {
-					return Err(DecodeError::TrailingBytes);
-				}
-				Ok(Location { group, object })
-			}
-			_ => {
-				let group = u64::decode(r, version)?;
-				let object = u64::decode(r, version)?;
-				Ok(Location { group, object })
-			}
+		let sv = location_inner_version(version);
+		let data = Vec::<u8>::decode(r, version)?;
+		let mut buf = bytes::Bytes::from(data);
+		let group = u64::decode(&mut buf, sv)?;
+		let object = u64::decode(&mut buf, sv)?;
+		if buf.has_remaining() {
+			return Err(DecodeError::TrailingBytes);
 		}
+		Ok(Location { group, object })
 	}
 }
 
@@ -693,11 +686,15 @@ mod tests {
 			group: 255,
 			object: 128,
 		};
+		// 0x09 is odd, so the Key-Value-Pair rule gives the value a Length on every
+		// draft; only the inner varint format differs (QUIC-style before draft-17,
+		// leading-ones after).
 		for (version, expected) in [
 			(Version::Draft16, &[0x01, 0x09, 0x04, 0x40, 0xff, 0x40, 0x80][..]),
-			(Version::Draft17, &[0x01, 0x09, 0x80, 0xff, 0x80, 0x80][..]),
-			(Version::Draft18, &[0x01, 0x09, 0x80, 0xff, 0x80, 0x80][..]),
-			(Version::Draft19, &[0x01, 0x09, 0x80, 0xff, 0x80, 0x80][..]),
+			(Version::Draft17, &[0x01, 0x09, 0x04, 0x80, 0xff, 0x80, 0x80][..]),
+			(Version::Draft18, &[0x01, 0x09, 0x04, 0x80, 0xff, 0x80, 0x80][..]),
+			(Version::Draft19, &[0x01, 0x09, 0x04, 0x80, 0xff, 0x80, 0x80][..]),
+			(Version::Draft20, &[0x01, 0x09, 0x04, 0x80, 0xff, 0x80, 0x80][..]),
 		] {
 			let mut buf = BytesMut::new();
 			encode_params!(&mut buf, version, 0x09 => location.clone());

--- a/rs/moq-net/src/ietf/parameters.rs
+++ b/rs/moq-net/src/ietf/parameters.rs
@@ -5,8 +5,8 @@ use num_enum::{FromPrimitive, IntoPrimitive};
 
 use crate::coding::*;
 
+use super::Location;
 use super::Version;
-use super::{FilterType, Location};
 
 const MAX_PARAMS: u64 = 64;
 /// Maximum byte value length in Key-Value-Pairs per spec Section 1.4.3.
@@ -340,35 +340,6 @@ impl Param for Location {
 	}
 }
 
-impl Param for FilterType {
-	fn param_encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
-		let mut buf = Vec::new();
-		// Use version-specific varint encoding for the inner value.
-		// Fixes draft-17 interop: inner varints now use leading-ones, not QUIC.
-		let sv = match version {
-			Version::Draft14 | Version::Draft15 | Version::Draft16 => Version::Draft15,
-			_ => version,
-		};
-		self.encode(&mut buf, sv)?;
-		buf.encode(w, version)?;
-		Ok(())
-	}
-
-	fn param_decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
-		let data = Vec::<u8>::decode(r, version)?;
-		let mut buf = bytes::Bytes::from(data);
-		let sv = match version {
-			Version::Draft14 | Version::Draft15 | Version::Draft16 => Version::Draft15,
-			_ => version,
-		};
-		let filter = FilterType::decode(&mut buf, sv)?;
-		if buf.has_remaining() {
-			return Err(DecodeError::TrailingBytes);
-		}
-		Ok(filter)
-	}
-}
-
 impl<T: Param> Param for Option<T> {
 	fn param_present(&self) -> bool {
 		self.is_some()
@@ -526,6 +497,7 @@ macro_rules! decode_params {
 
 #[cfg(test)]
 mod tests {
+	use super::super::Filter;
 	use super::*;
 	use bytes::{Buf, Bytes, BytesMut};
 
@@ -737,14 +709,14 @@ mod tests {
 				Ok(value)
 			})()
 			.expect("fixed Location vector should decode");
-			assert_eq!(decoded, Some(location.clone()), "{version}");
+			assert_eq!(decoded, Some(location), "{version}");
 			assert!(!encoded.has_remaining(), "{version}");
 		}
 		Ok(())
 	}
 
 	#[test]
-	fn test_param_filter_type_all_versions() {
+	fn test_param_filter_all_versions() {
 		for version in [
 			Version::Draft14,
 			Version::Draft15,
@@ -755,12 +727,12 @@ mod tests {
 			round_trip_params(
 				version,
 				|w, v| {
-					encode_params!(w, v, 0x21 => FilterType::LargestObject);
+					encode_params!(w, v, 0x21 => Filter::NextObject);
 					Ok(())
 				},
 				|r, v| {
-					decode_params!(r, v, 0x21 => val: Option<FilterType>);
-					assert_eq!(val, Some(FilterType::LargestObject));
+					decode_params!(r, v, 0x21 => val: Option<Filter>);
+					assert_eq!(val, Some(Filter::NextObject));
 					Ok(())
 				},
 			);
@@ -782,7 +754,7 @@ mod tests {
 					encode_params!(w, v,
 						0x10 => true,
 						0x20 => 200u8,
-						0x21 => FilterType::LargestObject,
+						0x21 => Filter::NextObject,
 						0x22 => 2u8,
 					);
 					Ok(())
@@ -791,12 +763,12 @@ mod tests {
 					decode_params!(r, v,
 						0x10 => forward: Option<bool>,
 						0x20 => sub_pri: Option<u8>,
-						0x21 => filter: Option<FilterType>,
+						0x21 => filter: Option<Filter>,
 						0x22 => group_order: Option<u8>,
 					);
 					assert_eq!(forward, Some(true));
 					assert_eq!(sub_pri, Some(200));
-					assert_eq!(filter, Some(FilterType::LargestObject));
+					assert_eq!(filter, Some(Filter::NextObject));
 					assert_eq!(group_order, Some(2));
 					Ok(())
 				},

--- a/rs/moq-net/src/ietf/publish.rs
+++ b/rs/moq-net/src/ietf/publish.rs
@@ -297,11 +297,32 @@ impl Message for Publish<'_> {
 			_ => {
 				// GROUP_ORDER is only legal here through draft-15, but keep accepting it so a
 				// peer that still sends it doesn't have its session torn down over a hint.
+				//
+				// Draft-20 moved the subscription parameters into PUBLISH, so they have to
+				// parse here even though reverse publishing is unsupported: an unlisted
+				// parameter fails the whole message, which would kill the session instead of
+				// letting the request reach its NOT_SUPPORTED response.
 				decode_params!(r, version,
+					0x02 => object_delivery_timeout: Option<u64>,
+					0x06 => subgroup_delivery_timeout: Option<u64>,
 					0x09 => largest_location: Option<Location>,
 					0x10 => forward: Option<bool>,
+					0x20 => subscriber_priority: Option<u8>,
+					0x21 => filter: Option<Filter>,
 					0x22 => group_order: Option<GroupOrder>,
 				);
+
+				// The values are dropped: we refuse the PUBLISH itself, so the subscription
+				// settings it proposes never take effect. They still have to be consumed.
+				let subscription_params = [
+					object_delivery_timeout.is_some(),
+					subgroup_delivery_timeout.is_some(),
+					subscriber_priority.is_some(),
+					filter.is_some(),
+				];
+				if subscription_params.contains(&true) && !Filter::is_draft20(version) {
+					return Err(DecodeError::InvalidValue);
+				}
 				let mut properties = Properties::decode(r, version)?;
 				properties.group_order = properties.group_order.or(group_order);
 
@@ -451,6 +472,45 @@ impl Message for PublishError<'_> {
 #[cfg(test)]
 mod tests {
 	use super::*;
+
+	/// Draft-20 moved the subscription parameters into PUBLISH. We refuse the request
+	/// itself, but the message still has to parse: an unlisted parameter fails the whole
+	/// decode, which kills the session instead of letting the peer get its refusal.
+	#[test]
+	fn publish_accepts_the_relocated_subscription_parameters() -> Result<(), EncodeError> {
+		let mut body = Vec::new();
+		RequestId(1).encode(&mut body, Version::Draft20).unwrap();
+		super::super::namespace::encode_namespace(&mut body, &crate::Path::new("broadcast"), Version::Draft20).unwrap();
+		"video".encode(&mut body, Version::Draft20).unwrap();
+		1u64.encode(&mut body, Version::Draft20).unwrap(); // track alias
+
+		// SUBSCRIBER_PRIORITY then LOCATION_FILTER, delta encoded from 0.
+		encode_params!(&mut body, Version::Draft20,
+			0x20 => 128u8,
+			0x21 => Filter::NextObject,
+		);
+		Properties::default().encode(&mut body, Version::Draft20).unwrap();
+
+		let mut buf = bytes::Bytes::from(body);
+		Publish::decode_msg(&mut buf, Version::Draft20).expect("draft-20 PUBLISH parameters must parse");
+		Ok(())
+	}
+
+	/// They arrived in draft-20, so an earlier peer sending one is still a violation.
+	#[test]
+	fn older_drafts_reject_the_relocated_parameters() -> Result<(), EncodeError> {
+		let mut body = Vec::new();
+		RequestId(1).encode(&mut body, Version::Draft19).unwrap();
+		super::super::namespace::encode_namespace(&mut body, &crate::Path::new("broadcast"), Version::Draft19).unwrap();
+		"video".encode(&mut body, Version::Draft19).unwrap();
+		1u64.encode(&mut body, Version::Draft19).unwrap();
+		encode_params!(&mut body, Version::Draft19, 0x20 => 128u8);
+		Properties::default().encode(&mut body, Version::Draft19).unwrap();
+
+		let mut buf = bytes::Bytes::from(body);
+		assert!(Publish::decode_msg(&mut buf, Version::Draft19).is_err());
+		Ok(())
+	}
 	use bytes::BytesMut;
 
 	fn encode_message<M: Message>(msg: &M, version: Version) -> Vec<u8> {

--- a/rs/moq-net/src/ietf/publish.rs
+++ b/rs/moq-net/src/ietf/publish.rs
@@ -305,6 +305,7 @@ impl Message for Publish<'_> {
 				decode_params!(r, version,
 					0x02 => object_delivery_timeout: Option<u64>,
 					0x06 => subgroup_delivery_timeout: Option<u64>,
+					0x08 => _expires: Option<u64>,
 					0x09 => largest_location: Option<Location>,
 					0x10 => forward: Option<bool>,
 					0x20 => subscriber_priority: Option<u8>,

--- a/rs/moq-net/src/ietf/publish.rs
+++ b/rs/moq-net/src/ietf/publish.rs
@@ -110,7 +110,7 @@ use crate::{
 	Path,
 	coding::{Decode, DecodeError, Encode, EncodeError},
 	ietf::{
-		FilterType, GroupOrder, Location, Parameters, Properties, RequestId,
+		Filter, GroupOrder, Location, Parameters, Properties, RequestId,
 		namespace::{decode_namespace, encode_namespace},
 	},
 };
@@ -137,7 +137,10 @@ impl PublishDoneStatus {
 			| Version::Draft16
 			| Version::Draft17
 			| Version::Draft18
-			| Version::Draft19 => match self {
+			| Version::Draft19
+			// Draft-20 removed SUBSCRIPTION_ENDED (0x3), which this implementation never
+			// emitted, and left the rest of the registry alone.
+			| Version::Draft20 => match self {
 				Self::InternalError => 0x0,
 				Self::TrackEnded => 0x2,
 			},
@@ -324,7 +327,7 @@ pub struct PublishOk {
 	pub forward: bool,
 	pub subscriber_priority: u8,
 	pub group_order: GroupOrder,
-	pub filter_type: FilterType,
+	pub filter: Filter,
 	// pub parameters: Parameters,
 }
 
@@ -347,19 +350,18 @@ impl Message for PublishOk {
 				self.group_order.encode(w, version)?;
 				// Same as SUBSCRIBE: the Location an absolute filter carries is dropped on
 				// decode, so encoding one would truncate the message.
-				if !matches!(self.filter_type, FilterType::LargestObject | FilterType::NextGroup) {
-					return Err(EncodeError::Unsupported);
-				}
-
-				self.filter_type.encode(w, version)?;
+				self.filter.encode(w, version)?;
 				// no parameters
 				0u8.encode(w, version)?;
 			}
+			// Draft-20 moved the subscription parameters out of PUBLISH_OK; they belong to
+			// PUBLISH and REQUEST_UPDATE now, so a PUBLISH_OK carries none of them.
+			_ if Filter::is_draft20(version) => encode_params!(w, version,),
 			_ => {
 				encode_params!(w, version,
 					0x10 => self.forward,
 					0x20 => self.subscriber_priority,
-					0x21 => self.filter_type,
+					0x21 => self.filter,
 					0x22 => self.group_order,
 				);
 			}
@@ -380,17 +382,7 @@ impl Message for PublishOk {
 				let forward = bool::decode(r, version)?;
 				let subscriber_priority = u8::decode(r, version)?;
 				let group_order = GroupOrder::decode(r, version)?;
-				let filter_type = FilterType::decode(r, version)?;
-				match filter_type {
-					FilterType::AbsoluteStart => {
-						let _start = Location::decode(r, version)?;
-					}
-					FilterType::AbsoluteRange => {
-						let _start = Location::decode(r, version)?;
-						let _end_group = u64::decode(r, version)?;
-					}
-					FilterType::NextGroup | FilterType::LargestObject => {}
-				};
+				let filter = Filter::decode(r, version)?;
 
 				// no parameters
 				let _params = Parameters::decode(r, version)?;
@@ -400,28 +392,28 @@ impl Message for PublishOk {
 					forward,
 					subscriber_priority,
 					group_order,
-					filter_type,
+					filter,
 				})
 			}
 			_ => {
 				decode_params!(r, version,
 					0x10 => forward: Option<bool>,
 					0x20 => subscriber_priority: Option<u8>,
-					0x21 => filter_type: Option<FilterType>,
+					0x21 => filter: Option<Filter>,
 					0x22 => group_order: Option<GroupOrder>,
 				);
 
 				let forward = forward.unwrap_or(true);
 				let subscriber_priority = subscriber_priority.unwrap_or(128);
 				let group_order = group_order.unwrap_or(GroupOrder::Descending);
-				let filter_type = filter_type.unwrap_or(FilterType::LargestObject);
+				let filter = filter.unwrap_or(Filter::Unfiltered);
 
 				Ok(Self {
 					request_id,
 					forward,
 					subscriber_priority,
 					group_order,
-					filter_type,
+					filter,
 				})
 			}
 		}
@@ -531,7 +523,7 @@ mod tests {
 			forward: true,
 			subscriber_priority: 128,
 			group_order: GroupOrder::Descending,
-			filter_type: FilterType::LargestObject,
+			filter: Filter::NextObject,
 		};
 
 		let encoded = encode_message(&msg, Version::Draft14);
@@ -549,7 +541,7 @@ mod tests {
 			forward: true,
 			subscriber_priority: 128,
 			group_order: GroupOrder::Descending,
-			filter_type: FilterType::LargestObject,
+			filter: Filter::NextObject,
 		};
 
 		let encoded = encode_message(&msg, Version::Draft15);
@@ -593,7 +585,7 @@ mod tests {
 			forward: true,
 			subscriber_priority: 128,
 			group_order: GroupOrder::Descending,
-			filter_type: FilterType::LargestObject,
+			filter: Filter::NextObject,
 		};
 
 		let encoded = encode_message(&msg, Version::Draft17);
@@ -762,7 +754,7 @@ mod tests {
 			forward: true,
 			subscriber_priority: 128,
 			group_order: GroupOrder::Descending,
-			filter_type: FilterType::LargestObject,
+			filter: Filter::NextObject,
 		};
 
 		let encoded = encode_message(&msg, Version::Draft18);

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -6,7 +6,7 @@ use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
 use crate::{
 	AsPath, Error, Timescale, Timestamp,
 	coding::{Stream, Writer},
-	ietf::{self, Control, FetchHeader, FetchType, FilterType, GroupOrder, Location, RequestId},
+	ietf::{self, Control, FetchHeader, FetchType, Fill, Filter, GroupOrder, Location, RequestId},
 	track::Subscription,
 	util::{MaybeBoxedExt, MaybeSendBox},
 };
@@ -514,16 +514,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 	/// Handle a SUBSCRIBE on its bidi stream.
 	async fn run_subscribe_stream(self, mut stream: Stream<S, Version>, msg: ietf::Subscribe<'_>) -> Result<(), Error> {
-		match msg.filter_type {
-			FilterType::AbsoluteStart | FilterType::AbsoluteRange => {
-				tracing::warn!(?msg, "absolute subscribe not supported, ignoring");
-			}
-			FilterType::NextGroup => {
-				tracing::warn!(?msg, "next group subscribe not supported, ignoring");
-			}
-			FilterType::LargestObject => {}
-		};
-
 		let request_id = msg.request_id;
 		let track_name = msg.track_name.clone();
 		let absolute = self.origin.absolute(&msg.track_namespace).to_owned();
@@ -550,12 +540,24 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			}
 		};
 
+		let track = match broadcast.track(&msg.track_name) {
+			Ok(track) => track,
+			Err(err) => {
+				return self.reject_subscribe(stream, request_id, 404, &err.to_string()).await;
+			}
+		};
+
+		// The filter is relative to the live edge, so resolving it needs the edge itself.
+		let (group_start, group_end) = subscribe_range(&msg, track.latest(), self.version);
+
 		let subscription = Subscription {
 			priority: super::priority::from_wire(msg.subscriber_priority),
+			group_start,
+			group_end,
 			..Default::default()
 		};
 
-		let track = match async { broadcast.track(&msg.track_name)?.subscribe(subscription).await }.await {
+		let track = match track.subscribe(subscription).await {
 			Ok(track) => track,
 			Err(err) => {
 				return self.reject_subscribe(stream, request_id, 404, &err.to_string()).await;
@@ -572,12 +574,17 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					_ => None,
 				},
 				track_alias: request_id.0,
-				properties: ietf::Properties {
+				properties: match msg.properties_wanted {
 					// Declaring the timescale is what opts the track into timestamps; every
 					// object Timestamp below is in these units.
-					timescale: Some(track.info().timescale),
 					// We serve the newest group first, matching moq-lite.
-					group_order: Some(GroupOrder::Descending),
+					true => ietf::Properties {
+						timescale: Some(track.info().timescale),
+						group_order: Some(GroupOrder::Descending),
+					},
+					// INCLUDE_PROPERTIES=0. The field stays present but empty, which also
+					// means the track opts out of timestamps for this subscriber.
+					false => ietf::Properties::default(),
 				},
 			})
 			.await?;
@@ -2832,7 +2839,9 @@ mod tests {
 					track_name: "video".into(),
 					subscriber_priority: 128,
 					group_order: GroupOrder::Descending,
-					filter_type: FilterType::LargestObject,
+					filter: Filter::NextObject,
+					fill: None,
+					properties_wanted: true,
 				},
 			)
 			.await
@@ -2871,7 +2880,7 @@ mod tests {
 	/// on a request we already refused. Finishing first makes the drop-time reset a no-op.
 	#[tokio::test]
 	async fn missing_broadcast_is_refused_without_resetting_the_stream() {
-		for version in [Version::Draft17, Version::Draft18, Version::Draft19] {
+		for version in [Version::Draft17, Version::Draft18, Version::Draft19, Version::Draft20] {
 			let (writes, resets) = subscribe_missing(version).await;
 
 			assert!(!writes.is_empty(), "{version}: nothing was sent");
@@ -2916,7 +2925,7 @@ mod tests {
 			]
 		};
 
-		for version in [Version::Draft17, Version::Draft18, Version::Draft19] {
+		for version in [Version::Draft17, Version::Draft18, Version::Draft19, Version::Draft20] {
 			for (label, fetch_type) in unsupported() {
 				let (writes, resets) = fetch_unsupported(version, fetch_type).await;
 
@@ -2932,5 +2941,205 @@ mod tests {
 				);
 			}
 		}
+	}
+}
+
+/// Resolve a SUBSCRIBE's Location Filter into the moq-lite group range to serve.
+///
+/// Returns `(group_start, group_end)` for [`Subscription`], where a `None` start means the
+/// latest group, which is what moq-lite treats as joining a live track.
+///
+/// Only draft-20 is honored. Earlier drafts have a Filter Type tag whose absolute forms we
+/// never served, and starting to interpret them now would change what an existing peer
+/// receives; draft-20 is also the first version whose relative forms can name a past group
+/// without the subscriber knowing Largest Object.
+///
+/// A fill is folded into the same range rather than answered on its own fetch stream. The
+/// fill reaches further back than the subscription by design, so the earlier of the two
+/// starts wins and everything is delivered as ordinary live subgroups.
+fn subscribe_range(msg: &ietf::Subscribe<'_>, latest: Option<u64>, version: Version) -> (Option<u64>, Option<u64>) {
+	if !Filter::is_draft20(version) {
+		if !matches!(msg.filter, Filter::NextObject | Filter::Unfiltered) {
+			tracing::warn!(filter = ?msg.filter, "filter not supported before draft-20, ignoring");
+		}
+		return (None, None);
+	}
+
+	let (start, end) = filter_range(msg.filter, latest);
+	let fill = msg.fill.map(|Fill { filter }| fill_floor(filter, latest));
+
+	// `None` is the live edge, which is later than any group a fill could name, so a fill
+	// start always wins over an absent subscription start.
+	let start = match (start, fill.flatten()) {
+		(Some(a), Some(b)) => Some(a.min(b)),
+		(Some(a), None) => Some(a),
+		(None, fill) => fill,
+	};
+
+	(start, end)
+}
+
+/// The first group a fill asks for, resolved against the live edge.
+///
+/// Identical to a subscription's filter except for the unfiltered case: on a subscription
+/// that means "no restriction", which is the live edge, but a fill with no filter asks for
+/// the whole track up to Largest Object.
+fn fill_floor(filter: Filter, latest: Option<u64>) -> Option<u64> {
+	match filter {
+		Filter::Unfiltered => Some(0),
+		_ => filter_range(filter, latest).0,
+	}
+}
+
+/// The group range a single Location Filter selects, resolved against the live edge.
+fn filter_range(filter: Filter, latest: Option<u64>) -> (Option<u64>, Option<u64>) {
+	match filter {
+		// Both mean "from the live edge onward". moq-lite starts at the beginning of the
+		// latest group, which is a slightly earlier point than Next Object names, so a
+		// subscriber can see the current group's earlier objects. That is the join point
+		// moq-lite is built around and the draft's own current-group recipe.
+		Filter::Unfiltered | Filter::NextObject => (None, None),
+		// `{Largest.Group + 1 - groups, 0}`: 0 is the next group, 1 is the current one.
+		Filter::Relative(groups) => match latest {
+			// Nothing published yet, so there is no edge to count back from.
+			None => (None, None),
+			Some(latest) => (Some(latest.saturating_add(1).saturating_sub(groups)), None),
+		},
+		Filter::Absolute { start, end } => (Some(start.group), end),
+	}
+}
+
+#[cfg(test)]
+mod range_tests {
+	use super::*;
+
+	fn subscribe(filter: Filter, fill: Option<Filter>) -> ietf::Subscribe<'static> {
+		ietf::Subscribe {
+			request_id: RequestId(1),
+			track_namespace: crate::Path::new("broadcast"),
+			track_name: "video".into(),
+			subscriber_priority: 128,
+			group_order: GroupOrder::Descending,
+			filter,
+			fill: fill.map(|filter| Fill { filter }),
+			properties_wanted: true,
+		}
+	}
+
+	const LATEST: Option<u64> = Some(100);
+
+	/// Earlier drafts never had their absolute filters served, so honoring one now would
+	/// change what an existing peer receives.
+	#[test]
+	fn older_drafts_are_ignored() {
+		let msg = subscribe(
+			Filter::Absolute {
+				start: Location { group: 4, object: 0 },
+				end: Some(9),
+			},
+			None,
+		);
+		assert_eq!(subscribe_range(&msg, LATEST, Version::Draft19), (None, None));
+	}
+
+	/// Both spellings mean "from the live edge onward", which moq-lite represents as no
+	/// explicit start.
+	#[test]
+	fn live_edge_has_no_floor() {
+		for filter in [Filter::NextObject, Filter::Unfiltered] {
+			let msg = subscribe(filter, None);
+			assert_eq!(
+				subscribe_range(&msg, LATEST, Version::Draft20),
+				(None, None),
+				"{filter:?}"
+			);
+		}
+	}
+
+	/// `{Largest.Group + 1 - groups, 0}`: one is the current group, zero is the next one,
+	/// and larger values reach further back.
+	#[test]
+	fn relative_counts_back_from_the_next_group() {
+		for (groups, expected) in [(0, 101), (1, 100), (2, 99), (5, 96)] {
+			let msg = subscribe(Filter::Relative(groups), None);
+			assert_eq!(
+				subscribe_range(&msg, LATEST, Version::Draft20),
+				(Some(expected), None),
+				"{groups} groups back"
+			);
+		}
+	}
+
+	/// Counting back further than the track goes lands at its start rather than wrapping.
+	#[test]
+	fn relative_saturates_at_the_start() {
+		let msg = subscribe(Filter::Relative(500), None);
+		assert_eq!(subscribe_range(&msg, LATEST, Version::Draft20), (Some(0), None));
+	}
+
+	/// Nothing published yet means there is no edge to count back from.
+	#[test]
+	fn relative_without_an_edge_stays_live() {
+		let msg = subscribe(Filter::Relative(3), None);
+		assert_eq!(subscribe_range(&msg, None, Version::Draft20), (None, None));
+	}
+
+	#[test]
+	fn absolute_carries_both_ends() {
+		let msg = subscribe(
+			Filter::Absolute {
+				start: Location { group: 4, object: 0 },
+				end: Some(9),
+			},
+			None,
+		);
+		assert_eq!(subscribe_range(&msg, LATEST, Version::Draft20), (Some(4), Some(9)));
+	}
+
+	/// The canonical current-group join: Next Object on the subscription, and a fill that
+	/// reaches back one group. The fill is what sets the floor.
+	#[test]
+	fn a_fill_lowers_the_floor() {
+		let msg = subscribe(Filter::NextObject, Some(Filter::Relative(1)));
+		assert_eq!(subscribe_range(&msg, LATEST, Version::Draft20), (Some(100), None));
+	}
+
+	/// A fill reaches further back than the subscription by design, so the earlier of the
+	/// two starts wins.
+	#[test]
+	fn the_earlier_start_wins() {
+		let msg = subscribe(
+			Filter::Absolute {
+				start: Location { group: 90, object: 0 },
+				end: None,
+			},
+			Some(Filter::Relative(20)),
+		);
+		assert_eq!(subscribe_range(&msg, LATEST, Version::Draft20), (Some(81), None));
+
+		let msg = subscribe(
+			Filter::Absolute {
+				start: Location { group: 50, object: 0 },
+				end: None,
+			},
+			Some(Filter::Relative(2)),
+		);
+		assert_eq!(subscribe_range(&msg, LATEST, Version::Draft20), (Some(50), None));
+	}
+
+	/// An empty fill scope asks for the whole track, which is the one case where the
+	/// unfiltered spelling means the start of the track rather than the live edge.
+	#[test]
+	fn an_unfiltered_fill_asks_for_the_whole_track() {
+		let msg = subscribe(Filter::NextObject, Some(Filter::Unfiltered));
+		assert_eq!(subscribe_range(&msg, LATEST, Version::Draft20), (Some(0), None));
+	}
+
+	/// The same spelling on the subscription itself is just "no restriction", so it stays
+	/// at the live edge.
+	#[test]
+	fn an_unfiltered_subscription_stays_live() {
+		let msg = subscribe(Filter::Unfiltered, None);
+		assert_eq!(subscribe_range(&msg, LATEST, Version::Draft20), (None, None));
 	}
 }

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -6,7 +6,7 @@ use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
 use crate::{
 	AsPath, Error, Timescale, Timestamp,
 	coding::{Stream, Writer},
-	ietf::{self, Control, FetchHeader, FetchType, Filter, GroupOrder, Location, RequestId},
+	ietf::{self, Control, EndLocation, FetchHeader, FetchType, Filter, GroupOrder, Location, RequestId},
 	track::Subscription,
 	util::{MaybeBoxedExt, MaybeSendBox},
 };
@@ -547,22 +547,45 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			}
 		};
 
-		// The filter is relative to the live edge, so resolving it needs the edge itself.
-		let (group_start, group_end) = subscribe_range(&msg, track.latest(), self.version);
+		let priority = super::priority::from_wire(msg.subscriber_priority);
 
-		let subscription = Subscription {
-			priority: super::priority::from_wire(msg.subscriber_priority),
-			group_start,
-			group_end,
-			..Default::default()
-		};
-
-		let track = match track.subscribe(subscription).await {
-			Ok(track) => track,
-			Err(err) => {
-				return self.reject_subscribe(stream, request_id, 404, &err.to_string()).await;
+		// Subscribe before resolving the filter: on a routed broadcast the live edge only
+		// becomes readable once the subscription's demand attaches a route, so the edge
+		// snapshot has to come after. The resolved range is applied to the preference
+		// right below, before anything is served.
+		let (cache, mut track) = {
+			let subscription = Subscription {
+				priority,
+				..Default::default()
+			};
+			match track.subscribe(subscription).await {
+				Ok(subscribed) => (track, subscribed),
+				Err(err) => {
+					return self.reject_subscribe(stream, request_id, 404, &err.to_string()).await;
+				}
 			}
 		};
+
+		// The filter and any fill are relative to the live edge, so snapshot it once:
+		// the fill ends exactly where a Next Object subscription begins, which is what
+		// lets the draft's current-group join (Next Object plus a StartGroup=1 fill)
+		// cover the group with no gap and no overlap.
+		let edge = live_edge(&cache);
+		let range = subscribe_range(&msg, edge, self.version);
+		let _ = track.update(Subscription {
+			priority,
+			group_start: range.start.map(|start| start.group),
+			group_end: range.end.map(|end| end.group),
+			..Default::default()
+		});
+
+		// A fill reads the group cache through its own consumer, independent of the
+		// subscription's cursor.
+		let fill = msg
+			.fill
+			.filter(|_| Filter::is_draft20(self.version))
+			.map(|fill| fill_range(fill.filter.unwrap_or(msg.filter), edge.largest))
+			.map(|fill| (fill, cache));
 
 		// Send SubscribeOk on the stream
 		stream.writer.encode(&ietf::SubscribeOk::ID).await?;
@@ -574,6 +597,9 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					_ => None,
 				},
 				track_alias: request_id.0,
+				// Required once the track has content; a fill-requesting subscriber
+				// sizes its backfill against this.
+				largest: edge.largest,
 				properties: match msg.properties_wanted {
 					// Declaring the timescale is what opts the track into timestamps; every
 					// object Timestamp below is in these units.
@@ -589,9 +615,21 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			})
 			.await?;
 
-		// Run the track, cancelling on reader close (Unsubscribe or stream close)
+		// Run the track, cancelling on reader close (Unsubscribe or stream close).
+		// The fill (when one was requested) runs alongside on its own fetch stream;
+		// its failures reset that stream and never touch the subscription.
 		let res = {
-			let mut serve = std::pin::pin!(self.run_track(track, request_id, group_start, group_end));
+			let serve = async {
+				match fill {
+					Some((fill, cache)) => {
+						let fill = self.run_fill(request_id, priority, fill, cache);
+						let (res, ()) = futures::join!(self.run_track(track, request_id, range), fill);
+						res
+					}
+					None => self.run_track(track, request_id, range).await,
+				}
+			};
+			let mut serve = std::pin::pin!(serve);
 			let mut reader_closed = std::pin::pin!(stream.reader.closed());
 			let mut session_closed = std::pin::pin!(self.session.closed());
 			kio::wait(|waiter| {
@@ -704,8 +742,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		&self,
 		mut track: track::Subscriber,
 		request_id: RequestId,
-		group_start: Option<u64>,
-		group_end: Option<u64>,
+		range: ServeRange,
 	) -> Result<(), Error> {
 		// The subscription range is a preference for what the publisher should keep
 		// available; the cursor is what this subscriber actually reads, and setting one does
@@ -713,15 +750,15 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		// live edge, where waiting for that group is the point. Only an absent start falls
 		// back to the live edge, since a fresh cursor starts at the oldest cached group and
 		// would otherwise replay the whole retained history at once.
-		match group_start {
-			Some(start) => track.start_at(start),
+		match range.start {
+			Some(start) => track.start_at(start.group),
 			None => {
 				if let Some(latest) = track.latest() {
 					track.start_at(latest);
 				}
 			}
 		}
-		track.end_at(group_end);
+		track.end_at(range.end.map(|end| end.group));
 
 		let mut tasks = FuturesUnordered::new();
 
@@ -745,6 +782,19 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			let sequence = group.sequence;
 			tracing::debug!(subscribe = %request_id, track = %track.name(), sequence, "serving group");
 
+			// Trim the boundary groups to the filter's object bounds, so nothing outside
+			// the requested range is sent. Interior groups are served whole.
+			let slice = GroupSlice {
+				skip: match range.start {
+					Some(start) if start.group == sequence => start.object,
+					_ => 0,
+				},
+				until: match range.end {
+					Some(end) if end.group == sequence => end.object.map(|object| object.saturating_add(1)),
+					_ => None,
+				},
+			};
+
 			let msg = ietf::GroupHeader {
 				track_alias: request_id.0,
 				group_id: sequence,
@@ -755,14 +805,27 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 				// track's, declared once in SUBSCRIBE_OK.
 				flags: ietf::GroupFlags {
 					has_extensions: true,
+					// Only honest when the stream really starts at the group's first
+					// object; a trimmed head starts partway through.
+					first_object: slice.skip == 0,
 					..Default::default()
 				},
 			};
 
 			let priority = track.subscription().priority;
 			let timescale = track.info().timescale;
-			tasks
-				.push(Self::run_group(self.session.clone(), msg, priority, group, timescale, self.version).map(|_| ()));
+			tasks.push(
+				Self::run_group(
+					self.session.clone(),
+					msg,
+					priority,
+					group,
+					timescale,
+					self.version,
+					slice,
+				)
+				.map(|_| ()),
+			);
 		}
 	}
 
@@ -773,6 +836,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		mut group: group::Consumer,
 		timescale: Timescale,
 		version: Version,
+		slice: GroupSlice,
 	) -> Result<(), Error> {
 		let stream = session.open_uni().await.map_err(Error::from_transport)?;
 
@@ -781,11 +845,22 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		stream.encode(&msg).await?;
 
+		// The next object id to read. Ids below `slice.skip` are consumed without being
+		// written, and the first written id goes on the wire as its absolute delta, so
+		// the peer sees the true numbering rather than a silently renumbered group.
+		let mut index: u64 = 0;
+		let mut first_written = true;
+
 		// A subscriber catching up on a cached group takes the whole backlog under one
 		// lock; at the live edge the batch comes up empty and the open tail streams
 		// chunk by chunk, so forwarding never waits for a frame to complete.
 		let mut buf: frame::Buffer = frame::Buffer::new();
-		loop {
+		'serve: loop {
+			// The filter ends inside this group: everything at `until` and beyond is
+			// outside the requested range, so stop without waiting for the group's end.
+			if slice.until.is_some_and(|until| index >= until) {
+				break;
+			}
 			// Wait for whatever the group has next, bailing if the peer closes first.
 			let step = {
 				let mut closed = std::pin::pin!(stream.closed());
@@ -806,15 +881,23 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			match step? {
 				Step::Batch => {
 					for i in 0..buf.filled().len() {
-						let frame = buf.filled()[i].clone();
-						Self::write_object_header(&mut stream, &msg, frame.timestamp, timescale, version).await?;
-						stream.encode(&(frame.payload.len() as u64)).await?;
-						if frame.payload.is_empty() {
-							// Have to write the object status too.
-							stream.encode(&0u8).await?;
-						} else {
-							stream.write_chunk(frame.payload).await?;
+						if slice.until.is_some_and(|until| index >= until) {
+							break 'serve;
 						}
+						let frame = buf.filled()[i].clone();
+						if index >= slice.skip {
+							let delta = if std::mem::take(&mut first_written) { index } else { 0 };
+							Self::write_object_header(&mut stream, &msg, delta, frame.timestamp, timescale, version)
+								.await?;
+							stream.encode(&(frame.payload.len() as u64)).await?;
+							if frame.payload.is_empty() {
+								// Have to write the object status too.
+								stream.encode(&0u8).await?;
+							} else {
+								stream.write_chunk(frame.payload).await?;
+							}
+						}
+						index += 1;
 						// The fill stamped the group once. A flow-controlled peer can
 						// take longer than `latency_max` to accept one batch, so keep
 						// stamping or the rest of the group expires mid-serve.
@@ -822,7 +905,30 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					}
 				}
 				Step::Partial(mut frame) => {
-					Self::write_object_header(&mut stream, &msg, frame.timestamp, timescale, version).await?;
+					if index < slice.skip {
+						// A skipped frame still has to be drained to advance the cursor.
+						loop {
+							let chunk = {
+								let mut closed = std::pin::pin!(stream.closed());
+								kio::wait(|waiter| {
+									if waiter.poll_future(closed.as_mut()).is_ready() {
+										return Poll::Ready(Err(Error::Cancel));
+									}
+									frame.poll_read_chunk(waiter)
+								})
+								.await
+							};
+							if chunk?.is_none() {
+								break;
+							}
+						}
+						index += 1;
+						continue;
+					}
+
+					let delta = if std::mem::take(&mut first_written) { index } else { 0 };
+					Self::write_object_header(&mut stream, &msg, delta, frame.timestamp, timescale, version).await?;
+					index += 1;
 
 					// Write the size of the frame.
 					stream.encode(&frame.size).await?;
@@ -867,17 +973,20 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		Ok(())
 	}
 
-	/// Write one object's header: the id delta (always 0) and, when the group carries
-	/// extensions, the presentation timestamp.
+	/// Write one object's header: the id delta and, when the group carries extensions,
+	/// the presentation timestamp.
+	///
+	/// The first object's delta is its absolute Object ID; every later one is the prior
+	/// ID plus the delta plus one, so a contiguous group is a zero delta throughout.
 	async fn write_object_header(
 		stream: &mut Writer<S::SendStream, Version>,
 		msg: &ietf::GroupHeader,
+		delta: u64,
 		timestamp: Timestamp,
 		timescale: Timescale,
 		version: Version,
 	) -> Result<(), Error> {
-		// object id delta is always 0.
-		stream.encode(&0u64).await?;
+		stream.encode(&delta).await?;
 
 		// Per-object extension headers carry the frame's presentation timestamp.
 		if msg.flags.has_extensions {
@@ -886,6 +995,224 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 			stream.encode(&(ext.len() as u64)).await?;
 			stream.write_chunk(ext.freeze()).await?;
 		}
+
+		Ok(())
+	}
+
+	/// Serve a draft-20 fill on its own fetch stream: the requested range, read from the
+	/// group cache, capped at the Largest Object snapshot.
+	///
+	/// A fill is a promise once requested. An empty range opens no stream, but a range we
+	/// cannot serve still opens one and resets it right after the FETCH_HEADER, the
+	/// draft's fill-failure signal. Nothing here touches the subscription either way.
+	async fn run_fill(&self, request_id: RequestId, priority: u8, fill: FillServe, track: track::Consumer) {
+		if matches!(fill, FillServe::Empty) {
+			return;
+		}
+
+		let stream = match self.session.open_uni().await {
+			Ok(stream) => stream,
+			Err(err) => {
+				tracing::debug!(err = %Error::from_transport(err), fill = %request_id, "fill stream failed to open");
+				return;
+			}
+		};
+		let mut stream = Writer::new(stream, self.version);
+		stream.set_priority(priority);
+
+		let res = async {
+			stream.encode(&FetchHeader::TYPE).await?;
+			stream.encode(&FetchHeader { request_id }).await?;
+
+			let FillServe::Group { sequence, skip, until } = fill else {
+				return Err(Error::Unsupported);
+			};
+
+			let group = track.fetch_group(sequence, group::Fetch { priority }).await?;
+			Self::write_fill_group(&mut stream, group, sequence, skip, until, self.version).await
+		}
+		.await;
+
+		match res {
+			Ok(()) => {
+				// Close waits for the acknowledgement, and consuming the writer disarms
+				// the Drop fallback that would reset a finished stream.
+				if let Err(err) = stream.close().await {
+					tracing::debug!(%err, fill = %request_id, "fill stream close failed");
+				} else {
+					tracing::debug!(fill = %request_id, "fill complete");
+				}
+			}
+			Err(err) => {
+				tracing::debug!(%err, fill = %request_id, "fill failed, resetting its stream");
+				stream.abort(&err);
+			}
+		}
+	}
+
+	/// Write one group's frames as draft-20 fetch objects (section 11.4.4).
+	///
+	/// The first object carries its absolute Group and Object IDs plus the priority;
+	/// every later one inherits them and increments the Object ID, so only the
+	/// properties (the timestamp) and the payload go on the wire. A fetch object has no
+	/// status field: a zero payload length is simply an empty object.
+	async fn write_fill_group(
+		stream: &mut Writer<S::SendStream, Version>,
+		mut group: group::Consumer,
+		sequence: u64,
+		skip: u64,
+		until: Option<u64>,
+		version: Version,
+	) -> Result<(), Error> {
+		let timescale = group.timescale();
+		let mut index: u64 = 0;
+		let mut first = true;
+
+		let mut buf: frame::Buffer = frame::Buffer::new();
+		'serve: loop {
+			// The cap is the Largest Object snapshot: the group may keep growing, but
+			// everything past the snapshot belongs to the subscription, not the fill.
+			if until.is_some_and(|until| index >= until) {
+				break;
+			}
+
+			let step = {
+				let mut closed = std::pin::pin!(stream.closed());
+				kio::wait(|waiter| {
+					if waiter.poll_future(closed.as_mut()).is_ready() {
+						return Poll::Ready(Err(Error::Cancel));
+					}
+					match group.poll_read_frames(waiter, &mut buf) {
+						Poll::Pending => group
+							.poll_next_frame(waiter)
+							.map_ok(|frame| frame.map_or(Step::Done, Step::Partial)),
+						res => res.map_ok(|count| if count == 0 { Step::Done } else { Step::Batch }),
+					}
+				})
+				.await
+			};
+
+			match step? {
+				Step::Batch => {
+					for i in 0..buf.filled().len() {
+						if until.is_some_and(|until| index >= until) {
+							break 'serve;
+						}
+						let frame = buf.filled()[i].clone();
+						if index >= skip {
+							Self::write_fill_object(
+								stream,
+								sequence,
+								index,
+								std::mem::take(&mut first),
+								frame.timestamp,
+								timescale,
+								version,
+							)
+							.await?;
+							stream.encode(&(frame.payload.len() as u64)).await?;
+							if !frame.payload.is_empty() {
+								stream.write_chunk(frame.payload).await?;
+							}
+						}
+						index += 1;
+						group.keep_alive();
+					}
+				}
+				Step::Partial(mut frame) => {
+					if index < skip {
+						// A skipped frame still has to be drained to advance the cursor.
+						loop {
+							let chunk = {
+								let mut closed = std::pin::pin!(stream.closed());
+								kio::wait(|waiter| {
+									if waiter.poll_future(closed.as_mut()).is_ready() {
+										return Poll::Ready(Err(Error::Cancel));
+									}
+									frame.poll_read_chunk(waiter)
+								})
+								.await
+							};
+							if chunk?.is_none() {
+								break;
+							}
+						}
+						index += 1;
+						continue;
+					}
+
+					Self::write_fill_object(
+						stream,
+						sequence,
+						index,
+						std::mem::take(&mut first),
+						frame.timestamp,
+						timescale,
+						version,
+					)
+					.await?;
+					index += 1;
+
+					stream.encode(&frame.size).await?;
+					loop {
+						let chunk = {
+							let mut closed = std::pin::pin!(stream.closed());
+							kio::wait(|waiter| {
+								if waiter.poll_future(closed.as_mut()).is_ready() {
+									return Poll::Ready(Err(Error::Cancel));
+								}
+								frame.poll_read_chunk(waiter)
+							})
+							.await
+						};
+
+						match chunk? {
+							Some(chunk) => stream.write_chunk(chunk).await?,
+							None => break,
+						}
+					}
+				}
+				Step::Done => break,
+			}
+		}
+
+		Ok(())
+	}
+
+	/// Write one fetch object's header: the Serialization Flags, the fields they
+	/// declare, and the properties block carrying the timestamp.
+	async fn write_fill_object(
+		stream: &mut Writer<S::SendStream, Version>,
+		sequence: u64,
+		object: u64,
+		first: bool,
+		timestamp: Timestamp,
+		timescale: Timescale,
+		version: Version,
+	) -> Result<(), Error> {
+		// Serialization Flags: the two low bits encode the subgroup (00 = subgroup
+		// zero), then per-field presence bits.
+		const OBJECT_ID: u64 = 0x04;
+		const GROUP_ID: u64 = 0x08;
+		const PRIORITY: u64 = 0x10;
+		const PROPERTIES: u64 = 0x20;
+
+		if first {
+			// The first object must carry its absolute Group and Object IDs. Include the
+			// priority too: "same as the prior object" has no prior to refer to.
+			stream.encode(&(GROUP_ID | OBJECT_ID | PRIORITY | PROPERTIES)).await?;
+			stream.encode(&sequence).await?;
+			stream.encode(&object).await?;
+			stream.encode(&0u8).await?;
+		} else {
+			// Same group and priority; the Object ID is the prior one plus one.
+			stream.encode(&PROPERTIES).await?;
+		}
+
+		let mut ext = bytes::BytesMut::new();
+		ietf::encode_object_time(&mut ext, timestamp, timescale, version)?;
+		stream.encode(&(ext.len() as u64)).await?;
+		stream.write_chunk(ext.freeze()).await?;
 
 		Ok(())
 	}
@@ -1631,9 +1958,17 @@ mod group_priority_test {
 			flags: Default::default(),
 		};
 
-		Publisher::<SinkSession>::run_group(session, msg, 200, consumer, Timescale::default(), Version::Draft14)
-			.await
-			.unwrap();
+		Publisher::<SinkSession>::run_group(
+			session,
+			msg,
+			200,
+			consumer,
+			Timescale::default(),
+			Version::Draft14,
+			GroupSlice::default(),
+		)
+		.await
+		.unwrap();
 
 		assert_eq!(
 			log.priorities(),
@@ -1681,9 +2016,17 @@ mod group_priority_test {
 			let consumer = group.consume();
 			group.finish().unwrap();
 
-			Publisher::<SinkSession>::run_group(session, header(), 0, consumer, Timescale::default(), Version::Draft14)
-				.await
-				.unwrap();
+			Publisher::<SinkSession>::run_group(
+				session,
+				header(),
+				0,
+				consumer,
+				Timescale::default(),
+				Version::Draft14,
+				GroupSlice::default(),
+			)
+			.await
+			.unwrap();
 			log.writes.lock().unwrap().clone()
 		};
 
@@ -1702,7 +2045,8 @@ mod group_priority_test {
 				0,
 				consumer,
 				Timescale::default(),
-				Version::Draft14
+				Version::Draft14,
+				GroupSlice::default(),
 			));
 			// Past the group header, parked with nothing to send.
 			assert!(futures::poll!(serve.as_mut()).is_pending());
@@ -1769,7 +2113,8 @@ mod group_priority_test {
 			0,
 			consumer,
 			Timescale::default(),
-			Version::Draft14
+			Version::Draft14,
+			GroupSlice::default(),
 		));
 		// Let it run until it blocks on the rest of the frame.
 		assert!(futures::poll!(serving.as_mut()).is_pending());
@@ -1820,10 +2165,307 @@ mod subscribe_cursor_test {
 		let subscriber = track.subscribe(None);
 		track.finish().unwrap();
 
-		publisher.run_track(subscriber, RequestId(1), None, None).await.unwrap();
+		publisher
+			.run_track(subscriber, RequestId(1), ServeRange::default())
+			.await
+			.unwrap();
 
 		// `run_group` sets the priority once per stream it opens, so this counts groups served.
 		assert_eq!(log.priorities().len(), 1, "only group 3 should have been served");
+	}
+}
+
+#[cfg(test)]
+mod serve_tests {
+	use super::*;
+	use crate::lite::test_transport::{Log, ScriptedSession, SinkSession};
+
+	fn occurrences(log: &Log, needle: &[u8]) -> usize {
+		let writes = log.writes.lock().unwrap();
+		writes.windows(needle.len()).filter(|window| *window == needle).count()
+	}
+
+	fn timestamp() -> crate::Timestamp {
+		crate::Timestamp::from_millis(0).unwrap()
+	}
+
+	/// A publisher whose origin serves one broadcast ("room") with one track ("video").
+	struct Serve {
+		publisher: Publisher<ScriptedSession>,
+		session: ScriptedSession,
+		log: Log,
+		track: track::Producer,
+		_origin: origin::Producer,
+		_broadcast: crate::broadcast::Producer,
+	}
+
+	fn serve(version: Version) -> Serve {
+		let origin = crate::origin::Info::new(crate::Origin::new(1).unwrap()).produce();
+		let mut broadcast = origin
+			.create_broadcast("room", crate::broadcast::Route::new().with_announce(true))
+			.unwrap();
+		let track = broadcast.create_track("video", None).unwrap();
+
+		let session = ScriptedSession::per_stream(vec![Vec::new()]);
+		let log = session.log.clone();
+
+		let peer_setup = peer::PeerSetup::default();
+		peer_setup.set(peer::Peer::default());
+
+		let publisher = Publisher::new(
+			session.clone(),
+			origin.consume(),
+			Control::new(None, false),
+			None,
+			peer_setup,
+			version,
+		);
+
+		Serve {
+			publisher,
+			session,
+			log,
+			track,
+			_origin: origin,
+			_broadcast: broadcast,
+		}
+	}
+
+	/// A distinctive request id, so `[FetchHeader::TYPE, REQUEST_ID]` is a usable needle.
+	const REQUEST_ID: u64 = 0x2B;
+
+	fn subscribe(filter: Filter, fill: Option<ietf::Fill>) -> ietf::Subscribe<'static> {
+		ietf::Subscribe {
+			request_id: RequestId(REQUEST_ID),
+			track_namespace: crate::Path::new("room"),
+			track_name: "video".into(),
+			subscriber_priority: 128,
+			group_order: GroupOrder::Descending,
+			filter,
+			fill,
+			properties_wanted: true,
+		}
+	}
+
+	/// The bytes that begin every fill fetch stream.
+	const FETCH_STREAM: &[u8] = &[FetchHeader::TYPE as u8, REQUEST_ID as u8];
+
+	/// Serve `msg` against the live track, then finish the track so the subscription
+	/// completes. Subscribing after the finish would be rejected instead of served.
+	async fn run_live(h: &mut Serve, msg: ietf::Subscribe<'static>) {
+		// `create_broadcast` registers the broadcast from a spawned task, so yield to the
+		// runtime before subscribing or the lookup 404s.
+		tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+
+		let stream = Stream::open(&h.session, h.publisher.version).await.unwrap();
+		let mut serve = std::pin::pin!(h.publisher.clone().run_subscribe_stream(stream, msg));
+
+		// Everything cached serves immediately; the subscription then parks at the live
+		// edge, which is where the track is allowed to finish.
+		for _ in 0..200 {
+			assert!(
+				futures::poll!(serve.as_mut()).is_pending(),
+				"subscription ended before the track finished"
+			);
+		}
+
+		h.track.finish().unwrap();
+		serve.await.unwrap();
+	}
+
+	/// The draft's canonical current-group join: a Next Object subscription plus a
+	/// StartGroup=1 fill. The published head arrives exactly once, on a fetch stream,
+	/// and the subscription starts past the snapshot, so nothing is duplicated and
+	/// nothing outside the requested range is sent.
+	#[tokio::test]
+	async fn canonical_join_serves_the_head_on_a_fetch_stream() {
+		let mut h = serve(Version::Draft20);
+
+		let mut group = h.track.create_group(group::Info { sequence: 0 }).unwrap();
+		for payload in [b"head-0", b"head-1", b"head-2"] {
+			group.write_frame(timestamp(), payload.as_slice()).unwrap();
+		}
+		group.finish().unwrap();
+
+		run_live(
+			&mut h,
+			subscribe(
+				Filter::NextObject,
+				Some(ietf::Fill {
+					filter: Some(Filter::Relative(1)),
+				}),
+			),
+		)
+		.await;
+
+		assert_eq!(occurrences(&h.log, FETCH_STREAM), 1, "expected one fill fetch stream");
+		for payload in [b"head-0", b"head-1", b"head-2"] {
+			assert_eq!(
+				occurrences(&h.log, payload),
+				1,
+				"each object exactly once, via the fill"
+			);
+		}
+		assert!(h.log.resets().is_empty(), "a served fill must not reset");
+	}
+
+	/// moq-lite's own join over draft-20: Relative(1) names the start of the current
+	/// group, so the cache replays the whole group on the subscription stream.
+	#[tokio::test]
+	async fn relative_one_replays_the_current_group() {
+		let mut h = serve(Version::Draft20);
+
+		let mut group = h.track.create_group(group::Info { sequence: 0 }).unwrap();
+		for payload in [b"head-0", b"head-1", b"head-2"] {
+			group.write_frame(timestamp(), payload.as_slice()).unwrap();
+		}
+		group.finish().unwrap();
+
+		run_live(&mut h, subscribe(Filter::Relative(1), None)).await;
+
+		assert_eq!(occurrences(&h.log, FETCH_STREAM), 0, "no fill was requested");
+		for payload in [b"head-0", b"head-1", b"head-2"] {
+			assert_eq!(occurrences(&h.log, payload), 1, "the whole group replays in range");
+		}
+	}
+
+	/// A Next Object subscription never receives the already-published head of the
+	/// current group: everything below the snapshot is outside the requested range.
+	#[tokio::test]
+	async fn next_object_does_not_replay_the_head() {
+		let mut h = serve(Version::Draft20);
+
+		let mut group = h.track.create_group(group::Info { sequence: 0 }).unwrap();
+		for payload in [b"head-0", b"head-1", b"head-2"] {
+			group.write_frame(timestamp(), payload.as_slice()).unwrap();
+		}
+		group.finish().unwrap();
+
+		run_live(&mut h, subscribe(Filter::NextObject, None)).await;
+
+		for payload in [b"head-0", b"head-1", b"head-2"] {
+			assert_eq!(
+				occurrences(&h.log, payload),
+				0,
+				"the head is outside the requested range"
+			);
+		}
+	}
+
+	/// A fill spanning several groups is refused by resetting the fetch stream right
+	/// after the FETCH_HEADER, the draft's fill-failure signal; the subscription itself
+	/// is untouched and still completes.
+	#[tokio::test]
+	async fn a_multi_group_fill_resets_its_stream() {
+		let mut h = serve(Version::Draft20);
+
+		for sequence in 0..2 {
+			let mut group = h.track.create_group(group::Info { sequence }).unwrap();
+			group.write_frame(timestamp(), b"frame".as_slice()).unwrap();
+			group.finish().unwrap();
+		}
+
+		run_live(
+			&mut h,
+			subscribe(
+				Filter::NextObject,
+				Some(ietf::Fill {
+					filter: Some(Filter::Relative(2)),
+				}),
+			),
+		)
+		.await;
+
+		assert_eq!(occurrences(&h.log, FETCH_STREAM), 1, "the promised stream still opens");
+		assert_eq!(h.log.resets().len(), 1, "and is reset as the failure signal");
+	}
+
+	/// A fill against an empty track has an empty range: no fetch stream is owed.
+	#[tokio::test]
+	async fn an_empty_track_opens_no_fill_stream() {
+		let mut h = serve(Version::Draft20);
+
+		run_live(
+			&mut h,
+			subscribe(
+				Filter::NextObject,
+				Some(ietf::Fill {
+					filter: Some(Filter::Relative(1)),
+				}),
+			),
+		)
+		.await;
+
+		assert_eq!(occurrences(&h.log, FETCH_STREAM), 0);
+		assert!(h.log.resets().is_empty());
+	}
+
+	/// The filter's object bounds trim what `run_group` writes: the skipped head is not
+	/// sent, the first written object's delta is its absolute id, and a capped tail stops
+	/// early. Extensions are off so the wire is just deltas, sizes, and payloads.
+	#[tokio::test]
+	async fn run_group_honors_the_slice() {
+		fn header() -> ietf::GroupHeader {
+			ietf::GroupHeader {
+				track_alias: 0,
+				group_id: 0,
+				sub_group_id: 0,
+				publisher_priority: 0,
+				flags: ietf::GroupFlags {
+					first_object: false,
+					..Default::default()
+				},
+			}
+		}
+
+		async fn serve_slice(slice: GroupSlice) -> Vec<u8> {
+			let log = Log::default();
+			let session = SinkSession::new(log.clone());
+			let mut track = track::Producer::new(std::sync::Arc::new(crate::broadcast::Info::default()), "test", None);
+			let mut group = track.create_group(group::Info { sequence: 0 }).unwrap();
+			for payload in [b"aa", b"bb", b"cc", b"dd"] {
+				group.write_frame(timestamp(), payload.as_slice()).unwrap();
+			}
+			let consumer = group.consume();
+			group.finish().unwrap();
+
+			Publisher::<SinkSession>::run_group(
+				session,
+				header(),
+				0,
+				consumer,
+				Timescale::default(),
+				Version::Draft20,
+				slice,
+			)
+			.await
+			.unwrap();
+
+			log.writes.lock().unwrap().clone()
+		}
+
+		// Skip 2: the head is dropped and the first delta is the absolute id 2.
+		let trimmed = serve_slice(GroupSlice { skip: 2, until: None }).await;
+		assert!(
+			trimmed.ends_with(&[0x02, 0x02, b'c', b'c', 0x00, 0x02, b'd', b'd']),
+			"expected delta 2 then cc, delta 0 then dd, got {trimmed:x?}"
+		);
+
+		// Until 2: only the head is written, stopping before the cap.
+		let capped = serve_slice(GroupSlice {
+			skip: 0,
+			until: Some(2),
+		})
+		.await;
+		assert!(
+			capped.ends_with(&[0x00, 0x02, b'a', b'a', 0x00, 0x02, b'b', b'b']),
+			"expected aa then bb only, got {capped:x?}"
+		);
+		assert_eq!(
+			capped.windows(2).filter(|w| *w == b"cc").count(),
+			0,
+			"the cap excludes cc"
+		);
 	}
 }
 
@@ -2959,51 +3601,190 @@ mod tests {
 	}
 }
 
-/// Resolve a SUBSCRIBE's Location Filter into the moq-lite group range to serve.
+/// The live edge a SUBSCRIBE resolves against, snapshotted once so the subscription
+/// floor, the fill cap, and the advertised LARGEST_OBJECT all agree on where it is.
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+struct LiveEdge {
+	/// The newest group sequence, `None` before any group exists.
+	latest: Option<u64>,
+	/// The precise Largest Object. `None` when the track is empty, or when the newest
+	/// group's frames cannot be read right now (none written yet, or a spliced track
+	/// between segments), in which case nothing is advertised and no fill is servable.
+	largest: Option<Location>,
+	/// One past the Largest Object, which is where a Next Object subscription begins.
+	/// When the edge is imprecise this falls back to the next group boundary: never below
+	/// the true Next Object, at worst under-delivering the current group's tail.
+	next: Option<Location>,
+}
+
+/// Snapshot the live edge of a track.
+fn live_edge(track: &track::Consumer) -> LiveEdge {
+	let Some(latest) = track.latest() else {
+		return LiveEdge::default();
+	};
+
+	match track.peek_latest() {
+		Some(group) if group.sequence == latest => {
+			let count = group.frame_count() as u64;
+			LiveEdge {
+				latest: Some(latest),
+				// A group with no frames yet has no objects; the largest then sits in an
+				// earlier group we do not walk back to, so nothing is advertised.
+				largest: count.checked_sub(1).map(|object| Location { group: latest, object }),
+				next: Some(Location {
+					group: latest,
+					object: count,
+				}),
+			}
+		}
+		_ => LiveEdge {
+			latest: Some(latest),
+			largest: None,
+			next: Some(Location {
+				group: latest.saturating_add(1),
+				object: 0,
+			}),
+		},
+	}
+}
+
+/// The Locations a SUBSCRIBE's Location Filter selects, resolved against the live edge.
 ///
-/// Returns `(group_start, group_end)` for [`Subscription`], where a `None` start means the
-/// latest group, which is what moq-lite treats as joining a live track.
+/// `start: None` joins at the beginning of the latest group, which is what moq-lite means
+/// by joining a live track. An explicit start is honored down to the object: the start
+/// group is served from `start.object` and the end group up to `end.object`, so a filter
+/// is never widened into objects the subscriber excluded.
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+struct ServeRange {
+	/// The first Location to serve, or `None` for the start of the latest group.
+	start: Option<Location>,
+	/// Where the range ends, inclusive. `None` is open ended. The subscription stays
+	/// open once the range is exhausted; draft-20 removed the notion of a filter ending
+	/// a subscription.
+	end: Option<EndLocation>,
+}
+
+/// The slice of one group a subscription's [`ServeRange`] selects.
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+struct GroupSlice {
+	/// Frames dropped from the front; also the first written object's absolute id.
+	skip: u64,
+	/// One past the last object to write, when the filter ends inside this group.
+	until: Option<u64>,
+}
+
+/// Resolve a SUBSCRIBE's Location Filter into the range to serve.
 ///
 /// Only draft-20 is honored. Earlier drafts have a Filter Type tag whose absolute forms we
 /// never served, and starting to interpret them now would change what an existing peer
 /// receives; draft-20 is also the first version whose relative forms can name a past group
 /// without the subscriber knowing Largest Object.
-///
-/// FILL_PARAMETERS is parsed but not acted on: we do not support fills. Answering one as
-/// ordinary subgroups looks like support without being it, since a subscriber waiting on
-/// the fetch stream the draft promises may discard those subgroups as outside its own
-/// Location Filter. Ignoring the parameter leaves the live subscription working and the
-/// backfill simply not delivered.
-fn subscribe_range(msg: &ietf::Subscribe<'_>, latest: Option<u64>, version: Version) -> (Option<u64>, Option<u64>) {
+fn subscribe_range(msg: &ietf::Subscribe<'_>, edge: LiveEdge, version: Version) -> ServeRange {
 	if !Filter::is_draft20(version) {
 		if !matches!(msg.filter, Filter::NextObject | Filter::Unfiltered) {
 			tracing::warn!(filter = ?msg.filter, "filter not supported before draft-20, ignoring");
 		}
-		return (None, None);
+		return ServeRange::default();
 	}
 
-	if msg.fill.is_some() {
-		tracing::debug!("fill requested but not supported, serving the subscription only");
-	}
-
-	filter_range(msg.filter, latest)
+	filter_range(msg.filter, edge)
 }
 
-/// The group range a single Location Filter selects, resolved against the live edge.
-fn filter_range(filter: Filter, latest: Option<u64>) -> (Option<u64>, Option<u64>) {
+/// The Locations a single Location Filter selects, resolved against the live edge.
+fn filter_range(filter: Filter, edge: LiveEdge) -> ServeRange {
 	match filter {
-		// Both mean "from the live edge onward". moq-lite starts at the beginning of the
-		// latest group, which is a slightly earlier point than Next Object names, so a
-		// subscriber can see the current group's earlier objects. That is the join point
-		// moq-lite is built around and the draft's own current-group recipe.
-		Filter::Unfiltered | Filter::NextObject => (None, None),
-		// `{Largest.Group + 1 - groups, 0}`: 0 is the next group, 1 is the current one.
-		Filter::Relative(groups) => match latest {
-			// Nothing published yet, so there is no edge to count back from.
-			None => (None, None),
-			Some(latest) => (Some(latest.saturating_add(1).saturating_sub(groups)), None),
+		// No restriction. moq-lite starts at the beginning of the latest group, which is
+		// the join point it is built around; a subscription passes objects as they are
+		// published, so an absent filter is not a request to replay history.
+		Filter::Unfiltered => ServeRange::default(),
+		// `{Largest.Group, Largest.Object + 1}`. Everything below it, including the
+		// already-published head of the current group, is outside the requested range,
+		// so the join is mid-group by construction. The draft pairs this with a fill
+		// when the subscriber wants the head; see `run_fill`.
+		Filter::NextObject => ServeRange {
+			start: edge.next,
+			end: None,
 		},
-		Filter::Absolute { start, end } => (Some(start.group), end.map(|end| end.group)),
+		// `{Largest.Group + 1 - groups, 0}`: 0 is the next group and 1 is the current one.
+		Filter::Relative(groups) => ServeRange {
+			start: edge.latest.map(|latest| Location {
+				group: latest.saturating_add(1).saturating_sub(groups),
+				object: 0,
+			}),
+			end: None,
+		},
+		Filter::Absolute { start, end } => ServeRange {
+			start: Some(start),
+			end,
+		},
+	}
+}
+
+/// What a draft-20 fill request resolves to.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FillServe {
+	/// The range is empty, so no fetch stream is opened at all.
+	Empty,
+	/// A single group served from the cache: `skip` frames dropped from the front, and
+	/// delivery stopping before `until` when set (the current group is capped at the
+	/// Largest Object snapshot; a whole past group reads to its end).
+	Group {
+		sequence: u64,
+		skip: u64,
+		until: Option<u64>,
+	},
+	/// A range spanning several groups, which we do not serve: multi-group fetch
+	/// serialization depends on a negotiated group order we do not implement, so the
+	/// stream is reset instead, the draft's fill-failure signal.
+	Unsupported,
+}
+
+/// Resolve a fill's Location Filter using the Fetch rules: relative to Largest Object
+/// and never extending beyond it.
+fn fill_range(filter: Filter, largest: Option<Location>) -> FillServe {
+	// Nothing published (or no precise edge to cap at) means no fill is servable; an
+	// empty range opens no stream.
+	let Some(largest) = largest else {
+		return FillServe::Empty;
+	};
+
+	let start = match filter {
+		// A Fetch without a filter is the whole track up to Largest Object.
+		Filter::Unfiltered => Location { group: 0, object: 0 },
+		// One past the edge, which for a Fetch is always empty.
+		Filter::NextObject => return FillServe::Empty,
+		Filter::Relative(groups) => Location {
+			group: largest.group.saturating_add(1).saturating_sub(groups),
+			object: 0,
+		},
+		Filter::Absolute { start, .. } => start,
+	};
+
+	// Cap the requested end at Largest Object.
+	let end = match filter {
+		Filter::Absolute { end: Some(end), .. }
+			if end.group < largest.group
+				|| (end.group == largest.group && end.object.is_some_and(|object| object < largest.object)) =>
+		{
+			end
+		}
+		_ => EndLocation {
+			group: largest.group,
+			object: Some(largest.object),
+		},
+	};
+
+	if start.group > end.group || (start.group == end.group && end.object.is_some_and(|object| object < start.object)) {
+		return FillServe::Empty;
+	}
+	if start.group != end.group {
+		return FillServe::Unsupported;
+	}
+
+	FillServe::Group {
+		sequence: start.group,
+		skip: start.object,
+		until: end.object.map(|object| object.saturating_add(1)),
 	}
 }
 
@@ -3012,7 +3793,7 @@ mod range_tests {
 	use super::*;
 	use crate::ietf::EndLocation;
 
-	fn subscribe(filter: Filter, fill: Option<Filter>) -> ietf::Subscribe<'static> {
+	fn subscribe(filter: Filter) -> ietf::Subscribe<'static> {
 		ietf::Subscribe {
 			request_id: RequestId(1),
 			track_namespace: crate::Path::new("broadcast"),
@@ -3020,12 +3801,17 @@ mod range_tests {
 			subscriber_priority: 128,
 			group_order: GroupOrder::Descending,
 			filter,
-			fill: fill.map(|filter| ietf::Fill { filter }),
+			fill: None,
 			properties_wanted: true,
 		}
 	}
 
-	const LATEST: Option<u64> = Some(100);
+	/// A live edge of group 100 whose current group has objects 0 through 4.
+	const EDGE: LiveEdge = LiveEdge {
+		latest: Some(100),
+		largest: Some(Location { group: 100, object: 4 }),
+		next: Some(Location { group: 100, object: 5 }),
+	};
 
 	/// A start past the live edge is what the subscriber asked for, so it is used as given.
 	/// Clamping it to the live edge would serve a group outside the requested range.
@@ -3065,28 +3851,52 @@ mod range_tests {
 	/// change what an existing peer receives.
 	#[test]
 	fn older_drafts_are_ignored() {
-		let msg = subscribe(
-			Filter::Absolute {
-				start: Location { group: 4, object: 0 },
-				end: Some(EndLocation { group: 9, object: None }),
-			},
-			None,
-		);
-		assert_eq!(subscribe_range(&msg, LATEST, Version::Draft19), (None, None));
+		let msg = subscribe(Filter::Absolute {
+			start: Location { group: 4, object: 0 },
+			end: Some(EndLocation { group: 9, object: None }),
+		});
+		assert_eq!(subscribe_range(&msg, EDGE, Version::Draft19), ServeRange::default());
 	}
 
-	/// Both spellings mean "from the live edge onward", which moq-lite represents as no
-	/// explicit start.
+	/// An absent filter is "no restriction on what is forwarded", not a request for
+	/// history, so it joins at the live edge.
 	#[test]
-	fn live_edge_has_no_floor() {
-		for filter in [Filter::NextObject, Filter::Unfiltered] {
-			let msg = subscribe(filter, None);
-			assert_eq!(
-				subscribe_range(&msg, LATEST, Version::Draft20),
-				(None, None),
-				"{filter:?}"
-			);
-		}
+	fn an_unfiltered_subscription_stays_live() {
+		let msg = subscribe(Filter::Unfiltered);
+		assert_eq!(subscribe_range(&msg, EDGE, Version::Draft20), ServeRange::default());
+	}
+
+	/// Next Object starts one past the Largest Object, mid-group. Everything below it,
+	/// including the current group's head, is outside the requested range.
+	#[test]
+	fn next_object_starts_past_the_largest_object() {
+		let msg = subscribe(Filter::NextObject);
+		assert_eq!(
+			subscribe_range(&msg, EDGE, Version::Draft20),
+			ServeRange {
+				start: Some(Location { group: 100, object: 5 }),
+				end: None,
+			}
+		);
+	}
+
+	/// When the edge cannot be read precisely, Next Object falls back to the next group
+	/// boundary: never below the true Next Object, so nothing already published is sent.
+	#[test]
+	fn next_object_without_a_precise_edge_waits_for_the_next_group() {
+		let edge = LiveEdge {
+			latest: Some(100),
+			largest: None,
+			next: Some(Location { group: 101, object: 0 }),
+		};
+		let msg = subscribe(Filter::NextObject);
+		assert_eq!(
+			subscribe_range(&msg, edge, Version::Draft20),
+			ServeRange {
+				start: Some(Location { group: 101, object: 0 }),
+				end: None,
+			}
+		);
 	}
 
 	/// `{Largest.Group + 1 - groups, 0}`: one is the current group, zero is the next one,
@@ -3094,10 +3904,16 @@ mod range_tests {
 	#[test]
 	fn relative_counts_back_from_the_next_group() {
 		for (groups, expected) in [(0, 101), (1, 100), (2, 99), (5, 96)] {
-			let msg = subscribe(Filter::Relative(groups), None);
+			let msg = subscribe(Filter::Relative(groups));
 			assert_eq!(
-				subscribe_range(&msg, LATEST, Version::Draft20),
-				(Some(expected), None),
+				subscribe_range(&msg, EDGE, Version::Draft20),
+				ServeRange {
+					start: Some(Location {
+						group: expected,
+						object: 0,
+					}),
+					end: None,
+				},
 				"{groups} groups back"
 			);
 		}
@@ -3106,58 +3922,195 @@ mod range_tests {
 	/// Counting back further than the track goes lands at its start rather than wrapping.
 	#[test]
 	fn relative_saturates_at_the_start() {
-		let msg = subscribe(Filter::Relative(500), None);
-		assert_eq!(subscribe_range(&msg, LATEST, Version::Draft20), (Some(0), None));
+		let msg = subscribe(Filter::Relative(500));
+		assert_eq!(
+			subscribe_range(&msg, EDGE, Version::Draft20),
+			ServeRange {
+				start: Some(Location { group: 0, object: 0 }),
+				end: None,
+			}
+		);
 	}
 
 	/// Nothing published yet means there is no edge to count back from.
 	#[test]
 	fn relative_without_an_edge_stays_live() {
-		let msg = subscribe(Filter::Relative(3), None);
-		assert_eq!(subscribe_range(&msg, None, Version::Draft20), (None, None));
+		let msg = subscribe(Filter::Relative(3));
+		assert_eq!(
+			subscribe_range(&msg, LiveEdge::default(), Version::Draft20),
+			ServeRange::default()
+		);
 	}
 
+	/// Both ends carry through, object bounds included, so the boundary groups can be
+	/// trimmed rather than widened.
 	#[test]
 	fn absolute_carries_both_ends() {
-		let msg = subscribe(
-			Filter::Absolute {
-				start: Location { group: 4, object: 0 },
-				end: Some(EndLocation { group: 9, object: None }),
-			},
-			None,
+		let msg = subscribe(Filter::Absolute {
+			start: Location { group: 4, object: 3 },
+			end: Some(EndLocation {
+				group: 9,
+				object: Some(6),
+			}),
+		});
+		assert_eq!(
+			subscribe_range(&msg, EDGE, Version::Draft20),
+			ServeRange {
+				start: Some(Location { group: 4, object: 3 }),
+				end: Some(EndLocation {
+					group: 9,
+					object: Some(6)
+				}),
+			}
 		);
-		assert_eq!(subscribe_range(&msg, LATEST, Version::Draft20), (Some(4), Some(9)));
+	}
+}
+
+#[cfg(test)]
+mod fill_range_tests {
+	use super::*;
+
+	/// Objects 0 through 4 of group 100 are published.
+	const LARGEST: Option<Location> = Some(Location { group: 100, object: 4 });
+
+	/// The canonical current-group join: a fill one group back covers the published head
+	/// of the current group, capped at the Largest Object snapshot.
+	#[test]
+	fn current_group_fill() {
+		assert_eq!(
+			fill_range(Filter::Relative(1), LARGEST),
+			FillServe::Group {
+				sequence: 100,
+				skip: 0,
+				until: Some(5),
+			}
+		);
 	}
 
-	/// We do not support fills, so asking for one changes nothing about what is served.
-	/// Answering it at all would look like support without being it.
+	/// A fill of the next group starts past the Largest Object, which for a Fetch is
+	/// always empty, as is an explicit Next Object.
 	#[test]
-	fn a_fill_is_parsed_but_not_served() {
-		for fill in [Filter::Relative(1), Filter::Relative(20), Filter::Unfiltered] {
-			let msg = subscribe(Filter::NextObject, Some(fill));
-			assert_eq!(
-				subscribe_range(&msg, LATEST, Version::Draft20),
-				(None, None),
-				"{fill:?}"
-			);
-		}
-
-		// The subscription's own filter still decides the range.
-		let msg = subscribe(
-			Filter::Absolute {
-				start: Location { group: 90, object: 0 },
-				end: None,
-			},
-			Some(Filter::Relative(20)),
-		);
-		assert_eq!(subscribe_range(&msg, LATEST, Version::Draft20), (Some(90), None));
+	fn a_future_fill_is_empty() {
+		assert_eq!(fill_range(Filter::Relative(0), LARGEST), FillServe::Empty);
+		assert_eq!(fill_range(Filter::NextObject, LARGEST), FillServe::Empty);
 	}
 
-	/// An absent filter is "no restriction on what is forwarded", not a request for
-	/// history, so it stays at the live edge.
+	/// Nothing published means every fill range is empty; no stream is owed.
 	#[test]
-	fn an_unfiltered_subscription_stays_live() {
-		let msg = subscribe(Filter::Unfiltered, None);
-		assert_eq!(subscribe_range(&msg, LATEST, Version::Draft20), (None, None));
+	fn no_content_means_no_fill() {
+		assert_eq!(fill_range(Filter::Relative(1), None), FillServe::Empty);
+		assert_eq!(fill_range(Filter::Unfiltered, None), FillServe::Empty);
+	}
+
+	/// A whole past group is served to its end; only the current group is capped.
+	#[test]
+	fn a_past_group_is_served_whole() {
+		assert_eq!(
+			fill_range(
+				Filter::Absolute {
+					start: Location { group: 7, object: 0 },
+					end: Some(EndLocation { group: 7, object: None }),
+				},
+				LARGEST
+			),
+			FillServe::Group {
+				sequence: 7,
+				skip: 0,
+				until: None,
+			}
+		);
+	}
+
+	/// Object bounds inside the group carry through to the served slice.
+	#[test]
+	fn object_bounds_trim_the_group() {
+		assert_eq!(
+			fill_range(
+				Filter::Absolute {
+					start: Location { group: 7, object: 2 },
+					end: Some(EndLocation {
+						group: 7,
+						object: Some(5)
+					}),
+				},
+				LARGEST
+			),
+			FillServe::Group {
+				sequence: 7,
+				skip: 2,
+				until: Some(6),
+			}
+		);
+	}
+
+	/// An end past the edge is capped at the Largest Object, per the Fetch rules.
+	#[test]
+	fn the_end_is_capped_at_the_largest_object() {
+		assert_eq!(
+			fill_range(
+				Filter::Absolute {
+					start: Location { group: 100, object: 0 },
+					end: Some(EndLocation {
+						group: 100,
+						object: Some(1000),
+					}),
+				},
+				LARGEST
+			),
+			FillServe::Group {
+				sequence: 100,
+				skip: 0,
+				until: Some(5),
+			}
+		);
+	}
+
+	/// A range spanning several groups is refused rather than served in an order the
+	/// peer may not expect; the reset is the draft's fill-failure signal.
+	#[test]
+	fn a_multi_group_fill_is_unsupported() {
+		assert_eq!(fill_range(Filter::Relative(3), LARGEST), FillServe::Unsupported);
+		assert_eq!(fill_range(Filter::Unfiltered, LARGEST), FillServe::Unsupported);
+		assert_eq!(
+			fill_range(
+				Filter::Absolute {
+					start: Location { group: 7, object: 0 },
+					end: Some(EndLocation { group: 9, object: None }),
+				},
+				LARGEST
+			),
+			FillServe::Unsupported
+		);
+	}
+
+	/// A backwards range is empty, not an error.
+	#[test]
+	fn a_backwards_range_is_empty() {
+		assert_eq!(
+			fill_range(
+				Filter::Absolute {
+					start: Location { group: 7, object: 5 },
+					end: Some(EndLocation {
+						group: 7,
+						object: Some(2)
+					}),
+				},
+				LARGEST
+			),
+			FillServe::Empty
+		);
+	}
+
+	/// The whole track fits in one group only when the track has exactly one group.
+	#[test]
+	fn unfiltered_with_one_group_is_the_canonical_fill() {
+		assert_eq!(
+			fill_range(Filter::Unfiltered, Some(Location { group: 0, object: 9 })),
+			FillServe::Group {
+				sequence: 0,
+				skip: 0,
+				until: Some(10),
+			}
+		);
 	}
 }

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -3745,11 +3745,18 @@ fn filter_range(filter: Filter, edge: LiveEdge) -> ServeRange {
 			end: None,
 		},
 		// `{Largest.Group + 1 - groups, 0}`: 0 is the next group and 1 is the current one.
+		// Counted from `Largest.Group`, which sits below the newest group while that
+		// group has no objects yet; only with no largest at all does the newest group
+		// stand in for it.
 		Filter::Relative(groups) => ServeRange {
-			start: edge.latest.map(|latest| Location {
-				group: latest.saturating_add(1).saturating_sub(groups),
-				object: 0,
-			}),
+			start: edge
+				.largest
+				.map(|largest| largest.group)
+				.or(edge.latest)
+				.map(|group| Location {
+					group: group.saturating_add(1).saturating_sub(groups),
+					object: 0,
+				}),
 			end: None,
 		},
 		Filter::Absolute { start, end } => ServeRange {
@@ -3963,6 +3970,25 @@ mod range_tests {
 				"{groups} groups back"
 			);
 		}
+	}
+
+	/// Relative counts from `Largest.Group`, which is below the newest group while that
+	/// group has no objects yet, so a current-group join still reaches the content.
+	#[test]
+	fn relative_counts_from_the_largest_group_over_an_empty_newest_group() {
+		let edge = LiveEdge {
+			latest: Some(1),
+			largest: Some(Location { group: 0, object: 2 }),
+			next: Some(Location { group: 0, object: 3 }),
+		};
+		let msg = subscribe(Filter::Relative(1));
+		assert_eq!(
+			subscribe_range(&msg, edge, Version::Draft20),
+			ServeRange {
+				start: Some(Location { group: 0, object: 0 }),
+				end: None,
+			}
+		);
 	}
 
 	/// Counting back further than the track goes lands at its start rather than wrapping.

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -707,14 +707,19 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		group_start: Option<u64>,
 		group_end: Option<u64>,
 	) -> Result<(), Error> {
-		// A fresh cursor starts at the oldest cached group, so leaving it there replays the
-		// whole retained history at once, one concurrent stream per group. The subscription
-		// range is a preference for what the publisher should keep available; the cursor is
-		// what this subscriber actually reads, and setting one does not move the other.
-		if let Some(latest) = track.latest() {
-			track.start_at(group_start.unwrap_or(latest).min(latest));
-		} else if let Some(start) = group_start {
-			track.start_at(start);
+		// The subscription range is a preference for what the publisher should keep
+		// available; the cursor is what this subscriber actually reads, and setting one does
+		// not move the other. A requested start is used as given, including one past the
+		// live edge, where waiting for that group is the point. Only an absent start falls
+		// back to the live edge, since a fresh cursor starts at the oldest cached group and
+		// would otherwise replay the whole retained history at once.
+		match group_start {
+			Some(start) => track.start_at(start),
+			None => {
+				if let Some(latest) = track.latest() {
+					track.start_at(latest);
+				}
+			}
 		}
 		track.end_at(group_end);
 
@@ -3022,6 +3027,40 @@ mod range_tests {
 
 	const LATEST: Option<u64> = Some(100);
 
+	/// A start past the live edge is what the subscriber asked for, so it is used as given.
+	/// Clamping it to the live edge would serve a group outside the requested range.
+	#[tokio::test]
+	async fn a_future_start_is_not_clamped_to_the_live_edge() {
+		let mut track = track::Producer::new(std::sync::Arc::new(crate::broadcast::Info::default()), "video", None);
+		track
+			.create_group(group::Info { sequence: 7 })
+			.unwrap()
+			.finish()
+			.unwrap();
+		track
+			.create_group(group::Info { sequence: 8 })
+			.unwrap()
+			.finish()
+			.unwrap();
+
+		// Next Group against a live edge of 8 asks for 9, which does not exist yet.
+		let mut subscriber = track.subscribe(None);
+		subscriber.start_at(9);
+		assert!(
+			futures::poll!(std::pin::pin!(subscriber.recv_group())).is_pending(),
+			"a future start must wait for its group rather than serving the live edge"
+		);
+
+		// The group it asked for is what it gets once published.
+		track
+			.create_group(group::Info { sequence: 9 })
+			.unwrap()
+			.finish()
+			.unwrap();
+		let group = subscriber.recv_group().await.unwrap().expect("group 9");
+		assert_eq!(group.sequence, 9);
+	}
+
 	/// Earlier drafts never had their absolute filters served, so honoring one now would
 	/// change what an existing peer receives.
 	#[test]
@@ -3091,7 +3130,7 @@ mod range_tests {
 	}
 
 	/// We do not support fills, so asking for one changes nothing about what is served.
-	/// Answering it as ordinary subgroups would look like support without being it.
+	/// Answering it at all would look like support without being it.
 	#[test]
 	fn a_fill_is_parsed_but_not_served() {
 		for fill in [Filter::Relative(1), Filter::Relative(20), Filter::Unfiltered] {

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -6,7 +6,7 @@ use futures::{FutureExt, StreamExt, stream::FuturesUnordered};
 use crate::{
 	AsPath, Error, Timescale, Timestamp,
 	coding::{Stream, Writer},
-	ietf::{self, Control, FetchHeader, FetchType, Fill, Filter, GroupOrder, Location, RequestId},
+	ietf::{self, Control, FetchHeader, FetchType, Filter, GroupOrder, Location, RequestId},
 	track::Subscription,
 	util::{MaybeBoxedExt, MaybeSendBox},
 };
@@ -2964,9 +2964,11 @@ mod tests {
 /// receives; draft-20 is also the first version whose relative forms can name a past group
 /// without the subscriber knowing Largest Object.
 ///
-/// A fill is folded into the same range rather than answered on its own fetch stream. The
-/// fill reaches further back than the subscription by design, so the earlier of the two
-/// starts wins and everything is delivered as ordinary live subgroups.
+/// FILL_PARAMETERS is parsed but not acted on: we do not support fills. Answering one as
+/// ordinary subgroups looks like support without being it, since a subscriber waiting on
+/// the fetch stream the draft promises may discard those subgroups as outside its own
+/// Location Filter. Ignoring the parameter leaves the live subscription working and the
+/// backfill simply not delivered.
 fn subscribe_range(msg: &ietf::Subscribe<'_>, latest: Option<u64>, version: Version) -> (Option<u64>, Option<u64>) {
 	if !Filter::is_draft20(version) {
 		if !matches!(msg.filter, Filter::NextObject | Filter::Unfiltered) {
@@ -2975,30 +2977,11 @@ fn subscribe_range(msg: &ietf::Subscribe<'_>, latest: Option<u64>, version: Vers
 		return (None, None);
 	}
 
-	let (start, end) = filter_range(msg.filter, latest);
-	let fill = msg.fill.map(|Fill { filter }| fill_floor(filter, latest));
-
-	// `None` is the live edge, which is later than any group a fill could name, so a fill
-	// start always wins over an absent subscription start.
-	let start = match (start, fill.flatten()) {
-		(Some(a), Some(b)) => Some(a.min(b)),
-		(Some(a), None) => Some(a),
-		(None, fill) => fill,
-	};
-
-	(start, end)
-}
-
-/// The first group a fill asks for, resolved against the live edge.
-///
-/// Identical to a subscription's filter except for the unfiltered case: on a subscription
-/// that means "no restriction", which is the live edge, but a fill with no filter asks for
-/// the whole track up to Largest Object.
-fn fill_floor(filter: Filter, latest: Option<u64>) -> Option<u64> {
-	match filter {
-		Filter::Unfiltered => Some(0),
-		_ => filter_range(filter, latest).0,
+	if msg.fill.is_some() {
+		tracing::debug!("fill requested but not supported, serving the subscription only");
 	}
+
+	filter_range(msg.filter, latest)
 }
 
 /// The group range a single Location Filter selects, resolved against the live edge.
@@ -3032,7 +3015,7 @@ mod range_tests {
 			subscriber_priority: 128,
 			group_order: GroupOrder::Descending,
 			filter,
-			fill: fill.map(|filter| Fill { filter }),
+			fill: fill.map(|filter| ietf::Fill { filter }),
 			properties_wanted: true,
 		}
 	}
@@ -3107,18 +3090,20 @@ mod range_tests {
 		assert_eq!(subscribe_range(&msg, LATEST, Version::Draft20), (Some(4), Some(9)));
 	}
 
-	/// The canonical current-group join: Next Object on the subscription, and a fill that
-	/// reaches back one group. The fill is what sets the floor.
+	/// We do not support fills, so asking for one changes nothing about what is served.
+	/// Answering it as ordinary subgroups would look like support without being it.
 	#[test]
-	fn a_fill_lowers_the_floor() {
-		let msg = subscribe(Filter::NextObject, Some(Filter::Relative(1)));
-		assert_eq!(subscribe_range(&msg, LATEST, Version::Draft20), (Some(100), None));
-	}
+	fn a_fill_is_parsed_but_not_served() {
+		for fill in [Filter::Relative(1), Filter::Relative(20), Filter::Unfiltered] {
+			let msg = subscribe(Filter::NextObject, Some(fill));
+			assert_eq!(
+				subscribe_range(&msg, LATEST, Version::Draft20),
+				(None, None),
+				"{fill:?}"
+			);
+		}
 
-	/// A fill reaches further back than the subscription by design, so the earlier of the
-	/// two starts wins.
-	#[test]
-	fn the_earlier_start_wins() {
+		// The subscription's own filter still decides the range.
 		let msg = subscribe(
 			Filter::Absolute {
 				start: Location { group: 90, object: 0 },
@@ -3126,28 +3111,11 @@ mod range_tests {
 			},
 			Some(Filter::Relative(20)),
 		);
-		assert_eq!(subscribe_range(&msg, LATEST, Version::Draft20), (Some(81), None));
-
-		let msg = subscribe(
-			Filter::Absolute {
-				start: Location { group: 50, object: 0 },
-				end: None,
-			},
-			Some(Filter::Relative(2)),
-		);
-		assert_eq!(subscribe_range(&msg, LATEST, Version::Draft20), (Some(50), None));
+		assert_eq!(subscribe_range(&msg, LATEST, Version::Draft20), (Some(90), None));
 	}
 
-	/// An empty fill scope asks for the whole track, which is the one case where the
-	/// unfiltered spelling means the start of the track rather than the live edge.
-	#[test]
-	fn an_unfiltered_fill_asks_for_the_whole_track() {
-		let msg = subscribe(Filter::NextObject, Some(Filter::Unfiltered));
-		assert_eq!(subscribe_range(&msg, LATEST, Version::Draft20), (Some(0), None));
-	}
-
-	/// The same spelling on the subscription itself is just "no restriction", so it stays
-	/// at the live edge.
+	/// An absent filter is "no restriction on what is forwarded", not a request for
+	/// history, so it stays at the live edge.
 	#[test]
 	fn an_unfiltered_subscription_stays_live() {
 		let msg = subscribe(Filter::Unfiltered, None);

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -3628,11 +3628,17 @@ fn live_edge(track: &track::Consumer) -> LiveEdge {
 	match track.peek_latest() {
 		Some(group) if group.sequence == latest => {
 			let count = group.frame_count() as u64;
+			let largest = match count.checked_sub(1) {
+				Some(object) => Some(Location { group: latest, object }),
+				// A group with no frames yet has no objects, so the largest sits in an
+				// earlier group. Walk back through the cache to find it, or a peer that
+				// subscribes in the instant between a group's creation and its first
+				// frame is told the track is empty and gets no fill.
+				None => largest_before(track, latest),
+			};
 			LiveEdge {
 				latest: Some(latest),
-				// A group with no frames yet has no objects; the largest then sits in an
-				// earlier group we do not walk back to, so nothing is advertised.
-				largest: count.checked_sub(1).map(|object| Location { group: latest, object }),
+				largest,
 				next: Some(Location {
 					group: latest,
 					object: count,
@@ -3647,6 +3653,23 @@ fn live_edge(track: &track::Consumer) -> LiveEdge {
 				object: 0,
 			}),
 		},
+	}
+}
+
+/// The last object before `sequence`: the nearest earlier cached group that has started a
+/// frame. The walk only continues over empty groups, which exist for at most the instant
+/// between a group's creation and its first frame, and a cache miss ends it with nothing.
+fn largest_before(track: &track::Consumer, sequence: u64) -> Option<Location> {
+	let mut sequence = sequence;
+	loop {
+		sequence = sequence.checked_sub(1)?;
+		let group = track.peek_group(sequence)?;
+		if let Some(object) = (group.frame_count() as u64).checked_sub(1) {
+			return Some(Location {
+				group: sequence,
+				object,
+			});
+		}
 	}
 }
 
@@ -3949,6 +3972,31 @@ mod range_tests {
 			subscribe_range(&msg, LiveEdge::default(), Version::Draft20),
 			ServeRange::default()
 		);
+	}
+
+	/// A group created but not yet written has no objects, so the largest sits in the
+	/// group before it. Losing it would tell a fill-requesting peer the track is empty.
+	#[tokio::test]
+	async fn an_empty_newest_group_walks_back_for_the_largest() {
+		let mut track = track::Producer::new(std::sync::Arc::new(crate::broadcast::Info::default()), "video", None);
+		let mut first = track.create_group(group::Info { sequence: 0 }).unwrap();
+		for _ in 0..3 {
+			first
+				.write_frame(crate::Timestamp::from_millis(0).unwrap(), b"frame".as_slice())
+				.unwrap();
+		}
+		first.finish().unwrap();
+		let _open = track.create_group(group::Info { sequence: 1 }).unwrap();
+
+		let edge = live_edge(&track.consume());
+		assert_eq!(edge.latest, Some(1));
+		assert_eq!(
+			edge.largest,
+			Some(Location { group: 0, object: 2 }),
+			"the largest object is the previous group's last frame"
+		);
+		// The next object is still the new group's start: nothing exists between the two.
+		assert_eq!(edge.next, Some(Location { group: 1, object: 0 }));
 	}
 
 	/// Both ends carry through, object bounds included, so the boundary groups can be

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -584,8 +584,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		let fill = msg
 			.fill
 			.filter(|_| Filter::is_draft20(self.version))
-			.map(|fill| fill_range(fill.filter.unwrap_or(msg.filter), edge.largest))
-			.map(|fill| (fill, cache));
+			.map(|fill| (fill_range(fill, msg.filter, edge.largest), cache));
 
 		// Send SubscribeOk on the stream
 		stream.writer.encode(&ietf::SubscribeOk::ID).await?;
@@ -2293,6 +2292,7 @@ mod serve_tests {
 				Filter::NextObject,
 				Some(ietf::Fill {
 					filter: Some(Filter::Relative(1)),
+					range_filters: false,
 				}),
 			),
 		)
@@ -2371,6 +2371,7 @@ mod serve_tests {
 				Filter::NextObject,
 				Some(ietf::Fill {
 					filter: Some(Filter::Relative(2)),
+					range_filters: false,
 				}),
 			),
 		)
@@ -2391,6 +2392,7 @@ mod serve_tests {
 				Filter::NextObject,
 				Some(ietf::Fill {
 					filter: Some(Filter::Relative(1)),
+					range_filters: false,
 				}),
 			),
 		)
@@ -3739,9 +3741,16 @@ enum FillServe {
 	Unsupported,
 }
 
-/// Resolve a fill's Location Filter using the Fetch rules: relative to Largest Object
-/// and never extending beyond it.
-fn fill_range(filter: Filter, largest: Option<Location>) -> FillServe {
+/// Resolve a fill request using the Fetch rules: relative to Largest Object and never
+/// extending beyond it. An omitted Location Filter inherits the subscription's.
+fn fill_range(fill: ietf::Fill, subscription: Filter, largest: Option<Location>) -> FillServe {
+	// A Range Filter narrows which objects pass, which we do not implement; serving the
+	// unfiltered range instead would deliver objects the peer excluded, so refuse it.
+	if fill.range_filters {
+		return FillServe::Unsupported;
+	}
+	let filter = fill.filter.unwrap_or(subscription);
+
 	// Nothing published (or no precise edge to cap at) means no fill is servable; an
 	// empty range opens no stream.
 	let Some(largest) = largest else {
@@ -3973,12 +3982,20 @@ mod fill_range_tests {
 	/// Objects 0 through 4 of group 100 are published.
 	const LARGEST: Option<Location> = Some(Location { group: 100, object: 4 });
 
+	/// A fill with an explicit Location Filter and no range filters.
+	fn fill(filter: Filter) -> ietf::Fill {
+		ietf::Fill {
+			filter: Some(filter),
+			range_filters: false,
+		}
+	}
+
 	/// The canonical current-group join: a fill one group back covers the published head
 	/// of the current group, capped at the Largest Object snapshot.
 	#[test]
 	fn current_group_fill() {
 		assert_eq!(
-			fill_range(Filter::Relative(1), LARGEST),
+			fill_range(fill(Filter::Relative(1)), Filter::NextObject, LARGEST),
 			FillServe::Group {
 				sequence: 100,
 				skip: 0,
@@ -3991,15 +4008,27 @@ mod fill_range_tests {
 	/// always empty, as is an explicit Next Object.
 	#[test]
 	fn a_future_fill_is_empty() {
-		assert_eq!(fill_range(Filter::Relative(0), LARGEST), FillServe::Empty);
-		assert_eq!(fill_range(Filter::NextObject, LARGEST), FillServe::Empty);
+		assert_eq!(
+			fill_range(fill(Filter::Relative(0)), Filter::NextObject, LARGEST),
+			FillServe::Empty
+		);
+		assert_eq!(
+			fill_range(fill(Filter::NextObject), Filter::NextObject, LARGEST),
+			FillServe::Empty
+		);
 	}
 
 	/// Nothing published means every fill range is empty; no stream is owed.
 	#[test]
 	fn no_content_means_no_fill() {
-		assert_eq!(fill_range(Filter::Relative(1), None), FillServe::Empty);
-		assert_eq!(fill_range(Filter::Unfiltered, None), FillServe::Empty);
+		assert_eq!(
+			fill_range(fill(Filter::Relative(1)), Filter::NextObject, None),
+			FillServe::Empty
+		);
+		assert_eq!(
+			fill_range(fill(Filter::Unfiltered), Filter::NextObject, None),
+			FillServe::Empty
+		);
 	}
 
 	/// A whole past group is served to its end; only the current group is capped.
@@ -4007,10 +4036,11 @@ mod fill_range_tests {
 	fn a_past_group_is_served_whole() {
 		assert_eq!(
 			fill_range(
-				Filter::Absolute {
+				fill(Filter::Absolute {
 					start: Location { group: 7, object: 0 },
 					end: Some(EndLocation { group: 7, object: None }),
-				},
+				}),
+				Filter::NextObject,
 				LARGEST
 			),
 			FillServe::Group {
@@ -4026,13 +4056,14 @@ mod fill_range_tests {
 	fn object_bounds_trim_the_group() {
 		assert_eq!(
 			fill_range(
-				Filter::Absolute {
+				fill(Filter::Absolute {
 					start: Location { group: 7, object: 2 },
 					end: Some(EndLocation {
 						group: 7,
 						object: Some(5)
 					}),
-				},
+				}),
+				Filter::NextObject,
 				LARGEST
 			),
 			FillServe::Group {
@@ -4048,13 +4079,14 @@ mod fill_range_tests {
 	fn the_end_is_capped_at_the_largest_object() {
 		assert_eq!(
 			fill_range(
-				Filter::Absolute {
+				fill(Filter::Absolute {
 					start: Location { group: 100, object: 0 },
 					end: Some(EndLocation {
 						group: 100,
 						object: Some(1000),
 					}),
-				},
+				}),
+				Filter::NextObject,
 				LARGEST
 			),
 			FillServe::Group {
@@ -4069,17 +4101,53 @@ mod fill_range_tests {
 	/// peer may not expect; the reset is the draft's fill-failure signal.
 	#[test]
 	fn a_multi_group_fill_is_unsupported() {
-		assert_eq!(fill_range(Filter::Relative(3), LARGEST), FillServe::Unsupported);
-		assert_eq!(fill_range(Filter::Unfiltered, LARGEST), FillServe::Unsupported);
+		assert_eq!(
+			fill_range(fill(Filter::Relative(3)), Filter::NextObject, LARGEST),
+			FillServe::Unsupported
+		);
+		assert_eq!(
+			fill_range(fill(Filter::Unfiltered), Filter::NextObject, LARGEST),
+			FillServe::Unsupported
+		);
 		assert_eq!(
 			fill_range(
-				Filter::Absolute {
+				fill(Filter::Absolute {
 					start: Location { group: 7, object: 0 },
 					end: Some(EndLocation { group: 9, object: None }),
-				},
+				}),
+				Filter::NextObject,
 				LARGEST
 			),
 			FillServe::Unsupported
+		);
+	}
+
+	/// A Range Filter narrows which objects pass; refusing beats serving objects the
+	/// peer excluded.
+	#[test]
+	fn a_range_filtered_fill_is_unsupported() {
+		let fill = ietf::Fill {
+			filter: Some(Filter::Relative(1)),
+			range_filters: true,
+		};
+		assert_eq!(fill_range(fill, Filter::NextObject, LARGEST), FillServe::Unsupported);
+	}
+
+	/// An omitted Location Filter inherits the subscription's, per the draft: a fill
+	/// scope carries only the settings that differ.
+	#[test]
+	fn an_omitted_filter_inherits_the_subscription() {
+		let empty = ietf::Fill::default();
+		// A Next Object subscription inherited into a Fetch is always empty.
+		assert_eq!(fill_range(empty, Filter::NextObject, LARGEST), FillServe::Empty);
+		// A current-group subscription inherited into the fill covers its head.
+		assert_eq!(
+			fill_range(empty, Filter::Relative(1), LARGEST),
+			FillServe::Group {
+				sequence: 100,
+				skip: 0,
+				until: Some(5),
+			}
 		);
 	}
 
@@ -4088,13 +4156,14 @@ mod fill_range_tests {
 	fn a_backwards_range_is_empty() {
 		assert_eq!(
 			fill_range(
-				Filter::Absolute {
+				fill(Filter::Absolute {
 					start: Location { group: 7, object: 5 },
 					end: Some(EndLocation {
 						group: 7,
 						object: Some(2)
 					}),
-				},
+				}),
+				Filter::NextObject,
 				LARGEST
 			),
 			FillServe::Empty
@@ -4105,7 +4174,11 @@ mod fill_range_tests {
 	#[test]
 	fn unfiltered_with_one_group_is_the_canonical_fill() {
 		assert_eq!(
-			fill_range(Filter::Unfiltered, Some(Location { group: 0, object: 9 })),
+			fill_range(
+				fill(Filter::Unfiltered),
+				Filter::NextObject,
+				Some(Location { group: 0, object: 9 })
+			),
 			FillServe::Group {
 				sequence: 0,
 				skip: 0,

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -591,7 +591,7 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		// Run the track, cancelling on reader close (Unsubscribe or stream close)
 		let res = {
-			let mut serve = std::pin::pin!(self.run_track(track, request_id));
+			let mut serve = std::pin::pin!(self.run_track(track, request_id, group_start, group_end));
 			let mut reader_closed = std::pin::pin!(stream.reader.closed());
 			let mut session_closed = std::pin::pin!(self.session.closed());
 			kio::wait(|waiter| {
@@ -700,13 +700,23 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 	}
 
 	/// Serve a track using FuturesUnordered for unlimited concurrent groups.
-	async fn run_track(&self, mut track: track::Subscriber, request_id: RequestId) -> Result<(), Error> {
+	async fn run_track(
+		&self,
+		mut track: track::Subscriber,
+		request_id: RequestId,
+		group_start: Option<u64>,
+		group_end: Option<u64>,
+	) -> Result<(), Error> {
 		// A fresh cursor starts at the oldest cached group, so leaving it there replays the
-		// whole retained history at once, one concurrent stream per group. LargestObject is
-		// the only filter we accept and it means the live edge.
+		// whole retained history at once, one concurrent stream per group. The subscription
+		// range is a preference for what the publisher should keep available; the cursor is
+		// what this subscriber actually reads, and setting one does not move the other.
 		if let Some(latest) = track.latest() {
-			track.start_at(latest);
+			track.start_at(group_start.unwrap_or(latest).min(latest));
+		} else if let Some(start) = group_start {
+			track.start_at(start);
 		}
+		track.end_at(group_end);
 
 		let mut tasks = FuturesUnordered::new();
 
@@ -1805,7 +1815,7 @@ mod subscribe_cursor_test {
 		let subscriber = track.subscribe(None);
 		track.finish().unwrap();
 
-		publisher.run_track(subscriber, RequestId(1)).await.unwrap();
+		publisher.run_track(subscriber, RequestId(1), None, None).await.unwrap();
 
 		// `run_group` sets the priority once per stream it opens, so this counts groups served.
 		assert_eq!(log.priorities().len(), 1, "only group 3 should have been served");
@@ -3005,13 +3015,14 @@ fn filter_range(filter: Filter, latest: Option<u64>) -> (Option<u64>, Option<u64
 			None => (None, None),
 			Some(latest) => (Some(latest.saturating_add(1).saturating_sub(groups)), None),
 		},
-		Filter::Absolute { start, end } => (Some(start.group), end),
+		Filter::Absolute { start, end } => (Some(start.group), end.map(|end| end.group)),
 	}
 }
 
 #[cfg(test)]
 mod range_tests {
 	use super::*;
+	use crate::ietf::EndLocation;
 
 	fn subscribe(filter: Filter, fill: Option<Filter>) -> ietf::Subscribe<'static> {
 		ietf::Subscribe {
@@ -3035,7 +3046,7 @@ mod range_tests {
 		let msg = subscribe(
 			Filter::Absolute {
 				start: Location { group: 4, object: 0 },
-				end: Some(9),
+				end: Some(EndLocation { group: 9, object: None }),
 			},
 			None,
 		);
@@ -3089,7 +3100,7 @@ mod range_tests {
 		let msg = subscribe(
 			Filter::Absolute {
 				start: Location { group: 4, object: 0 },
-				end: Some(9),
+				end: Some(EndLocation { group: 9, object: None }),
 			},
 			None,
 		);

--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -3636,13 +3636,25 @@ fn live_edge(track: &track::Consumer) -> LiveEdge {
 				// frame is told the track is empty and gets no fill.
 				None => largest_before(track, latest),
 			};
+			// One past the edge, even when the edge sits below the newest group: a group
+			// may keep writing after a newer one exists, and a floor above the true Next
+			// Object would strand those objects between the fill cap and the
+			// subscription. With no readable object anywhere, the newest group's start
+			// excludes nothing the cache can still name.
+			let next = match largest {
+				Some(largest) => Location {
+					group: largest.group,
+					object: largest.object.saturating_add(1),
+				},
+				None => Location {
+					group: latest,
+					object: 0,
+				},
+			};
 			LiveEdge {
 				latest: Some(latest),
 				largest,
-				next: Some(Location {
-					group: latest,
-					object: count,
-				}),
+				next: Some(next),
 			}
 		}
 		_ => LiveEdge {
@@ -3656,20 +3668,22 @@ fn live_edge(track: &track::Consumer) -> LiveEdge {
 	}
 }
 
-/// The last object before `sequence`: the nearest earlier cached group that has started a
-/// frame. The walk only continues over empty groups, which exist for at most the instant
-/// between a group's creation and its first frame, and a cache miss ends it with nothing.
+/// The last object below `sequence`: the nearest earlier cached group that has started a
+/// frame, walked in cache order so legal gaps in the group numbering are crossed. Empty
+/// groups exist for at most the instant between creation and first frame, so the walk is
+/// one step in practice. A group evicted from the cache is not visible, which is fine:
+/// Largest Object is the track from this publisher's perspective, and that is the cache.
 fn largest_before(track: &track::Consumer, sequence: u64) -> Option<Location> {
 	let mut sequence = sequence;
 	loop {
-		sequence = sequence.checked_sub(1)?;
-		let group = track.peek_group(sequence)?;
+		let group = track.peek_before(sequence)?;
 		if let Some(object) = (group.frame_count() as u64).checked_sub(1) {
 			return Some(Location {
-				group: sequence,
+				group: group.sequence,
 				object,
 			});
 		}
+		sequence = group.sequence;
 	}
 }
 
@@ -3974,8 +3988,11 @@ mod range_tests {
 		);
 	}
 
-	/// A group created but not yet written has no objects, so the largest sits in the
-	/// group before it. Losing it would tell a fill-requesting peer the track is empty.
+	/// A group created but not yet written has no objects, so the largest sits in an
+	/// earlier group. Losing it would tell a fill-requesting peer the track is empty, and
+	/// a floor above the true Next Object would strand a late object of the earlier group
+	/// between the fill cap and the subscription: a group may keep writing after a newer
+	/// one exists, so the earlier group is deliberately left unfinished here.
 	#[tokio::test]
 	async fn an_empty_newest_group_walks_back_for_the_largest() {
 		let mut track = track::Producer::new(std::sync::Arc::new(crate::broadcast::Info::default()), "video", None);
@@ -3985,7 +4002,6 @@ mod range_tests {
 				.write_frame(crate::Timestamp::from_millis(0).unwrap(), b"frame".as_slice())
 				.unwrap();
 		}
-		first.finish().unwrap();
 		let _open = track.create_group(group::Info { sequence: 1 }).unwrap();
 
 		let edge = live_edge(&track.consume());
@@ -3995,8 +4011,30 @@ mod range_tests {
 			Some(Location { group: 0, object: 2 }),
 			"the largest object is the previous group's last frame"
 		);
-		// The next object is still the new group's start: nothing exists between the two.
-		assert_eq!(edge.next, Some(Location { group: 1, object: 0 }));
+		assert_eq!(
+			edge.next,
+			Some(Location { group: 0, object: 3 }),
+			"the floor is one past the largest, so a late object of group 0 is not stranded"
+		);
+	}
+
+	/// Group numbering may legally skip sequences, so the walk follows the cache's own
+	/// order rather than decrementing by one.
+	#[tokio::test]
+	async fn the_walkback_crosses_a_gap_in_the_numbering() {
+		let mut track = track::Producer::new(std::sync::Arc::new(crate::broadcast::Info::default()), "video", None);
+		let mut first = track.create_group(group::Info { sequence: 0 }).unwrap();
+		first
+			.write_frame(crate::Timestamp::from_millis(0).unwrap(), b"frame".as_slice())
+			.unwrap();
+		first.finish().unwrap();
+		// Sequence 1 never exists; the newest group is empty.
+		let _open = track.create_group(group::Info { sequence: 2 }).unwrap();
+
+		let edge = live_edge(&track.consume());
+		assert_eq!(edge.latest, Some(2));
+		assert_eq!(edge.largest, Some(Location { group: 0, object: 0 }));
+		assert_eq!(edge.next, Some(Location { group: 0, object: 1 }));
 	}
 
 	/// Both ends carry through, object bounds included, so the boundary groups can be

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -602,7 +602,10 @@ async fn run_uni_group<S: web_transport_trait::Session>(
 	}
 
 	match kind {
-		FetchHeader::TYPE => Err(Error::Unsupported),
+		// Draft-20 answers a FILL_PARAMETERS subscription on a fetch stream. Earlier drafts
+		// have no fill, so a fetch stream there answers a standalone FETCH we never sent,
+		// which `recv_fill` refuses.
+		FetchHeader::TYPE => subscriber.recv_fill(stream).await,
 		_ => Err(Error::UnexpectedStream),
 	}
 }

--- a/rs/moq-net/src/ietf/session.rs
+++ b/rs/moq-net/src/ietf/session.rs
@@ -602,10 +602,10 @@ async fn run_uni_group<S: web_transport_trait::Session>(
 	}
 
 	match kind {
-		// Draft-20 answers a FILL_PARAMETERS subscription on a fetch stream. Earlier drafts
-		// have no fill, so a fetch stream there answers a standalone FETCH we never sent,
-		// which `recv_fill` refuses.
-		FetchHeader::TYPE => subscriber.recv_fill(stream).await,
+		// We never request a fill, so a fetch stream answers a request we did not make. Its
+		// objects would duplicate a group the live subscription is already delivering, and
+		// two producers for one sequence is a `Duplicate` error, so refuse the stream.
+		FetchHeader::TYPE => Err(Error::Unsupported),
 		_ => Err(Error::UnexpectedStream),
 	}
 }

--- a/rs/moq-net/src/ietf/solicit.rs
+++ b/rs/moq-net/src/ietf/solicit.rs
@@ -57,7 +57,7 @@ mod tests {
 	/// Options: an old peer can opt out too.
 	#[test]
 	fn every_version_round_trips() {
-		for version in [Version::Draft14, Version::Draft15, Version::Draft16, Version::Draft19] {
+		for version in [Version::Draft14, Version::Draft15, Version::Draft16, Version::Draft20] {
 			let mut params = super::super::Parameters::default();
 			into_setup(&mut params, version);
 			assert_eq!(from_setup(&params, version).unwrap(), Some(true));

--- a/rs/moq-net/src/ietf/subscribe.rs
+++ b/rs/moq-net/src/ietf/subscribe.rs
@@ -472,7 +472,14 @@ impl Message for SubscribeUpdate {
 					0x10 => forward: Option<bool>,
 					0x20 => subscriber_priority: Option<u8>,
 					0x21 => _filter: Option<Filter>,
+					0x23 => fill: Option<Fill>,
 				);
+
+				// FILL_PARAMETERS is a draft-20 addition, so an earlier peer sending one is
+				// still the protocol violation it was.
+				if fill.is_some() && !Filter::is_draft20(version) {
+					return Err(DecodeError::InvalidValue);
+				}
 
 				let subscriber_priority = subscriber_priority.unwrap_or(128);
 				let forward = forward.unwrap_or(true);

--- a/rs/moq-net/src/ietf/subscribe.rs
+++ b/rs/moq-net/src/ietf/subscribe.rs
@@ -2,12 +2,10 @@
 
 use std::borrow::Cow;
 
-use num_enum::{IntoPrimitive, TryFromPrimitive};
-
 use crate::{
 	Path,
 	coding::*,
-	ietf::{GroupOrder, Location, Parameters, Properties, RequestId},
+	ietf::{Fill, Filter, GroupOrder, Location, Param, Parameters, Properties, RequestId},
 };
 
 use super::Message;
@@ -15,26 +13,28 @@ use super::namespace::{decode_namespace, encode_namespace};
 
 use super::Version;
 
-#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, TryFromPrimitive, IntoPrimitive)]
-#[repr(u64)]
-pub enum FilterType {
-	NextGroup = 0x01,
-	#[default]
-	LargestObject = 0x2,
-	AbsoluteStart = 0x3,
-	AbsoluteRange = 0x4,
-}
+/// The INCLUDE_PROPERTIES parameter (0x35), draft-20's opt-out from Track Properties.
+///
+/// Length prefixed despite holding a single byte. The Key-Value-Pair rule keys the framing
+/// off the parameter id's parity and 0x35 is odd, so a Length is present even though the
+/// parameter's own section calls the value a uint8. Parity is what the generic parser uses
+/// to skip a parameter it does not know, so following the prose instead would desync every
+/// parameter after this one.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct IncludeProperties(pub bool);
 
-impl Encode<Version> for FilterType {
-	fn encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
-		u64::from(*self).encode(w, version)?;
-		Ok(())
+impl Param for IncludeProperties {
+	fn param_encode<W: bytes::BufMut>(&self, w: &mut W, version: Version) -> Result<(), EncodeError> {
+		vec![u8::from(self.0)].encode(w, version)
 	}
-}
 
-impl Decode<Version> for FilterType {
-	fn decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
-		Self::try_from(u64::decode(r, version)?).map_err(|_| DecodeError::InvalidValue)
+	fn param_decode<R: bytes::Buf>(r: &mut R, version: Version) -> Result<Self, DecodeError> {
+		match Vec::<u8>::decode(r, version)?[..] {
+			// The draft allows exactly 0 or 1; anything else is a protocol violation.
+			[0] => Ok(Self(false)),
+			[1] => Ok(Self(true)),
+			_ => Err(DecodeError::InvalidValue),
+		}
 	}
 }
 
@@ -47,7 +47,12 @@ pub struct Subscribe<'a> {
 	pub track_name: Cow<'a, str>,
 	pub subscriber_priority: u8,
 	pub group_order: GroupOrder,
-	pub filter_type: FilterType,
+	/// Which Objects the subscription delivers.
+	pub filter: Filter,
+	/// The draft-20 backfill request, if the subscriber asked for one.
+	pub fill: Option<Fill>,
+	/// Whether the subscriber wants Track Properties on the response (draft-20).
+	pub properties_wanted: bool,
 }
 
 impl Message for Subscribe<'_> {
@@ -71,17 +76,7 @@ impl Message for Subscribe<'_> {
 					return Err(DecodeError::Unsupported);
 				}
 
-				let filter_type = FilterType::decode(r, version)?;
-				match filter_type {
-					FilterType::AbsoluteStart => {
-						let _start = Location::decode(r, version)?;
-					}
-					FilterType::AbsoluteRange => {
-						let _start = Location::decode(r, version)?;
-						let _end_group = u64::decode(r, version)?;
-					}
-					FilterType::NextGroup | FilterType::LargestObject => {}
-				};
+				let filter = Filter::decode(r, version)?;
 
 				let _params = Parameters::decode(r, version)?;
 
@@ -91,7 +86,9 @@ impl Message for Subscribe<'_> {
 					track_name,
 					subscriber_priority,
 					group_order,
-					filter_type,
+					filter,
+					fill: None,
+					properties_wanted: true,
 				})
 			}
 			_ => {
@@ -99,9 +96,21 @@ impl Message for Subscribe<'_> {
 					0x04 => rendezvous_timeout: Option<u64>,
 					0x10 => forward: Option<bool>,
 					0x20 => subscriber_priority: Option<u8>,
-					0x21 => filter_type: Option<FilterType>,
+					0x21 => filter: Option<Filter>,
 					0x22 => group_order: Option<GroupOrder>,
+					0x23 => fill: Option<Fill>,
+					0x35 => include_properties: Option<IncludeProperties>,
 				);
+
+				// FILL_PARAMETERS and INCLUDE_PROPERTIES are draft-20 additions. An unknown
+				// message parameter is a protocol violation, so they stay rejected on the
+				// drafts that predate them rather than being quietly tolerated.
+				if (fill.is_some() || include_properties.is_some()) && !Filter::is_draft20(version) {
+					return Err(DecodeError::InvalidValue);
+				}
+
+				// Defaults to 1, so an absent parameter means the subscriber wants them.
+				let properties_wanted = include_properties.is_none_or(|p| p.0);
 
 				// RENDEZVOUS_TIMEOUT arrived in draft-17; 0x04 means MAX_CACHE_DURATION in
 				// draft-15, which is a publisher parameter with no business in a SUBSCRIBE.
@@ -121,7 +130,8 @@ impl Message for Subscribe<'_> {
 
 				let subscriber_priority = subscriber_priority.unwrap_or(128);
 				let group_order = group_order.unwrap_or(GroupOrder::Descending);
-				let filter_type = filter_type.unwrap_or(FilterType::LargestObject);
+				// An absent LOCATION_FILTER means the subscription is unfiltered.
+				let filter = filter.unwrap_or(Filter::Unfiltered);
 
 				Ok(Self {
 					request_id,
@@ -129,7 +139,9 @@ impl Message for Subscribe<'_> {
 					track_name,
 					subscriber_priority,
 					group_order,
-					filter_type,
+					filter,
+					fill,
+					properties_wanted,
 				})
 			}
 		}
@@ -149,24 +161,21 @@ impl Message for Subscribe<'_> {
 				self.group_order.encode(w, version)?;
 				true.encode(w, version)?; // forward
 
-				// Decoding keeps the filter type but drops the Location an absolute filter
-				// carries after it, so there is nothing left to write. Refuse rather than
-				// emit a truncated SUBSCRIBE whose next field the peer would read as that
-				// Location. Reachable from a peer's own message, so it is an error, not an
-				// assertion.
-				if matches!(self.filter_type, FilterType::AbsoluteStart | FilterType::AbsoluteRange) {
-					return Err(EncodeError::Unsupported);
-				}
-
-				self.filter_type.encode(w, version)?;
+				self.filter.encode(w, version)?;
 				0u8.encode(w, version)?; // no parameters
 			}
 			_ => {
+				// FILL_PARAMETERS arrived in draft-20. Sending it to an older peer would be an
+				// unknown parameter, which is a protocol violation, so it is dropped instead.
+				// A subscriber there simply joins mid-group, which is what it did all along.
+				let fill = self.fill.filter(|_| Filter::is_draft20(version));
+
 				encode_params!(w, version,
 					0x10 => true,
 					0x20 => self.subscriber_priority,
-					0x21 => self.filter_type,
+					0x21 => self.filter,
 					0x22 => self.group_order,
+					0x23 => fill,
 				);
 			}
 		}
@@ -375,7 +384,7 @@ impl Message for SubscribeUpdate {
 				encode_params!(w, version,
 					0x10 => self.forward,
 					0x20 => self.subscriber_priority,
-					0x21 => FilterType::LargestObject,
+					0x21 => Filter::NextObject,
 				);
 			}
 			_ => {
@@ -391,7 +400,7 @@ impl Message for SubscribeUpdate {
 				encode_params!(w, version,
 					0x10 => self.forward,
 					0x20 => self.subscriber_priority,
-					0x21 => FilterType::LargestObject,
+					0x21 => Filter::NextObject,
 				);
 			}
 		}
@@ -425,7 +434,7 @@ impl Message for SubscribeUpdate {
 				decode_params!(r, version,
 					0x10 => forward: Option<bool>,
 					0x20 => subscriber_priority: Option<u8>,
-					0x21 => _filter_type: Option<FilterType>,
+					0x21 => _filter: Option<Filter>,
 				);
 
 				let subscriber_priority = subscriber_priority.unwrap_or(128);
@@ -449,7 +458,7 @@ impl Message for SubscribeUpdate {
 				decode_params!(r, version,
 					0x10 => forward: Option<bool>,
 					0x20 => subscriber_priority: Option<u8>,
-					0x21 => _filter_type: Option<FilterType>,
+					0x21 => _filter: Option<Filter>,
 				);
 
 				let subscriber_priority = subscriber_priority.unwrap_or(128);
@@ -492,7 +501,9 @@ mod tests {
 			track_name: "video".into(),
 			subscriber_priority: 128,
 			group_order: GroupOrder::Descending,
-			filter_type: FilterType::LargestObject,
+			filter: Filter::NextObject,
+			fill: None,
+			properties_wanted: true,
 		};
 
 		let encoded = encode_message(&msg, Version::Draft14);
@@ -512,7 +523,9 @@ mod tests {
 			track_name: "video".into(),
 			subscriber_priority: 128,
 			group_order: GroupOrder::Descending,
-			filter_type: FilterType::LargestObject,
+			filter: Filter::NextObject,
+			fill: None,
+			properties_wanted: true,
 		};
 
 		let encoded = encode_message(&msg, Version::Draft15);
@@ -549,7 +562,7 @@ mod tests {
 	/// SUBSCRIBE.
 	#[test]
 	fn rendezvous_timeout_is_accepted_and_ignored() {
-		for version in [Version::Draft17, Version::Draft18, Version::Draft19] {
+		for version in [Version::Draft17, Version::Draft18, Version::Draft19, Version::Draft20] {
 			for millis in [0, 5000] {
 				let encoded = subscribe_with_rendezvous(millis, version);
 				let msg: Subscribe = decode_message(&encoded, version)
@@ -600,10 +613,12 @@ mod tests {
 			track_name: "video".into(),
 			subscriber_priority: 128,
 			group_order: GroupOrder::Descending,
-			filter_type: FilterType::LargestObject,
+			filter: Filter::NextObject,
+			fill: None,
+			properties_wanted: true,
 		};
 
-		for version in [Version::Draft17, Version::Draft18, Version::Draft19] {
+		for version in [Version::Draft17, Version::Draft18, Version::Draft19, Version::Draft20] {
 			// The reader has to be able to see a 0x04, or its absence below proves nothing.
 			assert_eq!(
 				first_param_key(&subscribe_with_rendezvous(5000, version), version),
@@ -627,7 +642,9 @@ mod tests {
 			track_name: "audio".into(),
 			subscriber_priority: 255,
 			group_order: GroupOrder::Descending,
-			filter_type: FilterType::LargestObject,
+			filter: Filter::NextObject,
+			fill: None,
+			properties_wanted: true,
 		};
 
 		let encoded = encode_message(&msg, Version::Draft14);
@@ -706,7 +723,7 @@ mod tests {
 	}
 
 	#[test]
-	fn test_subscribe_rejects_invalid_filter_type() {
+	fn test_subscribe_rejects_invalid_filter() {
 		#[rustfmt::skip]
 		let invalid_bytes = vec![
 			0x01, // subscribe_id
@@ -789,7 +806,9 @@ mod tests {
 			track_name: "video".into(),
 			subscriber_priority: 128,
 			group_order: GroupOrder::Descending,
-			filter_type: FilterType::LargestObject,
+			filter: Filter::NextObject,
+			fill: None,
+			properties_wanted: true,
 		};
 
 		let encoded = encode_message(&msg, Version::Draft17);
@@ -844,7 +863,9 @@ mod tests {
 			track_name: "video".into(),
 			subscriber_priority: 128,
 			group_order: GroupOrder::Descending,
-			filter_type: FilterType::LargestObject,
+			filter: Filter::NextObject,
+			fill: None,
+			properties_wanted: true,
 		};
 
 		let encoded = encode_message(&msg, Version::Draft18);

--- a/rs/moq-net/src/ietf/subscribe.rs
+++ b/rs/moq-net/src/ietf/subscribe.rs
@@ -170,12 +170,19 @@ impl Message for Subscribe<'_> {
 				// A subscriber there simply joins mid-group, which is what it did all along.
 				let fill = self.fill.filter(|_| Filter::is_draft20(version));
 
+				// INCLUDE_PROPERTIES defaults to 1, so only the opt-out is worth bytes. It
+				// arrived in draft-20, and an older peer would read it as an unknown
+				// parameter, which is a protocol violation.
+				let include_properties =
+					(!self.properties_wanted && Filter::is_draft20(version)).then_some(IncludeProperties(false));
+
 				encode_params!(w, version,
 					0x10 => true,
 					0x20 => self.subscriber_priority,
 					0x21 => self.filter,
 					0x22 => self.group_order,
 					0x23 => fill,
+					0x35 => include_properties,
 				);
 			}
 		}
@@ -720,6 +727,34 @@ mod tests {
 		let decoded: Unsubscribe = decode_message(&encoded, Version::Draft14).unwrap();
 
 		assert_eq!(decoded.request_id, RequestId(999));
+	}
+
+	/// The opt-out has to reach the wire, or a subscriber that asked for no Track
+	/// Properties decodes back as wanting them.
+	#[test]
+	fn include_properties_round_trips() {
+		for (wanted, version) in [
+			(false, Version::Draft20),
+			(true, Version::Draft20),
+			// Older drafts have no such parameter, so the opt-out is dropped rather than
+			// sent as one they would treat as a protocol violation.
+			(true, Version::Draft19),
+		] {
+			let msg = Subscribe {
+				request_id: RequestId(1),
+				track_namespace: crate::Path::new("broadcast"),
+				track_name: "video".into(),
+				subscriber_priority: 128,
+				group_order: GroupOrder::Descending,
+				filter: Filter::NextObject,
+				fill: None,
+				properties_wanted: wanted,
+			};
+
+			let encoded = encode_message(&msg, version);
+			let decoded: Subscribe = decode_message(&encoded, version).unwrap();
+			assert_eq!(decoded.properties_wanted, wanted, "{version}");
+		}
 	}
 
 	#[test]

--- a/rs/moq-net/src/ietf/subscribe.rs
+++ b/rs/moq-net/src/ietf/subscribe.rs
@@ -199,6 +199,14 @@ pub struct SubscribeOk {
 	pub request_id: Option<RequestId>,
 	pub track_alias: u64,
 
+	/// The largest Location in the track (LARGEST_OBJECT, 0x09), which the spec requires
+	/// once the track has content. It is what a subscriber sizes a fill against.
+	///
+	/// Encoded on draft-20 only: the parameter is legal on earlier drafts too, but peers
+	/// built before we sent it reject an unexpected SUBSCRIBE_OK parameter by closing the
+	/// session, so emitting it there would break existing deployments over a hint.
+	pub largest: Option<Location>,
+
 	/// Metadata about the track, sent as Track Properties (draft-17+).
 	pub properties: Properties,
 }
@@ -237,7 +245,11 @@ impl Message for SubscribeOk {
 					_ => None,
 				};
 
+				// See the field doc for why LARGEST_OBJECT stays draft-20 only.
+				let largest = self.largest.filter(|_| Filter::is_draft20(version));
+
 				encode_params!(w, version,
+					0x09 => largest,
 					0x22 => group_order,
 				);
 
@@ -277,31 +289,29 @@ impl Message for SubscribeOk {
 			_ => {
 				// GROUP_ORDER is only legal here through draft-15, but keep accepting it so a
 				// peer that still sends it doesn't have its session torn down over a hint.
-				let group_order = match version {
-					Version::Draft15 | Version::Draft16 => {
-						// LARGEST_OBJECT is required here once the track has content, but
-						// the session model does not currently expose the location.
-						decode_params!(r, version,
-							0x09 => _largest_location: Option<Location>,
-							0x22 => group_order: Option<GroupOrder>,
-						);
-						group_order
-					}
-					_ => {
-						decode_params!(r, version,
-							0x22 => group_order: Option<GroupOrder>,
-						);
-						group_order
-					}
-				};
+				// LARGEST_OBJECT is required on every draft once the track has content, so
+				// rejecting it would tear down a session over a parameter compliant
+				// publishers must send.
+				decode_params!(r, version,
+					0x09 => largest: Option<Location>,
+					0x22 => group_order: Option<GroupOrder>,
+				);
 				properties = Properties::decode(r, version)?;
 				properties.group_order = properties.group_order.or(group_order);
+
+				return Ok(Self {
+					request_id,
+					track_alias,
+					largest,
+					properties,
+				});
 			}
 		}
 
 		Ok(Self {
 			request_id,
 			track_alias,
+			largest: None,
 			properties,
 		})
 	}
@@ -678,6 +688,7 @@ mod tests {
 		let msg = SubscribeOk {
 			request_id: Some(RequestId(42)),
 			track_alias: 42,
+			largest: None,
 			properties: Properties::default(),
 		};
 
@@ -696,7 +707,45 @@ mod tests {
 
 			assert_eq!(decoded.request_id, Some(RequestId(4)));
 			assert_eq!(decoded.track_alias, 4);
+			assert_eq!(decoded.largest, Some(Location { group: 5, object: 0 }), "{version}");
 		}
+	}
+
+	/// LARGEST_OBJECT is required in SUBSCRIBE_OK once the track has content, so a
+	/// draft-17+ decoder must accept it rather than tearing down the session over a
+	/// parameter compliant publishers have to send. The empty Track Properties block
+	/// follows the parameters.
+	#[test]
+	fn test_subscribe_ok_accepts_largest_object_draft17_on() {
+		let payload = [0x04, 0x01, 0x09, 0x02, 0x05, 0x00];
+		for version in [Version::Draft17, Version::Draft18, Version::Draft19, Version::Draft20] {
+			let decoded: SubscribeOk = decode_message(&payload, version).unwrap();
+
+			assert_eq!(decoded.request_id, None, "{version}");
+			assert_eq!(decoded.track_alias, 4, "{version}");
+			assert_eq!(decoded.largest, Some(Location { group: 5, object: 0 }), "{version}");
+		}
+	}
+
+	/// The encoder emits LARGEST_OBJECT on draft-20 only: it is legal earlier, but peers
+	/// built before we sent it reject an unexpected SUBSCRIBE_OK parameter by closing the
+	/// session.
+	#[test]
+	fn test_subscribe_ok_largest_object_round_trips_on_draft20_only() {
+		let msg = SubscribeOk {
+			request_id: None,
+			track_alias: 7,
+			largest: Some(Location { group: 9, object: 3 }),
+			properties: Properties::default(),
+		};
+
+		let encoded = encode_message(&msg, Version::Draft20);
+		let decoded: SubscribeOk = decode_message(&encoded, Version::Draft20).unwrap();
+		assert_eq!(decoded.largest, Some(Location { group: 9, object: 3 }));
+
+		let encoded = encode_message(&msg, Version::Draft19);
+		let decoded: SubscribeOk = decode_message(&encoded, Version::Draft19).unwrap();
+		assert_eq!(decoded.largest, None, "draft-19 must not carry the parameter");
 	}
 
 	#[test]
@@ -704,6 +753,7 @@ mod tests {
 		let msg = SubscribeOk {
 			request_id: Some(RequestId(42)),
 			track_alias: 42,
+			largest: None,
 			properties: Properties::default(),
 		};
 
@@ -894,6 +944,7 @@ mod tests {
 		let msg = SubscribeOk {
 			request_id: None,
 			track_alias: 42,
+			largest: None,
 			properties: Properties::default(),
 		};
 
@@ -951,6 +1002,7 @@ mod tests {
 		let msg = SubscribeOk {
 			request_id: None,
 			track_alias: 42,
+			largest: None,
 			properties: Properties::default(),
 		};
 
@@ -970,6 +1022,7 @@ mod tests {
 		let msg = SubscribeOk {
 			request_id: None,
 			track_alias: 42,
+			largest: None,
 			properties: Properties {
 				timescale: None,
 				group_order: Some(GroupOrder::Descending),
@@ -996,6 +1049,7 @@ mod tests {
 		let msg = SubscribeOk {
 			request_id: Some(RequestId(7)),
 			track_alias: 42,
+			largest: None,
 			properties: Properties {
 				timescale: None,
 				group_order: Some(GroupOrder::Descending),

--- a/rs/moq-net/src/ietf/subscribe.rs
+++ b/rs/moq-net/src/ietf/subscribe.rs
@@ -93,7 +93,9 @@ impl Message for Subscribe<'_> {
 			}
 			_ => {
 				decode_params!(r, version,
+					0x02 => _object_delivery_timeout: Option<u64>,
 					0x04 => rendezvous_timeout: Option<u64>,
+					0x06 => _subgroup_delivery_timeout: Option<u64>,
 					0x10 => forward: Option<bool>,
 					0x20 => subscriber_priority: Option<u8>,
 					0x21 => filter: Option<Filter>,
@@ -439,6 +441,8 @@ impl Message for SubscribeUpdate {
 				let request_id = RequestId::decode(r, version)?;
 				let subscription_request_id = Some(RequestId::decode(r, version)?);
 				decode_params!(r, version,
+					0x02 => _object_delivery_timeout: Option<u64>,
+					0x06 => _subgroup_delivery_timeout: Option<u64>,
 					0x10 => forward: Option<bool>,
 					0x20 => subscriber_priority: Option<u8>,
 					0x21 => _filter: Option<Filter>,
@@ -463,6 +467,8 @@ impl Message for SubscribeUpdate {
 					let _required_request_id_delta = u64::decode(r, version)?;
 				}
 				decode_params!(r, version,
+					0x02 => _object_delivery_timeout: Option<u64>,
+					0x06 => _subgroup_delivery_timeout: Option<u64>,
 					0x10 => forward: Option<bool>,
 					0x20 => subscriber_priority: Option<u8>,
 					0x21 => _filter: Option<Filter>,
@@ -727,6 +733,27 @@ mod tests {
 		let decoded: Unsubscribe = decode_message(&encoded, Version::Draft14).unwrap();
 
 		assert_eq!(decoded.request_id, RequestId(999));
+	}
+
+	/// Every parameter the draft lets a message carry has to parse, even the ones we act on
+	/// nowhere: an unlisted key fails the whole message, which tears the session down
+	/// instead of letting the request reach its answer.
+	#[test]
+	fn subscribe_accepts_the_delivery_timeouts() -> Result<(), EncodeError> {
+		for version in [Version::Draft19, Version::Draft20] {
+			let mut body = Vec::new();
+			RequestId(1).encode(&mut body, version)?;
+			encode_namespace(&mut body, &crate::Path::new("broadcast"), version)?;
+			"video".encode(&mut body, version)?;
+			encode_params!(&mut body, version,
+				0x02 => 5000u64,
+				0x06 => 9000u64,
+			);
+
+			let mut buf = bytes::Bytes::from(body);
+			Subscribe::decode_msg(&mut buf, version).unwrap_or_else(|e| panic!("{version}: {e}"));
+		}
+		Ok(())
 	}
 
 	/// The opt-out has to reach the wire, or a subscriber that asked for no Track

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -2402,6 +2402,7 @@ mod tests {
 						_ => None,
 					},
 					track_alias: 7,
+					largest: None,
 					properties: Default::default(),
 				})
 				.await
@@ -3610,12 +3611,17 @@ mod tests {
 /// Object. Earlier drafts have no such spelling, so they keep asking for the next Object
 /// and joining mid-group, exactly as they always did.
 ///
-/// No fill is requested. A fill is capped at Largest Object, so pairing one with a live
-/// subscription splits a single group across two streams: the fill carries the head, the
-/// subscription the tail, and the two cannot be reassembled into one group here. Asking
-/// for the current group directly keeps a group whole and on one stream, which is what
-/// moq-lite is built around. Fills are unsupported in both directions: we request none, we
-/// do not serve one a peer asks for, and we refuse an incoming fetch stream.
+/// No fill is requested. The draft's own current-group join is Next Object plus a
+/// `StartGroup=1` fill, which splits the group across two streams: the fill carries the
+/// head on a fetch stream and the subscription the tail. Reassembling those into the one
+/// group producer the model expects means buffering the live tail until the fill
+/// finishes, which this subscriber does not do yet. Relative(1) instead asks for the
+/// whole group on the subscription: our own publisher replays it from the cache since it
+/// is inside the requested range, while a strict publisher only delivers from the next
+/// published object, whose mid-group stream [`next_object_id`] then drops, degrading the
+/// join to the next group boundary. Since we never request a fill, an incoming fetch
+/// stream answers no request of ours and is refused; the publisher side does serve fills
+/// (see `publisher::run_fill`).
 fn subscribe_filter(start: Option<u64>, end: Option<u64>, version: Version) -> Filter {
 	if !Filter::is_draft20(version) {
 		return Filter::NextObject;

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -3615,8 +3615,9 @@ mod tests {
 /// subscription splits a single group across two streams: the fill carries the head, the
 /// subscription the tail, and the two cannot be reassembled into one group here. Asking
 /// for the current group directly keeps a group whole and on one stream, which is what
-/// moq-lite is built around. We still serve a fill a peer asks us for, and still read one
-/// a peer sends us.
+/// moq-lite is built around. We still serve a fill a peer asks us for; we do not read one,
+/// since having requested none, an incoming fetch stream would duplicate a group the
+/// subscription is already delivering.
 fn subscribe_filter(start: Option<u64>, end: Option<u64>, version: Version) -> Filter {
 	if !Filter::is_draft20(version) {
 		return Filter::NextObject;

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -8,7 +8,7 @@ use crate::{
 	Error, Path, PathOwned, Timescale, broadcast,
 	coding::{Reader, Stream},
 	frame, group,
-	ietf::{self, Control, FilterType, GroupOrder, RequestId},
+	ietf::{self, Control, Fill, Filter, GroupOrder, RequestId},
 	origin, track,
 	util::{MaybeBoxedExt, MaybeSendBox, TaskSet, Tasks},
 };
@@ -1472,6 +1472,13 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		broadcast: &Path<'_>,
 		track: &track::Producer,
 	) -> Result<(), Error> {
+		let subscription = track.subscription();
+		let (filter, fill) = subscribe_filter(
+			subscription.as_ref().and_then(|s| s.group_start),
+			subscription.as_ref().and_then(|s| s.group_end),
+			self.version,
+		);
+
 		stream.writer.encode(&ietf::Subscribe::ID).await?;
 		stream
 			.writer
@@ -1481,7 +1488,9 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				track_name: track.name().into(),
 				subscriber_priority: super::priority::to_wire(track.subscription().map(|s| s.priority).unwrap_or(0)),
 				group_order: GroupOrder::Descending,
-				filter_type: FilterType::LargestObject,
+				filter,
+				fill,
+				properties_wanted: true,
 			})
 			.await?;
 		Ok(())
@@ -1513,6 +1522,65 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				Err(Error::Cancel)
 			}
 			_ => Err(Error::UnexpectedMessage),
+		}
+	}
+
+	/// Read a fill fetch stream, which draft-20 opens in response to FILL_PARAMETERS.
+	///
+	/// The FETCH_HEADER names the SUBSCRIBE's Request ID rather than a track alias, so the
+	/// subscription resolves directly instead of waiting on the alias table.
+	///
+	/// We only ever ask to fill the current group, so the stream carries exactly one group.
+	/// A second group means the publisher answered a request we did not make, and its
+	/// objects would land in the wrong group here.
+	pub async fn recv_fill(&mut self, stream: &mut Reader<S::RecvStream, Version>) -> Result<(), Error> {
+		// The dispatcher only peeked the type, so it is still on the stream. Unlike
+		// SUBGROUP_HEADER, FETCH_HEADER carries no flags packed into it.
+		// Only draft-20 has a fill. A fetch stream on any earlier version answers a
+		// standalone FETCH, which we never send and cannot serve.
+		if !Filter::is_draft20(self.version) {
+			return Err(Error::Unsupported);
+		}
+
+		let kind: u64 = stream.decode().await?;
+		debug_assert_eq!(kind, ietf::FetchHeader::TYPE);
+
+		let header: ietf::FetchHeader = stream.decode().await?;
+
+		let (mut track, timescale) = {
+			let state = self.state.lock();
+			let subscribe = state.subscribes.get(&header.request_id).ok_or(Error::NotFound)?;
+			(subscribe.producer.clone(), subscribe.timescale)
+		};
+
+		let mut group: Option<group::Producer> = None;
+		let res = {
+			let watch = track.clone();
+			let mut serve = std::pin::pin!(run_fill(stream, &mut track, timescale, &mut group, self.version));
+			kio::wait(|waiter| {
+				if let Poll::Ready(err) = watch.poll_closed(waiter) {
+					return Poll::Ready(Err(err));
+				}
+				waiter.poll_future(serve.as_mut())
+			})
+			.await
+		};
+
+		// A fill that dies part way leaves a group with a hole in it, which moq-lite has no
+		// way to represent, so the group is aborted rather than finished short.
+		match (res, group) {
+			(Ok(()), Some(mut group)) => {
+				group.finish()?;
+				Ok(())
+			}
+			(Ok(()), None) => Ok(()),
+			(Err(err), group) => {
+				if let Some(group) = group {
+					tracing::debug!(%err, group = %group.sequence, "fill error");
+					let _ = group.abort(err.clone());
+				}
+				Err(err)
+			}
 		}
 	}
 
@@ -2069,7 +2137,7 @@ mod tests {
 	/// turns a routine unsubscribe into an endless "unknown track alias" stream.
 	#[tokio::test(start_paused = true)]
 	async fn cancelling_a_subscription_stops_the_publisher() {
-		for version in [Version::Draft16, Version::Draft19] {
+		for version in [Version::Draft16, Version::Draft20] {
 			let log = cancel_a_subscription(version).await;
 			// CANCELLED, not the moq-lite cancel code: 0 on this wire is INTERNAL_ERROR, so a
 			// routine unsubscribe would read to the publisher as a fault on our side.
@@ -2369,7 +2437,7 @@ mod tests {
 	/// fallback, so a reset here means the cancellation never landed.
 	#[tokio::test(start_paused = true)]
 	async fn cancelling_does_not_reset_away_the_unsubscribe() {
-		for version in [Version::Draft16, Version::Draft19] {
+		for version in [Version::Draft16, Version::Draft20] {
 			let log = cancel_a_subscription(version).await;
 			assert!(
 				log.resets().is_empty(),
@@ -3592,5 +3660,411 @@ mod tests {
 			1,
 			"the decline reaches the peer as NOT_SUPPORTED"
 		);
+	}
+}
+
+/// The Location Filter, and any fill, that expresses a moq-lite subscription's group range.
+///
+/// moq-lite joins a track at the *start* of the current group, which is a decodable point.
+/// No Location Filter can say that on its own: the filter only restricts which newly
+/// published Objects are forwarded, it never asks for ones already published. So every past
+/// group we want, the current one included, is named as a fill too, which is the draft's own
+/// recipe for joining at the current group.
+///
+/// Only draft-20 has a fill, and it is also the first version that can name a group relative
+/// to a live edge the subscriber has not learned yet. Earlier drafts keep asking for the next
+/// Object and joining mid-group, exactly as they always did: their absolute filters were
+/// never honored by the publishers we talk to, so naming one now would change what an
+/// existing peer sends us.
+fn subscribe_filter(start: Option<u64>, end: Option<u64>, version: Version) -> (Filter, Option<Fill>) {
+	if !Filter::is_draft20(version) {
+		return (Filter::NextObject, None);
+	}
+
+	let fill = |filter| Some(Fill { filter });
+
+	match start {
+		// Live. Ask for the next Object, and fill the current group from its start.
+		None => (Filter::NextObject, fill(Filter::Relative(1))),
+		// The whole track. An absent filter is unrestricted, and an empty fill scope asks
+		// for everything up to Largest Object.
+		Some(0) if end.is_none() => (Filter::Unfiltered, fill(Filter::Unfiltered)),
+		Some(group) => {
+			let range = Filter::Absolute {
+				start: ietf::Location { group, object: 0 },
+				end,
+			};
+			(range, fill(range))
+		}
+	}
+}
+
+#[cfg(test)]
+mod filter_tests {
+	use super::*;
+
+	/// The canonical live join: Next Object on the subscription, with the current group
+	/// filled in from its start so playback has a decodable point.
+	#[test]
+	fn live_fills_the_current_group() {
+		let (filter, fill) = subscribe_filter(None, None, Version::Draft20);
+		assert_eq!(filter, Filter::NextObject);
+		assert_eq!(
+			fill,
+			Some(Fill {
+				filter: Filter::Relative(1)
+			})
+		);
+	}
+
+	/// A past start is named twice: once to restrict what the subscription forwards, and
+	/// once as the fill that actually retrieves it.
+	#[test]
+	fn a_past_start_is_also_a_fill() {
+		let range = Filter::Absolute {
+			start: ietf::Location { group: 7, object: 0 },
+			end: Some(9),
+		};
+		assert_eq!(
+			subscribe_filter(Some(7), Some(9), Version::Draft20),
+			(range, Some(Fill { filter: range }))
+		);
+	}
+
+	/// The whole track: nothing to restrict, and an empty fill scope asks for all of it.
+	#[test]
+	fn the_whole_track_is_unfiltered() {
+		assert_eq!(
+			subscribe_filter(Some(0), None, Version::Draft20),
+			(
+				Filter::Unfiltered,
+				Some(Fill {
+					filter: Filter::Unfiltered
+				})
+			)
+		);
+	}
+
+	/// Earlier drafts have no fill and never had their absolute filters honored, so they
+	/// keep asking for exactly what they always did.
+	#[test]
+	fn older_drafts_ask_for_the_next_object() {
+		for version in [Version::Draft14, Version::Draft16, Version::Draft19] {
+			assert_eq!(
+				subscribe_filter(Some(7), Some(9), version),
+				(Filter::NextObject, None),
+				"{version}"
+			);
+		}
+	}
+}
+
+/// Serialization Flags on a fetch object (draft-20 section 11.4.4.1).
+mod fill_flags {
+	/// The two low bits select how the Subgroup ID is encoded.
+	pub const SUBGROUP_MASK: u64 = 0x03;
+	/// Subgroup ID is zero.
+	pub const SUBGROUP_ZERO: u64 = 0x00;
+	/// Subgroup ID is the prior Object's.
+	pub const SUBGROUP_PRIOR: u64 = 0x01;
+	/// Subgroup ID is present as its own field.
+	pub const SUBGROUP_PRESENT: u64 = 0x03;
+
+	pub const OBJECT_DELTA: u64 = 0x04;
+	pub const GROUP_DELTA: u64 = 0x08;
+	pub const PRIORITY: u64 = 0x10;
+	pub const PROPERTIES: u64 = 0x20;
+	pub const DATAGRAM: u64 = 0x40;
+
+	/// Every bit with a meaning. A set bit outside this set is a protocol violation.
+	pub const KNOWN: u64 = SUBGROUP_MASK | OBJECT_DELTA | GROUP_DELTA | PRIORITY | PROPERTIES | DATAGRAM;
+}
+
+/// Read the objects on a fill fetch stream into a single group.
+///
+/// `group` is threaded in from the caller so a stream that dies part way still leaves the
+/// group it had opened where the caller can abort it. It is created lazily, because the
+/// group id arrives with the first object rather than in the header.
+///
+/// The subset accepted here is what moq-lite can represent: one group, subgroup zero, and
+/// objects numbered from zero with no gaps. Anything else resets this stream and leaves the
+/// live subscription running, so a fill we cannot read costs the head of a group, not the
+/// subscription.
+async fn run_fill<R: web_transport_trait::RecvStream>(
+	stream: &mut Reader<R, Version>,
+	track: &mut track::Producer,
+	timescale: Option<Timescale>,
+	group: &mut Option<group::Producer>,
+	version: Version,
+) -> Result<(), Error> {
+	let mut prior: Option<(u64, u64)> = None;
+
+	while let Some(flags) = stream.decode_maybe::<u64>().await? {
+		// The three End of Range markers are the only legal values above the flag range.
+		// Each one declares a span of objects that will not be serialized, which is a gap,
+		// and moq-lite tracks have none.
+		if flags & !fill_flags::KNOWN != 0 {
+			tracing::warn!(flags, "unsupported fetch object flags, dropping fill");
+			return Err(Error::Unsupported);
+		}
+
+		// A datagram-preference object has no subgroup, so it cannot join one here.
+		if flags & fill_flags::DATAGRAM != 0 {
+			tracing::warn!("datagram object on a fill, dropping fill");
+			return Err(Error::Unsupported);
+		}
+
+		let group_delta = match flags & fill_flags::GROUP_DELTA != 0 {
+			true => Some(stream.decode::<u64>().await?),
+			false => None,
+		};
+
+		let subgroup = match flags & fill_flags::SUBGROUP_MASK {
+			fill_flags::SUBGROUP_ZERO => 0,
+			// The prior object's, which this loop only ever lets be zero.
+			fill_flags::SUBGROUP_PRIOR if prior.is_some() => 0,
+			fill_flags::SUBGROUP_PRESENT => stream.decode::<u64>().await?,
+			// Prior-plus-one is always non-zero, and a prior-relative mode on the first
+			// object has no prior to read.
+			_ => {
+				tracing::warn!(flags, "unsupported subgroup on a fill, dropping fill");
+				return Err(Error::Unsupported);
+			}
+		};
+		if subgroup != 0 {
+			tracing::warn!(subgroup, "subgroup ID is not supported, dropping fill");
+			return Err(Error::Unsupported);
+		}
+
+		let object_delta = match flags & fill_flags::OBJECT_DELTA != 0 {
+			true => Some(stream.decode::<u64>().await?),
+			false => None,
+		};
+
+		if flags & fill_flags::PRIORITY != 0 {
+			let _priority: u8 = stream.decode().await?;
+		}
+
+		// Object Properties carry the frame's presentation timestamp in the units the
+		// track declared, exactly as the per-object extensions do on a subgroup.
+		let timestamp = match (flags & fill_flags::PROPERTIES != 0, timescale) {
+			(true, Some(timescale)) => {
+				let size: usize = stream.decode().await?;
+				let mut properties = stream.read_exact(size).await?;
+				ietf::decode_object_time(&mut properties, timescale, version)?
+			}
+			(true, None) => {
+				let size: usize = stream.decode().await?;
+				stream.read_exact(size).await?;
+				None
+			}
+			(false, _) => None,
+		};
+
+		let (sequence, object) = match (prior, group_delta, object_delta) {
+			// The first object carries both deltas, and they are the absolute ids.
+			(None, Some(sequence), Some(object)) => (sequence, object),
+			(None, _, _) => {
+				tracing::warn!(flags, "first fill object must carry both deltas, dropping fill");
+				return Err(Error::Unsupported);
+			}
+			// A group delta after the first object names a second group. We asked to fill
+			// one, so the rest of this stream belongs somewhere we cannot put it.
+			(Some(_), Some(_), _) => {
+				tracing::warn!("fill carried more than one group, dropping fill");
+				return Err(Error::Unsupported);
+			}
+			// Within the group: an explicit delta from the prior id, or implicitly one on.
+			(Some((sequence, prior_object)), None, delta) => {
+				let object = prior_object
+					.checked_add(delta.unwrap_or(1))
+					.ok_or(Error::Decode(crate::coding::DecodeError::BoundsExceeded))?;
+				(sequence, object)
+			}
+		};
+
+		// moq-lite groups start at object zero and never skip one, so a gap here would
+		// silently renumber every frame after it.
+		let expected = prior.map_or(0, |(_, prior_object)| prior_object + 1);
+		if object != expected {
+			tracing::warn!(object, expected, "gap in a fill, dropping fill");
+			return Err(Error::Unsupported);
+		}
+		prior = Some((sequence, object));
+
+		if group.is_none() {
+			// Stats (groups/frames/bytes) are counted in the model as the group is
+			// written, through the tagged `track::Producer`.
+			*group = Some(track.create_group(group::Info { sequence })?);
+		}
+		let group = group.as_mut().expect("group was just created");
+
+		// A fetch object has no Object Status: the draft says it is only present on a
+		// subscription, so a zero length here is an empty object rather than a status.
+		let size: u64 = stream.decode().await?;
+		let timestamp = timestamp.unwrap_or_else(crate::Timestamp::now);
+
+		// `create_frame` is the allocation chokepoint and rejects an oversized `size`
+		// before allocating, so no pre-check is needed.
+		let mut frame = group.create_frame(frame::Info { size, timestamp })?;
+		while frame.remaining() > 0 {
+			match stream.read_chunk(frame.remaining()).await? {
+				Some(chunk) if !chunk.is_empty() => frame.write(chunk)?,
+				_ => {
+					let _ = frame.abort(Error::WrongSize);
+					return Err(Error::WrongSize);
+				}
+			}
+		}
+		frame.finish()?;
+	}
+
+	Ok(())
+}
+
+#[cfg(test)]
+mod fill_tests {
+	use super::*;
+	use crate::coding::Encode as _;
+	use crate::lite::test_transport::SinkError;
+
+	/// A stream that hands back a fixed script and then reports EOF, so `run_fill` can be
+	/// driven all the way through its exit path.
+	struct Script(Vec<u8>);
+
+	impl web_transport_trait::RecvStream for Script {
+		type Error = SinkError;
+
+		async fn read(&mut self, dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
+			if self.0.is_empty() {
+				return Ok(None);
+			}
+			let take = dst.len().min(self.0.len());
+			dst[..take].copy_from_slice(&self.0[..take]);
+			self.0.drain(..take);
+			Ok(Some(take))
+		}
+
+		fn stop(&mut self, _code: u32) {}
+
+		async fn closed(&mut self) -> Result<(), Self::Error> {
+			std::future::pending().await
+		}
+	}
+
+	fn varint(out: &mut Vec<u8>, v: u64) {
+		v.encode(out, Version::Draft20).expect("varint");
+	}
+
+	/// One object: flags, then the fields those flags say are present, then the payload.
+	fn object(out: &mut Vec<u8>, flags: u64, fields: &[u64], payload: &[u8]) {
+		varint(out, flags);
+		for field in fields {
+			varint(out, *field);
+		}
+		varint(out, payload.len() as u64);
+		out.extend_from_slice(payload);
+	}
+
+	/// The first object carries both deltas, which are the absolute Group and Object ids.
+	const FIRST: u64 = fill_flags::GROUP_DELTA | fill_flags::OBJECT_DELTA;
+	/// A follow-on object in the same group and subgroup, one object id later.
+	const NEXT: u64 = 0;
+
+	/// The track producer comes back with the result: dropping it would close the track,
+	/// and the consumer would then see a clean end instead of the group just written.
+	async fn run(
+		script: Vec<u8>,
+	) -> (
+		Result<(), Error>,
+		Option<group::Producer>,
+		track::Producer,
+		track::Subscriber,
+	) {
+		let mut track = track::Producer::new(std::sync::Arc::new(crate::broadcast::Info::default()), "video", None);
+		let consumer = track.subscribe(None);
+		let mut reader = Reader::new(Script(script), Version::Draft20);
+		let mut group = None;
+		let res = run_fill(&mut reader, &mut track, None, &mut group, Version::Draft20).await;
+		(res, group, track, consumer)
+	}
+
+	#[tokio::test]
+	async fn reads_one_group() {
+		let mut script = Vec::new();
+		object(&mut script, FIRST, &[7, 0], b"first");
+		object(&mut script, NEXT, &[], b"second");
+
+		let (res, group, _track, mut consumer) = run(script).await;
+		res.expect("fill should decode");
+
+		let mut group = group.expect("a group was opened");
+		assert_eq!(group.sequence, 7, "the first object's deltas are absolute ids");
+		group.finish().expect("finish");
+
+		let mut group = consumer.recv_group().await.expect("group").expect("some");
+		let first = group.read_frame().await.unwrap().unwrap();
+		assert_eq!(first.payload.as_ref(), &b"first"[..]);
+		let second = group.read_frame().await.unwrap().unwrap();
+		assert_eq!(second.payload.as_ref(), &b"second"[..]);
+	}
+
+	/// We ask to fill exactly one group, so a second one is a request we never made and
+	/// its objects would land in the wrong group.
+	#[tokio::test]
+	async fn rejects_a_second_group() {
+		let mut script = Vec::new();
+		object(&mut script, FIRST, &[7, 0], b"first");
+		object(&mut script, FIRST, &[8, 0], b"next group");
+
+		let (res, ..) = run(script).await;
+		assert!(matches!(res, Err(Error::Unsupported)), "{res:?}");
+	}
+
+	/// moq-lite groups never skip an object, so a gap would silently renumber every frame
+	/// after it.
+	#[tokio::test]
+	async fn rejects_a_gap() {
+		let mut script = Vec::new();
+		object(&mut script, FIRST, &[7, 0], b"first");
+		// An explicit delta of 2 skips object 1.
+		object(&mut script, fill_flags::OBJECT_DELTA, &[2], b"third");
+
+		let (res, ..) = run(script).await;
+		assert!(matches!(res, Err(Error::Unsupported)), "{res:?}");
+	}
+
+	/// The first object has no prior to reference, so it must carry both deltas.
+	#[tokio::test]
+	async fn rejects_a_first_object_without_deltas() {
+		let mut script = Vec::new();
+		object(&mut script, NEXT, &[], b"nope");
+
+		let (res, ..) = run(script).await;
+		assert!(matches!(res, Err(Error::Unsupported)), "{res:?}");
+	}
+
+	/// A set bit with no meaning is a protocol violation, and the End of Range markers all
+	/// declare a span that will not be serialized, which is a gap.
+	#[tokio::test]
+	async fn rejects_unknown_flags() {
+		for flags in [0x80, 0x8C, 0x10C, 0x20C] {
+			let mut script = Vec::new();
+			object(&mut script, flags, &[7, 0], b"");
+
+			let (res, ..) = run(script).await;
+			assert!(matches!(res, Err(Error::Unsupported)), "{flags:#x}: {res:?}");
+		}
+	}
+
+	/// A subgroup is not something moq-lite can represent, so an explicit non-zero one is
+	/// refused rather than flattened into the group.
+	#[tokio::test]
+	async fn rejects_a_subgroup() {
+		let mut script = Vec::new();
+		object(&mut script, FIRST | fill_flags::SUBGROUP_PRESENT, &[7, 3, 0], b"nope");
+
+		let (res, ..) = run(script).await;
+		assert!(matches!(res, Err(Error::Unsupported)), "{res:?}");
 	}
 }

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -1605,11 +1605,10 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		mut producer: group::Producer,
 		timescale: Option<Timescale>,
 	) -> Result<(), Error> {
+		let mut prior_object: Option<u64> = None;
+
 		while let Some(id_delta) = stream.decode_maybe::<u64>().await? {
-			if id_delta != 0 {
-				tracing::warn!(id_delta = %id_delta, "object ID delta is not supported, dropping stream");
-				return Err(Error::Unsupported);
-			}
+			prior_object = Some(next_object_id(prior_object, id_delta)?);
 
 			// Per-object extension headers may carry the frame's presentation timestamp
 			// (the Timestamp Object Property), in the units the track declared. A track
@@ -3632,6 +3631,69 @@ fn subscribe_filter(start: Option<u64>, end: Option<u64>, version: Version) -> F
 			start: ietf::Location { group, object: 0 },
 			end: end.map(|group| ietf::EndLocation { group, object: None }),
 		},
+	}
+}
+
+/// The absolute Object ID for a subgroup object, given the prior one and its delta.
+///
+/// The first object's delta is its absolute Object ID; every later one is the prior ID plus
+/// the delta plus one. moq-lite groups start at object 0 and never skip one, so anything
+/// else is refused: a group that starts partway through has a hole at the front, and a gap
+/// in the middle would renumber every frame after it. Checked against the ID rather than
+/// the header's FIRST_OBJECT bit, which is only the publisher's claim.
+fn next_object_id(prior: Option<u64>, delta: u64) -> Result<u64, Error> {
+	let object = match prior {
+		None => delta,
+		Some(prior) => prior
+			.checked_add(delta)
+			.and_then(|id| id.checked_add(1))
+			.ok_or(Error::Decode(crate::coding::DecodeError::BoundsExceeded))?,
+	};
+
+	let expected = prior.map_or(0, |prior| prior.saturating_add(1));
+	if object != expected {
+		tracing::warn!(object, expected, "object IDs must start at 0 and increment by 1");
+		return Err(Error::Unsupported);
+	}
+
+	Ok(object)
+}
+
+#[cfg(test)]
+mod object_id_tests {
+	use super::*;
+
+	/// A zero delta throughout is a group numbered from 0 with no gaps, which is the only
+	/// shape moq-lite can represent.
+	#[test]
+	fn accepts_sequential_ids_from_zero() {
+		let mut prior = None;
+		for expected in 0..4 {
+			let object = next_object_id(prior, 0).expect("sequential");
+			assert_eq!(object, expected);
+			prior = Some(object);
+		}
+	}
+
+	/// The first object's delta is its absolute Object ID, so a non-zero one means the
+	/// group starts partway through and has a hole at the front.
+	#[test]
+	fn rejects_a_group_that_does_not_start_at_zero() {
+		assert!(matches!(next_object_id(None, 6), Err(Error::Unsupported)));
+	}
+
+	/// A later delta skips objects, which would renumber every frame after it.
+	#[test]
+	fn rejects_a_gap() {
+		assert!(matches!(next_object_id(Some(0), 1), Err(Error::Unsupported)));
+		assert!(matches!(next_object_id(Some(3), 9), Err(Error::Unsupported)));
+	}
+
+	/// The running ID is bounded, and the draft makes an overflow a protocol violation
+	/// rather than something to wrap.
+	#[test]
+	fn rejects_an_overflow() {
+		assert!(next_object_id(Some(u64::MAX), 0).is_err());
 	}
 }
 

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -3614,9 +3614,8 @@ mod tests {
 /// subscription splits a single group across two streams: the fill carries the head, the
 /// subscription the tail, and the two cannot be reassembled into one group here. Asking
 /// for the current group directly keeps a group whole and on one stream, which is what
-/// moq-lite is built around. We still serve a fill a peer asks us for; we do not read one,
-/// since having requested none, an incoming fetch stream would duplicate a group the
-/// subscription is already delivering.
+/// moq-lite is built around. Fills are unsupported in both directions: we request none, we
+/// do not serve one a peer asks for, and we refuse an incoming fetch stream.
 fn subscribe_filter(start: Option<u64>, end: Option<u64>, version: Version) -> Filter {
 	if !Filter::is_draft20(version) {
 		return Filter::NextObject;

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -8,7 +8,7 @@ use crate::{
 	Error, Path, PathOwned, Timescale, broadcast,
 	coding::{Reader, Stream},
 	frame, group,
-	ietf::{self, Control, Fill, Filter, GroupOrder, RequestId},
+	ietf::{self, Control, Filter, GroupOrder, RequestId},
 	origin, track,
 	util::{MaybeBoxedExt, MaybeSendBox, TaskSet, Tasks},
 };
@@ -1473,7 +1473,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		track: &track::Producer,
 	) -> Result<(), Error> {
 		let subscription = track.subscription();
-		let (filter, fill) = subscribe_filter(
+		let filter = subscribe_filter(
 			subscription.as_ref().and_then(|s| s.group_start),
 			subscription.as_ref().and_then(|s| s.group_end),
 			self.version,
@@ -1489,7 +1489,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				subscriber_priority: super::priority::to_wire(track.subscription().map(|s| s.priority).unwrap_or(0)),
 				group_order: GroupOrder::Descending,
 				filter,
-				fill,
+				fill: None,
 				properties_wanted: true,
 			})
 			.await?;
@@ -1522,65 +1522,6 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				Err(Error::Cancel)
 			}
 			_ => Err(Error::UnexpectedMessage),
-		}
-	}
-
-	/// Read a fill fetch stream, which draft-20 opens in response to FILL_PARAMETERS.
-	///
-	/// The FETCH_HEADER names the SUBSCRIBE's Request ID rather than a track alias, so the
-	/// subscription resolves directly instead of waiting on the alias table.
-	///
-	/// We only ever ask to fill the current group, so the stream carries exactly one group.
-	/// A second group means the publisher answered a request we did not make, and its
-	/// objects would land in the wrong group here.
-	pub async fn recv_fill(&mut self, stream: &mut Reader<S::RecvStream, Version>) -> Result<(), Error> {
-		// The dispatcher only peeked the type, so it is still on the stream. Unlike
-		// SUBGROUP_HEADER, FETCH_HEADER carries no flags packed into it.
-		// Only draft-20 has a fill. A fetch stream on any earlier version answers a
-		// standalone FETCH, which we never send and cannot serve.
-		if !Filter::is_draft20(self.version) {
-			return Err(Error::Unsupported);
-		}
-
-		let kind: u64 = stream.decode().await?;
-		debug_assert_eq!(kind, ietf::FetchHeader::TYPE);
-
-		let header: ietf::FetchHeader = stream.decode().await?;
-
-		let (mut track, timescale) = {
-			let state = self.state.lock();
-			let subscribe = state.subscribes.get(&header.request_id).ok_or(Error::NotFound)?;
-			(subscribe.producer.clone(), subscribe.timescale)
-		};
-
-		let mut group: Option<group::Producer> = None;
-		let res = {
-			let watch = track.clone();
-			let mut serve = std::pin::pin!(run_fill(stream, &mut track, timescale, &mut group, self.version));
-			kio::wait(|waiter| {
-				if let Poll::Ready(err) = watch.poll_closed(waiter) {
-					return Poll::Ready(Err(err));
-				}
-				waiter.poll_future(serve.as_mut())
-			})
-			.await
-		};
-
-		// A fill that dies part way leaves a group with a hole in it, which moq-lite has no
-		// way to represent, so the group is aborted rather than finished short.
-		match (res, group) {
-			(Ok(()), Some(mut group)) => {
-				group.finish()?;
-				Ok(())
-			}
-			(Ok(()), None) => Ok(()),
-			(Err(err), group) => {
-				if let Some(group) = group {
-					tracing::debug!(%err, group = %group.sequence, "fill error");
-					let _ = group.abort(err.clone());
-				}
-				Err(err)
-			}
 		}
 	}
 
@@ -3663,39 +3604,33 @@ mod tests {
 	}
 }
 
-/// The Location Filter, and any fill, that expresses a moq-lite subscription's group range.
+/// The Location Filter that expresses a moq-lite subscription's group range.
 ///
-/// moq-lite joins a track at the *start* of the current group, which is a decodable point.
-/// No Location Filter can say that on its own: the filter only restricts which newly
-/// published Objects are forwarded, it never asks for ones already published. So every past
-/// group we want, the current one included, is named as a fill too, which is the draft's own
-/// recipe for joining at the current group.
+/// moq-lite joins a track at the *start* of the current group, which is a decodable point,
+/// and draft-20's relative form is the first that can name it without knowing Largest
+/// Object. Earlier drafts have no such spelling, so they keep asking for the next Object
+/// and joining mid-group, exactly as they always did.
 ///
-/// Only draft-20 has a fill, and it is also the first version that can name a group relative
-/// to a live edge the subscriber has not learned yet. Earlier drafts keep asking for the next
-/// Object and joining mid-group, exactly as they always did: their absolute filters were
-/// never honored by the publishers we talk to, so naming one now would change what an
-/// existing peer sends us.
-fn subscribe_filter(start: Option<u64>, end: Option<u64>, version: Version) -> (Filter, Option<Fill>) {
+/// No fill is requested. A fill is capped at Largest Object, so pairing one with a live
+/// subscription splits a single group across two streams: the fill carries the head, the
+/// subscription the tail, and the two cannot be reassembled into one group here. Asking
+/// for the current group directly keeps a group whole and on one stream, which is what
+/// moq-lite is built around. We still serve a fill a peer asks us for, and still read one
+/// a peer sends us.
+fn subscribe_filter(start: Option<u64>, end: Option<u64>, version: Version) -> Filter {
 	if !Filter::is_draft20(version) {
-		return (Filter::NextObject, None);
+		return Filter::NextObject;
 	}
 
-	let fill = |filter| Some(Fill { filter });
-
 	match start {
-		// Live. Ask for the next Object, and fill the current group from its start.
-		None => (Filter::NextObject, fill(Filter::Relative(1))),
-		// The whole track. An absent filter is unrestricted, and an empty fill scope asks
-		// for everything up to Largest Object.
-		Some(0) if end.is_none() => (Filter::Unfiltered, fill(Filter::Unfiltered)),
-		Some(group) => {
-			let range = Filter::Absolute {
-				start: ietf::Location { group, object: 0 },
-				end,
-			};
-			(range, fill(range))
-		}
+		// One group back from the next group is the current one.
+		None => Filter::Relative(1),
+		// An absolute {0, 0} with no end is defined as unfiltered, so it spells itself.
+		Some(0) if end.is_none() => Filter::Unfiltered,
+		Some(group) => Filter::Absolute {
+			start: ietf::Location { group, object: 0 },
+			end: end.map(|group| ietf::EndLocation { group, object: None }),
+		},
 	}
 }
 
@@ -3703,368 +3638,40 @@ fn subscribe_filter(start: Option<u64>, end: Option<u64>, version: Version) -> (
 mod filter_tests {
 	use super::*;
 
-	/// The canonical live join: Next Object on the subscription, with the current group
-	/// filled in from its start so playback has a decodable point.
+	/// The live join: one group back from the next group is the current one, which is a
+	/// decodable start. No fill, so the group is never split across two streams.
 	#[test]
-	fn live_fills_the_current_group() {
-		let (filter, fill) = subscribe_filter(None, None, Version::Draft20);
-		assert_eq!(filter, Filter::NextObject);
-		assert_eq!(
-			fill,
-			Some(Fill {
-				filter: Filter::Relative(1)
-			})
-		);
+	fn live_asks_for_the_current_group() {
+		assert_eq!(subscribe_filter(None, None, Version::Draft20), Filter::Relative(1));
 	}
 
-	/// A past start is named twice: once to restrict what the subscription forwards, and
-	/// once as the fill that actually retrieves it.
 	#[test]
-	fn a_past_start_is_also_a_fill() {
-		let range = Filter::Absolute {
-			start: ietf::Location { group: 7, object: 0 },
-			end: Some(9),
-		};
+	fn a_past_start_is_absolute() {
 		assert_eq!(
 			subscribe_filter(Some(7), Some(9), Version::Draft20),
-			(range, Some(Fill { filter: range }))
+			Filter::Absolute {
+				start: ietf::Location { group: 7, object: 0 },
+				end: Some(ietf::EndLocation { group: 9, object: None }),
+			}
 		);
 	}
 
-	/// The whole track: nothing to restrict, and an empty fill scope asks for all of it.
+	/// The whole track has a spelling of its own: an absent filter is unrestricted.
 	#[test]
 	fn the_whole_track_is_unfiltered() {
-		assert_eq!(
-			subscribe_filter(Some(0), None, Version::Draft20),
-			(
-				Filter::Unfiltered,
-				Some(Fill {
-					filter: Filter::Unfiltered
-				})
-			)
-		);
+		assert_eq!(subscribe_filter(Some(0), None, Version::Draft20), Filter::Unfiltered);
 	}
 
-	/// Earlier drafts have no fill and never had their absolute filters honored, so they
-	/// keep asking for exactly what they always did.
+	/// Earlier drafts cannot name a group relative to a live edge they have not learned,
+	/// so they keep asking for exactly what they always did.
 	#[test]
 	fn older_drafts_ask_for_the_next_object() {
 		for version in [Version::Draft14, Version::Draft16, Version::Draft19] {
 			assert_eq!(
 				subscribe_filter(Some(7), Some(9), version),
-				(Filter::NextObject, None),
+				Filter::NextObject,
 				"{version}"
 			);
 		}
-	}
-}
-
-/// Serialization Flags on a fetch object (draft-20 section 11.4.4.1).
-mod fill_flags {
-	/// The two low bits select how the Subgroup ID is encoded.
-	pub const SUBGROUP_MASK: u64 = 0x03;
-	/// Subgroup ID is zero.
-	pub const SUBGROUP_ZERO: u64 = 0x00;
-	/// Subgroup ID is the prior Object's.
-	pub const SUBGROUP_PRIOR: u64 = 0x01;
-	/// Subgroup ID is present as its own field.
-	pub const SUBGROUP_PRESENT: u64 = 0x03;
-
-	pub const OBJECT_DELTA: u64 = 0x04;
-	pub const GROUP_DELTA: u64 = 0x08;
-	pub const PRIORITY: u64 = 0x10;
-	pub const PROPERTIES: u64 = 0x20;
-	pub const DATAGRAM: u64 = 0x40;
-
-	/// Every bit with a meaning. A set bit outside this set is a protocol violation.
-	pub const KNOWN: u64 = SUBGROUP_MASK | OBJECT_DELTA | GROUP_DELTA | PRIORITY | PROPERTIES | DATAGRAM;
-}
-
-/// Read the objects on a fill fetch stream into a single group.
-///
-/// `group` is threaded in from the caller so a stream that dies part way still leaves the
-/// group it had opened where the caller can abort it. It is created lazily, because the
-/// group id arrives with the first object rather than in the header.
-///
-/// The subset accepted here is what moq-lite can represent: one group, subgroup zero, and
-/// objects numbered from zero with no gaps. Anything else resets this stream and leaves the
-/// live subscription running, so a fill we cannot read costs the head of a group, not the
-/// subscription.
-async fn run_fill<R: web_transport_trait::RecvStream>(
-	stream: &mut Reader<R, Version>,
-	track: &mut track::Producer,
-	timescale: Option<Timescale>,
-	group: &mut Option<group::Producer>,
-	version: Version,
-) -> Result<(), Error> {
-	let mut prior: Option<(u64, u64)> = None;
-
-	while let Some(flags) = stream.decode_maybe::<u64>().await? {
-		// The three End of Range markers are the only legal values above the flag range.
-		// Each one declares a span of objects that will not be serialized, which is a gap,
-		// and moq-lite tracks have none.
-		if flags & !fill_flags::KNOWN != 0 {
-			tracing::warn!(flags, "unsupported fetch object flags, dropping fill");
-			return Err(Error::Unsupported);
-		}
-
-		// A datagram-preference object has no subgroup, so it cannot join one here.
-		if flags & fill_flags::DATAGRAM != 0 {
-			tracing::warn!("datagram object on a fill, dropping fill");
-			return Err(Error::Unsupported);
-		}
-
-		let group_delta = match flags & fill_flags::GROUP_DELTA != 0 {
-			true => Some(stream.decode::<u64>().await?),
-			false => None,
-		};
-
-		let subgroup = match flags & fill_flags::SUBGROUP_MASK {
-			fill_flags::SUBGROUP_ZERO => 0,
-			// The prior object's, which this loop only ever lets be zero.
-			fill_flags::SUBGROUP_PRIOR if prior.is_some() => 0,
-			fill_flags::SUBGROUP_PRESENT => stream.decode::<u64>().await?,
-			// Prior-plus-one is always non-zero, and a prior-relative mode on the first
-			// object has no prior to read.
-			_ => {
-				tracing::warn!(flags, "unsupported subgroup on a fill, dropping fill");
-				return Err(Error::Unsupported);
-			}
-		};
-		if subgroup != 0 {
-			tracing::warn!(subgroup, "subgroup ID is not supported, dropping fill");
-			return Err(Error::Unsupported);
-		}
-
-		let object_delta = match flags & fill_flags::OBJECT_DELTA != 0 {
-			true => Some(stream.decode::<u64>().await?),
-			false => None,
-		};
-
-		if flags & fill_flags::PRIORITY != 0 {
-			let _priority: u8 = stream.decode().await?;
-		}
-
-		// Object Properties carry the frame's presentation timestamp in the units the
-		// track declared, exactly as the per-object extensions do on a subgroup.
-		let timestamp = match (flags & fill_flags::PROPERTIES != 0, timescale) {
-			(true, Some(timescale)) => {
-				let size: usize = stream.decode().await?;
-				let mut properties = stream.read_exact(size).await?;
-				ietf::decode_object_time(&mut properties, timescale, version)?
-			}
-			(true, None) => {
-				let size: usize = stream.decode().await?;
-				stream.read_exact(size).await?;
-				None
-			}
-			(false, _) => None,
-		};
-
-		let (sequence, object) = match (prior, group_delta, object_delta) {
-			// The first object carries both deltas, and they are the absolute ids.
-			(None, Some(sequence), Some(object)) => (sequence, object),
-			(None, _, _) => {
-				tracing::warn!(flags, "first fill object must carry both deltas, dropping fill");
-				return Err(Error::Unsupported);
-			}
-			// A group delta after the first object names a second group. We asked to fill
-			// one, so the rest of this stream belongs somewhere we cannot put it.
-			(Some(_), Some(_), _) => {
-				tracing::warn!("fill carried more than one group, dropping fill");
-				return Err(Error::Unsupported);
-			}
-			// Within the group: an explicit delta from the prior id, or implicitly one on.
-			(Some((sequence, prior_object)), None, delta) => {
-				let object = prior_object
-					.checked_add(delta.unwrap_or(1))
-					.ok_or(Error::Decode(crate::coding::DecodeError::BoundsExceeded))?;
-				(sequence, object)
-			}
-		};
-
-		// moq-lite groups start at object zero and never skip one, so a gap here would
-		// silently renumber every frame after it.
-		let expected = prior.map_or(0, |(_, prior_object)| prior_object + 1);
-		if object != expected {
-			tracing::warn!(object, expected, "gap in a fill, dropping fill");
-			return Err(Error::Unsupported);
-		}
-		prior = Some((sequence, object));
-
-		if group.is_none() {
-			// Stats (groups/frames/bytes) are counted in the model as the group is
-			// written, through the tagged `track::Producer`.
-			*group = Some(track.create_group(group::Info { sequence })?);
-		}
-		let group = group.as_mut().expect("group was just created");
-
-		// A fetch object has no Object Status: the draft says it is only present on a
-		// subscription, so a zero length here is an empty object rather than a status.
-		let size: u64 = stream.decode().await?;
-		let timestamp = timestamp.unwrap_or_else(crate::Timestamp::now);
-
-		// `create_frame` is the allocation chokepoint and rejects an oversized `size`
-		// before allocating, so no pre-check is needed.
-		let mut frame = group.create_frame(frame::Info { size, timestamp })?;
-		while frame.remaining() > 0 {
-			match stream.read_chunk(frame.remaining()).await? {
-				Some(chunk) if !chunk.is_empty() => frame.write(chunk)?,
-				_ => {
-					let _ = frame.abort(Error::WrongSize);
-					return Err(Error::WrongSize);
-				}
-			}
-		}
-		frame.finish()?;
-	}
-
-	Ok(())
-}
-
-#[cfg(test)]
-mod fill_tests {
-	use super::*;
-	use crate::coding::Encode as _;
-	use crate::lite::test_transport::SinkError;
-
-	/// A stream that hands back a fixed script and then reports EOF, so `run_fill` can be
-	/// driven all the way through its exit path.
-	struct Script(Vec<u8>);
-
-	impl web_transport_trait::RecvStream for Script {
-		type Error = SinkError;
-
-		async fn read(&mut self, dst: &mut [u8]) -> Result<Option<usize>, Self::Error> {
-			if self.0.is_empty() {
-				return Ok(None);
-			}
-			let take = dst.len().min(self.0.len());
-			dst[..take].copy_from_slice(&self.0[..take]);
-			self.0.drain(..take);
-			Ok(Some(take))
-		}
-
-		fn stop(&mut self, _code: u32) {}
-
-		async fn closed(&mut self) -> Result<(), Self::Error> {
-			std::future::pending().await
-		}
-	}
-
-	fn varint(out: &mut Vec<u8>, v: u64) {
-		v.encode(out, Version::Draft20).expect("varint");
-	}
-
-	/// One object: flags, then the fields those flags say are present, then the payload.
-	fn object(out: &mut Vec<u8>, flags: u64, fields: &[u64], payload: &[u8]) {
-		varint(out, flags);
-		for field in fields {
-			varint(out, *field);
-		}
-		varint(out, payload.len() as u64);
-		out.extend_from_slice(payload);
-	}
-
-	/// The first object carries both deltas, which are the absolute Group and Object ids.
-	const FIRST: u64 = fill_flags::GROUP_DELTA | fill_flags::OBJECT_DELTA;
-	/// A follow-on object in the same group and subgroup, one object id later.
-	const NEXT: u64 = 0;
-
-	/// The track producer comes back with the result: dropping it would close the track,
-	/// and the consumer would then see a clean end instead of the group just written.
-	async fn run(
-		script: Vec<u8>,
-	) -> (
-		Result<(), Error>,
-		Option<group::Producer>,
-		track::Producer,
-		track::Subscriber,
-	) {
-		let mut track = track::Producer::new(std::sync::Arc::new(crate::broadcast::Info::default()), "video", None);
-		let consumer = track.subscribe(None);
-		let mut reader = Reader::new(Script(script), Version::Draft20);
-		let mut group = None;
-		let res = run_fill(&mut reader, &mut track, None, &mut group, Version::Draft20).await;
-		(res, group, track, consumer)
-	}
-
-	#[tokio::test]
-	async fn reads_one_group() {
-		let mut script = Vec::new();
-		object(&mut script, FIRST, &[7, 0], b"first");
-		object(&mut script, NEXT, &[], b"second");
-
-		let (res, group, _track, mut consumer) = run(script).await;
-		res.expect("fill should decode");
-
-		let mut group = group.expect("a group was opened");
-		assert_eq!(group.sequence, 7, "the first object's deltas are absolute ids");
-		group.finish().expect("finish");
-
-		let mut group = consumer.recv_group().await.expect("group").expect("some");
-		let first = group.read_frame().await.unwrap().unwrap();
-		assert_eq!(first.payload.as_ref(), &b"first"[..]);
-		let second = group.read_frame().await.unwrap().unwrap();
-		assert_eq!(second.payload.as_ref(), &b"second"[..]);
-	}
-
-	/// We ask to fill exactly one group, so a second one is a request we never made and
-	/// its objects would land in the wrong group.
-	#[tokio::test]
-	async fn rejects_a_second_group() {
-		let mut script = Vec::new();
-		object(&mut script, FIRST, &[7, 0], b"first");
-		object(&mut script, FIRST, &[8, 0], b"next group");
-
-		let (res, ..) = run(script).await;
-		assert!(matches!(res, Err(Error::Unsupported)), "{res:?}");
-	}
-
-	/// moq-lite groups never skip an object, so a gap would silently renumber every frame
-	/// after it.
-	#[tokio::test]
-	async fn rejects_a_gap() {
-		let mut script = Vec::new();
-		object(&mut script, FIRST, &[7, 0], b"first");
-		// An explicit delta of 2 skips object 1.
-		object(&mut script, fill_flags::OBJECT_DELTA, &[2], b"third");
-
-		let (res, ..) = run(script).await;
-		assert!(matches!(res, Err(Error::Unsupported)), "{res:?}");
-	}
-
-	/// The first object has no prior to reference, so it must carry both deltas.
-	#[tokio::test]
-	async fn rejects_a_first_object_without_deltas() {
-		let mut script = Vec::new();
-		object(&mut script, NEXT, &[], b"nope");
-
-		let (res, ..) = run(script).await;
-		assert!(matches!(res, Err(Error::Unsupported)), "{res:?}");
-	}
-
-	/// A set bit with no meaning is a protocol violation, and the End of Range markers all
-	/// declare a span that will not be serialized, which is a gap.
-	#[tokio::test]
-	async fn rejects_unknown_flags() {
-		for flags in [0x80, 0x8C, 0x10C, 0x20C] {
-			let mut script = Vec::new();
-			object(&mut script, flags, &[7, 0], b"");
-
-			let (res, ..) = run(script).await;
-			assert!(matches!(res, Err(Error::Unsupported)), "{flags:#x}: {res:?}");
-		}
-	}
-
-	/// A subgroup is not something moq-lite can represent, so an explicit non-zero one is
-	/// refused rather than flattened into the group.
-	#[tokio::test]
-	async fn rejects_a_subgroup() {
-		let mut script = Vec::new();
-		object(&mut script, FIRST | fill_flags::SUBGROUP_PRESENT, &[7, 3, 0], b"nope");
-
-		let (res, ..) = run(script).await;
-		assert!(matches!(res, Err(Error::Unsupported)), "{res:?}");
 	}
 }

--- a/rs/moq-net/src/ietf/track.rs
+++ b/rs/moq-net/src/ietf/track.rs
@@ -7,7 +7,7 @@ use num_enum::{IntoPrimitive, TryFromPrimitive};
 use crate::{
 	Path,
 	coding::*,
-	ietf::{FilterType, GroupOrder, Parameters, RequestId},
+	ietf::{Filter, GroupOrder, Parameters, RequestId},
 };
 
 use super::Message;
@@ -41,7 +41,7 @@ impl Message for TrackStatus<'_> {
 				0u8.encode(w, version)?; // subscriber priority
 				GroupOrder::Descending.encode(w, version)?;
 				false.encode(w, version)?; // forward
-				FilterType::LargestObject.encode(w, version)?; // filter type
+				Filter::NextObject.encode(w, version)?; // filter
 				0u8.encode(w, version)?; // no parameters
 			}
 			_ => {

--- a/rs/moq-net/src/ietf/version.rs
+++ b/rs/moq-net/src/ietf/version.rs
@@ -9,6 +9,7 @@ pub enum Version {
 	Draft17,
 	Draft18,
 	Draft19,
+	Draft20,
 }
 
 impl fmt::Display for Version {
@@ -20,6 +21,7 @@ impl fmt::Display for Version {
 			Self::Draft17 => write!(f, "moq-transport-17"),
 			Self::Draft18 => write!(f, "moq-transport-18"),
 			Self::Draft19 => write!(f, "moq-transport-19"),
+			Self::Draft20 => write!(f, "moq-transport-20"),
 		}
 	}
 }

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -716,6 +716,15 @@ impl Consumer {
 		self.track.timescale
 	}
 
+	/// The number of frames written so far (completed plus any in-flight), independent of
+	/// how many this consumer has read. The final total once the group is finished.
+	pub fn frame_count(&self) -> usize {
+		let state = self.state.read();
+		state
+			.fin
+			.unwrap_or(state.offset + state.frames.len() + state.partial.is_some() as usize)
+	}
+
 	// A helper to automatically apply Dropped if the state is closed without an error.
 	fn poll<F, R>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<R>>
 	where

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -507,6 +507,13 @@ impl Consumer {
 		let track = self.state.read().segments.last().map(|segment| segment.track.clone())?;
 		track.peek_group(sequence)
 	}
+
+	/// The nearest cached group below `sequence` in the newest segment; see
+	/// [`track::Consumer::peek_before`].
+	pub(crate) fn peek_before(&self, sequence: u64) -> Option<group::Consumer> {
+		let track = self.state.read().segments.last().map(|segment| segment.track.clone())?;
+		track.peek_before(sequence)
+	}
 }
 
 /// The pollable state of a [`Consumer::fetch_group`]; awaited via the

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -500,6 +500,13 @@ impl Consumer {
 		let track = self.state.read().segments.last().map(|segment| segment.track.clone())?;
 		track.peek_latest()
 	}
+
+	/// A cached group by sequence from the newest segment; see
+	/// [`track::Consumer::peek_group`].
+	pub(crate) fn peek_group(&self, sequence: u64) -> Option<group::Consumer> {
+		let track = self.state.read().segments.last().map(|segment| segment.track.clone())?;
+		track.peek_group(sequence)
+	}
 }
 
 /// The pollable state of a [`Consumer::fetch_group`]; awaited via the

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -493,6 +493,13 @@ impl Consumer {
 	pub fn latest(&self) -> Option<u64> {
 		self.state.read().latest()
 	}
+
+	/// The newest segment's newest cached group, resolved synchronously; see
+	/// [`track::Consumer::peek_latest`].
+	pub(crate) fn peek_latest(&self) -> Option<group::Consumer> {
+		let track = self.state.read().segments.last().map(|segment| segment.track.clone())?;
+		track.peek_latest()
+	}
 }
 
 /// The pollable state of a [`Consumer::fetch_group`]; awaited via the

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -441,19 +441,6 @@ impl TrackState {
 		Poll::Pending
 	}
 
-	/// Find a cached group by sequence; an aborted (evicted) group is a miss, so a
-	/// fetch re-fetches it. Synchronous, never blocks. Test hook for `peek_group`;
-	/// the real fetch path is [`Self::poll_fetch_cached`], which also refreshes the
-	/// group.
-	#[cfg(test)]
-	fn cached_group(&self, sequence: u64) -> Option<group::Consumer> {
-		let slot = self.lookup.get(&sequence)?;
-		if slot.group.is_aborted() {
-			return None;
-		}
-		Some(slot.group.consume())
-	}
-
 	/// The publisher's latency window, or `None` while the info is unknown (an
 	/// unaccepted [`Request`]). Bounds the aggregate subscription; see [`clamp_combined`].
 	fn latency_bound(&self) -> Option<Duration> {
@@ -1735,16 +1722,34 @@ impl Consumer {
 		})
 	}
 
-	// Peek at a cached group by sequence without blocking, or `None` if it isn't in the
-	// cache. A test hook for asserting cache state; the library reads
-	// `TrackState::cached_group` directly, and callers want `fetch_group`.
-	#[cfg(test)]
+	/// The newest group, when it is already cached: resolved synchronously, without
+	/// counting as a fetch or a delivery. The IETF publisher snapshots its frame count to
+	/// resolve Largest Object; a group that is not immediately available reads as no edge.
+	pub(crate) fn peek_latest(&self) -> Option<group::Consumer> {
+		match &self.inner {
+			ConsumerKind::Plain(state) => {
+				let sequence = state.read().max_sequence?;
+				self.peek_group(sequence)
+			}
+			ConsumerKind::Spliced(resume) => resume.peek_latest(),
+		}
+	}
+
+	/// A cached group by sequence, under the same terms as [`Self::peek_latest`]. Unlike a
+	/// fetch, a peek does not refresh the group's cache standing, so it never keeps a
+	/// group alive over one a subscriber actually read; an aborted (evicted) group is a
+	/// miss.
 	pub(crate) fn peek_group(&self, sequence: u64) -> Option<group::Consumer> {
 		match &self.inner {
-			ConsumerKind::Plain(state) => state.read().cached_group(sequence),
-			// Spliced tracks have no cache of their own; peek the newest segment
-			// via `fetch_group` instead.
-			ConsumerKind::Spliced(_) => None,
+			ConsumerKind::Plain(state) => {
+				let state = state.read();
+				let slot = state.lookup.get(&sequence)?;
+				if slot.group.is_aborted() {
+					return None;
+				}
+				Some(slot.group.consume())
+			}
+			ConsumerKind::Spliced(resume) => resume.peek_group(sequence),
 		}
 	}
 
@@ -1755,23 +1760,6 @@ impl Consumer {
 	/// the request (a wire FETCH for a relay). `options` accepts `None`, a [`group::Fetch`],
 	/// or `group::Fetch::default()`.
 	///
-	/// The newest group, when it is already cached: resolved synchronously, without
-	/// counting as a fetch or a delivery. The IETF publisher snapshots its frame count to
-	/// resolve Largest Object; a group that is not immediately available reads as no edge.
-	pub(crate) fn peek_latest(&self) -> Option<group::Consumer> {
-		match &self.inner {
-			ConsumerKind::Plain(state) => {
-				let state = state.read();
-				let sequence = state.max_sequence?;
-				match state.poll_fetch_cached(sequence) {
-					Poll::Ready(Ok(group)) => Some(group),
-					_ => None,
-				}
-			}
-			ConsumerKind::Spliced(resume) => resume.peek_latest(),
-		}
-	}
-
 	/// The returned future resolves to [`Error::NotFound`] when the group can never be served
 	/// (past the final sequence, or no [`Dynamic`] on the track), or the track's abort error
 	/// if it's already closed. Concurrent fetches for the same sequence coalesce onto one

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1755,6 +1755,23 @@ impl Consumer {
 	/// the request (a wire FETCH for a relay). `options` accepts `None`, a [`group::Fetch`],
 	/// or `group::Fetch::default()`.
 	///
+	/// The newest group, when it is already cached: resolved synchronously, without
+	/// counting as a fetch or a delivery. The IETF publisher snapshots its frame count to
+	/// resolve Largest Object; a group that is not immediately available reads as no edge.
+	pub(crate) fn peek_latest(&self) -> Option<group::Consumer> {
+		match &self.inner {
+			ConsumerKind::Plain(state) => {
+				let state = state.read();
+				let sequence = state.max_sequence?;
+				match state.poll_fetch_cached(sequence) {
+					Poll::Ready(Ok(group)) => Some(group),
+					_ => None,
+				}
+			}
+			ConsumerKind::Spliced(resume) => resume.peek_latest(),
+		}
+	}
+
 	/// The returned future resolves to [`Error::NotFound`] when the group can never be served
 	/// (past the final sequence, or no [`Dynamic`] on the track), or the track's abort error
 	/// if it's already closed. Concurrent fetches for the same sequence coalesce onto one

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1735,6 +1735,25 @@ impl Consumer {
 		}
 	}
 
+	/// The nearest cached group below `sequence`, under the same terms as
+	/// [`Self::peek_group`]. Walks the cache's own order, so gaps in the group numbering
+	/// are crossed and aborted (evicted) entries are skipped.
+	pub(crate) fn peek_before(&self, sequence: u64) -> Option<group::Consumer> {
+		match &self.inner {
+			ConsumerKind::Plain(state) => {
+				let state = state.read();
+				state
+					.lookup
+					.range(..sequence)
+					.rev()
+					.map(|(_, slot)| &slot.group)
+					.find(|group| !group.is_aborted())
+					.map(|group| group.consume())
+			}
+			ConsumerKind::Spliced(resume) => resume.peek_before(sequence),
+		}
+	}
+
 	/// A cached group by sequence, under the same terms as [`Self::peek_latest`]. Unlike a
 	/// fetch, a peek does not refresh the group's cache standing, so it never keeps a
 	/// group alive over one a subscriber actually read; an aborted (evicted) group is a

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -1,6 +1,6 @@
 use crate::origin;
 use crate::{
-	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05,
+	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_20, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05,
 	ALPN_LITE_06_WIP, Consume, Driver, Error, NEGOTIATED, Role, Session, Version, Versions,
 	coding::{Decode, Encode, Stream},
 	ietf, lite, setup, stats,
@@ -93,6 +93,12 @@ impl Server {
 		};
 
 		let (encoding, supported) = match session.protocol() {
+			Some(ALPN_20) => {
+				self.versions
+					.select(Version::Ietf(ietf::Version::Draft20))
+					.ok_or(Error::Version)?;
+				return self.accept_ietf_modern(session, ietf::Version::Draft20).await;
+			}
 			Some(ALPN_19) => {
 				self.versions
 					.select(Version::Ietf(ietf::Version::Draft19))

--- a/rs/moq-net/src/setup.rs
+++ b/rs/moq-net/src/setup.rs
@@ -76,7 +76,8 @@ impl SetupVersion {
 			Version::Ietf(ietf::Version::Draft15) | Version::Ietf(ietf::Version::Draft16) => Self::Draft15Plus,
 			Version::Ietf(ietf::Version::Draft17)
 			| Version::Ietf(ietf::Version::Draft18)
-			| Version::Ietf(ietf::Version::Draft19) => Self::Modern,
+			| Version::Ietf(ietf::Version::Draft19)
+			| Version::Ietf(ietf::Version::Draft20) => Self::Modern,
 			Version::Lite(lite::Version::Lite01) | Version::Lite(lite::Version::Lite02) => Self::LiteLegacy,
 			Version::Lite(_) => Self::Unsupported,
 		}

--- a/rs/moq-net/src/version.rs
+++ b/rs/moq-net/src/version.rs
@@ -26,6 +26,7 @@ pub const ALPNS: &[&str] = &[
 	ALPN_LITE_04,
 	ALPN_LITE_03,
 	ALPN_LITE,
+	ALPN_20,
 	ALPN_19,
 	ALPN_18,
 	ALPN_17,
@@ -46,14 +47,16 @@ pub(crate) const ALPN_16: &str = "moqt-16";
 pub(crate) const ALPN_17: &str = "moqt-17";
 pub(crate) const ALPN_18: &str = "moqt-18";
 pub(crate) const ALPN_19: &str = "moqt-19";
+pub(crate) const ALPN_20: &str = "moqt-20";
 
-const ALL: [Version; 12] = [
+const ALL: [Version; 13] = [
 	Version::Lite(lite::Version::Lite06Wip),
 	Version::Lite(lite::Version::Lite05),
 	Version::Lite(lite::Version::Lite04),
 	Version::Lite(lite::Version::Lite03),
 	Version::Lite(lite::Version::Lite02),
 	Version::Lite(lite::Version::Lite01),
+	Version::Ietf(ietf::Version::Draft20),
 	Version::Ietf(ietf::Version::Draft19),
 	Version::Ietf(ietf::Version::Draft18),
 	Version::Ietf(ietf::Version::Draft17),
@@ -92,6 +95,7 @@ impl Version {
 			Self::Ietf(ietf::Version::Draft17) => "moq-transport-17",
 			Self::Ietf(ietf::Version::Draft18) => "moq-transport-18",
 			Self::Ietf(ietf::Version::Draft19) => "moq-transport-19",
+			Self::Ietf(ietf::Version::Draft20) => "moq-transport-20",
 		}
 	}
 
@@ -110,6 +114,7 @@ impl Version {
 			0xff000011 => Some(Self::Ietf(ietf::Version::Draft17)),
 			0xff000012 => Some(Self::Ietf(ietf::Version::Draft18)),
 			0xff000013 => Some(Self::Ietf(ietf::Version::Draft19)),
+			0xff000014 => Some(Self::Ietf(ietf::Version::Draft20)),
 			_ => None,
 		}
 	}
@@ -129,6 +134,7 @@ impl Version {
 			Self::Ietf(ietf::Version::Draft17) => 0xff000011,
 			Self::Ietf(ietf::Version::Draft18) => 0xff000012,
 			Self::Ietf(ietf::Version::Draft19) => 0xff000013,
+			Self::Ietf(ietf::Version::Draft20) => 0xff000014,
 		}
 	}
 
@@ -149,6 +155,7 @@ impl Version {
 			ALPN_17 => Some(Self::Ietf(ietf::Version::Draft17)),
 			ALPN_18 => Some(Self::Ietf(ietf::Version::Draft18)),
 			ALPN_19 => Some(Self::Ietf(ietf::Version::Draft19)),
+			ALPN_20 => Some(Self::Ietf(ietf::Version::Draft20)),
 			_ => None,
 		}
 	}
@@ -167,6 +174,7 @@ impl Version {
 			Self::Ietf(ietf::Version::Draft17) => ALPN_17,
 			Self::Ietf(ietf::Version::Draft18) => ALPN_18,
 			Self::Ietf(ietf::Version::Draft19) => ALPN_19,
+			Self::Ietf(ietf::Version::Draft20) => ALPN_20,
 		}
 	}
 

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -225,7 +225,7 @@ const QMUX_VERSIONS: &[qmux::Version] = &[qmux::Version::QMux01, qmux::Version::
 
 /// moq-transport-18 and -19 require qmux-01, so we never pair them with qmux-00.
 /// Mirrors `js/net`'s `connect.ts` and moq-native's `websocket_subprotocols`.
-const QMUX01_ONLY_ALPNS: &[&str] = &["moqt-18", "moqt-19"];
+const QMUX01_ONLY_ALPNS: &[&str] = &["moqt-18", "moqt-19", "moqt-20"];
 
 /// Subprotocols to advertise on the WebSocket upgrade.
 ///
@@ -430,7 +430,7 @@ mod tests {
 				.iter()
 				.map(|&a| moq_net::Version::from_alpn(a).map(|v| v.code()))
 				.collect::<Vec<_>>(),
-			vec![Some(0xff000012), Some(0xff000013)]
+			vec![Some(0xff000012), Some(0xff000013), Some(0xff000014)]
 		);
 
 		let list = supported_subprotocols(moq_net::ALPNS);


### PR DESCRIPTION
## Summary

Registers ALPN `moqt-20` / wire code `0xff000014`, and implements the draft-19 -> draft-20 changes that affect messages we already send. Unlike the 18 -> 19 bump this is not a pure registration.

- **LOCATION_FILTER (0x21) is restructured.** The Filter Type tag is replaced by a length-delimited list of up to four varints, where the number present selects the meaning: 0 fields unfiltered, 1 a *relative* `StartGroup` (`{Largest.Group + 1 - N, 0}`, so 0 is the next group and 1 is the current one), 2 both-zero Next Object, 2+ otherwise absolute, then `EndGroupDelta` and `EndObject`. A new `ietf::Filter` carries the range and encodes either wire form by version. Its variants are the shapes the wire can express, so a relative start with an end cannot be constructed. An open-ended absolute `{0,0}` is defined as equivalent to unfiltered, which keeps it from colliding with the two-zero-field Next Object spelling.

- **Filters are honored down to the object, not widened.** `subscribe_range` resolves a draft-20 filter into a `ServeRange` of `Location`s, and delivery trims the boundary groups to it: the start group is served from the requested object (the first object-ID delta carries its absolute id, so a trimmed head is never silently renumbered, and `FIRST_OBJECT` is only claimed when true) and the end group stops at the requested object. In particular a Next Object subscriber no longer receives the already-published head of the current group, which is outside its requested range and was previously replayed whole ("A publisher MUST NOT send subscription-delivered objects from outside the requested range"). Bounded subscriptions stay open once the range is exhausted, as draft-20 requires.

- **The publisher serves fills, single-group.** `FILL_PARAMETERS` obligates a fetch stream, and the draft's own current-group join (section 5.1.6) is a Next Object subscription plus a `StartGroup=1` fill. That fill is exactly one group, which the model already retains, so `run_fill` serves it from the group cache on a real fetch stream: `FETCH_HEADER`, objects with absolute first Group/Object IDs and per-object timestamp properties, FIN. The Largest Object snapshot that caps the fill is the same one that floors the subscription, so the two cover the group with no gap and no overlap, and is advertised as `LARGEST_OBJECT` in `SUBSCRIBE_OK` (required once the track has content). A fill range spanning several groups opens the stream and resets it, the draft's fill-failure signal, because multi-group fetch serialization depends on a negotiated group order we do not implement; an empty range opens no stream.

- **The subscriber requests no fill and asks for the current group directly** (`Relative(1)`), which draft-20 is the first version able to name without knowing Largest Object. Against our own publishers the whole in-range group replays from the cache, preserving moq-lite's decodable join; a strict publisher only delivers from the next published object, and that mid-group stream is dropped per-stream (session intact), degrading the join to the next group boundary. Reassembling the canonical join's two streams (fill head + live tail) into the one group producer the model expects is follow-up work. Since we never request a fill, an incoming fetch stream answers no request of ours and is refused.

- **Subgroup numbering is checked against the Object ID.** The first object's delta is its absolute Object ID and every later one is the prior ID plus the delta plus one, so a group numbered from zero with no gaps is a zero delta throughout. A group that starts partway through, or one with a gap, is refused rather than admitted and silently renumbered. This is checked against the ID rather than the header's FIRST_OBJECT bit, which is only the publisher's claim; the bit is now decoded rather than stripped, and encoded from the flag rather than unconditionally, so it states what we actually do.

- **Subscription parameters moved out of `PUBLISH_OK`** into PUBLISH and REQUEST_UPDATE, so a draft-20 `PUBLISH_OK` sends none.

- **`INCLUDE_PROPERTIES` (0x35)** is obeyed by the publisher; the subscriber sends it only to opt out, since 1 is the default.

The new semantics are honored on draft-20 only. Earlier drafts keep asking for the next Object and keep ignoring absolute filters, whose forms were never served, so what an existing peer sends is unchanged.

Not implemented: `PUBLISH_STATE_NOTIFY` (0x22), requesting fills as a subscriber, and serving multi-group or Range-Filtered fills (both are refused by resetting the fetch stream).

### Three spec conflicts worth a second opinion

All are places where a parameter's own section looks at odds with the Key-Value-Pair framing rule, and all resolve the same way: **a section that spells out the serialization (an explicit `Length` field) wins; one that only names the value's type gets its framing from the KVP parity rule.**

- `INCLUDE_PROPERTIES` is called "a uint8" but has the **odd** id 0x35 and shows no Length field. Treated as length-prefixed, because parity is what a generic parser uses to skip it.
- The Range Filters `OBJECTID_FILTER` (0x26) and `OBJECT_PROPERTY_FILTER` (0x28) are written with an explicit `Length` despite **even** ids. Treated as length-prefixed, so decoding them by parity cannot desync the parameters after them.
- `LARGEST_OBJECT` (0x09) "is a Location" (two varints) with no Length shown, but the id is **odd**, so it is length-prefixed. Both language codecs framed it bare on draft-17+, which no compliant peer would parse; both now length-prefix it on every draft (byte-pinned against each other), and the draft-17+ `SUBSCRIBE_OK` decoder accepts it instead of tearing down the session over a parameter the spec requires publishers to send.

## Public API changes

`moq_net::group::Consumer::frame_count()` is new and additive: the number of frames written so far, the final total once the group finishes (mirrors the existing `Producer::frame_count`). Everything else is internal: `mod ietf` is private, so `Filter`, `EndLocation`, `Fill`, `IncludeProperties`, `SubscribeOk::largest`, the removed `FilterType`, and the reshaped `Subscribe`/`PublishOk`/`GroupFlags` are not exposed. `moq_net::Version` is `#[non_exhaustive]` and its inner `ietf::Version` is crate-private, so the new `Draft20` variant is additive. `ietf::Location` gained `Copy`.

## Known limitations

- The subscriber does not request fills, so joining a strict draft-20 publisher starts at the next group boundary rather than the current group (see above); stitching the canonical join's fetch stream into the live group is follow-up work.
- Multi-group fills, and fills carrying a Range Filter (0x25-0x28), are refused (stream reset) rather than served.
- A moq-lite `group_start: Some(0)` cannot be expressed as a history request over draft-20 without a fill, so it degrades to live delivery.
- The JS publisher parses the Location Filter, `FILL_PARAMETERS`, and `INCLUDE_PROPERTIES` but does not act on them; it never honored filters. The fill serving and object-trimmed delivery above are Rust-side (which includes the relay).
- `LARGEST_OBJECT` is encoded on draft-20 only, though it is legal (and required) on earlier drafts too: peers built before this change reject an unexpected `SUBSCRIBE_OK` parameter by closing the session, so emitting it to existing draft-17/18/19 deployments would break them over a hint. Decoding accepts it on every draft.

## Test plan

- `cargo test -p moq-net`: 903 pass. Everything from before, plus: the fill range resolution (canonical current-group fill, past-group, object-trimmed, capped-at-largest, multi-group unsupported, backwards/empty, no-content), end-to-end serving through `run_subscribe_stream` (the canonical join delivers each head object exactly once on a real fetch stream; `Relative(1)` still replays the whole group; Next Object gets no head; a multi-group fill opens and resets its stream; an empty track opens none), `run_group` slice trimming pinned byte-for-byte (absolute first delta, capped tail), `ServeRange` resolution per filter (including the imprecise-edge fallback to the next group boundary), `LARGEST_OBJECT` accepted on draft-17+ and round-tripped on draft-20 only, and the corrected length-prefixed `Location` wire vectors on draft-16 through 20.
- `cargo test -p moq-native`: 253 pass, including the draft-20 handshake and broadcast matrices over raw QUIC and WebTransport.
- `bun test` in `js/net`: 483 pass; biome and `tsc` clean via `just check`.
- `nix develop --command just fix`, `just check`, and `just test` (2998 tests) all pass, which is exactly what CI runs.
- `just test smoke-full` (cross-language interop matrix): all 21 publisher/subscriber combinations pass (rust/python/js publishers against rust/python/js/js-node/js-bun/c/gst subscribers over a real relay).

## Cross-package sync

`rs/moq-net` wire change is mirrored in `js/net` (the `LARGEST_OBJECT` framing fix and parameter registrations), and `doc/concept/layer/moq-lite.md`'s fill and group-granularity bullets describe the implemented behavior. `rs/libmoq`'s supported-version range doc is bumped. No `drafts/` update: `drafts/` holds only our own `draft-lcurley-*` specs, and `draft-ietf-moq-transport` is the working group's document, so there is no matching draft in this repo to update.

## Note for reviewers

Draft-19 is missing from the WebSocket fallback's version map in `connect.ts` (only 18 was there). This PR adds 20; the 19 gap predates it and is left alone rather than changing negotiation for existing sessions.

(Written by Claude Opus 5, taken over and extended by Claude Fable 5)
