### PR TITLE
refactor(net): finish the Hop rename in test names and log fields

### DIFF
--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -2103,7 +2103,7 @@ mod tests {
 	/// echo the peer's own content back at it. A broadcast with an independent
 	/// route still is.
 	#[tokio::test(start_paused = true)]
-	async fn assigned_peer_origin_filters_echoed_announces() {
+	async fn assigned_peer_hop_filters_echoed_announces() {
 		let assigned = crate::Hop::new(777).unwrap();
 		let (publisher, consumer, _routes) = echo_harness(assigned).await;
 
@@ -2123,7 +2123,7 @@ mod tests {
 	/// assigned identity is a state this peer class cannot reach; see
 	/// [`a_declared_zero_chain_is_still_advertised_back`] for what it gets instead.
 	#[tokio::test(start_paused = true)]
-	async fn withheld_peer_origin_falls_back_to_assigned() {
+	async fn withheld_peer_hop_falls_back_to_assigned() {
 		let assigned = crate::Hop::new(777).unwrap();
 		let declared = crate::Hop::new(9).unwrap();
 		let (publisher, _consumer, _routes) = echo_harness(assigned).await;

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -2626,7 +2626,7 @@ mod tests {
 	/// resolve to one recognizable route, and a reconnect splices rather than
 	/// replacing.
 	#[tokio::test]
-	async fn assigned_peer_origin_attributes_announces() {
+	async fn assigned_peer_hop_attributes_announces() {
 		let session = crate::lite::test_transport::SinkSession::new(Default::default());
 		let assigned = crate::Hop::new(777).unwrap();
 

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -2048,7 +2048,7 @@ mod tests {
 	/// assigned it (`Client::with_peer_hop`), so every session dialing the same
 	/// relay yields one recognizable hop instead of a random id per connection.
 	#[tokio::test]
-	async fn assigned_peer_origin_attributes_announces() {
+	async fn assigned_peer_hop_attributes_announces() {
 		let session = SinkSession::new(Default::default());
 		let assigned = crate::Hop::new(777).unwrap();
 
@@ -2093,7 +2093,7 @@ mod tests {
 	/// gets an identity, and whether two of its sessions share it, is the caller's
 	/// policy, and a minted id here would be indistinguishable from a declared one.
 	#[tokio::test]
-	async fn absent_peer_origin_stamps_unknown() {
+	async fn absent_peer_hop_stamps_unknown() {
 		let (mut subscriber, consumer) = restart_subscriber(SinkSession::new(Default::default()));
 
 		let mut announced = Announced::default();

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -1082,18 +1082,18 @@ mod tests {
 	}
 
 	#[tokio::test(start_paused = true)]
-	async fn accept_request_reads_lite05_peer_origin() {
-		let origin = Hop::new(42).unwrap();
-		let session = FakeSession::new(ALPN_LITE_05, [lite05_setup(None, None, Some(origin))]);
+	async fn accept_request_reads_lite05_peer_hop() {
+		let hop = Hop::new(42).unwrap();
+		let session = FakeSession::new(ALPN_LITE_05, [lite05_setup(None, None, Some(hop))]);
 		let request = Server::new()
 			.accept_request(crate::runtime::tokio_test::Tokio::new(), session)
 			.await
 			.unwrap();
-		assert_eq!(request.peer_hop(), Some(origin));
+		assert_eq!(request.peer_hop(), Some(hop));
 	}
 
 	#[tokio::test(start_paused = true)]
-	async fn anonymous_peer_origin_filters_routes_from_server_session() {
+	async fn anonymous_peer_hop_filters_routes_from_server_session() {
 		let other = Hop::new(778).unwrap();
 		let origin = crate::origin::Info::new(Hop::new(1).unwrap()).produce();
 

--- a/rs/moq-net/tests/goaway.rs
+++ b/rs/moq-net/tests/goaway.rs
@@ -13,8 +13,8 @@ use support::harness::{MockConnectOptions, MockPair, connect_mock};
 use support::mock::create_mock_session_pair;
 
 /// Build an origin producer, spawning its driver on the ambient runtime.
-fn produce_origin(origin: Hop) -> moq_net::origin::Producer {
-	let (producer, driver) = moq_net::origin::Producer::new(moq_net::origin::Info::new(origin));
+fn produce_origin(hop: Hop) -> moq_net::origin::Producer {
+	let (producer, driver) = moq_net::origin::Producer::new(moq_net::origin::Info::new(hop));
 	tokio::spawn(driver.run(support::harness::TokioRuntime::<()>::new()));
 	producer
 }

--- a/rs/moq-relay/src/cluster.rs
+++ b/rs/moq-relay/src/cluster.rs
@@ -676,7 +676,7 @@ impl Cluster {
 		let info = origin::Info::new(id);
 		let origin = moq_tokio::origin::spawn(info.clone());
 		let nodes = crate::nodes::Nodes::new(origin.clone());
-		tracing::info!(origin_id = %origin.id(), configured = config.id.is_some(), "cluster initialized");
+		tracing::info!(hop_id = %origin.id(), configured = config.id.is_some(), "cluster initialized");
 		Ok(Cluster {
 			config,
 			client: None,


### PR DESCRIPTION
Follow-up to #3252, which renamed the hop identifier from `Origin` to `Hop`. That PR was scoped to the published surface and deliberately stopped there, so a few internal identifiers kept the old spelling.

- **Seven test functions** still said `peer_origin`, sitting directly under the `with_peer_hop` / `peer_hop` API they exercise (`moq-net`: `server.rs`, `lite/subscriber.rs`, `ietf/subscriber.rs`, `ietf/publisher.rs`).
- **The cluster startup log emitted `origin_id`** (`moq-relay/src/cluster.rs`). This is the one a reader could actually trip on: the value is `origin.id()`, a `Hop`, and every other hop id the relay reports now spells it `hop_id` — including `GET /nodes`, which #3252 renamed. The two disagreeing was a live inconsistency in operator-facing output, not just naming taste.
- **Two locals held a bare `Hop` under the name `origin`** (`server.rs`, `tests/goaway.rs`). Note that most `origin` locals in these files are correct and untouched: they hold an `origin::Producer` from `Hop::…().produce()`, which is genuinely the routing table.

Also unchanged, for the same reason #3252 gave: `origin::Producer`'s private `info` field still holds a `Hop`, and untangling it collides with a dozen sites where `info` is a local for the real `Info`.

No public surface moves, so this targets `dev` only because the rename it finishes lives there.

## Verification

`just check` passed but dispatched **no Rust step at all** despite a diff of six `rs/` files, so the Rust half was run directly against the same nix-store toolchain instead:

- `cargo clippy -p moq-net -p moq-relay --all-targets --locked -- -D warnings` — clean
- `cargo nextest run -p moq-net -p moq-relay --locked` — **1297 passed**, 1 skipped
- The 7 renamed tests confirmed present and passing under their new names (`-E "test(peer_hop)"`), so the rename didn't quietly orphan them

That `just check` skipped Rust here looks like a real bug in the diff-aware scoping rather than anything about this branch, and it's worth a look on its own — it means a Rust-only change can pass `just check` locally without being compiled. Filing separately.

(Written by Claude Opus 5)