### PR TITLE
fix(watch): guard read() against a re-anchor rebasing the ring under it

### DIFF
--- a/js/watch/src/audio/shared-ring-buffer.test.ts
+++ b/js/watch/src/audio/shared-ring-buffer.test.ts
@@ -893,7 +893,12 @@ describe("read() racing a re-anchor", () => {
 			};
 
 			try {
-				worklet.read(out);
+				// The raced read must discard its quantum: not just report zero, but leave no
+				// old-timeline samples in the buffer it was handed, since the worklet renders
+				// whatever is there regardless of the count it gets back.
+				out[0].fill(-1);
+				expect(worklet.read(out)).toBe(0);
+				expect(out[0].some((sample) => sample !== 0 && sample !== -1)).toBe(false);
 			} finally {
 				atomics.compareExchange = realExchange;
 			}
@@ -911,6 +916,86 @@ describe("read() racing a re-anchor", () => {
 			let played = 0;
 			for (let i = 0; i < 8; i++) played += worklet.read(out);
 			expect(played).toBeGreaterThan(0);
+		});
+	}
+});
+
+describe("read() rejecting a raced quantum", () => {
+	// `#advanceRead` loads GENERATION, READ and WRITE separately, so a re-anchor can land between
+	// any pair of them. Sweeping the trigger across every load inside read() covers the windows a
+	// single fixed pause point misses, notably an old READ paired with a rebased WRITE, which
+	// reads as "already ahead" and would report an advance nobody made.
+	for (let trigger = 1; trigger <= 12; trigger++) {
+		it(`never renders old-timeline samples when the re-anchor lands at load ${trigger}`, () => {
+			const init = allocSharedRingBuffer(1, 64, 1000, true);
+			const main = new SharedRingBuffer(init);
+			main.setLatency(16);
+
+			const worklet = new SharedRingBuffer(main.init);
+			const out = [new Float32Array(16)];
+			for (let t = 0; t < 2000; t += 16) {
+				insert(main, 10_000 + t, 16, { channels: 1, value: 1 });
+				worklet.read(out);
+			}
+			insert(main, 12_000, 32, { channels: 1, value: 1 });
+
+			// Whether the read had already published its advance when the re-anchor landed. Firing
+			// after that point is a legitimate ordering: the quantum was valid when it committed.
+			let committed = false;
+			let firedAfterCommit = false;
+			// The generation `read` snapshotted (its first GENERATION load), against the one in
+			// force just before the re-anchor. Equal means the read is working on the timeline the
+			// re-anchor is about to replace.
+			let snapshot: number | undefined;
+			let generationAtFire = -1;
+			let calls = 0;
+			let fired = false;
+
+			const atomics = Atomics as { load: unknown; compareExchange: unknown };
+			const realLoad = Atomics.load;
+			const realExchange = Atomics.compareExchange;
+
+			atomics.compareExchange = (arr: Int32Array, idx: number, expected: number, replacement: number) => {
+				const witnessed = realExchange(arr, idx, expected, replacement);
+				if (idx === 1 && witnessed === expected) committed = true;
+				return witnessed;
+			};
+			const control = new Int32Array(main.init.control);
+			atomics.load = (arr: Int32Array, idx: number) => {
+				const value = realLoad(arr, idx);
+				if (idx === 4 && snapshot === undefined) snapshot = value;
+				if (!fired && ++calls === trigger) {
+					fired = true;
+					firedAfterCommit = committed;
+					generationAtFire = realLoad(control, 4);
+					main.reset();
+					insert(main, 30_000, 32, { channels: 1, value: 2 });
+				}
+				return value;
+			};
+
+			out[0].fill(-1);
+			let result = 0;
+			try {
+				result = worklet.read(out);
+			} finally {
+				atomics.load = realLoad;
+				atomics.compareExchange = realExchange;
+			}
+
+			if (!fired) return; // read() took a shorter path than this trigger
+
+			// A re-anchor that beat the commit, on the timeline the read had already snapshotted,
+			// invalidates the quantum: it has to be reported as nothing read and scrubbed from the
+			// buffer the worklet renders. Firing before the snapshot means the read simply picked
+			// up the new timeline, and firing after the commit means the quantum was already valid.
+			if (!firedAfterCommit && snapshot === generationAtFire) {
+				expect(result).toBe(0);
+				expect(out[0].some((sample) => sample === 1)).toBe(false);
+			}
+
+			// Either way the ring stays usable for the new utterance.
+			expect((Atomics.load(control, 0) - Atomics.load(control, 1)) | 0).toBeGreaterThanOrEqual(0);
 		});
 	}
 });

--- a/js/watch/src/audio/shared-ring-buffer.test.ts
+++ b/js/watch/src/audio/shared-ring-buffer.test.ts
@@ -857,3 +857,60 @@ describe("buffered mode", () => {
 		expect(read(buffer, 100, 1)[0].length).toBe(0);
 	});
 });
+
+describe("read() racing a re-anchor", () => {
+	// `buffered` picks which advance inside read() the re-anchor races: the latency skip only
+	// runs in non-buffered mode, so buffered mode leaves the final commit as the only one.
+	for (const buffered of [false, true]) {
+		it(`stays usable when a re-anchor races the ${buffered ? "commit" : "latency skip"}`, () => {
+			const init = allocSharedRingBuffer(1, 64, 1000, buffered);
+			const main = new SharedRingBuffer(init);
+			main.setLatency(16);
+
+			// A long first utterance, mostly played out, so READ sits far from zero.
+			const worklet = new SharedRingBuffer(main.init);
+			const out = [new Float32Array(16)];
+			for (let t = 0; t < 2000; t += 16) {
+				insert(main, 10_000 + t, 16, { channels: 1, value: 1 });
+				worklet.read(out);
+			}
+
+			// Leave something buffered so the final read reaches its commit.
+			insert(main, 12_000, 32, { channels: 1, value: 1 });
+
+			// The read has snapshotted READ/WRITE by the time it compare-exchanges, so firing the
+			// re-anchor here is exactly the window: the commit lands on the rebased timeline.
+			let fired = false;
+			const atomics = Atomics as { compareExchange: unknown };
+			const realExchange = Atomics.compareExchange;
+			atomics.compareExchange = (arr: Int32Array, idx: number, expected: number, replacement: number) => {
+				if (!fired) {
+					fired = true;
+					main.reset();
+					insert(main, 30_000, 32, { channels: 1, value: 2 });
+				}
+				return realExchange(arr, idx, expected, replacement);
+			};
+
+			try {
+				worklet.read(out);
+			} finally {
+				atomics.compareExchange = realExchange;
+			}
+
+			expect(fired).toBe(true);
+
+			// The new utterance must still be playable: READ cannot be left beyond WRITE.
+			const control = new Int32Array(main.init.control);
+			const read = Atomics.load(control, 1);
+			const write = Atomics.load(control, 0);
+			expect((write - read) | 0).toBeGreaterThanOrEqual(0);
+
+			// And it must actually come back out.
+			insert(main, 30_032, 32, { channels: 1, value: 2 });
+			let played = 0;
+			for (let i = 0; i < 8; i++) played += worklet.read(out);
+			expect(played).toBeGreaterThan(0);
+		});
+	}
+});

--- a/js/watch/src/audio/shared-ring-buffer.ts
+++ b/js/watch/src/audio/shared-ring-buffer.ts
@@ -157,13 +157,10 @@ export class SharedRingBuffer {
 	#reconcile(source: SharedRingBuffer): void {
 		if (source.channels !== this.channels || source.rate !== this.rate) return;
 
-		const candidate = Atomics.load(source.#control, READ);
+		const generation = Atomics.load(this.#control, GENERATION);
+		if (Atomics.load(source.#control, GENERATION) !== generation) return;
 
-		for (;;) {
-			const generation = Atomics.load(this.#control, GENERATION);
-			if (Atomics.load(source.#control, GENERATION) !== generation) return;
-			if (this.#advanceRead(candidate, generation)) return;
-		}
+		this.#advanceRead(Atomics.load(source.#control, READ), generation);
 	}
 
 	/**
@@ -185,20 +182,25 @@ export class SharedRingBuffer {
 	 * What survives is bounded: READ at most at WRITE, which is the empty ring `truncate`
 	 * already documents, costing a quantum of silence that heals on the next insert.
 	 */
-	#advanceRead(candidate: number, generation: number): boolean {
-		const current = Atomics.load(this.#control, READ);
-		const write = Atomics.load(this.#control, WRITE);
+	#advanceRead(candidate: number, generation: number): number | undefined {
+		for (;;) {
+			if (Atomics.load(this.#control, GENERATION) !== generation) return undefined;
 
-		const target = ((candidate - write) | 0) > 0 ? write : candidate;
-		if (((target - current) | 0) <= 0) return true;
+			const current = Atomics.load(this.#control, READ);
+			const write = Atomics.load(this.#control, WRITE);
 
-		if (Atomics.compareExchange(this.#control, READ, current, target) !== current) return false;
+			const target = ((candidate - write) | 0) > 0 ? write : candidate;
+			if (((target - current) | 0) <= 0) return current;
 
-		if (Atomics.load(this.#control, GENERATION) !== generation) {
-			Atomics.compareExchange(this.#control, READ, target, current);
+			if (Atomics.compareExchange(this.#control, READ, current, target) !== current) continue;
+
+			if (Atomics.load(this.#control, GENERATION) !== generation) {
+				Atomics.compareExchange(this.#control, READ, target, current);
+				return undefined;
+			}
+
+			return target;
 		}
-
-		return true;
 	}
 
 	/**
@@ -301,6 +303,12 @@ export class SharedRingBuffer {
 	read(output: Float32Array[]): number {
 		if (Atomics.load(this.#control, STALLED) === 1) return 0;
 
+		// The timeline this read belongs to. STALLED is only checked on entry, so a reset plus a
+		// re-anchoring insert can rebase the cursors while this read is still copying. Everything
+		// below derives from the snapshot taken here, and committing any of it afterwards would
+		// park the playhead against an anchor that no longer exists.
+		const generation = Atomics.load(this.#control, GENERATION);
+
 		let read = Atomics.load(this.#control, READ);
 		const write = Atomics.load(this.#control, WRITE);
 		const latency = Atomics.load(this.#control, LATENCY);
@@ -311,7 +319,9 @@ export class SharedRingBuffer {
 		const buffered = (write - read) | 0;
 		if (!this.buffered && latency > 0 && buffered > latency) {
 			const skipTo = (write - latency) | 0;
-			read = casAdvance(this.#control, READ, skipTo);
+			const skipped = this.#advanceRead(skipTo, generation);
+			if (skipped === undefined) return 0;
+			read = skipped;
 		}
 
 		const available = (write - read) | 0;
@@ -327,8 +337,10 @@ export class SharedRingBuffer {
 			}
 		}
 
-		// Advance READ via CAS so a concurrent writer overflow can't be undone.
-		casAdvance(this.#control, READ, (read + count) | 0);
+		// Commit through the same guard: a re-anchor while we were copying means these samples
+		// belong to a playhead that no longer exists, so drop the quantum rather than publish a
+		// stale cursor. A quantum of silence is what `truncate` already trades for the same reason.
+		if (this.#advanceRead((read + count) | 0, generation) === undefined) return 0;
 
 		return count;
 	}

--- a/js/watch/src/audio/shared-ring-buffer.ts
+++ b/js/watch/src/audio/shared-ring-buffer.ts
@@ -190,7 +190,13 @@ export class SharedRingBuffer {
 			const write = Atomics.load(this.#control, WRITE);
 
 			const target = ((candidate - write) | 0) > 0 ? write : candidate;
-			if (((target - current) | 0) <= 0) return current;
+			if (((target - current) | 0) <= 0) {
+				// `current` and `write` are separate loads. A re-anchor between them pairs an old
+				// cursor with a rebased bound, which reads as "already ahead" and would report an
+				// advance nobody made, so confirm the timeline held before believing it.
+				if (Atomics.load(this.#control, GENERATION) !== generation) return undefined;
+				return current;
+			}
 
 			if (Atomics.compareExchange(this.#control, READ, current, target) !== current) continue;
 
@@ -340,7 +346,13 @@ export class SharedRingBuffer {
 		// Commit through the same guard: a re-anchor while we were copying means these samples
 		// belong to a playhead that no longer exists, so drop the quantum rather than publish a
 		// stale cursor. A quantum of silence is what `truncate` already trades for the same reason.
-		if (this.#advanceRead((read + count) | 0, generation) === undefined) return 0;
+		if (this.#advanceRead((read + count) | 0, generation) === undefined) {
+			// The copy above already filled `output`, and the worklet takes the return value as an
+			// underflow count rather than clearing what it was handed. Silence it here or the
+			// dropped quantum plays anyway.
+			for (let channel = 0; channel < this.channels; channel++) output[channel].fill(0, 0, count);
+			return 0;
+		}
 
 		return count;
 	}


### PR DESCRIPTION
Closes #3253, found by Codex while reviewing [#3197](https://github.com/moq-dev/moq/pull/3197) and confirmed pre-existing (`read()` was byte-identical on `main` and that branch).

## Root cause

`read()` checks STALLED only on entry, then snapshots READ and WRITE, copies samples, and only afterwards advances READ. A `reset()` plus a re-anchoring `insert()` landing in that window rebases both cursors, so the advance commits a playhead measured against an anchor that no longer exists.

On a long-running stream READ lands far past the new WRITE. The ring then reads as empty and `insert()` discards new samples as too old until WRITE catches up, which is the same failure shape [#3197](https://github.com/moq-dev/moq/pull/3197) fixed for the resize handoff. The regression test reproduces it at 2000 samples past WRITE.

## Fix: one guarded advance, not three

[#3197](https://github.com/moq-dev/moq/pull/3197) already had to solve this for the reconcile, and got it wrong twice before it was right. So rather than duplicate that reasoning into `read()`, this folds it into a single `#advanceRead(candidate, generation)` that returns the resulting cursor, or `undefined` when the timeline moved under it. It keeps the three properties that took two rounds to get right:

- clamp to a freshly loaded WRITE, so a racing advance cannot park READ beyond the new timeline
- compare-exchange from an exact observed READ, so the re-anchor's `store(READ, 0)` makes it fail and retry
- re-read GENERATION after a successful exchange and undo, catching the ABA where the observed READ was already 0

All of it rests on `insert()` bumping GENERATION *before* rebasing the cursors, which is what [#3197](https://github.com/moq-dev/moq/pull/3197) established.

Both of `read()`'s advances now go through it: the latency skip and the final commit. Either one seeing a moved timeline drops the quantum, since the copied samples belong to a playhead that no longer exists. A quantum of silence is what `truncate()` already trades for the same reason.

`#reconcile` uses the same helper, so the concurrency argument lives in exactly one place.

## Test plan

- `nix develop --command just js check`
- `nix develop --command just js test` (all packages, 0 fail)

Two tests force the interleaving by firing the re-anchor from inside `Atomics.compareExchange`, which is precisely the window: the read has already snapshotted its cursors by then. `buffered` mode picks which advance is under test, since the latency skip only runs in non-buffered mode, leaving the commit as the only advance in buffered mode.

Both guards are independently load-bearing: removing either one fails exactly its own test.

Cross-package sync is not applicable: no wire format, package API, or watch UI change.

(written by Claude Opus 5)