### PR TITLE
fix(moq-mux): wait for late groups within the latency budget

### DIFF
--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -26,9 +26,11 @@ use super::{Container, Frame};
 /// consumer waits for it until everything it could still present (bounded by where the
 /// next group begins) falls a full budget behind the newest content.
 ///
-/// A [`Subscription::group_start`](moq_net::track::Subscription::group_start) request
-/// pins where delivery begins: the consumer waits for that group under the same budget
-/// instead of latching onto whichever group's frames win the arrival race.
+/// Delivery starts at [`Subscription::group_start`](moq_net::track::Subscription::group_start)
+/// (or group 0), and that same budget is the one rule that catches the consumer up to
+/// the live edge: there is no separate startup path racing on arrival order. History the
+/// publisher no longer serves expires like any other gap, since its reach sits a full
+/// budget behind the newest content.
 ///
 /// A stalled group is also skipped early, regardless of the latency budget, once it has
 /// presented up to where the next group begins. CMAF frames carry a per-sample duration,
@@ -56,10 +58,6 @@ pub struct Consumer<F: Container> {
 
 	// Groups that we are monitoring, sorted by sequence ascending.
 	pending: VecDeque<GroupBuffer>,
-
-	// When true, we haven't returned a frame yet and need to select the first group.
-	// We wait until we have at least one frame before finalizing `current`
-	startup: bool,
 
 	// The maximum buffer size before skipping a group.
 	latency: std::time::Duration,
@@ -138,16 +136,15 @@ impl<F: Container> Consumer<F> {
 	///
 	/// Skips aggressively by default; raise the tolerance with [`with_latency`](Self::with_latency).
 	pub fn new(track: moq_net::track::Subscriber, format: F) -> Self {
-		// An explicit start group says exactly where delivery begins, so there is no
-		// first-arrival race to resolve: wait for that group under the latency budget
-		// instead of latching onto whichever stream wins.
+		// Delivery starts at the requested group (or 0); the latency budget is the one
+		// rule that catches the cursor up to the live edge, so there is no separate
+		// startup path racing on arrival order.
 		let start = track.subscription().group_start;
 		Self {
 			track,
 			format,
 			current: start.unwrap_or(0),
 			pending: VecDeque::new(),
-			startup: start.is_none(),
 			latency: std::time::Duration::ZERO,
 			rewind: Rewind::default(),
 			end: None,
@@ -158,8 +155,12 @@ impl<F: Container> Consumer<F> {
 	///
 	/// Groups with timestamps older than the newest timestamp minus this value are skipped. Zero
 	/// (the default) skips aggressively: any group with a newer alternative is dropped.
+	///
+	/// Clamped to the publisher's retention window
+	/// ([`Info::latency_max`](moq_net::track::Info::latency_max)): a group can't be
+	/// waited for longer than it's kept around, so a larger budget would only stall.
 	pub fn with_latency(mut self, latency: std::time::Duration) -> Self {
-		self.latency = latency;
+		self.set_latency(latency);
 		self
 	}
 
@@ -202,23 +203,6 @@ impl<F: Container> Consumer<F> {
 	pub fn poll_read(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<Frame>, F::Error>> {
 		// Grab any new groups from the track, recording whether the track is finished.
 		let finished = self.poll_read_finish(waiter)?.is_ready();
-
-		// On startup, wait until at least one group has a frame, then start from the
-		// lowest arrived sequence. An earlier group whose frames merely lost the race
-		// stays pending: the latency budget below decides whether to wait for it or
-		// skip it, rather than the winning stream deciding by arrival order.
-		if self.startup {
-			// NOTE: poll_min_timestamp buffers at least one frame per group and
-			// registers the waiter on the ones still empty.
-			let any_frame = self
-				.pending
-				.iter_mut()
-				.any(|group| matches!(group.poll_min_timestamp(waiter, &self.format), Poll::Ready(Ok(_))));
-			if any_frame {
-				self.current = self.pending.front().expect("a group has a frame").sequence;
-				self.startup = false;
-			}
-		}
 
 		loop {
 			// A newer group whose timestamps jumped backwards means the publisher reneged
@@ -543,9 +527,10 @@ impl<F: Container> Consumer<F> {
 		Ok(())
 	}
 
-	/// Set the maximum latency tolerance.
+	/// Set the maximum latency tolerance, clamped to the publisher's retention window
+	/// like [`with_latency`](Self::with_latency).
 	pub fn set_latency(&mut self, latency: std::time::Duration) {
-		self.latency = latency;
+		self.latency = latency.min(self.track.info().latency_max);
 	}
 }
 
@@ -1588,9 +1573,8 @@ mod tests {
 	}
 
 	/// An explicit start group pins where delivery begins: when a later group's stream
-	/// wins the arrival race, startup waits for the requested head under the latency
-	/// budget instead of latching onto the winner and dropping the head on arrival
-	/// (#3258).
+	/// wins the arrival race, the consumer waits for the requested head under the
+	/// latency budget instead of dropping it on arrival (#3258).
 	#[tokio::test]
 	async fn startup_keeps_late_arriving_head_group_within_latency() {
 		tokio::time::pause();
@@ -1620,9 +1604,8 @@ mod tests {
 		assert_eq!(micros, vec![0, 100_000], "the head group is delivered first");
 	}
 
-	/// A group whose stream arrived first but whose frames lost the race is not drained
-	/// by startup: the consumer starts from the lowest arrived sequence and reads the
-	/// slow group's frames once they land (#3258).
+	/// A group whose frames lost the race to a newer group's stream is still read once
+	/// they land: the cursor starts at group 0 and waits under the budget (#3258).
 	#[tokio::test]
 	async fn startup_keeps_slow_earlier_stream_within_latency() {
 		tokio::time::pause();
@@ -1658,14 +1641,14 @@ mod tests {
 
 		let frames = read_all(&mut consumer).await.unwrap();
 		let micros: Vec<u128> = frames.iter().map(|f| f.timestamp.as_micros()).collect();
-		assert_eq!(micros, vec![0, 100_000], "the slow stream's frames survive startup");
+		assert_eq!(micros, vec![0, 100_000], "the slow stream's frames are delivered");
 	}
 
 	// ---- Decode errors ----
 
 	/// A container that decodes each frame's payload as an 8-byte LE microsecond
 	/// timestamp, but treats a `FAIL` payload as a malformed frame. Lets a test put a
-	/// decodable frame first (so startup selects the group) and a decode failure after.
+	/// decodable frame first (so the consumer reads the group) and a decode failure after.
 	struct FailingDecode;
 
 	impl ContainerTrait for FailingDecode {
@@ -1710,7 +1693,7 @@ mod tests {
 		let consumer_track = track.subscribe(None);
 		let mut consumer = Consumer::new(consumer_track, FailingDecode);
 
-		// A decodable frame first (so startup selects the group), then a malformed one.
+		// A decodable frame first, then a malformed one.
 		let mut group = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
 		group
 			.write_frame(moq_net::Timestamp::ZERO, Bytes::from(0u64.to_le_bytes().to_vec()))

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -306,6 +306,25 @@ impl<F: Container> Consumer<F> {
 				}
 			}
 
+			// Walk the cursor over missing sequences below the first arrived group.
+			// Groups race on independent QUIC streams (newer ones at higher priority),
+			// so a buffered higher sequence proves nothing: the missing one may be
+			// merely late, and there is no way to tell that from an eviction. The
+			// latency budget is the gate: everything a missing group could still
+			// present is bounded by where the next stamped group begins. A finished
+			// track closes the gap outright, since no new group can arrive. That proof
+			// covers only sequences that never arrived: finishing the track ends new
+			// groups, not the frames still flowing on ones already open, so arrived
+			// groups are settled below by their own FIN, abort, or the budget.
+			if let Some(front_sequence) = self.pending.front().map(|g| g.sequence)
+				&& front_sequence > self.current
+				&& let Some((_, next_start)) = next_group
+				&& (finished || max_timestamp.saturating_sub(next_start) >= self.latency)
+			{
+				self.current = front_sequence;
+				continue;
+			}
+
 			let should_skip = if let Some((_, next_start)) = next_group {
 				if let Some(oldest) = oldest_timestamp {
 					// Current group is blocking. Skip if newer groups have pulled past
@@ -316,16 +335,10 @@ impl<F: Container> Consumer<F> {
 					let covered = current_end.is_some_and(|end| end >= next_start);
 					over_latency || covered
 				} else {
-					// The current group can't produce a timestamp: either it's missing
-					// entirely, or it's arrived but frameless. Groups race on independent
-					// QUIC streams (newer ones at higher priority), so a buffered higher
-					// sequence proves nothing: the missing one may be merely late, and
-					// there is no way to tell that from an eviction. The latency budget is
-					// the only gate: everything the missing group could still present is
-					// bounded by where the next group begins, so skip once the newest
-					// content is a full budget past that point. A finished track can
-					// never deliver it, so skip immediately.
-					finished || max_timestamp.saturating_sub(next_start) >= self.latency
+					// The current group has arrived but has no frame yet. Its content
+					// is bounded by where the next stamped group begins the same way a
+					// missing one's is, so give it the same budget before giving up.
+					max_timestamp.saturating_sub(next_start) >= self.latency
 				}
 			} else {
 				false
@@ -531,6 +544,13 @@ impl<F: Container> Consumer<F> {
 	/// like [`with_latency`](Self::with_latency).
 	pub fn set_latency(&mut self, latency: std::time::Duration) {
 		self.latency = latency.min(self.track.info().latency_max);
+		// The transport enforces the same budget on the subscription itself, so a
+		// tolerance set here has to reach it: otherwise moq-net skips the very groups
+		// this consumer was told to wait for, before they ever get here. The
+		// subscription keeps the requested value verbatim; the publisher applies its
+		// own window to the aggregate.
+		let subscription = self.track.subscription().with_latency_max(latency);
+		let _ = self.track.update(subscription);
 	}
 }
 
@@ -1961,6 +1981,9 @@ mod tests {
 		finisher.await.unwrap();
 	}
 
+	/// An arrived group with no frames yet is settled only by its own FIN, abort, or the
+	/// latency budget, never by the track finishing: the track boundary ends new groups,
+	/// not the frames still flowing on open ones. Here the budget expires it.
 	#[tokio::test]
 	async fn startup_skips_groups_without_data() {
 		tokio::time::pause();
@@ -1970,19 +1993,77 @@ mod tests {
 
 		let _group5 = track.create_group(moq_net::group::Info { sequence: 5 }).unwrap();
 		write_group(&mut track, 7, &[ts(210_000)]);
+
+		// Group 5 is open and within budget: its frames may still arrive, so wait.
+		assert!(
+			tokio::time::timeout(Duration::from_millis(50), consumer.read())
+				.await
+				.is_err(),
+			"an open frameless group within budget must be waited for"
+		);
+
+		// Group 9 pushes the newest content a full budget past what group 5 could still
+		// present (bounded by group 7's start), expiring it.
+		write_group(&mut track, 9, &[ts(800_000)]);
 		track.finish().unwrap();
 
-		let frames = tokio::time::timeout(Duration::from_millis(500), async {
-			let mut frames = Vec::new();
-			while let Some(frame) = consumer.read().await.unwrap() {
-				frames.push(frame);
-			}
-			frames
-		})
-		.await
-		.expect("should not hang");
+		let frames = read_all(&mut consumer).await.unwrap();
+		let micros: Vec<u128> = frames.iter().map(|f| f.timestamp.as_micros()).collect();
+		assert_eq!(micros, vec![210_000, 800_000], "the expired frameless group is skipped");
+	}
 
-		assert!(!frames.is_empty());
+	/// Track completion is not group completion: a group already open when the track
+	/// finishes can still receive frames, so it must not be skipped as if it were a
+	/// missing sequence. Its late frames are delivered when they land within budget.
+	#[tokio::test]
+	async fn finished_track_waits_for_an_open_head_group() {
+		tokio::time::pause();
+		let mut track = track_producer("test", hang::container::track_info());
+		let consumer_track = track.subscribe(None);
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+
+		// Group 0's stream is open but its frames lose the race; the track boundary
+		// arrives before them.
+		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
+		write_group(&mut track, 1, &[ts(100_000)]);
+		track.finish().unwrap();
+
+		assert!(
+			tokio::time::timeout(Duration::from_millis(50), consumer.read())
+				.await
+				.is_err(),
+			"the open head group is within budget and must be waited for"
+		);
+
+		// Its frames land moments later, well within the 500ms budget.
+		Container::Legacy
+			.write(
+				&mut group0,
+				&[Frame {
+					timestamp: ts(0),
+					payload: Bytes::from_static(&[0xDE, 0xAD]),
+					keyframe: false,
+					duration: None,
+				}],
+			)
+			.unwrap();
+		group0.finish().unwrap();
+
+		let frames = read_all(&mut consumer).await.unwrap();
+		let micros: Vec<u128> = frames.iter().map(|f| f.timestamp.as_micros()).collect();
+		assert_eq!(micros, vec![0, 100_000], "the open group's late frames are delivered");
+	}
+
+	/// The latency tolerance reaches the wire subscription, so moq-net doesn't skip the
+	/// very groups this consumer was told to wait for before they get here.
+	#[tokio::test]
+	async fn with_latency_updates_the_wire_budget() {
+		let track = track_producer("test", hang::container::track_info());
+		let consumer_track = track.subscribe(None);
+		let _consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(250));
+
+		let aggregate = track.subscription().expect("a live subscriber");
+		assert_eq!(aggregate.latency_max, Duration::from_millis(250));
 	}
 
 	#[tokio::test]

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -21,7 +21,14 @@ use super::{Container, Frame};
 /// and the newest available timestamp exceeds the configured latency. With the default
 /// latency of zero, the consumer skips aggressively. Any group that has a newer
 /// alternative is dropped. With a non-zero latency, slow groups are tolerated up to that
-/// budget before being skipped.
+/// budget before being skipped. A missing sequence gets the same tolerance: there is no
+/// way to tell a stream that lost the delivery race from one the cache evicted, so the
+/// consumer waits for it until everything it could still present (bounded by where the
+/// next group begins) falls a full budget behind the newest content.
+///
+/// A [`Subscription::group_start`](moq_net::track::Subscription::group_start) request
+/// pins where delivery begins: the consumer waits for that group under the same budget
+/// instead of latching onto whichever group's frames win the arrival race.
 ///
 /// A stalled group is also skipped early, regardless of the latency budget, once it has
 /// presented up to where the next group begins. CMAF frames carry a per-sample duration,
@@ -131,12 +138,16 @@ impl<F: Container> Consumer<F> {
 	///
 	/// Skips aggressively by default; raise the tolerance with [`with_latency`](Self::with_latency).
 	pub fn new(track: moq_net::track::Subscriber, format: F) -> Self {
+		// An explicit start group says exactly where delivery begins, so there is no
+		// first-arrival race to resolve: wait for that group under the latency budget
+		// instead of latching onto whichever stream wins.
+		let start = track.subscription().group_start;
 		Self {
 			track,
 			format,
-			current: 0,
+			current: start.unwrap_or(0),
 			pending: VecDeque::new(),
-			startup: true,
+			startup: start.is_none(),
 			latency: std::time::Duration::ZERO,
 			rewind: Rewind::default(),
 			end: None,
@@ -192,21 +203,20 @@ impl<F: Container> Consumer<F> {
 		// Grab any new groups from the track, recording whether the track is finished.
 		let finished = self.poll_read_finish(waiter)?.is_ready();
 
-		// On startup, we want to poll every pending group and advance self.current to the first with a frame.
+		// On startup, wait until at least one group has a frame, then start from the
+		// lowest arrived sequence. An earlier group whose frames merely lost the race
+		// stays pending: the latency budget below decides whether to wait for it or
+		// skip it, rather than the winning stream deciding by arrival order.
 		if self.startup {
-			// NOTE: We loop in ascending order, so earlier groups will win the race.
-			for (i, group) in self.pending.iter_mut().enumerate() {
-				// We call poll_min_timestamp to try to buffer at least one frame per group.
-				// This returns Ready(Ok) if there is a buffered frame.
-				if !matches!(group.poll_min_timestamp(waiter, &self.format), Poll::Ready(Ok(_))) {
-					continue;
-				}
-
-				// Start reading from this group and skip any previous groups.
-				self.current = group.sequence;
+			// NOTE: poll_min_timestamp buffers at least one frame per group and
+			// registers the waiter on the ones still empty.
+			let any_frame = self
+				.pending
+				.iter_mut()
+				.any(|group| matches!(group.poll_min_timestamp(waiter, &self.format), Poll::Ready(Ok(_))));
+			if any_frame {
+				self.current = self.pending.front().expect("a group has a frame").sequence;
 				self.startup = false;
-				self.pending.drain(0..i);
-				break;
 			}
 		}
 
@@ -323,12 +333,15 @@ impl<F: Container> Consumer<F> {
 					over_latency || covered
 				} else {
 					// The current group can't produce a timestamp: either it's missing
-					// entirely -- a lower sequence the cache evicted, so `front` is already
-					// past `current` -- or it's finished/empty. With a newer group buffered,
-					// skip if the track is done OR the current sequence is simply gone. On a
-					// live track a buffered higher sequence means the missing one was evicted
-					// (the relay delivers in order), not merely late, so waiting is futile.
-					finished || self.pending.front().is_some_and(|g| g.sequence > self.current)
+					// entirely, or it's arrived but frameless. Groups race on independent
+					// QUIC streams (newer ones at higher priority), so a buffered higher
+					// sequence proves nothing: the missing one may be merely late, and
+					// there is no way to tell that from an eviction. The latency budget is
+					// the only gate: everything the missing group could still present is
+					// bounded by where the next group begins, so skip once the newest
+					// content is a full budget past that point. A finished track can
+					// never deliver it, so skip immediately.
+					finished || max_timestamp.saturating_sub(next_start) >= self.latency
 				}
 			} else {
 				false
@@ -339,12 +352,16 @@ impl<F: Container> Consumer<F> {
 			{
 				// A zero-frame group is ambiguous until its FIN arrives. Keep it in order so a
 				// delayed empty-group boundary cannot be discarded before it is recognized.
+				// With nothing delivered since the last boundary there is no codec state to
+				// reset, so a would-be discontinuity is redundant and the wait is skipped.
 				let mut discontinuities = 0;
-				for group in self.pending.iter_mut().take(new_idx) {
-					match group.poll_empty(waiter) {
-						Poll::Ready(true) => discontinuities += 1,
-						Poll::Ready(false) => {}
-						Poll::Pending => return Poll::Pending,
+				if self.rewind.live_edge.is_some() {
+					for group in self.pending.iter_mut().take(new_idx) {
+						match group.poll_empty(waiter) {
+							Poll::Ready(true) => discontinuities += 1,
+							Poll::Ready(false) => {}
+							Poll::Pending => return Poll::Pending,
+						}
 					}
 				}
 				self.pending.drain(0..new_idx);
@@ -1501,10 +1518,12 @@ mod tests {
 		assert_eq!(next.timestamp, ts(150_000), "skipped the evicted gap to the live group");
 	}
 
-	/// A missing (evicted) sequence with a newer group buffered must be skipped even
-	/// while the track is still LIVE -- not only once it's finished. This is the
-	/// recorder resume stall: `current` points at a sequence the cache dropped, a
-	/// higher group is buffered, and the track never finishes.
+	/// A missing (evicted) sequence with a newer group buffered must be skipped once the
+	/// latency budget runs out, even while the track is still LIVE -- not only once it's
+	/// finished. This is the recorder resume stall: `current` points at a sequence the
+	/// cache dropped, higher groups are buffered, and the track never finishes. The gap
+	/// is indistinguishable from a stream that lost the delivery race, so the skip fires
+	/// only once the newest content is a full budget past what the gap could still hold.
 	#[tokio::test]
 	async fn missing_sequence_skips_on_live_track() {
 		let mut track = track_producer("test", hang::container::track_info());
@@ -1512,9 +1531,11 @@ mod tests {
 		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(100));
 
 		// Group 0, then group 2 -- sequence 1 is missing (evicted) and never arrives.
-		// The track is NOT finished (live), the case that used to hang.
+		// The track is NOT finished (live), the case that used to hang. Group 3 pushes
+		// the live edge a full budget past group 2's start, expiring the gap at 1.
 		write_group(&mut track, 0, &[ts(0), ts(20_000)]);
 		write_group(&mut track, 2, &[ts(200_000)]);
+		write_group(&mut track, 3, &[ts(320_000)]);
 
 		// Reading must reach group 2 across the gap instead of waiting forever for 1.
 		let reached = tokio::time::timeout(Duration::from_secs(1), async {
@@ -1527,6 +1548,117 @@ mod tests {
 		})
 		.await;
 		assert!(reached.is_ok(), "consumer hung on a missing sequence on a live track");
+	}
+
+	/// The other half of the budget-gated gap: while the newest content is still within
+	/// the latency budget of what the missing sequence could present, the consumer waits
+	/// for it instead of writing it off, and delivers it when its stream loses the race
+	/// but still arrives (#3258).
+	#[tokio::test]
+	async fn gap_keeps_late_arriving_group_within_latency() {
+		tokio::time::pause();
+		let mut track = track_producer("test", hang::container::track_info());
+		let consumer_track =
+			track.subscribe(moq_net::track::Subscription::default().with_latency_max(Duration::from_millis(500)));
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+
+		// Group 2's stream beats group 1's, which hasn't arrived at all yet.
+		write_group(&mut track, 0, &[ts(0)]);
+		write_group(&mut track, 2, &[ts(200_000)]);
+
+		let first = consumer.read().await.unwrap().expect("group 0 frame");
+		assert_eq!(first.timestamp, ts(0));
+
+		// Group 0 is done; group 1's stream is still racing. Within the budget the
+		// consumer waits at the gap rather than skipping to group 2.
+		assert!(
+			tokio::time::timeout(Duration::from_millis(50), consumer.read())
+				.await
+				.is_err(),
+			"the gap at sequence 1 is within budget and must be waited for"
+		);
+
+		// Group 1's stream opens moments later, well within the 500ms budget.
+		write_group(&mut track, 1, &[ts(100_000)]);
+		track.finish().unwrap();
+
+		let frames = read_all(&mut consumer).await.unwrap();
+		let micros: Vec<u128> = frames.iter().map(|f| f.timestamp.as_micros()).collect();
+		assert_eq!(micros, vec![100_000, 200_000], "the late group is delivered in order");
+	}
+
+	/// An explicit start group pins where delivery begins: when a later group's stream
+	/// wins the arrival race, startup waits for the requested head under the latency
+	/// budget instead of latching onto the winner and dropping the head on arrival
+	/// (#3258).
+	#[tokio::test]
+	async fn startup_keeps_late_arriving_head_group_within_latency() {
+		tokio::time::pause();
+		let mut track = track_producer("test", hang::container::track_info());
+		let consumer_track = track.subscribe(
+			moq_net::track::Subscription::default()
+				.with_group_start(0)
+				.with_latency_max(Duration::from_millis(500)),
+		);
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+
+		// Group 1's stream wins the race, and the consumer polls before group 0 lands.
+		write_group(&mut track, 1, &[ts(100_000)]);
+		assert!(
+			tokio::time::timeout(Duration::from_millis(50), consumer.read())
+				.await
+				.is_err(),
+			"the requested head is within budget and must be waited for"
+		);
+
+		// Group 0 arrives moments later, well within the 500ms budget.
+		write_group(&mut track, 0, &[ts(0)]);
+		track.finish().unwrap();
+
+		let frames = read_all(&mut consumer).await.unwrap();
+		let micros: Vec<u128> = frames.iter().map(|f| f.timestamp.as_micros()).collect();
+		assert_eq!(micros, vec![0, 100_000], "the head group is delivered first");
+	}
+
+	/// A group whose stream arrived first but whose frames lost the race is not drained
+	/// by startup: the consumer starts from the lowest arrived sequence and reads the
+	/// slow group's frames once they land (#3258).
+	#[tokio::test]
+	async fn startup_keeps_slow_earlier_stream_within_latency() {
+		tokio::time::pause();
+		let mut track = track_producer("test", hang::container::track_info());
+		let consumer_track = track.subscribe(None);
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+
+		// Group 0's stream opens first but carries no frames yet; group 1's frame wins.
+		let mut group0 = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
+		write_group(&mut track, 1, &[ts(100_000)]);
+
+		// Startup latches onto the lowest arrived sequence and waits under the budget.
+		assert!(
+			tokio::time::timeout(Duration::from_millis(50), consumer.read())
+				.await
+				.is_err(),
+			"group 0's frames are within budget and must be waited for"
+		);
+
+		Container::Legacy
+			.write(
+				&mut group0,
+				&[Frame {
+					timestamp: ts(0),
+					payload: Bytes::from_static(&[0xDE, 0xAD]),
+					keyframe: false,
+					duration: None,
+				}],
+			)
+			.unwrap();
+		group0.finish().unwrap();
+		track.finish().unwrap();
+
+		let frames = read_all(&mut consumer).await.unwrap();
+		let micros: Vec<u128> = frames.iter().map(|f| f.timestamp.as_micros()).collect();
+		assert_eq!(micros, vec![0, 100_000], "the slow stream's frames survive startup");
 	}
 
 	// ---- Decode errors ----

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -229,6 +229,17 @@ impl<F: Container> Consumer<F> {
 			}
 		}
 
+		// Reap aborted groups the cursor hasn't reached: nothing below settles them
+		// (the read arm only handles the front at the cursor, and neither the skip
+		// target scan nor the empty-group check counts an abort), so one left ahead
+		// of a sequence gap would park the consumer forever. Buffered frames read
+		// before the abort stay deliverable, so such a group is kept; the front at
+		// the cursor keeps the eviction fast path in the read arm below.
+		// poll_aborted registers the waiter on live groups, so a later abort re-polls.
+		let current = self.current;
+		self.pending
+			.retain_mut(|group| group.sequence <= current || !group.buffered.is_empty() || !group.poll_aborted(waiter));
+
 		loop {
 			// A newer group whose timestamps jumped backwards means the publisher reneged
 			// the buffered tail. Record the boundary and resume from the new epoch, then restart.
@@ -2035,6 +2046,36 @@ mod tests {
 		let frames = read_all(&mut consumer).await.unwrap();
 		let micros: Vec<u128> = frames.iter().map(|f| f.timestamp.as_micros()).collect();
 		assert_eq!(micros, vec![210_000, 800_000], "the expired frameless group is skipped");
+	}
+
+	/// An aborted frameless group beyond a sequence gap is reaped rather than parked on
+	/// forever: nothing else settles a group the cursor hasn't reached, so a finished
+	/// track would otherwise never report its end.
+	#[tokio::test]
+	async fn aborted_frameless_group_after_a_gap_ends_the_track() {
+		tokio::time::pause();
+		let mut track = track_producer("test", hang::container::track_info());
+		let consumer_track = track.subscribe(None);
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+
+		// Sequence 0 never arrives; sequence 1's stream opens but never carries a frame.
+		let group1 = track.create_group(moq_net::group::Info { sequence: 1 }).unwrap();
+		track.finish().unwrap();
+
+		// While group 1 is open its frames may still come, so the consumer waits.
+		assert!(
+			tokio::time::timeout(Duration::from_millis(50), consumer.read())
+				.await
+				.is_err(),
+			"an open frameless group must be waited for"
+		);
+
+		// The abort (an eviction) settles it, and the finished track ends cleanly.
+		group1.abort(moq_net::Error::Old).unwrap();
+		let end = tokio::time::timeout(Duration::from_millis(200), consumer.read())
+			.await
+			.expect("an aborted frameless group must not park the consumer");
+		assert!(end.unwrap().is_none(), "the track ends cleanly");
 	}
 
 	/// Track completion is not group completion: a group already open when the track

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -27,10 +27,11 @@ use super::{Container, Frame};
 /// next group begins) falls a full budget behind the newest content.
 ///
 /// Delivery starts at [`Subscription::group_start`](moq_net::track::Subscription::group_start)
-/// (or group 0), and that same budget is the one rule that catches the consumer up to
-/// the live edge: there is no separate startup path racing on arrival order. History the
-/// publisher no longer serves expires like any other gap, since its reach sits a full
-/// budget behind the newest content.
+/// when one is named, waiting for that group under the budget; without one it starts
+/// wherever the publisher does, adopted from the first served groups. From there the
+/// same budget is the one rule that catches the consumer up to the live edge, and
+/// history the publisher no longer serves expires like any other gap, since its reach
+/// sits a full budget behind the newest content.
 ///
 /// A stalled group is also skipped early, regardless of the latency budget, once it has
 /// presented up to where the next group begins. CMAF frames carry a per-sample duration,
@@ -58,6 +59,10 @@ pub struct Consumer<F: Container> {
 
 	// Groups that we are monitoring, sorted by sequence ascending.
 	pending: VecDeque<GroupBuffer>,
+
+	// Latches the cursor onto the publisher's first served group when the
+	// subscription names no start. Cleared once a first group is chosen.
+	startup: bool,
 
 	// The maximum buffer size before skipping a group.
 	latency: std::time::Duration,
@@ -136,15 +141,17 @@ impl<F: Container> Consumer<F> {
 	///
 	/// Skips aggressively by default; raise the tolerance with [`with_latency`](Self::with_latency).
 	pub fn new(track: moq_net::track::Subscriber, format: F) -> Self {
-		// Delivery starts at the requested group (or 0); the latency budget is the one
-		// rule that catches the cursor up to the live edge, so there is no separate
-		// startup path racing on arrival order.
+		// Delivery starts at the requested group; without one it starts wherever the
+		// publisher does, adopted from the first arrivals (see poll_read). Either way
+		// the latency budget is the one rule that catches the cursor up to the live
+		// edge from there.
 		let start = track.subscription().group_start;
 		Self {
 			track,
 			format,
 			current: start.unwrap_or(0),
 			pending: VecDeque::new(),
+			startup: start.is_none(),
 			latency: std::time::Duration::ZERO,
 			rewind: Rewind::default(),
 			end: None,
@@ -203,6 +210,24 @@ impl<F: Container> Consumer<F> {
 	pub fn poll_read(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<Frame>, F::Error>> {
 		// Grab any new groups from the track, recording whether the track is finished.
 		let finished = self.poll_read_finish(waiter)?.is_ready();
+
+		// A subscription with no explicit start begins wherever the publisher does:
+		// the lowest sequence it actually serves. Timestamps can't reveal that point
+		// (a gap below the served window looks like in-flight groups until the budget
+		// expires, or forever on a quiet track), so the cursor adopts it from the
+		// first arrivals instead of assuming group 0. Skipping stays the budget's job.
+		if self.startup {
+			// NOTE: poll_min_timestamp buffers at least one frame per group and
+			// registers the waiter on the ones still empty.
+			let any_frame = self
+				.pending
+				.iter_mut()
+				.any(|group| matches!(group.poll_min_timestamp(waiter, &self.format), Poll::Ready(Ok(_))));
+			if any_frame {
+				self.current = self.pending.front().expect("a group has a frame").sequence;
+				self.startup = false;
+			}
+		}
 
 		loop {
 			// A newer group whose timestamps jumped backwards means the publisher reneged
@@ -2077,6 +2102,28 @@ mod tests {
 
 		let frames = read_all(&mut consumer).await.unwrap();
 		assert_eq!(frames.len(), 1);
+	}
+
+	/// An unfloored mid-stream join adopts the publisher's served start instead of
+	/// waiting for a gap below it to expire: on a quiet track that gap never would,
+	/// since nothing newer arrives to age it out.
+	#[tokio::test]
+	async fn startup_mid_stream_live_track_starts_at_the_served_group() {
+		tokio::time::pause();
+		let mut track = track_producer("test", hang::container::track_info());
+		let consumer_track = track.subscribe(None);
+		let mut consumer = Consumer::new(consumer_track, Container::Legacy).with_latency(Duration::from_millis(500));
+
+		// The track is far along and stays live (never finished); only the current
+		// group is served, and nothing else arrives.
+		write_group(&mut track, 100, &[ts(3_000_000)]);
+
+		let frame = tokio::time::timeout(Duration::from_millis(200), consumer.read())
+			.await
+			.expect("an unfloored join must not wait out a gap below the served start")
+			.unwrap()
+			.expect("track still live");
+		assert_eq!(frame.timestamp, ts(3_000_000));
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
Fixes #3258 on main. Port of #3270 (the dev fix) onto main's knob surface: `latency` / `Subscription::group_start` here instead of dev's `max_age` / `Subscription::start`.

## Root cause

Groups travel on independent QUIC streams with newer sequences at higher priority, so a higher group's stream regularly beats a lower one onto the wire. `moq_mux::container::Consumer::poll_read` treated a buffered higher sequence as proof that the missing lower sequence was evicted, in two places:

1. **Startup** latched onto the first group with a buffered frame and drained every earlier pending group, then dropped the real head on arrival (`sequence < self.current` in `poll_read_finish`).
2. **The sequence-gap arm** skipped a missing sequence the moment any newer group was buffered, on the claim that "the relay delivers in order". It doesn't: delivery order is arrival order, and priority scheduling makes higher-first arrival routine.

An evicted group never opens a stream toward the subscriber, so nothing ever aborts it: late-vs-evicted is undecidable at this layer and the latency budget is the only gate.

## Fix

- The startup path is gone entirely (second commit). A fresh consumer is a cursor at group 0 (or `Subscription::group_start`) with a gap above it, and the latency budget is the single rule that catches it up to the live edge. No more skipping decided by arrival order.
- The gap arm becomes `finished || max_timestamp - next_start >= self.latency`: the missing group's reach is bounded by where the next group with data begins. With the default latency of zero the old aggressive behavior is unchanged, including at startup: joining at the live edge skips the gap below the first arrival in one poll.
- `with_latency`/`set_latency` clamp to the publisher's retention window (`Info::latency_max`): history the track no longer keeps can't be waited for and would otherwise stall the catch-up by the excess.
- The skip drain's wait-for-FIN on ambiguous empty groups is bypassed while nothing has been delivered since the last boundary (no codec state to reset makes the discontinuity redundant), which keeps frameless groups from stalling the initial catch-up.

`missing_sequence_skips_on_live_track` was updated to the budget-gated semantics (one more group expires the gap). The three new regression tests (scenarios from @kidq330's repro) fail on the previous code and pass with the fix; `just check` and `just test` (1374 tests across moq-mux and its dependents) pass.

## Review follow-ups

Adversarial review (Codex + CodeRabbit) added three commits mirroring the dev PR (#3270), plus one main-only fix:

- **Track completion is not group completion.** A finished track closes only gaps of never-arrived sequences; an arrived frameless group is settled by its own FIN, abort, or the budget. Regression: `finished_track_waits_for_an_open_head_group`.
- **The latency tolerance reaches the wire** (main-only): `set_latency` updates the subscription's `latency_max` verbatim, matching dev's `set_max_age`, so moq-net keeps serving the groups the consumer was told to wait for. The moq-audio/moq-video decoders get this through `with_latency`. Test: `with_latency_updates_the_wire_budget`.
- **An unfloored join adopts the publisher's served start** rather than pinning to group 0. Regression: `startup_mid_stream_live_track_starts_at_the_served_group`.
- **Aborted groups beyond the cursor are reaped** so they cannot park the consumer. Regression: `aborted_frameless_group_after_a_gap_ends_the_track`.

(Written by Claude Fable 5)
