### PR TITLE
bench: compare relay runtime topologies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ nix develop --command just fix-all      # Same as fix, over every package
 nix develop --command just build        # Build all packages
 nix develop --command just bench        # Benchmark the current tree
 nix develop --command just bench BASE   # Compare BASE with the current tree
+nix develop --command just bench-runtime  # Compare relay runtime topologies
 ```
 
 Use the Nix dev shell for project commands so local runs match CI tooling. If Nix is unavailable, use `cargo` or `bun` directly.
@@ -70,6 +71,7 @@ Key architectural rule: The CDN/relay does not know anything about media. Anythi
 Top-level layout only. Per-crate and per-package detail lives in the nested guides (see [Per-Directory Guides](#per-directory-guides)), which sit next to the code and don't rot here.
 
 - `/rs/` - Rust crates: core networking (`moq-net`), native helpers, the relay, CLIs, media muxing/codecs, and the FFI/C bindings. See `rs/CLAUDE.md`.
+- `/bench/` - Repository-level benchmark orchestration, workload fixtures, and methodology. Rust benchmark binaries and microbenchmarks stay under `/rs/`.
 - `/js/` - TypeScript/JavaScript packages for the browser, published as `@moq/*`. See `js/CLAUDE.md`.
 - `/py/`, `/swift/`, `/kt/`, `/go/` - language wrappers over `rs/moq-ffi` (see [Language Bindings](#language-bindings)). `/py/` has `py/CLAUDE.md`; the others defer to their `README.md`.
 - `/cpp/` - C/C++ consumers of `libmoq`. `cpp/obs/` is the OBS Studio plugin (CMake; links `libmoq` via `MOQ_LOCAL`), licensed GPL-2.0-or-later because it links `libobs`. `just check` type-checks it via `just obs compile`, which needs headers rather than an obs-deps download, and obs.yml links it on Linux for `cpp/obs/` and `rs/libmoq/` PRs. Still manual, like `just rs macos`: `just obs build` (a loadable plugin, and the only path on macOS/Windows) and `just obs test` (`cpp/obs/test/` against stubbed libobs/libmoq under ThreadSanitizer). See `doc/bin/obs.md`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4699,6 +4699,7 @@ dependencies = [
  "humantime",
  "moq-net",
  "moq-tokio",
+ "moq-uring",
  "procfs 0.18.0",
  "rand 0.10.2",
  "rustls",

--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,54 @@
+# Benchmarks
+
+This directory contains repository-level benchmark orchestration. Rust
+microbenchmarks stay beside their crates under `rs/*/benches`, while the
+`moq-bench` load generator and host sampler stay in `rs/moq-bench`.
+
+`run.sh` owns builds, comparison rounds, and reporting. `relay.sh` owns the
+temporary relay lifecycle and load execution shared by each comparison mode.
+
+## Commands
+
+Run every Criterion target plus the local relay workloads:
+
+```bash
+nix develop --command just bench
+```
+
+Compare the current tree with another revision:
+
+```bash
+nix develop --command just bench origin/main
+```
+
+Compare one multi-threaded Tokio runtime with the same number of independent
+Tokio/epoll and io\_uring workers:
+
+```bash
+nix develop --command just bench-runtime
+nix develop --command just bench-runtime 5 16
+```
+
+Runtime comparison requires Linux because io\_uring and relay process metrics
+come from Linux interfaces. The default worker count is the number of online
+logical CPUs.
+
+## Workloads
+
+The `workloads/` TOML files contain only traffic shape. The harness supplies the
+temporary relay URL, TLS settings, startup ramp, run duration, reporting
+interval, and output paths so every runtime receives the same load.
+
+- `video`: light many-to-many video traffic.
+- `fanout`: light one-to-many traffic.
+- `video-heavy`: multicore many-to-many video traffic.
+- `fanout-heavy`: multicore one-to-many traffic near saturation.
+
+The runtime matrix rotates execution order between rounds, then reports the
+median throughput, loss, latency, CPU split, context switches, RSS, and thread
+count. Compare CPU only when delivered throughput and loss are equivalent. A
+runtime that falls behind can use less CPU simply because it completed less
+work.
+
+Benchmark output is informational and machine-specific. Crashes, zero delivery,
+and invalid samples still fail the command.

--- a/bench/justfile
+++ b/bench/justfile
@@ -1,0 +1,19 @@
+#!/usr/bin/env just --justfile
+
+set working-directory := '..'
+
+# Benchmark the current tree, or compare it with a commit.
+compare $BASE="":
+    #!/usr/bin/env bash
+    exec bench/run.sh "$BASE"
+
+# Compare the shared Tokio runtime with independent Tokio and io_uring workers.
+runtime $ROUNDS="3" $WORKERS="":
+    #!/usr/bin/env bash
+    MOQ_BENCH_RUNTIME_ROUNDS="$ROUNDS" MOQ_BENCH_RUNTIME_WORKERS="$WORKERS" \
+        exec bench/run.sh --runtime
+
+# Compile every binary and feature used by the repository-level harness.
+check:
+    cargo check --locked --package moq-relay --package moq-bench \
+        --features moq-relay/io-uring-quinn

--- a/bench/relay.sh
+++ b/bench/relay.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+
+# Sourced by run.sh, which owns these process and output paths.
+# shellcheck disable=SC2153,SC2154
+
+relay_config() {
+    local path=$1
+    local port=$2
+    local runtime=${3:-}
+    local workers=${4:-1}
+    local -a tls runtime_config
+
+    if [[ -n $runtime ]]; then
+        tls=(
+            "tls.cert = [\"$RUN/localhost.crt\"]"
+            "tls.key = [\"$RUN/localhost.key\"]"
+        )
+    else
+        tls=('tls.generate = ["localhost"]')
+    fi
+
+    case $runtime in
+        '' | tokio-shared)
+            runtime_config=()
+            ;;
+        tokio-workers)
+            runtime_config=(
+                ''
+                '[runtime]'
+                "workers = $workers"
+                'pin = false'
+            )
+            ;;
+        io-uring-workers)
+            runtime_config=(
+                ''
+                '[runtime]'
+                "workers = $workers"
+                'pin = false'
+                'io_uring = true'
+            )
+            ;;
+        *)
+            printf 'unknown relay runtime: %s\n' "$runtime" >&2
+            return 1
+            ;;
+    esac
+
+    printf '%s\n' \
+        '[log]' \
+        'level = "warn"' \
+        '' \
+        '[server]' \
+        "bind = \"127.0.0.1:$port\"" \
+        "${tls[@]}" \
+        '' \
+        '[web.http]' \
+        "listen = \"127.0.0.1:$port\"" \
+        '' \
+        '[auth]' \
+        'public = ""' \
+        "${runtime_config[@]}" >"$path"
+}
+
+start_relay() {
+    local relay=$1
+    local directory=$2
+    local runtime=${3:-}
+    local workers=${4:-1}
+    local attempt port config log tokio_threads
+
+    case $runtime in
+        tokio-shared)
+            tokio_threads=$workers
+            ;;
+        tokio-workers | io-uring-workers)
+            tokio_threads=1
+            ;;
+        '')
+            tokio_threads=
+            ;;
+    esac
+
+    for attempt in {1..5}; do
+        port=$((40000 + (RANDOM % 20000)))
+        config=$directory/relay-$attempt.toml
+        log=$directory/relay-$attempt.log
+        relay_config "$config" "$port" "$runtime" "$workers"
+
+        if [[ -n $tokio_threads ]]; then
+            env TOKIO_WORKER_THREADS="$tokio_threads" RUST_LOG=warn \
+                "$relay" "$config" >"$log" 2>&1 &
+        else
+            RUST_LOG=warn "$relay" "$config" >"$log" 2>&1 &
+        fi
+        RELAY_PID=$!
+
+        for _ in {1..100}; do
+            if ! kill -0 "$RELAY_PID" 2>/dev/null; then
+                wait "$RELAY_PID" 2>/dev/null || true
+                RELAY_PID=
+                break
+            fi
+            if (: <>"/dev/tcp/127.0.0.1/$port") 2>/dev/null; then
+                RELAY_PORT=$port
+                return 0
+            fi
+            sleep 0.1
+        done
+
+        if [[ -n $RELAY_PID ]]; then
+            kill "$RELAY_PID" 2>/dev/null || true
+            wait "$RELAY_PID" 2>/dev/null || true
+            RELAY_PID=
+        fi
+    done
+
+    printf 'relay failed to start:\n' >&2
+    cat "$log" >&2
+    return 1
+}
+
+stop_relay() {
+    if [[ -z $RELAY_PID ]]; then
+        return 0
+    fi
+
+    local status=0
+    local signaled=false
+    if kill -0 "$RELAY_PID" 2>/dev/null && kill "$RELAY_PID" 2>/dev/null; then
+        signaled=true
+    fi
+    wait "$RELAY_PID" 2>/dev/null || status=$?
+    RELAY_PID=
+
+    if [[ $signaled == true ]] && ((status == 0 || status == 143)); then
+        return 0
+    fi
+
+    printf 'relay exited during workload (status %d)\n' "$status" >&2
+    return 1
+}
+
+summarize_load() {
+    local stats=$1
+    local output=$2
+    local workload=$3
+
+    # The counters are sampled independently, so mirror moq-bench's saturating
+    # subtraction when a snapshot catches one update between the two loads.
+    jq -s --arg workload "$workload" '
+		if length < 2 then error("load benchmark produced fewer than two samples") else . end
+		| .[-1] as $last
+		| ($last.timestamp_ms - 5000) as $floor
+		| map(select(.timestamp_ms >= $floor))
+		| .[0] as $first
+		| .[-1] as $last
+		| (($last.timestamp_ms - $first.timestamp_ms) / 1000) as $seconds
+		| if $seconds <= 0 then error("load benchmark time did not advance")
+		elif $last.frames_recv <= $first.frames_recv then error("load benchmark delivered zero frames")
+		elif $last.bytes_sent < $first.bytes_sent or $last.bytes_recv < $first.bytes_recv
+			then error("load benchmark counters moved backwards")
+		elif $last.latency_p50_ms == null or $last.latency_p99_ms == null
+			or $last.latency_p50_ms < 0 or $last.latency_p99_ms < $last.latency_p50_ms
+			then error("load benchmark latency sample is invalid")
+		else {
+			workload: $workload,
+			send_mbps: (($last.bytes_sent - $first.bytes_sent) * 8 / $seconds / 1000000),
+			recv_mbps: (($last.bytes_recv - $first.bytes_recv) * 8 / $seconds / 1000000),
+			send_fps: (($last.frames_sent - $first.frames_sent) / $seconds),
+			recv_fps: (($last.frames_recv - $first.frames_recv) / $seconds),
+			loss_pct: (if $last.groups_expected == 0 or $last.groups_present >= $last.groups_expected then 0 else
+				(($last.groups_expected - $last.groups_present) * 100 / $last.groups_expected)
+			end),
+			latency_p50_ms: $last.latency_p50_ms,
+			latency_p99_ms: $last.latency_p99_ms
+		}
+		end
+	' "$stats" >"$output"
+}
+
+add_host_summary() {
+    local host=$1
+    local summary=$2
+    local enriched=$summary.enriched
+
+    jq -s '
+		if length < 2 then error("host benchmark produced fewer than two samples") else . end
+		| .[-1] as $last
+		| ($last.timestamp_ms - 5000) as $floor
+		| map(select(.timestamp_ms >= $floor)) as $window
+		| $window[0] as $first
+		| $window[-1] as $last
+		| (($last.timestamp_ms - $first.timestamp_ms) / 1000) as $seconds
+		| if $seconds <= 0 then error("host benchmark time did not advance")
+		elif $last.cpu_user < $first.cpu_user or $last.cpu_system < $first.cpu_system
+			or $last.ctx_voluntary < $first.ctx_voluntary
+			or $last.ctx_involuntary < $first.ctx_involuntary
+			then error("host benchmark counters moved backwards")
+		else {
+			cpu_user_cores: (($last.cpu_user - $first.cpu_user) / $seconds),
+			cpu_system_cores: (($last.cpu_system - $first.cpu_system) / $seconds),
+			cpu_cores: ((($last.cpu_user + $last.cpu_system) - ($first.cpu_user + $first.cpu_system)) / $seconds),
+			ctx_voluntary_s: (($last.ctx_voluntary - $first.ctx_voluntary) / $seconds),
+			ctx_involuntary_s: (($last.ctx_involuntary - $first.ctx_involuntary) / $seconds),
+			rss_bytes: ($window | map(.rss_bytes) | max),
+			threads: ($window | map(.threads) | max)
+		}
+		end
+	' "$host" | jq -s '.[0] * .[1]' "$summary" - >"$enriched"
+    mv "$enriched" "$summary"
+}
+
+run_workload() {
+    local label=$1
+    local relay=$2
+    local workload=$3
+    local runtime=${4:-}
+    local workers=${5:-1}
+    local directory=$RUN/relay/$label/$workload
+    local stats=$directory/load.jsonl
+    local host=$directory/host.jsonl
+    local summary=$directory/summary.json
+    local config=$ROOT/bench/workloads/$workload.toml
+
+    if [[ ! -f $config ]]; then
+        printf 'unknown relay workload: %s\n' "$workload" >&2
+        return 1
+    fi
+
+    mkdir -p "$directory"
+    start_relay "$relay" "$directory" "$runtime" "$workers"
+
+    if [[ $(uname -s) == Linux ]]; then
+        "$HOST_BIN" --pid "$RELAY_PID" --interval 500ms --duration 10s --output "$host" \
+            >"$directory/host.log" 2>&1 &
+        HOST_PID=$!
+    fi
+
+    if ! "$LOAD_BIN" \
+        --file "$config" \
+        --connect "https://localhost:$RELAY_PORT" \
+        --connect-tls-insecure \
+        --name "bench-$label-$workload" \
+        --startup 2s \
+        --duration 10s \
+        --report 500ms \
+        --output "$stats" >"$directory/load.log" 2>&1; then
+        printf 'load benchmark failed: %s/%s\n' "$label" "$workload" >&2
+        cat "$directory/load.log" >&2
+        return 1
+    fi
+
+    if [[ -n $HOST_PID ]]; then
+        if ! wait "$HOST_PID"; then
+            printf 'host benchmark failed: %s/%s\n' "$label" "$workload" >&2
+            cat "$directory/host.log" >&2
+            HOST_PID=
+            return 1
+        fi
+        HOST_PID=
+    fi
+    stop_relay
+
+    summarize_load "$stats" "$summary" "$workload"
+    if [[ -s $host ]]; then
+        add_host_summary "$host" "$summary"
+    fi
+}
+
+run_relay_suite() {
+    local label=$1
+    local relay=$2
+    printf '\nRelay workloads: %s\n' "$label"
+    run_workload "$label" "$relay" video
+    run_workload "$label" "$relay" fanout
+}

--- a/bench/run.sh
+++ b/bench/run.sh
@@ -3,10 +3,38 @@ set -euo pipefail
 
 # Runs every Criterion target plus two local relay workloads. With a base commit,
 # Criterion compares matching cases directly and the relay summary prints the
-# base/current delta. The current load generator drives both relay binaries so a
-# generator change cannot make the two sides different workloads.
+# base/current delta. `--runtime` instead compares one multi-threaded Tokio
+# runtime with the same number of independent Tokio/epoll and io_uring workers
+# on the current tree. The current load generator drives every relay so the
+# workloads stay identical.
 
-BASE=${1:-}
+MODE=${1:-}
+case $MODE in
+    --runtime)
+        BASE=
+        RUNTIME_ROUNDS=${MOQ_BENCH_RUNTIME_ROUNDS:-3}
+        RUNTIME_WORKERS=${MOQ_BENCH_RUNTIME_WORKERS:-}
+        if [[ -z $RUNTIME_WORKERS ]]; then
+            RUNTIME_WORKERS=$(getconf _NPROCESSORS_ONLN)
+            if ((RUNTIME_WORKERS > 256)); then
+                RUNTIME_WORKERS=256
+            fi
+        fi
+        if [[ ! $RUNTIME_ROUNDS =~ ^[0-9]+$ ]] || ((10#$RUNTIME_ROUNDS < 1)); then
+            printf 'runtime benchmark rounds must be a positive integer, got %q\n' "$RUNTIME_ROUNDS" >&2
+            exit 1
+        fi
+        if [[ ! $RUNTIME_WORKERS =~ ^[0-9]+$ ]] || ((10#$RUNTIME_WORKERS < 1 || 10#$RUNTIME_WORKERS > 256)); then
+            printf 'runtime benchmark workers must be an integer from 1 to 256, got %q\n' "$RUNTIME_WORKERS" >&2
+            exit 1
+        fi
+        RUNTIME_ROUNDS=$((10#$RUNTIME_ROUNDS))
+        RUNTIME_WORKERS=$((10#$RUNTIME_WORKERS))
+        ;;
+    *)
+        BASE=$MODE
+        ;;
+esac
 ROOT=$(git rev-parse --show-toplevel)
 TARGET=${CARGO_TARGET_DIR:-$ROOT/target/bench}
 if [[ $TARGET != /* ]]; then
@@ -195,229 +223,8 @@ report_set_changes() {
     fi
 }
 
-relay_config() {
-    local path=$1
-    local port=$2
-    printf '%s\n' \
-        '[log]' \
-        'level = "warn"' \
-        '' \
-        '[server]' \
-        "bind = \"127.0.0.1:$port\"" \
-        'tls.generate = ["localhost"]' \
-        '' \
-        '[web.http]' \
-        "listen = \"127.0.0.1:$port\"" \
-        '' \
-        '[auth]' \
-        'public = ""' >"$path"
-}
-
-start_relay() {
-    local relay=$1
-    local directory=$2
-    local attempt port config log
-
-    for attempt in {1..5}; do
-        port=$((40000 + (RANDOM % 20000)))
-        config=$directory/relay-$attempt.toml
-        log=$directory/relay-$attempt.log
-        relay_config "$config" "$port"
-
-        RUST_LOG=warn "$relay" "$config" >"$log" 2>&1 &
-        RELAY_PID=$!
-
-        for _ in {1..100}; do
-            if ! kill -0 "$RELAY_PID" 2>/dev/null; then
-                wait "$RELAY_PID" 2>/dev/null || true
-                RELAY_PID=
-                break
-            fi
-            if (: <>"/dev/tcp/127.0.0.1/$port") 2>/dev/null; then
-                RELAY_PORT=$port
-                return 0
-            fi
-            sleep 0.1
-        done
-
-        if [[ -n $RELAY_PID ]]; then
-            kill "$RELAY_PID" 2>/dev/null || true
-            wait "$RELAY_PID" 2>/dev/null || true
-            RELAY_PID=
-        fi
-    done
-
-    printf 'relay failed to start:\n' >&2
-    cat "$log" >&2
-    return 1
-}
-
-stop_relay() {
-    if [[ -z $RELAY_PID ]]; then
-        return 0
-    fi
-
-    local status=0
-    local signaled=false
-    if kill -0 "$RELAY_PID" 2>/dev/null && kill "$RELAY_PID" 2>/dev/null; then
-        signaled=true
-    fi
-    wait "$RELAY_PID" 2>/dev/null || status=$?
-    RELAY_PID=
-
-    if [[ $signaled == true ]] && ((status == 0 || status == 143)); then
-        return 0
-    fi
-
-    printf 'relay exited during workload (status %d)\n' "$status" >&2
-    return 1
-}
-
-summarize_load() {
-    local stats=$1
-    local output=$2
-    local workload=$3
-
-    jq -s --arg workload "$workload" '
-		if length < 2 then error("load benchmark produced fewer than two samples") else . end
-		| .[-1] as $last
-		| ($last.timestamp_ms - 5000) as $floor
-		| map(select(.timestamp_ms >= $floor))
-		| .[0] as $first
-		| .[-1] as $last
-		| (($last.timestamp_ms - $first.timestamp_ms) / 1000) as $seconds
-		| if $seconds <= 0 then error("load benchmark time did not advance")
-		elif $last.frames_recv <= $first.frames_recv then error("load benchmark delivered zero frames")
-		elif $last.bytes_sent < $first.bytes_sent or $last.bytes_recv < $first.bytes_recv
-			then error("load benchmark counters moved backwards")
-		elif $last.groups_present > $last.groups_expected then error("load benchmark group counts are invalid")
-		elif $last.latency_p50_ms == null or $last.latency_p99_ms == null
-			or $last.latency_p50_ms < 0 or $last.latency_p99_ms < $last.latency_p50_ms
-			then error("load benchmark latency sample is invalid")
-		else {
-			workload: $workload,
-			send_mbps: (($last.bytes_sent - $first.bytes_sent) * 8 / $seconds / 1000000),
-			recv_mbps: (($last.bytes_recv - $first.bytes_recv) * 8 / $seconds / 1000000),
-			send_fps: (($last.frames_sent - $first.frames_sent) / $seconds),
-			recv_fps: (($last.frames_recv - $first.frames_recv) / $seconds),
-			loss_pct: (if $last.groups_expected == 0 then 0 else
-				(($last.groups_expected - $last.groups_present) * 100 / $last.groups_expected)
-			end),
-			latency_p50_ms: $last.latency_p50_ms,
-			latency_p99_ms: $last.latency_p99_ms
-		}
-		end
-	' "$stats" >"$output"
-}
-
-add_host_summary() {
-    local host=$1
-    local summary=$2
-    local enriched=$summary.enriched
-
-    jq -s '
-		if length < 2 then error("host benchmark produced fewer than two samples") else . end
-		| .[-1] as $last
-		| ($last.timestamp_ms - 5000) as $floor
-		| map(select(.timestamp_ms >= $floor)) as $window
-		| $window[0] as $first
-		| $window[-1] as $last
-		| (($last.timestamp_ms - $first.timestamp_ms) / 1000) as $seconds
-		| if $seconds <= 0 then error("host benchmark time did not advance")
-		elif $last.cpu_user < $first.cpu_user or $last.cpu_system < $first.cpu_system
-			then error("host benchmark counters moved backwards")
-		else {
-			cpu_cores: ((($last.cpu_user + $last.cpu_system) - ($first.cpu_user + $first.cpu_system)) / $seconds),
-			rss_bytes: ($window | map(.rss_bytes) | max)
-		}
-		end
-	' "$host" | jq -s '.[0] * .[1]' "$summary" - >"$enriched"
-    mv "$enriched" "$summary"
-}
-
-run_workload() {
-    local label=$1
-    local relay=$2
-    local workload=$3
-    local directory=$RUN/relay/$label/$workload
-    local stats=$directory/load.jsonl
-    local host=$directory/host.jsonl
-    local summary=$directory/summary.json
-    local -a shape
-
-    mkdir -p "$directory"
-    start_relay "$relay" "$directory"
-
-    if [[ $(uname -s) == Linux ]]; then
-        "$HOST_BIN" --pid "$RELAY_PID" --interval 500ms --duration 10s --output "$host" \
-            >"$directory/host.log" 2>&1 &
-        HOST_PID=$!
-    fi
-
-    case $workload in
-        video)
-            shape=(
-                --connections 16
-                --broadcasts 1
-                --subscribe 2
-                --fps 30
-                --frame-size 1200
-                --group-size 59
-            )
-            ;;
-        fanout)
-            shape=(
-                --connections 65
-                --fanout fanout
-                --fps 10
-                --frame-size 400
-                --group-size 0
-            )
-            ;;
-        *)
-            printf 'unknown relay workload: %s\n' "$workload" >&2
-            return 1
-            ;;
-    esac
-
-    if ! "$LOAD_BIN" \
-        --connect "https://localhost:$RELAY_PORT" \
-        --connect-tls-insecure \
-        --name "bench-$label-$workload" \
-        --startup 2s \
-        --duration 10s \
-        --report 500ms \
-        --output "$stats" \
-        "${shape[@]}" >"$directory/load.log" 2>&1; then
-        printf 'load benchmark failed: %s/%s\n' "$label" "$workload" >&2
-        cat "$directory/load.log" >&2
-        return 1
-    fi
-
-    if [[ -n $HOST_PID ]]; then
-        if ! wait "$HOST_PID"; then
-            printf 'host benchmark failed: %s/%s\n' "$label" "$workload" >&2
-            cat "$directory/host.log" >&2
-            HOST_PID=
-            return 1
-        fi
-        HOST_PID=
-    fi
-    stop_relay
-
-    summarize_load "$stats" "$summary" "$workload"
-    if [[ -s $host ]]; then
-        add_host_summary "$host" "$summary"
-    fi
-}
-
-run_relay_suite() {
-    local label=$1
-    local relay=$2
-    printf '\nRelay workloads: %s\n' "$label"
-    run_workload "$label" "$relay" video
-    run_workload "$label" "$relay" fanout
-}
+# shellcheck source=bench/relay.sh
+source "$ROOT/bench/relay.sh"
 
 print_current_relay() {
     printf '\n%-10s %11s %11s %10s %10s %9s %9s %10s %10s\n' \
@@ -472,9 +279,160 @@ print_relay_comparison() {
     done
 }
 
+aggregate_runtime() {
+    local runtime=$1
+    local workload=$2
+    local output=$RUN/relay/$runtime/$workload.json
+    local -a samples=("$RUN"/relay/"$runtime"/round-*/"$workload"/summary.json)
+
+    jq -s --arg runtime "$runtime" --arg workload "$workload" '
+		def median:
+			sort as $values
+			| ($values | length) as $count
+			| if $count % 2 == 1 then $values[($count / 2 | floor)]
+			  else (($values[$count / 2 - 1] + $values[$count / 2]) / 2)
+			  end;
+		{
+			runtime: $runtime,
+			workload: $workload,
+			samples: length,
+			recv_mbps: (map(.recv_mbps) | median),
+			latency_p99_ms: (map(.latency_p99_ms) | median),
+			loss_pct: (map(.loss_pct) | median),
+			cpu_user_cores: (map(.cpu_user_cores) | median),
+			cpu_system_cores: (map(.cpu_system_cores) | median),
+			cpu_cores: (map(.cpu_cores) | median),
+			ctx_voluntary_s: (map(.ctx_voluntary_s) | median),
+			ctx_involuntary_s: (map(.ctx_involuntary_s) | median),
+			rss_bytes: (map(.rss_bytes) | median),
+			threads: (map(.threads) | median)
+		}
+	' "${samples[@]}" >"$output"
+}
+
+print_runtime_comparison() {
+    local workload runtime
+
+    for workload in video fanout video-heavy fanout-heavy; do
+        for runtime in tokio-shared tokio-workers io-uring-workers; do
+            aggregate_runtime "$runtime" "$workload"
+        done
+    done
+
+    printf '\nRuntime comparison (%d workers, median of %d rounds)\n' "$RUNTIME_WORKERS" "$RUNTIME_ROUNDS"
+    printf 'tokio-shared uses %d runtime threads; worker modes use %d data threads plus one control thread.\n' \
+        "$RUNTIME_WORKERS" "$RUNTIME_WORKERS"
+    printf '%-13s %-16s %10s %8s %7s %8s %8s %9s %9s %9s %9s %7s\n' \
+        workload runtime recv-Mbps p99-ms loss-% CPU user-CPU sys-CPU vol-ctx/s invol/s RSS-MiB threads
+    for workload in video fanout video-heavy fanout-heavy; do
+        for runtime in tokio-shared tokio-workers io-uring-workers; do
+            jq -r '[
+				.workload,
+				.runtime,
+				.recv_mbps,
+				.latency_p99_ms,
+				.loss_pct,
+				.cpu_cores,
+				.cpu_user_cores,
+				.cpu_system_cores,
+				.ctx_voluntary_s,
+				.ctx_involuntary_s,
+				(.rss_bytes / 1048576),
+				.threads
+			] | @tsv' "$RUN/relay/$runtime/$workload.json" |
+                while IFS=$'\t' read -r name mode recv p99 loss cpu user system voluntary involuntary rss threads; do
+                    printf '%-13s %-16s %10.3f %8.1f %7.3f %8.3f %8.3f %9.3f %9.1f %9.1f %9.1f %7.1f\n' \
+                        "$name" "$mode" "$recv" "$p99" "$loss" "$cpu" "$user" "$system" \
+                        "$voluntary" "$involuntary" "$rss" "$threads"
+                done
+        done
+    done
+
+    printf '\nMedian deltas (negative CPU means the second mode used less)\n'
+    printf '%-13s %-29s %12s %12s %12s\n' workload comparison CPU p99-ms sys-CPU
+    for workload in video fanout video-heavy fanout-heavy; do
+        jq -r -s '
+			def change($before; $after):
+				if $before == 0 then "n/a" else
+					((($after / $before - 1) * 10000 | round) / 100 | tostring) + "%"
+				end;
+			def comparison($before; $after):
+				[
+					$after.workload,
+					($before.runtime + " -> " + $after.runtime),
+					change($before.cpu_cores; $after.cpu_cores),
+					change($before.latency_p99_ms; $after.latency_p99_ms),
+					change($before.cpu_system_cores; $after.cpu_system_cores)
+				] | @tsv;
+			comparison(.[0]; .[1]), comparison(.[2]; .[3])
+		' "$RUN/relay/tokio-shared/$workload.json" "$RUN/relay/tokio-workers/$workload.json" \
+            "$RUN/relay/tokio-workers/$workload.json" "$RUN/relay/io-uring-workers/$workload.json" |
+            while IFS=$'\t' read -r name comparison cpu p99 system; do
+                printf '%-13s %-29s %12s %12s %12s\n' "$name" "$comparison" "$cpu" "$p99" "$system"
+            done
+    done
+}
+
+run_runtime_comparison() {
+    if [[ $(uname -s) != Linux ]]; then
+        printf 'runtime comparison needs Linux for io_uring and /proc metrics\n' >&2
+        return 1
+    fi
+    if ! command -v openssl >/dev/null; then
+        printf 'runtime comparison needs openssl to generate its temporary certificate\n' >&2
+        return 1
+    fi
+
+    umask 077
+    printf '[req]\ndistinguished_name = req_dn\n[req_dn]\n' >"$RUN/openssl.cnf"
+    if ! OPENSSL_CONF=$RUN/openssl.cnf \
+        openssl req -x509 -sha256 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes \
+        -days 1 -subj '/CN=localhost' -addext 'subjectAltName=DNS:localhost' \
+        -keyout "$RUN/localhost.key" -out "$RUN/localhost.crt" >"$RUN/openssl.log" 2>&1; then
+        printf 'failed to generate the temporary benchmark certificate:\n' >&2
+        cat "$RUN/openssl.log" >&2
+        return 1
+    fi
+
+    printf 'Building one relay binary with the Tokio and io_uring Quinn paths...\n'
+    CARGO_TARGET_DIR=$CURRENT_TARGET cargo build --locked --release \
+        -p moq-relay -p moq-bench \
+        --features moq-relay/io-uring-quinn,moq-bench/uring
+    LOAD_BIN=$CURRENT_TARGET/release/moq-bench
+    HOST_BIN=$CURRENT_TARGET/release/moq-bench-host
+
+    printf 'Checking io_uring support...\n'
+    if ! "$CURRENT_TARGET/release/moq-bench-uring-check"; then
+        printf 'runtime comparison needs Linux 6.12+ with io_uring permitted by the host\n' >&2
+        return 1
+    fi
+
+    local -a runtimes=(tokio-shared tokio-workers io-uring-workers)
+    local round workload offset index runtime
+    for workload in video fanout video-heavy fanout-heavy; do
+        printf '\nRelay runtime workload: %s\n' "$workload"
+        for ((round = 1; round <= RUNTIME_ROUNDS; round++)); do
+            # Rotate the order so thermal drift and other time-dependent noise do
+            # not consistently favor the same runtime.
+            offset=$(((round - 1) % ${#runtimes[@]}))
+            for ((index = 0; index < ${#runtimes[@]}; index++)); do
+                runtime=${runtimes[$(((index + offset) % ${#runtimes[@]}))]}
+                printf '  round %d/%d: %s\n' "$round" "$RUNTIME_ROUNDS" "$runtime"
+                run_workload "$runtime/round-$round" "$CURRENT_TARGET/release/moq-relay" \
+                    "$workload" "$runtime" "$RUNTIME_WORKERS"
+            done
+        done
+    done
+
+    print_runtime_comparison
+}
+
 cd "$ROOT"
 
-if [[ -n $BASE ]]; then
+if [[ $MODE == --runtime ]]; then
+    run_runtime_comparison
+    exit 0
+elif [[ -n $BASE ]]; then
     BASE_COMMIT=$(git rev-parse --verify "$BASE^{commit}")
     WORKTREE=$RUN/base
     git worktree add --detach "$WORKTREE" "$BASE_COMMIT" >/dev/null

--- a/bench/workloads/fanout-heavy.toml
+++ b/bench/workloads/fanout-heavy.toml
@@ -1,0 +1,5 @@
+connections = 257
+fanout = "fanout"
+fps = 60
+frame_size = 1200
+group_size = 0

--- a/bench/workloads/fanout.toml
+++ b/bench/workloads/fanout.toml
@@ -1,0 +1,5 @@
+connections = 65
+fanout = "fanout"
+fps = 10
+frame_size = 400
+group_size = 0

--- a/bench/workloads/video-heavy.toml
+++ b/bench/workloads/video-heavy.toml
@@ -1,0 +1,6 @@
+connections = 256
+broadcasts = 1
+subscribe = 2
+fps = 60
+frame_size = 1200
+group_size = 59

--- a/bench/workloads/video.toml
+++ b/bench/workloads/video.toml
@@ -1,0 +1,6 @@
+connections = 16
+broadcasts = 1
+subscribe = 2
+fps = 30
+frame_size = 1200
+group_size = 59

--- a/justfile
+++ b/justfile
@@ -47,7 +47,13 @@ dev:
 # Benchmark the current tree, or compare it with a commit: `just bench origin/main`.
 bench $BASE="":
     #!/usr/bin/env bash
-    exec rs/scripts/bench.sh "$BASE"
+    exec just --justfile bench/justfile compare "$BASE"
+
+# Compare one multi-threaded Tokio runtime with the same number of independent
+# Tokio/epoll and io_uring workers. Defaults to every logical CPU.
+bench-runtime $ROUNDS="3" $WORKERS="":
+    #!/usr/bin/env bash
+    exec just --justfile bench/justfile runtime "$ROUNDS" "$WORKERS"
 
 # Install repo-wide tooling. Per-language deps install on first check.
 install:
@@ -236,7 +242,7 @@ _tools $FILES="":
 
     # `_check-common` runs on every invocation, so its tools are unconditional.
     tools=(actionlint bun jq nix nixfmt shellcheck shfmt taplo)
-    scoped '^(quest/|rs/|Cargo\.(toml|lock)$|rust-toolchain\.toml$)' && tools+=(cargo)
+    scoped '^(bench/|quest/|rs/|Cargo\.(toml|lock)$|rust-toolchain\.toml$)' && tools+=(cargo)
     scoped '^(py/|pyproject\.toml$|uv\.lock$|rs/moq-ffi/)'     && tools+=(uv)
     scoped '^(kt/|rs/moq-ffi/)'                                && tools+=(gradle java)
     # cargo because `go check` builds moq-ffi for the host, and skips on a
@@ -300,6 +306,9 @@ check $BASE="":
     if [[ -n "$files" ]]; then
         just js check "$files"
         just rs check-changed "$files"
+        if echo "$files" | grep -q '^bench/'; then
+            just --justfile bench/justfile check
+        fi
         # Quest documents form one graph, so validate the whole living tree when
         # either a quest or its validator changes.
         if echo "$files" | grep -qE '^(quest/|rs/quest/)'; then
@@ -341,6 +350,7 @@ check-all *args:
     just js check
     just rs check --workspace {{ args }}
     just rs tokio-features
+    just --justfile bench/justfile check
     cargo run --quiet --locked --package quest -- check
     # Not covered by the line above: moq-wasm only exists on the wasm32 target.
     just rs wasm

--- a/rs/moq-bench/Cargo.toml
+++ b/rs/moq-bench/Cargo.toml
@@ -27,12 +27,20 @@ name = "moq-bench-host"
 path = "src/host.rs"
 doc = false
 
+# io_uring capability probe used before the runtime benchmark matrix.
+[[bin]]
+name = "moq-bench-uring-check"
+path = "src/uring.rs"
+required-features = ["uring"]
+doc = false
+
 [features]
 default = ["quinn", "websocket"]
 iroh = ["moq-tokio/iroh"]
 noq = ["moq-tokio/noq"]
 quinn = ["moq-tokio/quinn"]
 quiche = ["moq-tokio/quiche"]
+uring = ["dep:moq-uring"]
 websocket = ["moq-tokio/websocket"]
 
 [dependencies]
@@ -51,6 +59,7 @@ usage = { workspace = true, features = ["completions"] }
 
 # The host sampler reads /proc, so it is Linux-only (production relays are Linux).
 [target.'cfg(target_os = "linux")'.dependencies]
+moq-uring = { workspace = true, optional = true }
 procfs = "0.18"
 
 [dev-dependencies]

--- a/rs/moq-bench/src/uring.rs
+++ b/rs/moq-bench/src/uring.rs
@@ -1,0 +1,15 @@
+//! Checks whether the host can construct the io_uring worker used by runtime benchmarks.
+
+#[cfg(target_os = "linux")]
+fn main() {
+	if let Err(err) = moq_uring::Worker::new(Default::default()) {
+		eprintln!("{err}");
+		std::process::exit(1);
+	}
+}
+
+#[cfg(not(target_os = "linux"))]
+fn main() {
+	eprintln!("io_uring is only available on Linux");
+	std::process::exit(1);
+}


### PR DESCRIPTION
## Summary

- Add a top-level bench harness with methodology documentation, a local justfile, split orchestration and relay helpers, and reusable TOML workload fixtures.
- Preserve just bench and just bench-runtime while comparing one multi-threaded Tokio runtime with the same number of independent Tokio/epoll and io_uring workers.
- Rotate runtime order across rounds and report median throughput, loss, latency, CPU split, context switches, RSS, and thread count.
- Compile the exact relay and load-generator feature set whenever bench/ changes so the harness cannot drift from their CLIs.
- Target dev because the worker runtime and io_uring relay feature being measured are not present on main.

## Public API changes

None.

## Wire behavior changes

None.

## Test plan

- just _check-common
- just --justfile bench/justfile check
- just bench-runtime 1 16 on the updated commit
- just bench-runtime 5 16 during the spike; heavy video showed shared Tokio using 14.2% less CPU than independent Tokio workers, while io_uring used 16.1% less CPU than independent Tokio/epoll workers
- just check reaches the unchanged moq-rtc crate, then fails because current origin/dev references removed moq_net::Origin and broadcast::Route symbols

(written by GPT-5)