### PR TITLE
fix(stream): detect rolled logs eagerly

### DIFF
--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -396,7 +396,7 @@ A publisher that cannot write a payload MUST close the track rather than continu
 A second group would present a gap as if it were a complete log; ending the track surfaces the failure instead, and a publisher with more to say opens a new track.
 
 A consumer MUST NOT skip to the newest group, since a later group does not supersede an earlier one the way a `snapshot` group does.
-It reads the one group the track carries, and MUST fail the read if the track carries a second, since whatever would have completed the first group is gone and yielding the remainder would present that gap as a continuous log.
+It reads the one group the track carries, and MUST fail the read as soon as it receives a second, even if the first remains open or has unread frames, since yielding any more records would present the gap as a continuous log.
 This is why a consumer takes groups in arrival order rather than by ascending sequence: groups are separate streams, so a second group MAY arrive with a lower sequence than the first, and skipping it would report a truncated log as a whole one.
 
 Retention is bounded, and this is the limit of "lossless".

--- a/js/binary/src/stream/consumer.ts
+++ b/js/binary/src/stream/consumer.ts
@@ -29,7 +29,8 @@ export class Rolled extends Error {
  * The log is a single group. That is what makes the mode lossless: rolling to a second group means
  * the payloads that would have completed the first are gone, so a publisher that cannot write ends
  * the track instead. A second group is therefore a broken publisher, and reading it would present
- * a gap as a continuous log, so it throws {@link Rolled} rather than yielding the remainder.
+ * a gap as a continuous log, so it throws {@link Rolled} before yielding any more payloads from the
+ * first group.
  */
 export class Consumer {
 	#track: Moq.Track.Subscriber;
@@ -38,6 +39,10 @@ export class Consumer {
 	#group?: Moq.Group.Consumer;
 	// Whether the log's one group has been taken, so a second is a rolled log rather than the first.
 	#taken = false;
+	// The track read raced against the held group. Keep it across calls so it consumes one group.
+	#nextGroup?: Promise<Moq.Group.Consumer | undefined>;
+	#trackEnded = false;
+	#rolled?: Rolled;
 	// The DEFLATE window for the group, present while decompressing.
 	#flate?: Flate;
 
@@ -46,18 +51,44 @@ export class Consumer {
 		this.#decompress = config.compression ?? false;
 	}
 
+	#roll(): never {
+		this.#rolled ??= new Rolled();
+		throw this.#rolled;
+	}
+
 	/** Get the next payload, or `undefined` once the track ends. */
 	async next(): Promise<Uint8Array | undefined> {
+		if (this.#rolled) throw this.#rolled;
+
 		for (;;) {
 			if (!this.#group) {
+				if (this.#trackEnded) return undefined;
 				// Arrival order rather than sequence order, because there is only ever one group to
 				// take and a second one has to be seen whatever its sequence. The monotonic
 				// `nextGroup` would drop a late lower sequence, which is the very loss this reports.
-				this.#group = await this.#track.recvGroup();
+				this.#group = await (this.#nextGroup ?? this.#track.recvGroup());
+				this.#nextGroup = undefined;
 				if (!this.#group) return undefined;
-				if (this.#taken) throw new Rolled();
+				if (this.#taken) this.#roll();
 				this.#taken = true;
 				this.#flate = this.#decompress ? new Flate() : undefined;
+			}
+
+			const readable = this.#group.readable();
+			if (!this.#trackEnded) {
+				this.#nextGroup ??= this.#track.recvGroup();
+				const ready = await Promise.race([
+					this.#nextGroup.then((group) => ({ kind: "group" as const, group })),
+					readable.then(() => ({ kind: "frame" as const })),
+				]);
+				if (ready.kind === "group") {
+					this.#nextGroup = undefined;
+					if (ready.group) this.#roll();
+					this.#trackEnded = true;
+					await readable;
+				}
+			} else {
+				await readable;
 			}
 
 			const frame = await this.#group.readFrame();

--- a/js/binary/src/stream/stream.test.ts
+++ b/js/binary/src/stream/stream.test.ts
@@ -71,22 +71,25 @@ test("the shared window shrinks repetitive payloads", async () => {
 	expect(sizes[sizes.length - 1]).toBeLessThan(sizes[0] ?? 0);
 });
 
-test("a second group is a rolled log, not a continuation", async () => {
-	// A stream is one group. A publisher that rolls lost whatever would have completed the first,
-	// so the read reports that rather than handing back the remainder as a continuous log.
+test("a second group preempts an open group", async () => {
 	// Written by hand because this producer never rolls.
 	const track = new Track.Producer("test");
-	for (const pair of [payloads(2), payloads(2)]) {
-		const group = track.appendGroup();
-		for (const payload of pair) group.writeFrame({ payload, timestamp: Time.Timestamp.now() });
-		group.close();
-	}
-	track.close();
-
+	const first = track.appendGroup();
+	first.writeFrame({ payload: payloads(1)[0], timestamp: Time.Timestamp.now() });
 	const consumer = new Consumer(track.subscribe({ maxAge: REPLAY_LATENCY }));
 	expect(await consumer.next()).toBeDefined();
-	expect(await consumer.next()).toBeDefined();
+
+	const pending = consumer.next();
+	await Promise.resolve();
+	const second = track.appendGroup();
+	first.writeFrame({ payload: payloads(1)[0], timestamp: Time.Timestamp.now() });
+
+	await expect(pending).rejects.toThrow(Rolled);
 	await expect(consumer.next()).rejects.toThrow(Rolled);
+
+	first.close();
+	second.close();
+	track.close();
 });
 
 test("an undecodable payload ends the log for a reader already inside the group", async () => {

--- a/js/json/src/stream/consumer.ts
+++ b/js/json/src/stream/consumer.ts
@@ -25,8 +25,8 @@ export class Rolled extends Error {
  * which is what makes the mode lossless: rolling to a second group means the records that would
  * have completed the first are gone, so a {@link Producer} that cannot write ends the track
  * instead. A second group is therefore a broken publisher, and reading it would present a gap as a
- * continuous log, so it throws {@link Rolled} rather than yielding the remainder. When something
- * else already owns the track, use the {@link Decoder} directly.
+ * continuous log, so it throws {@link Rolled} before yielding any more records from the first
+ * group. When something else already owns the track, use the {@link Decoder} directly.
  */
 export class Consumer<T> {
 	#track: Moq.Track.Subscriber;
@@ -35,25 +35,55 @@ export class Consumer<T> {
 	#group?: Moq.Group.Consumer;
 	// Whether the log's one group has been taken, so a second is a rolled log rather than the first.
 	#taken = false;
+	// The track read raced against the held group. Keep it across calls so it consumes one group.
+	#nextGroup?: Promise<Moq.Group.Consumer | undefined>;
+	#trackEnded = false;
+	#rolled?: Rolled;
 
 	constructor(track: Moq.Track.Subscriber, config: ConsumerConfig = {}) {
 		this.#track = track;
 		this.#decoder = new Decoder(config);
 	}
 
+	#roll(): never {
+		this.#rolled ??= new Rolled();
+		throw this.#rolled;
+	}
+
 	/** Get the next record, or `undefined` once the track ends. */
 	async next(): Promise<T | undefined> {
+		if (this.#rolled) throw this.#rolled;
+
 		for (;;) {
 			if (!this.#group) {
+				if (this.#trackEnded) return undefined;
 				// Arrival order rather than sequence order, because there is only ever one group to
 				// take and a second one has to be seen whatever its sequence. The monotonic
 				// `nextGroup` would drop a late lower sequence, which is the very loss this reports.
-				this.#group = await this.#track.recvGroup();
+				this.#group = await (this.#nextGroup ?? this.#track.recvGroup());
+				this.#nextGroup = undefined;
 				if (!this.#group) return undefined;
-				if (this.#taken) throw new Rolled();
+				if (this.#taken) this.#roll();
 				this.#taken = true;
 				// Each group is its own compressed stream, so the window starts cold.
 				this.#decoder.reset();
+			}
+
+			const readable = this.#group.readable();
+			if (!this.#trackEnded) {
+				this.#nextGroup ??= this.#track.recvGroup();
+				const ready = await Promise.race([
+					this.#nextGroup.then((group) => ({ kind: "group" as const, group })),
+					readable.then(() => ({ kind: "frame" as const })),
+				]);
+				if (ready.kind === "group") {
+					this.#nextGroup = undefined;
+					if (ready.group) this.#roll();
+					this.#trackEnded = true;
+					await readable;
+				}
+			} else {
+				await readable;
 			}
 
 			const frame = await this.#group.readFrame();

--- a/js/json/src/stream/stream.test.ts
+++ b/js/json/src/stream/stream.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
 import { Track } from "@moq/net";
-import { Consumer, Producer } from "./index.ts";
+import { Consumer, Producer, Rolled } from "./index.ts";
 
 type Rec = { n: number };
 
@@ -46,6 +46,27 @@ test("the whole log rides one group, never rolled", async () => {
 	expect(group0?.sequence).toBe(0);
 	const group1 = await subscriber.nextGroup();
 	expect(group1).toBeUndefined();
+});
+
+test("a second group preempts an open group", async () => {
+	// Written by hand because this producer never rolls.
+	const track = new Track.Producer("test");
+	const first = track.appendGroup();
+	first.writeString(JSON.stringify({ n: 0 }));
+	const consumer = new Consumer<Rec>(track.subscribe());
+	expect(await consumer.next()).toEqual({ n: 0 });
+
+	const pending = consumer.next();
+	await Promise.resolve();
+	const second = track.appendGroup();
+	first.writeString(JSON.stringify({ n: 1 }));
+
+	await expect(pending).rejects.toThrow(Rolled);
+	await expect(consumer.next()).rejects.toThrow(Rolled);
+
+	first.close();
+	second.close();
+	track.close();
 });
 
 test("records with embedded newlines round-trip (JSON escapes the newline)", async () => {

--- a/rs/moq-binary/src/stream/consumer.rs
+++ b/rs/moq-binary/src/stream/consumer.rs
@@ -32,12 +32,13 @@ impl ConsumerConfig {
 /// means the records that would have completed the first are gone, so a publisher that cannot
 /// write ends the track instead. A second group is therefore a broken publisher, and reading it
 /// would present a gap as a continuous log, so it fails with
-/// [`Error::Rolled`](crate::Error::Rolled) rather than yielding the remainder.
+/// [`Error::Rolled`](crate::Error::Rolled) before yielding any more payloads from the first group.
 pub struct Consumer {
 	track: moq_net::track::Subscriber,
 	group: Option<moq_net::group::Consumer>,
 	/// Whether the log's one group has been taken, so a second is a rolled log rather than the first.
 	taken: bool,
+	rolled: bool,
 	/// The DEFLATE decoder for the group, `Some` while decompressing.
 	flate: Option<moq_flate::Decoder>,
 	compression: bool,
@@ -53,6 +54,7 @@ impl Consumer {
 			track,
 			group: None,
 			taken: false,
+			rolled: false,
 			flate: None,
 			compression: config.compression,
 		}
@@ -65,6 +67,10 @@ impl Consumer {
 
 	/// Poll for the next payload, without blocking.
 	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<Bytes>>> {
+		if self.rolled {
+			return Poll::Ready(Err(crate::Error::Rolled));
+		}
+
 		loop {
 			let Some(group) = &mut self.group else {
 				// Arrival order rather than sequence order, because there is only ever one group to
@@ -74,6 +80,7 @@ impl Consumer {
 				match self.track.poll_recv_group(waiter)? {
 					Poll::Ready(Some(group)) => {
 						if self.taken {
+							self.rolled = true;
 							return Poll::Ready(Err(crate::Error::Rolled));
 						}
 						self.taken = true;
@@ -85,6 +92,13 @@ impl Consumer {
 					Poll::Pending => return Poll::Pending,
 				}
 			};
+
+			// Once the first group is held, a second invalidates the log immediately. Poll it first so
+			// unread frames in the first group cannot delay the error.
+			if let Poll::Ready(Some(_)) = self.track.poll_recv_group(waiter)? {
+				self.rolled = true;
+				return Poll::Ready(Err(crate::Error::Rolled));
+			}
 
 			match group.poll_read_frame(waiter)? {
 				Poll::Ready(Some(frame)) => return Poll::Ready(self.decode(&frame.payload).map(Some)),

--- a/rs/moq-binary/src/stream/mod.rs
+++ b/rs/moq-binary/src/stream/mod.rs
@@ -245,42 +245,38 @@ mod test {
 		);
 	}
 
-	/// A stream is one group. A publisher that rolls to a second one lost whatever would have
-	/// completed the first, so the read reports that rather than handing back the remainder as a
-	/// continuous log. Written by hand because this producer never rolls.
+	/// A second group invalidates the log immediately, even when the first remains open and has a
+	/// readable payload. Written by hand because this producer never rolls.
 	#[test]
-	fn a_second_group_is_a_rolled_log() {
+	fn a_second_group_preempts_an_open_group() {
 		let mut track = moq_net::broadcast::Info::new()
 			.produce()
 			.create_track("test", None)
 			.unwrap();
 		let subscriber = track.subscribe(replaying());
+		let mut first = track.append_group().unwrap();
+		first.write_frame(moq_net::Timestamp::now(), b"first").unwrap();
 
-		for pair in payloads(4).chunks(2) {
-			// Each group is its own DEFLATE stream, which is what a recovery roll would produce.
-			let mut flate = moq_flate::Encoder::new();
-			let mut group = track.append_group().unwrap();
-			for payload in pair {
-				group
-					.write_frame(moq_net::Timestamp::now(), flate.frame(payload))
-					.unwrap();
-			}
-			group.finish().unwrap();
-		}
-		track.finish().unwrap();
-
-		let mut consumer = Consumer::new(subscriber, ConsumerConfig::default().with_compression(true));
+		let mut consumer = Consumer::new(subscriber, ConsumerConfig::default());
 		let waiter = kio::Waiter::noop();
-
-		// The log's one group reads normally.
 		assert!(matches!(consumer.poll_next(&waiter), Poll::Ready(Ok(Some(_)))));
-		assert!(matches!(consumer.poll_next(&waiter), Poll::Ready(Ok(Some(_)))));
+		assert!(matches!(consumer.poll_next(&waiter), Poll::Pending));
 
-		// The second group is a gap, not a continuation.
+		let mut second = track.append_group().unwrap();
+		first.write_frame(moq_net::Timestamp::now(), b"unread").unwrap();
+
 		assert!(matches!(
 			consumer.poll_next(&waiter),
 			Poll::Ready(Err(crate::Error::Rolled))
 		));
+		assert!(matches!(
+			consumer.poll_next(&waiter),
+			Poll::Ready(Err(crate::Error::Rolled))
+		));
+
+		first.finish().unwrap();
+		second.finish().unwrap();
+		track.finish().unwrap();
 	}
 
 	/// Groups are separate QUIC streams, so a second one can land before the first. Reading in
@@ -294,24 +290,28 @@ mod test {
 			.unwrap();
 		let subscriber = track.subscribe(replaying());
 
-		// Publish sequence 1 before sequence 0, the way reordering delivers them.
-		for sequence in [1u64, 0] {
-			let mut flate = moq_flate::Encoder::new();
-			let mut group = track.create_group(moq_net::group::Info { sequence }).unwrap();
-			group
-				.write_frame(moq_net::Timestamp::now(), flate.frame(&[sequence as u8; 8]))
-				.unwrap();
-			group.finish().unwrap();
-		}
-		track.finish().unwrap();
-
+		let mut flate = moq_flate::Encoder::new();
+		let mut first = track.create_group(moq_net::group::Info { sequence: 1 }).unwrap();
+		first
+			.write_frame(moq_net::Timestamp::now(), flate.frame(&[1u8; 8]))
+			.unwrap();
+		first.finish().unwrap();
 		let mut consumer = Consumer::new(subscriber, ConsumerConfig::default().with_compression(true));
 		let waiter = kio::Waiter::noop();
-
 		assert!(matches!(
 			consumer.poll_next(&waiter),
 			Poll::Ready(Ok(Some(payload))) if payload == vec![1u8; 8]
 		));
+
+		// Sequence 0 lands after sequence 1, the way reordering delivers it.
+		let mut flate = moq_flate::Encoder::new();
+		let mut second = track.create_group(moq_net::group::Info { sequence: 0 }).unwrap();
+		second
+			.write_frame(moq_net::Timestamp::now(), flate.frame(&[0u8; 8]))
+			.unwrap();
+		second.finish().unwrap();
+		track.finish().unwrap();
+
 		assert!(matches!(
 			consumer.poll_next(&waiter),
 			Poll::Ready(Err(crate::Error::Rolled))

--- a/rs/moq-json/src/stream/consumer.rs
+++ b/rs/moq-json/src/stream/consumer.rs
@@ -14,13 +14,14 @@ use crate::Result;
 /// would have completed the first are gone, so a [`Producer`](super::Producer) that cannot write
 /// ends the track instead. A second group is therefore a broken publisher, and reading it would
 /// present a gap as a continuous log, so it fails with [`Error::Rolled`](crate::Error::Rolled)
-/// rather than yielding the remainder. When something else already owns the track, use the
-/// [`Decoder`] directly.
+/// before yielding any more records from the first group. When something else already owns the
+/// track, use the [`Decoder`] directly.
 pub struct Consumer<T> {
 	track: moq_net::track::Subscriber,
 	group: Option<moq_net::group::Consumer>,
 	/// Whether the log's one group has been taken, so a second is a rolled log rather than the first.
 	taken: bool,
+	rolled: bool,
 	decoder: Decoder<T>,
 }
 
@@ -34,6 +35,7 @@ impl<T: DeserializeOwned> Consumer<T> {
 			track,
 			group: None,
 			taken: false,
+			rolled: false,
 			decoder: Decoder::new(config),
 		}
 	}
@@ -48,6 +50,10 @@ impl<T: DeserializeOwned> Consumer<T> {
 
 	/// Poll for the next record, without blocking.
 	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<T>>> {
+		if self.rolled {
+			return Poll::Ready(Err(crate::Error::Rolled));
+		}
+
 		loop {
 			let Some(group) = &mut self.group else {
 				// Arrival order rather than sequence order, because there is only ever one group to
@@ -57,6 +63,7 @@ impl<T: DeserializeOwned> Consumer<T> {
 				match self.track.poll_recv_group(waiter)? {
 					Poll::Ready(Some(group)) => {
 						if self.taken {
+							self.rolled = true;
 							return Poll::Ready(Err(crate::Error::Rolled));
 						}
 						self.taken = true;
@@ -68,6 +75,13 @@ impl<T: DeserializeOwned> Consumer<T> {
 					Poll::Pending => return Poll::Pending,
 				}
 			};
+
+			// Once the first group is held, a second invalidates the log immediately. Poll it first so
+			// unread records in the first group cannot delay the error.
+			if let Poll::Ready(Some(_)) = self.track.poll_recv_group(waiter)? {
+				self.rolled = true;
+				return Poll::Ready(Err(crate::Error::Rolled));
+			}
 
 			match group.poll_read_frame(waiter)? {
 				Poll::Ready(Some(frame)) => return Poll::Ready(Ok(Some(self.decoder.decode(&frame.payload)?))),

--- a/rs/moq-json/src/stream/mod.rs
+++ b/rs/moq-json/src/stream/mod.rs
@@ -112,6 +112,50 @@ mod test {
 		assert_eq!(drain(consumer(track, true)).len(), 50);
 	}
 
+	/// A second group invalidates the log immediately, even when the first remains open and has a
+	/// readable record. Written by hand because this producer never rolls.
+	#[test]
+	fn a_second_group_preempts_an_open_group() {
+		let mut track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let subscriber = track.subscribe(None);
+		let mut first = track.append_group().unwrap();
+		first
+			.write_frame(
+				moq_net::Timestamp::now(),
+				serde_json::to_vec(&json!({ "n": 0 })).unwrap(),
+			)
+			.unwrap();
+
+		let mut consumer = consumer(subscriber, false);
+		let waiter = kio::Waiter::noop();
+		assert!(matches!(consumer.poll_next(&waiter), Poll::Ready(Ok(Some(_)))));
+		assert!(matches!(consumer.poll_next(&waiter), Poll::Pending));
+
+		let mut second = track.append_group().unwrap();
+		first
+			.write_frame(
+				moq_net::Timestamp::now(),
+				serde_json::to_vec(&json!({ "n": 1 })).unwrap(),
+			)
+			.unwrap();
+
+		assert!(matches!(
+			consumer.poll_next(&waiter),
+			Poll::Ready(Err(crate::Error::Rolled))
+		));
+		assert!(matches!(
+			consumer.poll_next(&waiter),
+			Poll::Ready(Err(crate::Error::Rolled))
+		));
+
+		first.finish().unwrap();
+		second.finish().unwrap();
+		track.finish().unwrap();
+	}
+
 	#[test]
 	fn live_consumer_sees_each_record() {
 		let (mut producer, track) = producer(compressed());


### PR DESCRIPTION
## Summary

- Race the held stream group against the next track group in Rust and TypeScript.
- Report terminal `Rolled` immediately when a second group arrives, even while the first group is open or still has unread records.
- Root cause: consumers stopped polling the track after taking group one, so a second group could not wake the pending frame read and the broken log parked indefinitely.
- Specify the eager detection rule in the HANG draft.

Closes #3260

## Public API changes

None. Existing `Rolled` errors become eager and terminal.

## Wire behavior changes

No encoding changes. A consumer now reports `Rolled` as soon as it receives a second stream group instead of waiting for group one to end. Unread records in group one are not delivered after the violation.

## Cross-package sync

Updated both Rust and TypeScript implementations plus the normative HANG draft.

## Test plan

- `nix develop --command just rs check -p moq-binary -p moq-json`
- `nix develop --command just rs test -p moq-binary -p moq-json` (173 passed)
- `nix develop --command just js check`
- `nix develop --command just js test`
- `git diff --check`
- Top-level `just check` and `just test` reach pre-existing `origin/dev` failures in `moq-rtc` and `moq-video`.
- `just drafts check` reaches the pre-existing unresolved `{{field-timeline}}` reference already on `origin/dev`; VitePress draft rendering passes.

(written by GPT-5)