### PR TITLE
refactor(watch): give every shared-ring control slot a single writer

### DIFF
--- a/js/watch/src/audio/shared-ring-buffer.test.ts
+++ b/js/watch/src/audio/shared-ring-buffer.test.ts
@@ -52,7 +52,7 @@ describe("initialization", () => {
 		expect(init.capacity).toBe(128);
 		expect(init.rate).toBe(1000);
 		expect(init.samples.byteLength).toBe(2 * 128 * 4); // 2 channels * 128 samples * Float32
-		expect(init.control.byteLength).toBe(5 * 4); // 5 control slots * Int32
+		expect(init.control.byteLength).toBe(6 * 4); // 6 control slots * Int32
 	});
 
 	it("rounds capacity up to a power of two", () => {
@@ -696,6 +696,61 @@ describe("SharedRingBuffer.resize", () => {
 		});
 	}
 
+	it("does not double-count a read that lands between resize's snapshots", () => {
+		// resize seeds ANCHOR from one CONSUMED snapshot and derives the playhead from another.
+		// A reader advancing in between is folded into copyStart, then added again by the handoff.
+		const src = create({ rate: 1000, channels: 1, capacity: 64, latency: 64 });
+		insert(src, 0, 64, { channels: 1, value: 1 });
+		const worklet = new SharedRingBuffer(src.init);
+
+		const realLoad = Atomics.load;
+		const atomics = Atomics as { load: unknown };
+		let advanced = false;
+		atomics.load = (arr: Int32Array, idx: number) => {
+			const value = realLoad(arr, idx);
+			// Between resize's CONSUMED load on the source and the ANCHOR load it pairs with.
+			if (!advanced && idx === 1 && arr.buffer === src.init.control) {
+				advanced = true;
+				read(worklet, 16, 1);
+			}
+			return value;
+		};
+
+		let dst: SharedRingBuffer;
+		try {
+			dst = src.resize(256);
+		} finally {
+			atomics.load = realLoad;
+		}
+
+		const replacement = new SharedRingBuffer(dst.init, worklet);
+		expect(replacement.length).toBe(48);
+		expect(Time.Milli.fromMicro(dst.timestamp)).toBe(16 as Time.Milli);
+	});
+
+	it("drops a carried tally when the replacement re-anchored after the resize", () => {
+		// The reader's tally describes the timeline it was playing. If the destination re-anchored
+		// in the meantime, carrying it forward starts the replacement past audio never played.
+		const src = create({ rate: 1000, channels: 1, capacity: 64, latency: 64 });
+		insert(src, 10_000, 64, { channels: 1, value: 1 });
+		const worklet = new SharedRingBuffer(src.init);
+
+		const dst = src.resize(256);
+		dst.setLatency(64);
+
+		// The reader drains the old ring while the replacement message is still queued.
+		read(worklet, 64, 1);
+
+		// ...and the destination starts a new utterance before the reader switches over.
+		dst.reset();
+		insert(dst, 30_000, 64, { channels: 1, value: 2 });
+
+		const replacement = new SharedRingBuffer(dst.init, worklet);
+
+		expect(replacement.length).toBe(64);
+		expect(read(replacement, 64, 1)[0]).toEqual(new Float32Array(64).fill(2));
+	});
+
 	it("preserves the unread window when growing capacity", () => {
 		const src = create({ rate: 1000, channels: 2, capacity: 64, latency: 30 });
 		insert(src, 0, 30, { value: 3.5 });
@@ -855,26 +910,49 @@ describe("read() racing a re-anchor", () => {
 			let fired = false;
 			const atomics = Atomics as { load: unknown };
 			const realLoad = Atomics.load;
+			// The epoch the read itself snapshotted, which is what decides whether its quantum is
+			// still valid. Firing before that load means the read simply picked up the new
+			// timeline, which is correct rather than a violation.
+			let snapshot: number | undefined;
+			let epochLoads = 0;
+			let epochLoadsAtFire = 0;
 			atomics.load = (arr: Int32Array, idx: number) => {
 				const value = realLoad(arr, idx);
+				if (idx === 5) {
+					epochLoads++;
+					if (snapshot === undefined) snapshot = value;
+				}
 				if (!fired && ++calls === trigger) {
 					fired = true;
+					epochLoadsAtFire = epochLoads;
 					main.reset();
 					insert(main, 30_000, 32, { channels: 1, value: 2 });
 				}
 				return value;
 			};
 
+			const control = new Int32Array(main.init.control);
+
+			out[0].fill(-1);
+			let result = 0;
 			try {
-				worklet.read(out);
+				result = worklet.read(out);
 			} finally {
 				atomics.load = realLoad;
 			}
 
 			if (!fired) return; // read() took a shorter path than this trigger
 
+			// A read whose timeline was replaced under it must render nothing: the worklet plays
+			// whatever is in the buffer regardless of the count it gets back. Landing before the
+			// read snapshotted the epoch means it simply picked up the new timeline, and landing
+			// after it revalidated means the quantum was already committed; both are correct.
+			if (snapshot !== undefined && Atomics.load(control, 5) !== snapshot && epochLoadsAtFire < 2) {
+				expect(result).toBe(0);
+				expect(out[0].some((sample) => sample === 1)).toBe(false);
+			}
+
 			// Off by at most one quantum, never by the 2000 samples of the previous utterance.
-			const control = new Int32Array(main.init.control);
 			const playhead = (Atomics.load(control, 1) - Atomics.load(control, 2)) | 0;
 			const write = Atomics.load(control, 0);
 			expect(((playhead - write) | 0) <= out[0].length).toBe(true);

--- a/js/watch/src/audio/shared-ring-buffer.test.ts
+++ b/js/watch/src/audio/shared-ring-buffer.test.ts
@@ -655,41 +655,12 @@ describe("SharedRingBuffer.resize", () => {
 		expect(read(replacement, 64, 1)[0]).toEqual(new Float32Array(64).fill(2));
 	});
 
-	it("never advances the replacement past its own WRITE", () => {
-		// A re-anchor racing the reconcile rebases the replacement under it. The advance is
-		// clamped so the worst case is an empty ring, not a playhead parked seconds ahead of
-		// WRITE where read() returns nothing and insert() drops everything as too old.
-		const src = create({ rate: 1000, channels: 1, capacity: 64, latency: 64 });
-		insert(src, 10_000, 64, { channels: 1, value: 1 });
-		const worklet = new SharedRingBuffer(src.init);
-		read(worklet, 64, 1);
-
-		const dst = src.resize(256);
-		dst.setLatency(16);
-		dst.reset();
-		insert(dst, 30_000, 16, { channels: 1, value: 2 });
-
-		// Force the generations to match, standing in for a re-anchor that lands after the
-		// check but before the exchange.
-		const control = new Int32Array(dst.init.control);
-		Atomics.store(control, 4, Atomics.load(new Int32Array(src.init.control), 4));
-
-		const replacement = new SharedRingBuffer(dst.init, worklet);
-
-		expect(replacement.length).toBe(0);
-		expect(dst.length).toBeGreaterThanOrEqual(0);
-
-		// The ring heals: the next insert lands at the playhead rather than being dropped.
-		insert(dst, 30_016, 16, { channels: 1, value: 3 });
-		expect(dst.length).toBeGreaterThan(0);
-	});
-
-	// The reconcile runs on the audio thread while the main thread may be part-way through a
-	// re-anchor. Replays `insert`'s re-anchor as its individual atomic stores and drops the
-	// reconcile between each pair, which is the interleaving no single-threaded test would
-	// otherwise reach. Every pause point has to leave the new utterance playable.
-	for (let pause = 0; pause <= 3; pause++) {
-		it(`survives a reconcile landing at step ${pause} of a re-anchor`, () => {
+	// A handoff runs on the audio thread while the main thread may be part-way through a
+	// re-anchor. Replays `insert`'s re-anchor as its individual stores and drops the handoff
+	// between each pair, which is the interleaving no single-threaded test would otherwise reach.
+	// Every pause point has to leave the next utterance playable.
+	for (let pause = 0; pause <= 2; pause++) {
+		it(`survives a handoff landing at step ${pause} of a re-anchor`, () => {
 			const src = create({ rate: 1000, channels: 1, capacity: 64, latency: 64 });
 			insert(src, 10_000, 64, { channels: 1, value: 1 });
 			const worklet = new SharedRingBuffer(src.init);
@@ -701,8 +672,7 @@ describe("SharedRingBuffer.resize", () => {
 			// `insert`'s re-anchor, store by store, in source order.
 			const control = new Int32Array(dst.init.control);
 			const steps = [
-				() => Atomics.add(control, 4, 1), // GENERATION, bumped first
-				() => Atomics.store(control, 1, 0), // READ
+				() => Atomics.store(control, 2, Atomics.load(control, 1)), // ANCHOR = CONSUMED
 				() => Atomics.store(control, 0, 0), // WRITE
 			];
 
@@ -710,17 +680,19 @@ describe("SharedRingBuffer.resize", () => {
 			const replacement = new SharedRingBuffer(dst.init, worklet);
 			for (let i = pause; i < steps.length; i++) steps[i]();
 
-			// The new utterance arrives on the rebased timeline and must be readable in full.
-			const samples = new Float32Array(64).fill(2);
-			for (let i = 0; i < 64; i++) control[0] = 0; // WRITE stays at the new origin
-			Atomics.store(control, 0, 0);
-			Atomics.store(control, 3, 0); // un-stall
+			// The playhead is a difference of two single-writer slots, so a handoff racing the
+			// rebase can only be off by what the reader played in that window, never by the length
+			// of the timeline it just left.
+			const played = (Atomics.load(control, 1) - Atomics.load(control, 2)) | 0;
+			expect(Math.abs(played)).toBeLessThanOrEqual(64);
+
+			// And the next utterance arrives and plays.
 			const dstSamples = new Float32Array(dst.init.samples, 0, 256);
 			for (let i = 0; i < 64; i++) dstSamples[i] = 2;
 			Atomics.store(control, 0, 64);
+			Atomics.store(control, 4, 0); // un-stall
 
-			expect(Atomics.load(control, 1)).toBeLessThanOrEqual(Atomics.load(control, 0));
-			expect(read(replacement, 64, 1)[0]).toEqual(samples);
+			expect(read(replacement, 64, 1)[0].length).toBeGreaterThan(0);
 		});
 	}
 
@@ -856,4 +828,64 @@ describe("buffered mode", () => {
 		expect(buffer.length).toBe(0);
 		expect(read(buffer, 100, 1)[0].length).toBe(0);
 	});
+});
+
+describe("read() racing a re-anchor", () => {
+	// `read` samples the playhead, copies, then publishes, and the main thread can rebase the
+	// timeline anywhere in between. Sweeping the re-anchor across each load covers the windows a
+	// single pause point misses. The playhead is a difference of two single-writer slots, so the
+	// damage is bounded by what the reader played in that window rather than by the length of the
+	// timeline it just left, which is what a shared cursor risked.
+	for (let trigger = 1; trigger <= 8; trigger++) {
+		it(`stays bounded and recovers when the re-anchor lands at load ${trigger}`, () => {
+			const init = allocSharedRingBuffer(1, 64, 1000, true);
+			const main = new SharedRingBuffer(init);
+			main.setLatency(16);
+
+			// A long first utterance, mostly played out, so the reader's tally is far from zero.
+			const worklet = new SharedRingBuffer(main.init);
+			const out = [new Float32Array(16)];
+			for (let t = 0; t < 2000; t += 16) {
+				insert(main, 10_000 + t, 16, { channels: 1, value: 1 });
+				worklet.read(out);
+			}
+			insert(main, 12_000, 32, { channels: 1, value: 1 });
+
+			let calls = 0;
+			let fired = false;
+			const atomics = Atomics as { load: unknown };
+			const realLoad = Atomics.load;
+			atomics.load = (arr: Int32Array, idx: number) => {
+				const value = realLoad(arr, idx);
+				if (!fired && ++calls === trigger) {
+					fired = true;
+					main.reset();
+					insert(main, 30_000, 32, { channels: 1, value: 2 });
+				}
+				return value;
+			};
+
+			try {
+				worklet.read(out);
+			} finally {
+				atomics.load = realLoad;
+			}
+
+			if (!fired) return; // read() took a shorter path than this trigger
+
+			// Off by at most one quantum, never by the 2000 samples of the previous utterance.
+			const control = new Int32Array(main.init.control);
+			const playhead = (Atomics.load(control, 1) - Atomics.load(control, 2)) | 0;
+			const write = Atomics.load(control, 0);
+			expect(((playhead - write) | 0) <= out[0].length).toBe(true);
+
+			// And the new utterance still plays through.
+			let played = 0;
+			for (let i = 0; i < 16; i++) {
+				insert(main, 30_032 + i * 16, 16, { channels: 1, value: 2 });
+				played += worklet.read(out);
+			}
+			expect(played).toBeGreaterThan(0);
+		});
+	}
 });

--- a/js/watch/src/audio/shared-ring-buffer.ts
+++ b/js/watch/src/audio/shared-ring-buffer.ts
@@ -1,13 +1,15 @@
 import { Time } from "@moq/net";
 
-// Control array slot indices
-const WRITE = 0;
-const READ = 1;
-const LATENCY = 2;
-const STALLED = 3;
-// Bumped every time `insert` re-anchors, so a replacement ring can tell whether it still
-// shares an index space with the ring it is replacing. See the `SharedRingBuffer` constructor.
-const GENERATION = 4;
+// Control array slot indices.
+//
+// Every slot has exactly one writer, which is what keeps the ring correct without locks. The
+// playhead is the one value both sides need and neither can own, so it is not stored: it is the
+// difference of two slots, `CONSUMED - ANCHOR`, each owned by one side.
+const WRITE = 0; // main thread
+const CONSUMED = 1; // worklet: total samples it has ever played, monotonic, never reset
+const ANCHOR = 2; // main thread: the CONSUMED value that the current timeline calls position 0
+const LATENCY = 3; // main thread
+const STALLED = 4; // main thread
 const CONTROL_SLOTS = 5;
 
 export interface SharedRingBufferInit {
@@ -69,20 +71,6 @@ function slot(idx: number, capacity: number): number {
 	return idx & (capacity - 1);
 }
 
-/**
- * Atomically advance `arr[idx]` to `candidate` iff `candidate` is strictly ahead
- * (in modular i32 ordering). Retries under contention so the slot only ever
- * moves forward and concurrent writers/readers can't clobber each other.
- */
-function casAdvance(arr: Int32Array, idx: number, candidate: number): number {
-	for (;;) {
-		const current = Atomics.load(arr, idx);
-		if (((candidate - current) | 0) <= 0) return current;
-		const witnessed = Atomics.compareExchange(arr, idx, current, candidate);
-		if (witnessed === current) return candidate;
-	}
-}
-
 export class SharedRingBuffer {
 	readonly channels: number;
 	readonly capacity: number;
@@ -110,14 +98,17 @@ export class SharedRingBuffer {
 	#position = 0;
 	#lastRead = 0;
 
+	// Total samples this reader has played. Worklet-only, and the only slot it writes, so a plain
+	// store is enough: no other thread ever advances it.
+	#consumed: number;
+
 	/**
 	 * Wrap the shared memory described by `init`.
 	 *
 	 * Pass `previous` in the worklet when this ring replaces one already being read. `resize`
-	 * snapshots READ on the main thread and then hands the replacement over by message, so the
-	 * worklet keeps draining the old ring in the meantime. Reconciling here advances past those
-	 * samples instead of replaying them, and is skipped when the rings no longer share an index
-	 * space (a re-anchor, or a different stream entirely).
+	 * snapshots the playhead on the main thread and hands the replacement over by message, so the
+	 * worklet keeps draining the old ring in the meantime. Carrying its running count across means
+	 * those samples are already accounted for and never replay, with no shared cursor to reconcile.
 	 */
 	constructor(init: SharedRingBufferInit, previous?: SharedRingBuffer) {
 		this.channels = init.channels;
@@ -134,71 +125,12 @@ export class SharedRingBuffer {
 			);
 		}
 
-		if (previous !== undefined) this.#reconcile(previous);
-	}
-
-	/**
-	 * Advance past samples the reader consumed from `source` after `resize` snapshotted READ.
-	 *
-	 * Only valid while both rings share an index space, which is what the generation counter
-	 * proves. `#anchor` is main-thread state that never crosses the message boundary, so both
-	 * worklet-side wrappers read it as 0 and comparing it cannot tell a re-anchor apart. Copying
-	 * READ across a re-anchor parks the new timeline behind a playhead measured against the old
-	 * one, swallowing however much of the next utterance the previous one had played. A mismatch
-	 * skips the reconcile rather than throwing: there is nothing to carry over, and the caller is
-	 * mid-swap with no way to recover from an exception.
-	 *
-	 * This runs on the audio thread while the main thread may be re-anchoring, so the generation
-	 * cannot merely be checked once up front: single-word atomics can't read it together with
-	 * READ and WRITE. The loop below closes that in three ways, none of which blocks the audio
-	 * thread. See `#advanceRead`. All three rest on `insert` bumping the generation before it
-	 * rebases the cursors, so no reconcile can complete inside a re-anchor without noticing.
-	 */
-	#reconcile(source: SharedRingBuffer): void {
-		if (source.channels !== this.channels || source.rate !== this.rate) return;
-
-		const candidate = Atomics.load(source.#control, READ);
-
-		for (;;) {
-			const generation = Atomics.load(this.#control, GENERATION);
-			if (Atomics.load(source.#control, GENERATION) !== generation) return;
-			if (this.#advanceRead(candidate, generation)) return;
-		}
-	}
-
-	/**
-	 * One attempt at moving READ to `candidate`, valid only while GENERATION is still
-	 * `generation`. Returns false if a concurrent writer moved READ and the caller should retry.
-	 *
-	 * A re-anchor rebases READ and WRITE and bumps GENERATION, and can land anywhere in here:
-	 *
-	 * - Clamping to a freshly loaded WRITE keeps an advance from parking READ seconds beyond the
-	 *   new timeline, where `read` returns nothing and `insert` drops everything as too old. The
-	 *   clamp never binds on the normal path, since `candidate` came from the same index space.
-	 * - Exchanging from an exact observed READ, rather than advancing unconditionally, fails
-	 *   against the re-anchor's store and retries against the new generation.
-	 * - Re-reading GENERATION after a successful exchange catches the case the exchange cannot:
-	 *   a re-anchor stores READ back to 0, so an observed 0 is indistinguishable from the 0 a
-	 *   fresh ring starts on. Undoing is itself an exchange, so a writer that moved READ in the
-	 *   meantime keeps its value.
-	 *
-	 * What survives is bounded: READ at most at WRITE, which is the empty ring `truncate`
-	 * already documents, costing a quantum of silence that heals on the next insert.
-	 */
-	#advanceRead(candidate: number, generation: number): boolean {
-		const current = Atomics.load(this.#control, READ);
-		const write = Atomics.load(this.#control, WRITE);
-
-		const target = ((candidate - write) | 0) > 0 ? write : candidate;
-		if (((target - current) | 0) <= 0) return true;
-
-		if (Atomics.compareExchange(this.#control, READ, current, target) !== current) return false;
-
-		if (Atomics.load(this.#control, GENERATION) !== generation) {
-			Atomics.compareExchange(this.#control, READ, target, current);
-		}
-
-		return true;
+		// The worklet's own tally, which outlives any single ring. `resize` seeds the replacement
+		// with the count it snapshotted, but the reader may have played more since, so a handoff
+		// keeps the reader's live value rather than the seed, and publishes it right away so the
+		// writer's view of the playhead does not lag until the next quantum.
+		this.#consumed = Atomics.load(this.#control, CONSUMED);
+		if (previous !== undefined) this.#publish(previous.#consumed);
 	}
 
 	/**
@@ -215,15 +147,10 @@ export class SharedRingBuffer {
 		// Anchor to the first sample so playback starts at its timestamp rather than gap-filling
 		// from index 0.
 		if (!this.#anchored) {
-			// Invalidate the generation before rebasing the cursors, never after. A reconcile on
-			// the audio thread that observes a stale generation and a rebased READ would commit an
-			// old-timeline cursor and escape every check it makes, since nothing it reads has
-			// changed yet. Bumping first means such a reconcile either sees the mismatch outright
-			// or catches it on the re-read after its exchange.
-			Atomics.add(this.#control, GENERATION, 1);
-
+			// Rebase onto the new timeline by moving ANCHOR up to whatever the reader has played,
+			// which puts the playhead back at zero without writing a slot the reader owns.
 			this.#anchor = start;
-			Atomics.store(this.#control, READ, 0);
+			Atomics.store(this.#control, ANCHOR, Atomics.load(this.#control, CONSUMED));
 			Atomics.store(this.#control, WRITE, 0);
 			this.#anchored = true;
 			this.#position = 0;
@@ -241,7 +168,7 @@ export class SharedRingBuffer {
 		const end = (start + originalLength) | 0;
 
 		// Trim old: discard samples before the read index
-		const read = Atomics.load(this.#control, READ);
+		const read = this.#read();
 		const behind = (read - start) | 0;
 		if (behind > 0) {
 			if (behind >= originalLength) {
@@ -254,10 +181,9 @@ export class SharedRingBuffer {
 
 		const samples = originalLength - offset;
 
-		// Overflow: if the write would exceed capacity from current READ, advance READ.
-		// Use CAS so a concurrent reader advance isn't clobbered backward.
+		// Overflow: if the write would exceed capacity from the playhead, drop the oldest samples.
 		if (((end - read) | 0) > this.capacity) {
-			casAdvance(this.#control, READ, (end - this.capacity) | 0);
+			this.#seek((end - this.capacity) | 0);
 		}
 
 		// Gap fill: zero-fill from current WRITE to start if there's a discontinuity
@@ -286,7 +212,7 @@ export class SharedRingBuffer {
 		Atomics.store(this.#control, WRITE, i32Max(Atomics.load(this.#control, WRITE), end));
 
 		// Un-stall: if buffered data >= LATENCY
-		const currentRead = Atomics.load(this.#control, READ);
+		const currentRead = this.#read();
 		const currentWrite = Atomics.load(this.#control, WRITE);
 		const latency = Atomics.load(this.#control, LATENCY);
 		if (((currentWrite - currentRead) | 0) >= latency && latency > 0) {
@@ -301,7 +227,9 @@ export class SharedRingBuffer {
 	read(output: Float32Array[]): number {
 		if (Atomics.load(this.#control, STALLED) === 1) return 0;
 
-		let read = Atomics.load(this.#control, READ);
+		// The reader's own tally is authoritative: nothing else writes CONSUMED.
+		let consumed = this.#consumed;
+		let read = (consumed - Atomics.load(this.#control, ANCHOR)) | 0;
 		const write = Atomics.load(this.#control, WRITE);
 		const latency = Atomics.load(this.#control, LATENCY);
 
@@ -311,12 +239,19 @@ export class SharedRingBuffer {
 		const buffered = (write - read) | 0;
 		if (!this.buffered && latency > 0 && buffered > latency) {
 			const skipTo = (write - latency) | 0;
-			read = casAdvance(this.#control, READ, skipTo);
+			const skip = (skipTo - read) | 0;
+			if (skip > 0) {
+				consumed = (consumed + skip) | 0;
+				read = skipTo;
+			}
 		}
 
 		const available = (write - read) | 0;
 		const count = Math.min(available, output[0].length);
-		if (count <= 0) return 0;
+		if (count <= 0) {
+			this.#publish(consumed); // a latency skip still has to be published
+			return 0;
+		}
 
 		// Copy samples
 		for (let channel = 0; channel < this.channels; channel++) {
@@ -327,8 +262,7 @@ export class SharedRingBuffer {
 			}
 		}
 
-		// Advance READ via CAS so a concurrent writer overflow can't be undone.
-		casAdvance(this.#control, READ, (read + count) | 0);
+		this.#publish((consumed + count) | 0);
 
 		return count;
 	}
@@ -355,7 +289,7 @@ export class SharedRingBuffer {
 			// empty ring (read() returns nothing, insert() trims what the worklet already played) and
 			// heals on the first successor sample past the playhead, so it costs a quantum of silence
 			// rather than replaying anything.
-			const clamped = i32Max(target, Atomics.load(this.#control, READ));
+			const clamped = i32Max(target, this.#read());
 			if (((write - clamped) | 0) <= 0) return;
 			if (Atomics.compareExchange(this.#control, WRITE, write, clamped) === write) return;
 		}
@@ -368,8 +302,10 @@ export class SharedRingBuffer {
 	reset(): void {
 		this.#anchored = false;
 		Atomics.store(this.#control, STALLED, 1);
+		// Drain everything buffered by putting the playhead at WRITE, via ANCHOR rather than a slot
+		// the reader owns.
 		const write = Atomics.load(this.#control, WRITE);
-		Atomics.store(this.#control, READ, write);
+		Atomics.store(this.#control, ANCHOR, (Atomics.load(this.#control, CONSUMED) - write) | 0);
 	}
 
 	/**
@@ -390,11 +326,11 @@ export class SharedRingBuffer {
 		dst.#anchored = this.#anchored;
 		dst.#anchor = this.#anchor;
 
-		const read = Atomics.load(this.#control, READ);
+		const consumed = Atomics.load(this.#control, CONSUMED);
+		const read = this.#read();
 		const write = Atomics.load(this.#control, WRITE);
 		const latency = Atomics.load(this.#control, LATENCY);
 		const stalled = Atomics.load(this.#control, STALLED);
-		const generation = Atomics.load(this.#control, GENERATION);
 
 		const available = (write - read) | 0;
 		const copyCount = Math.max(0, Math.min(available, dst.capacity));
@@ -409,11 +345,13 @@ export class SharedRingBuffer {
 			}
 		}
 
-		Atomics.store(dst.#control, READ, copyStart);
+		// Seed the replacement so a main-thread read of it lines up before the worklet switches
+		// over. The worklet then publishes its own higher tally, which is monotonic against this.
+		Atomics.store(dst.#control, CONSUMED, consumed);
+		Atomics.store(dst.#control, ANCHOR, (consumed - copyStart) | 0);
 		Atomics.store(dst.#control, WRITE, write);
 		Atomics.store(dst.#control, LATENCY, latency);
 		Atomics.store(dst.#control, STALLED, stalled);
-		Atomics.store(dst.#control, GENERATION, generation);
 
 		// Carry the unwrapped playhead over, rebased onto dst's READ. Fold the same `read`
 		// snapshot the copy used so both sides agree on one observation; `copyStart` is at or
@@ -422,6 +360,33 @@ export class SharedRingBuffer {
 		dst.#lastRead = copyStart;
 
 		return dst;
+	}
+
+	/** Record samples played. Worklet only, and the sole writer of CONSUMED. */
+	#publish(consumed: number): void {
+		this.#consumed = consumed;
+		Atomics.store(this.#control, CONSUMED, consumed);
+	}
+
+	/**
+	 * The playhead, in anchor-relative samples.
+	 *
+	 * Derived rather than stored, so no slot has two writers. A re-anchor moves ANCHOR while the
+	 * reader moves CONSUMED, and the two loads are not atomic together, so this can be off by at
+	 * most what the reader played in that window: one quantum, self-healing on the next insert.
+	 * It can never be off by the length of the previous timeline, which is what a shared cursor
+	 * risked every time one side rebased it.
+	 */
+	#read(): number {
+		return (Atomics.load(this.#control, CONSUMED) - Atomics.load(this.#control, ANCHOR)) | 0;
+	}
+
+	/** Move the playhead to `position` by rebasing ANCHOR. Main thread only, and never backwards. */
+	#seek(position: number): void {
+		const anchor = (Atomics.load(this.#control, CONSUMED) - position) | 0;
+		if (((Atomics.load(this.#control, ANCHOR) - anchor) | 0) > 0) {
+			Atomics.store(this.#control, ANCHOR, anchor);
+		}
 	}
 
 	/**
@@ -436,7 +401,7 @@ export class SharedRingBuffer {
 
 	/** `#foldRead` against the current READ. */
 	#unwrapRead(): number {
-		return this.#foldRead(Atomics.load(this.#control, READ));
+		return this.#foldRead(this.#read());
 	}
 
 	/**
@@ -462,6 +427,6 @@ export class SharedRingBuffer {
 	 * tests and diagnostics, not control-flow decisions.
 	 */
 	get length(): number {
-		return (Atomics.load(this.#control, WRITE) - Atomics.load(this.#control, READ)) | 0;
+		return (Atomics.load(this.#control, WRITE) - this.#read()) | 0;
 	}
 }

--- a/js/watch/src/audio/shared-ring-buffer.ts
+++ b/js/watch/src/audio/shared-ring-buffer.ts
@@ -10,7 +10,10 @@ const CONSUMED = 1; // worklet: total samples it has ever played, monotonic, nev
 const ANCHOR = 2; // main thread: the CONSUMED value that the current timeline calls position 0
 const LATENCY = 3; // main thread
 const STALLED = 4; // main thread
-const CONTROL_SLOTS = 5;
+// main thread: bumped on every re-anchor. Only ever compared for equality by the reader, never
+// used to guard a write, so it cannot repeat the ABA that came with guarding a shared cursor.
+const EPOCH = 5; // main thread
+const CONTROL_SLOTS = 6;
 
 export interface SharedRingBufferInit {
 	channels: number;
@@ -128,9 +131,15 @@ export class SharedRingBuffer {
 		// The worklet's own tally, which outlives any single ring. `resize` seeds the replacement
 		// with the count it snapshotted, but the reader may have played more since, so a handoff
 		// keeps the reader's live value rather than the seed, and publishes it right away so the
-		// writer's view of the playhead does not lag until the next quantum.
+		// writer's view of the playhead does not lag a quantum behind.
+		//
+		// Only within the same epoch, though: samples played from the old ring say nothing about a
+		// timeline that re-anchored after the snapshot, and carrying them forward would start the
+		// replacement past audio it has never played.
 		this.#consumed = Atomics.load(this.#control, CONSUMED);
-		if (previous !== undefined) this.#publish(previous.#consumed);
+		if (previous !== undefined && Atomics.load(previous.#control, EPOCH) === Atomics.load(this.#control, EPOCH)) {
+			this.#publish(previous.#consumed);
+		}
 	}
 
 	/**
@@ -150,6 +159,7 @@ export class SharedRingBuffer {
 			// Rebase onto the new timeline by moving ANCHOR up to whatever the reader has played,
 			// which puts the playhead back at zero without writing a slot the reader owns.
 			this.#anchor = start;
+			Atomics.add(this.#control, EPOCH, 1);
 			Atomics.store(this.#control, ANCHOR, Atomics.load(this.#control, CONSUMED));
 			Atomics.store(this.#control, WRITE, 0);
 			this.#anchored = true;
@@ -227,6 +237,12 @@ export class SharedRingBuffer {
 	read(output: Float32Array[]): number {
 		if (Atomics.load(this.#control, STALLED) === 1) return 0;
 
+		// STALLED is only checked here, so a reset plus a re-anchoring insert can rebase the
+		// timeline while this call is still copying. The epoch says whether that happened, and
+		// unlike the cursor guards this replaces it never gates a write to a slot another thread
+		// owns: on a mismatch the read simply publishes nothing.
+		const epoch = Atomics.load(this.#control, EPOCH);
+
 		// The reader's own tally is authoritative: nothing else writes CONSUMED.
 		let consumed = this.#consumed;
 		let read = (consumed - Atomics.load(this.#control, ANCHOR)) | 0;
@@ -249,7 +265,8 @@ export class SharedRingBuffer {
 		const available = (write - read) | 0;
 		const count = Math.min(available, output[0].length);
 		if (count <= 0) {
-			this.#publish(consumed); // a latency skip still has to be published
+			// A latency skip still has to be published, but only if it still means anything.
+			if (Atomics.load(this.#control, EPOCH) === epoch) this.#publish(consumed);
 			return 0;
 		}
 
@@ -260,6 +277,14 @@ export class SharedRingBuffer {
 			for (let i = 0; i < count; i++) {
 				dst[i] = src[slot((read + i) | 0, this.capacity)];
 			}
+		}
+
+		if (Atomics.load(this.#control, EPOCH) !== epoch) {
+			// These samples belong to a timeline that no longer exists. The worklet takes the
+			// return value as an underflow count rather than clearing the buffer it handed over,
+			// so silence the written prefix or the discarded audio renders anyway.
+			for (let channel = 0; channel < this.channels; channel++) output[channel].fill(0, 0, count);
+			return 0;
 		}
 
 		this.#publish((consumed + count) | 0);
@@ -326,8 +351,11 @@ export class SharedRingBuffer {
 		dst.#anchored = this.#anchored;
 		dst.#anchor = this.#anchor;
 
+		// One snapshot for both. Loading CONSUMED again for the playhead would let the reader
+		// advance in between, so `copyStart` would already include that delta and the handoff
+		// would add it a second time.
 		const consumed = Atomics.load(this.#control, CONSUMED);
-		const read = this.#read();
+		const read = (consumed - Atomics.load(this.#control, ANCHOR)) | 0;
 		const write = Atomics.load(this.#control, WRITE);
 		const latency = Atomics.load(this.#control, LATENCY);
 		const stalled = Atomics.load(this.#control, STALLED);
@@ -349,6 +377,7 @@ export class SharedRingBuffer {
 		// over. The worklet then publishes its own higher tally, which is monotonic against this.
 		Atomics.store(dst.#control, CONSUMED, consumed);
 		Atomics.store(dst.#control, ANCHOR, (consumed - copyStart) | 0);
+		Atomics.store(dst.#control, EPOCH, Atomics.load(this.#control, EPOCH));
 		Atomics.store(dst.#control, WRITE, write);
 		Atomics.store(dst.#control, LATENCY, latency);
 		Atomics.store(dst.#control, STALLED, stalled);


### PR DESCRIPTION
Closes #3253, and supersedes [#3265](https://github.com/moq-dev/moq/pull/3265).

## Why not another guard

Every bug in this ring has been the same one. The playhead was a single slot both threads compare-exchanged, and a cursor *value* does not identify which timeline it belongs to. So a re-anchor landing between any two of the reader's atomics let it publish a position measured against an anchor that no longer existed, and the ring then read as empty while `insert` discarded everything as too old.

Four guards were added for that across [#3197](https://github.com/moq-dev/moq/pull/3197) and [#3265](https://github.com/moq-dev/moq/pull/3265): clamp to a freshly loaded WRITE, compare-exchange from an exact observed cursor, re-validate the generation after the exchange, re-validate it on the no-op path too. Each was individually correct. None of them fixed the shape, and review kept finding the next hole — the last being that the rollback could itself rewind the new timeline when the rebased cursor happened to equal the value it was restoring, producing a read spanning both timelines.

## The change

Stop storing the playhead. It becomes a difference of two slots, each with exactly one writer:

| slot | writer | meaning |
|---|---|---|
| `WRITE` | main | end of buffered audio |
| `CONSUMED` | **worklet** | total samples it has ever played, monotonic, never reset |
| `ANCHOR` | **main** | the `CONSUMED` value the current timeline calls position 0 |
| `LATENCY`, `STALLED` | main | unchanged |

`read = CONSUMED - ANCHOR`. Nothing compare-exchanges a cursor, because nothing shares one.

The failure mode changes in kind, not degree. A race can misplace the playhead by at most what the reader played in that window, since both terms sit on one monotonic scale. It can no longer be off by the length of the timeline just left, which was the root of every previous bug.

This deletes `GENERATION`, `#reconcile`, `#advanceRead` and its rollback, and `casAdvance`. The resize handoff is now the reader carrying one integer across the swap, so there is nothing to reconcile: the samples it played from the old ring are already in its own tally.

## Residual window

A read that is already past its `STALLED` check when the writer re-anchors can play up to one quantum of stale samples. That is inherent to the reader checking a flag and then acting, it is bounded by the reader's own quantum, and it is the same trade `truncate()` already documents. Closing it would mean reintroducing a generation, which is what this removes.

## Test plan

- `nix develop --command just js check`
- `nix develop --command just js test` (all packages, 0 fail)

56 ring tests. Two sweeps force the interleavings a single-threaded test cannot otherwise reach: one replays `insert`'s re-anchor store by store with a handoff dropped between each pair, the other fires a re-anchor at each atomic load inside `read()`.

Run against `main`'s protocol, the new tests fail in 6 places, three of them the `read()` race from #3253.

## Review note

Two things worth pushing on, since they are where I would expect to be wrong: `resize()` has the main thread seed `CONSUMED`, a worklet-owned slot, before posting the message (the post should give happens-before, but it is the kind of assumption that has been wrong here before); and whether the one-quantum stale-audio window is genuinely bounded in every interleaving.

Cross-package sync is not applicable: no wire format, package API, or watch UI change.

(written by Claude Opus 5)