### PR TITLE
fix(stream): detect a rolled log without waiting for the group to end

### DIFF
--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -399,6 +399,10 @@ A consumer MUST NOT skip to the newest group, since a later group does not super
 It reads the one group the track carries, and MUST fail the read if the track carries a second, since whatever would have completed the first group is gone and yielding the remainder would present that gap as a continuous log.
 This is why a consumer takes groups in arrival order rather than by ascending sequence: groups are separate streams, so a second group MAY arrive with a lower sequence than the first, and skipping it would report a truncated log as a whole one.
 
+A consumer MUST NOT wait for the first group to end before it looks for a second.
+A publisher that opens a second group while the first is still open is broken in exactly the way this rule exists to catch, and a consumer that only checks at the group boundary waits forever on a group that publisher may never finish.
+A consumer MAY yield payloads it has already received from the first group before it fails, since those payloads precede the gap, but it MUST fail rather than block once they run out.
+
 Retention is bounded, and this is the limit of "lossless".
 A group's cache is finite, so a publisher that writes more than it holds evicts the log's earliest frames.
 A consumer that has not kept up, or that subscribes later, then cannot read the log at all: the read fails once it reaches the evicted prefix, rather than silently resuming at whatever the cache still holds.

--- a/js/binary/src/stream/consumer.ts
+++ b/js/binary/src/stream/consumer.ts
@@ -30,6 +30,10 @@ export class Rolled extends Error {
  * the payloads that would have completed the first are gone, so a publisher that cannot write ends
  * the track instead. A second group is therefore a broken publisher, and reading it would present
  * a gap as a continuous log, so it throws {@link Rolled} rather than yielding the remainder.
+ *
+ * The failure does not wait for the first group to end: whatever has already arrived in it is
+ * yielded, and the read then throws rather than blocking on a group a broken publisher may never
+ * finish.
  */
 export class Consumer {
 	#track: Moq.Track.Subscriber;
@@ -38,6 +42,12 @@ export class Consumer {
 	#group?: Moq.Group.Consumer;
 	// Whether the log's one group has been taken, so a second is a rolled log rather than the first.
 	#taken = false;
+	// Sticky once a second group is seen: the payloads it displaced are gone, so every later read
+	// throws too rather than reporting the rest of the log as a whole one.
+	#rolled = false;
+	// The in-flight `recvGroup`, kept across reads. Racing it against a frame read leaves it
+	// outstanding whenever the frame wins, and a second call would take a second group off the track.
+	#pending?: Promise<Moq.Group.Consumer | undefined>;
 	// The DEFLATE window for the group, present while decompressing.
 	#flate?: Flate;
 
@@ -49,27 +59,68 @@ export class Consumer {
 	/** Get the next payload, or `undefined` once the track ends. */
 	async next(): Promise<Uint8Array | undefined> {
 		for (;;) {
+			if (this.#rolled) throw new Rolled();
+
 			if (!this.#group) {
-				// Arrival order rather than sequence order, because there is only ever one group to
-				// take and a second one has to be seen whatever its sequence. The monotonic
-				// `nextGroup` would drop a late lower sequence, which is the very loss this reports.
-				this.#group = await this.#track.recvGroup();
-				if (!this.#group) return undefined;
-				if (this.#taken) throw new Rolled();
+				const group = await this.#recvGroup();
+				this.#pending = undefined;
+				if (!group) return undefined;
+				if (this.#taken) {
+					this.#rolled = true;
+					continue;
+				}
 				this.#taken = true;
 				this.#flate = this.#decompress ? new Flate() : undefined;
+				this.#group = group;
 			}
 
-			const frame = await this.#group.readFrame();
-			if (frame === undefined) {
-				// The log's one group is exhausted. Keep reading the track so a clean end still
-				// reports the log as complete, and so a second group is caught as Rolled.
-				this.#group = undefined;
-				continue;
-			}
+			const frame = await this.#readFrame(this.#group);
+			if (frame) return this.#flate ? this.#flate.frame(frame.payload) : frame.payload;
 
-			return this.#flate ? this.#flate.frame(frame.payload) : frame.payload;
+			// The log's one group is exhausted. Keep reading the track so a clean end still
+			// reports the log as complete, and so a second group is caught as Rolled.
+			this.#group = undefined;
 		}
+	}
+
+	// Read the group's next frame, throwing {@link Rolled} if the track hands over a second group
+	// first. A stream is one group, so the track is watched while the group is held: a publisher
+	// that opens a second and leaves the first open would otherwise park this read forever on a log
+	// that has already lost payloads.
+	async #readFrame(group: Moq.Group.Consumer): Promise<Moq.Group.Frame | undefined> {
+		// Drain what already arrived before consulting the track, so only a read that would really
+		// block depends on which of the two lands first. `skipped` is the evicted prefix that
+		// `readFrame` reports as lagged and `tryReadFrame` would hand back across the gap.
+		if (!group.skipped) {
+			const buffered = group.tryReadFrame();
+			if (buffered) return buffered;
+		}
+
+		const frame = group.readFrame();
+		const winner = await Promise.race([
+			frame.then((frame) => ({ frame }) as const),
+			this.#recvGroup().then((group) => ({ group }) as const),
+		]);
+		if ("frame" in winner) return winner.frame;
+
+		this.#pending = undefined;
+		if (winner.group) {
+			this.#rolled = true;
+			throw new Rolled();
+		}
+
+		// The track is finished, which does not truncate the group in hand.
+		return await frame;
+	}
+
+	// Receive the track's next group, reusing the in-flight read a frame may have raced and won.
+	//
+	// Arrival order rather than sequence order, because there is only ever one group to take and a
+	// second one has to be seen whatever its sequence. The monotonic `nextGroup` would drop a late
+	// lower sequence, which is the very loss this reports.
+	#recvGroup(): Promise<Moq.Group.Consumer | undefined> {
+		this.#pending ??= this.#track.recvGroup();
+		return this.#pending;
 	}
 
 	/** Iterate over every payload in order, until the track ends. */

--- a/js/binary/src/stream/consumer.ts
+++ b/js/binary/src/stream/consumer.ts
@@ -42,12 +42,11 @@ export class Consumer {
 	#group?: Moq.Group.Consumer;
 	// Whether the log's one group has been taken, so a second is a rolled log rather than the first.
 	#taken = false;
-	// Sticky once a second group is seen: the payloads it displaced are gone, so every later read
-	// throws too rather than reporting the rest of the log as a whole one.
-	#rolled = false;
-	// The in-flight `recvGroup`, kept across reads. Racing it against a frame read leaves it
-	// outstanding whenever the frame wins, and a second call would take a second group off the track.
-	#pending?: Promise<Moq.Group.Consumer | undefined>;
+	// The in-flight `recvGroup`, tagged for the race and built once: a frame read that wins leaves it
+	// outstanding, a second call would take a second group off the track, and tagging it per read
+	// would chain a reaction onto it for every payload in the log. Cleared only when the group it
+	// carries is taken, so a second group stays resolved here and every later read fails on it again.
+	#pending?: Promise<{ group: Moq.Group.Consumer | undefined }>;
 	// The DEFLATE window for the group, present while decompressing.
 	#flate?: Flate;
 
@@ -59,16 +58,13 @@ export class Consumer {
 	/** Get the next payload, or `undefined` once the track ends. */
 	async next(): Promise<Uint8Array | undefined> {
 		for (;;) {
-			if (this.#rolled) throw new Rolled();
-
 			if (!this.#group) {
-				const group = await this.#recvGroup();
-				this.#pending = undefined;
+				const { group } = await this.#recvGroup();
 				if (!group) return undefined;
-				if (this.#taken) {
-					this.#rolled = true;
-					continue;
-				}
+				// The resolved `#pending` is the whole record of the failure: it is left in place, so
+				// every later read arrives back here and throws again rather than reading on.
+				if (this.#taken) throw new Rolled();
+				this.#pending = undefined;
 				this.#taken = true;
 				this.#flate = this.#decompress ? new Flate() : undefined;
 				this.#group = group;
@@ -97,15 +93,13 @@ export class Consumer {
 		}
 
 		const frame = group.readFrame();
-		const winner = await Promise.race([
-			frame.then((frame) => ({ frame }) as const),
-			this.#recvGroup().then((group) => ({ group }) as const),
-		]);
+		const winner = await Promise.race([frame.then((frame) => ({ frame }) as const), this.#recvGroup()]);
 		if ("frame" in winner) return winner.frame;
 
-		this.#pending = undefined;
 		if (winner.group) {
-			this.#rolled = true;
+			// Drop the group rather than drain the rest of a log that has already lost payloads: the next
+			// read then waits on the track, where the second group is still resolved and throws again.
+			this.#group = undefined;
 			throw new Rolled();
 		}
 
@@ -118,8 +112,8 @@ export class Consumer {
 	// Arrival order rather than sequence order, because there is only ever one group to take and a
 	// second one has to be seen whatever its sequence. The monotonic `nextGroup` would drop a late
 	// lower sequence, which is the very loss this reports.
-	#recvGroup(): Promise<Moq.Group.Consumer | undefined> {
-		this.#pending ??= this.#track.recvGroup();
+	#recvGroup(): Promise<{ group: Moq.Group.Consumer | undefined }> {
+		this.#pending ??= this.#track.recvGroup().then((group) => ({ group }));
 		return this.#pending;
 	}
 

--- a/js/binary/src/stream/consumer.ts
+++ b/js/binary/src/stream/consumer.ts
@@ -40,6 +40,8 @@ export class Consumer {
 	#decompress: boolean;
 
 	#group?: Moq.Group.Consumer;
+	// Whether a read is in flight, so a second concurrent one is refused rather than served wrong.
+	#reading = false;
 	// Whether the log's one group has been taken, so a second is a rolled log rather than the first.
 	#taken = false;
 	// The in-flight `recvGroup`, tagged for the race and built once: a frame read that wins leaves it
@@ -56,14 +58,27 @@ export class Consumer {
 	}
 
 	/** Get the next payload, or `undefined` once the track ends. */
-	async next(): Promise<Uint8Array | undefined> {
+	next(): Promise<Uint8Array | undefined> {
+		// One reader at a time. Two concurrent calls await the same `recvGroup`, so the second would
+		// take the first's group for a rolled log and fail a perfectly good one.
+		if (this.#reading) throw new Error("multiple calls to next not supported");
+		this.#reading = true;
+		return this.#read().finally(() => {
+			this.#reading = false;
+		});
+	}
+
+	async #read(): Promise<Uint8Array | undefined> {
 		for (;;) {
 			if (!this.#group) {
 				const { group } = await this.#recvGroup();
 				if (!group) return undefined;
 				// The resolved `#pending` is the whole record of the failure: it is left in place, so
 				// every later read arrives back here and throws again rather than reading on.
-				if (this.#taken) throw new Rolled();
+				if (this.#taken) {
+					group.close();
+					throw new Rolled();
+				}
 				this.#pending = undefined;
 				this.#taken = true;
 				this.#flate = this.#decompress ? new Flate() : undefined;
@@ -97,8 +112,12 @@ export class Consumer {
 		if ("frame" in winner) return winner.frame;
 
 		if (winner.group) {
-			// Drop the group rather than drain the rest of a log that has already lost payloads: the next
-			// read then waits on the track, where the second group is still resolved and throws again.
+			// Close both rather than drain the rest of a log that has already lost payloads. Closing the
+			// held group settles the read that just lost, which otherwise stays registered on the
+			// group's signals and keeps this consumer's subscription reachable after the caller drops
+			// it. The next read then waits on the track, where the second group is still resolved.
+			group.close();
+			winner.group.close();
 			this.#group = undefined;
 			throw new Rolled();
 		}

--- a/js/binary/src/stream/stream.test.ts
+++ b/js/binary/src/stream/stream.test.ts
@@ -89,6 +89,20 @@ test("a second group is a rolled log, not a continuation", async () => {
 	await expect(consumer.next()).rejects.toThrow(Rolled);
 });
 
+test("a second concurrent read is refused rather than served the first one's group", async () => {
+	// Both calls would await the same in-flight `recvGroup`, and the loser would take the winner's
+	// group for a second one and fail a perfectly good log. Rust gets this from `&mut self`.
+	const track = new Track.Producer("test");
+	const producer = new Producer(track);
+	producer.append(payloads(1)[0]);
+	producer.finish();
+
+	const consumer = new Consumer(track.subscribe());
+	const first = consumer.next();
+	expect(() => consumer.next()).toThrow("multiple calls to next not supported");
+	expect(await first).toEqual(payloads(1)[0]);
+});
+
 test("a second group is reported while the first is still open", async () => {
 	// A boundary-only check would never look at the track again while a group is open, so a
 	// publisher that opens a second group and leaves the first one running parks the read forever

--- a/js/binary/src/stream/stream.test.ts
+++ b/js/binary/src/stream/stream.test.ts
@@ -89,6 +89,27 @@ test("a second group is a rolled log, not a continuation", async () => {
 	await expect(consumer.next()).rejects.toThrow(Rolled);
 });
 
+test("a second group is reported while the first is still open", async () => {
+	// A boundary-only check would never look at the track again while a group is open, so a
+	// publisher that opens a second group and leaves the first one running parks the read forever
+	// on a log that already lost payloads. The payloads already in hand are still delivered.
+	const track = new Track.Producer("test");
+
+	// Both groups stay open, the way a publisher writing to two at once leaves them.
+	const first = track.appendGroup();
+	first.writeFrame({ payload: payloads(1)[0], timestamp: Time.Timestamp.now() });
+	const second = track.appendGroup();
+	second.writeFrame({ payload: payloads(2)[1], timestamp: Time.Timestamp.now() });
+
+	const consumer = new Consumer(track.subscribe({ maxAge: REPLAY_LATENCY }));
+	expect(await consumer.next()).toEqual(payloads(1)[0]);
+	await expect(consumer.next()).rejects.toThrow(Rolled);
+
+	// Sticky: a later read must not report the rest of the first group as a whole log.
+	first.writeFrame({ payload: payloads(3)[2], timestamp: Time.Timestamp.now() });
+	await expect(consumer.next()).rejects.toThrow(Rolled);
+});
+
 test("an undecodable payload ends the log for a reader already inside the group", async () => {
 	// The decoder-limit check ends the track like any other lost record, and by then an earlier
 	// append may already have opened the group. A reader that pulled that group has to see the

--- a/js/binary/src/stream/stream.test.ts
+++ b/js/binary/src/stream/stream.test.ts
@@ -119,6 +119,11 @@ test("a second group is reported while the first is still open", async () => {
 	expect(await consumer.next()).toEqual(payloads(1)[0]);
 	await expect(consumer.next()).rejects.toThrow(Rolled);
 
+	// Both mirrors are released. The read that lost the race would otherwise stay registered on the
+	// first group, keeping this consumer's subscription reachable after the caller drops it.
+	expect(first.used.peek()).toBe(false);
+	expect(second.used.peek()).toBe(false);
+
 	// Sticky: a later read must not report the rest of the first group as a whole log.
 	first.writeFrame({ payload: payloads(3)[2], timestamp: Time.Timestamp.now() });
 	await expect(consumer.next()).rejects.toThrow(Rolled);

--- a/js/json/src/stream/consumer.ts
+++ b/js/json/src/stream/consumer.ts
@@ -27,6 +27,10 @@ export class Rolled extends Error {
  * instead. A second group is therefore a broken publisher, and reading it would present a gap as a
  * continuous log, so it throws {@link Rolled} rather than yielding the remainder. When something
  * else already owns the track, use the {@link Decoder} directly.
+ *
+ * The failure does not wait for the first group to end: whatever has already arrived in it is
+ * yielded, and the read then throws rather than blocking on a group a broken publisher may never
+ * finish.
  */
 export class Consumer<T> {
 	#track: Moq.Track.Subscriber;
@@ -35,6 +39,12 @@ export class Consumer<T> {
 	#group?: Moq.Group.Consumer;
 	// Whether the log's one group has been taken, so a second is a rolled log rather than the first.
 	#taken = false;
+	// Sticky once a second group is seen: the records it displaced are gone, so every later read
+	// throws too rather than reporting the rest of the log as a whole one.
+	#rolled = false;
+	// The in-flight `recvGroup`, kept across reads. Racing it against a frame read leaves it
+	// outstanding whenever the frame wins, and a second call would take a second group off the track.
+	#pending?: Promise<Moq.Group.Consumer | undefined>;
 
 	constructor(track: Moq.Track.Subscriber, config: ConsumerConfig = {}) {
 		this.#track = track;
@@ -44,28 +54,69 @@ export class Consumer<T> {
 	/** Get the next record, or `undefined` once the track ends. */
 	async next(): Promise<T | undefined> {
 		for (;;) {
+			if (this.#rolled) throw new Rolled();
+
 			if (!this.#group) {
-				// Arrival order rather than sequence order, because there is only ever one group to
-				// take and a second one has to be seen whatever its sequence. The monotonic
-				// `nextGroup` would drop a late lower sequence, which is the very loss this reports.
-				this.#group = await this.#track.recvGroup();
-				if (!this.#group) return undefined;
-				if (this.#taken) throw new Rolled();
+				const group = await this.#recvGroup();
+				this.#pending = undefined;
+				if (!group) return undefined;
+				if (this.#taken) {
+					this.#rolled = true;
+					continue;
+				}
 				this.#taken = true;
 				// Each group is its own compressed stream, so the window starts cold.
 				this.#decoder.reset();
+				this.#group = group;
 			}
 
-			const frame = await this.#group.readFrame();
-			if (frame === undefined) {
-				// The log's one group is exhausted. Keep reading the track so a clean end still
-				// reports the log as complete, and so a second group is caught as Rolled.
-				this.#group = undefined;
-				continue;
-			}
+			const frame = await this.#readFrame(this.#group);
+			if (frame) return this.#decoder.decode(frame.payload);
 
-			return this.#decoder.decode(frame.payload);
+			// The log's one group is exhausted. Keep reading the track so a clean end still
+			// reports the log as complete, and so a second group is caught as Rolled.
+			this.#group = undefined;
 		}
+	}
+
+	// Read the group's next frame, throwing {@link Rolled} if the track hands over a second group
+	// first. A stream is one group, so the track is watched while the group is held: a publisher
+	// that opens a second and leaves the first open would otherwise park this read forever on a log
+	// that has already lost records.
+	async #readFrame(group: Moq.Group.Consumer): Promise<Moq.Group.Frame | undefined> {
+		// Drain what already arrived before consulting the track, so only a read that would really
+		// block depends on which of the two lands first. `skipped` is the evicted prefix that
+		// `readFrame` reports as lagged and `tryReadFrame` would hand back across the gap.
+		if (!group.skipped) {
+			const buffered = group.tryReadFrame();
+			if (buffered) return buffered;
+		}
+
+		const frame = group.readFrame();
+		const winner = await Promise.race([
+			frame.then((frame) => ({ frame }) as const),
+			this.#recvGroup().then((group) => ({ group }) as const),
+		]);
+		if ("frame" in winner) return winner.frame;
+
+		this.#pending = undefined;
+		if (winner.group) {
+			this.#rolled = true;
+			throw new Rolled();
+		}
+
+		// The track is finished, which does not truncate the group in hand.
+		return await frame;
+	}
+
+	// Receive the track's next group, reusing the in-flight read a frame may have raced and won.
+	//
+	// Arrival order rather than sequence order, because there is only ever one group to take and a
+	// second one has to be seen whatever its sequence. The monotonic `nextGroup` would drop a late
+	// lower sequence, which is the very loss this reports.
+	#recvGroup(): Promise<Moq.Group.Consumer | undefined> {
+		this.#pending ??= this.#track.recvGroup();
+		return this.#pending;
 	}
 
 	async *[Symbol.asyncIterator](): AsyncIterator<T> {

--- a/js/json/src/stream/consumer.ts
+++ b/js/json/src/stream/consumer.ts
@@ -37,6 +37,8 @@ export class Consumer<T> {
 	#decoder: Decoder<T>;
 
 	#group?: Moq.Group.Consumer;
+	// Whether a read is in flight, so a second concurrent one is refused rather than served wrong.
+	#reading = false;
 	// Whether the log's one group has been taken, so a second is a rolled log rather than the first.
 	#taken = false;
 	// The in-flight `recvGroup`, tagged for the race and built once: a frame read that wins leaves it
@@ -51,14 +53,27 @@ export class Consumer<T> {
 	}
 
 	/** Get the next record, or `undefined` once the track ends. */
-	async next(): Promise<T | undefined> {
+	next(): Promise<T | undefined> {
+		// One reader at a time. Two concurrent calls await the same `recvGroup`, so the second would
+		// take the first's group for a rolled log and fail a perfectly good one.
+		if (this.#reading) throw new Error("multiple calls to next not supported");
+		this.#reading = true;
+		return this.#read().finally(() => {
+			this.#reading = false;
+		});
+	}
+
+	async #read(): Promise<T | undefined> {
 		for (;;) {
 			if (!this.#group) {
 				const { group } = await this.#recvGroup();
 				if (!group) return undefined;
 				// The resolved `#pending` is the whole record of the failure: it is left in place, so
 				// every later read arrives back here and throws again rather than reading on.
-				if (this.#taken) throw new Rolled();
+				if (this.#taken) {
+					group.close();
+					throw new Rolled();
+				}
 				this.#pending = undefined;
 				this.#taken = true;
 				// Each group is its own compressed stream, so the window starts cold.
@@ -93,8 +108,12 @@ export class Consumer<T> {
 		if ("frame" in winner) return winner.frame;
 
 		if (winner.group) {
-			// Drop the group rather than drain the rest of a log that has already lost records: the next
-			// read then waits on the track, where the second group is still resolved and throws again.
+			// Close both rather than drain the rest of a log that has already lost records. Closing the
+			// held group settles the read that just lost, which otherwise stays registered on the
+			// group's signals and keeps this consumer's subscription reachable after the caller drops
+			// it. The next read then waits on the track, where the second group is still resolved.
+			group.close();
+			winner.group.close();
 			this.#group = undefined;
 			throw new Rolled();
 		}

--- a/js/json/src/stream/consumer.ts
+++ b/js/json/src/stream/consumer.ts
@@ -39,12 +39,11 @@ export class Consumer<T> {
 	#group?: Moq.Group.Consumer;
 	// Whether the log's one group has been taken, so a second is a rolled log rather than the first.
 	#taken = false;
-	// Sticky once a second group is seen: the records it displaced are gone, so every later read
-	// throws too rather than reporting the rest of the log as a whole one.
-	#rolled = false;
-	// The in-flight `recvGroup`, kept across reads. Racing it against a frame read leaves it
-	// outstanding whenever the frame wins, and a second call would take a second group off the track.
-	#pending?: Promise<Moq.Group.Consumer | undefined>;
+	// The in-flight `recvGroup`, tagged for the race and built once: a frame read that wins leaves it
+	// outstanding, a second call would take a second group off the track, and tagging it per read
+	// would chain a reaction onto it for every record in the log. Cleared only when the group it
+	// carries is taken, so a second group stays resolved here and every later read fails on it again.
+	#pending?: Promise<{ group: Moq.Group.Consumer | undefined }>;
 
 	constructor(track: Moq.Track.Subscriber, config: ConsumerConfig = {}) {
 		this.#track = track;
@@ -54,16 +53,13 @@ export class Consumer<T> {
 	/** Get the next record, or `undefined` once the track ends. */
 	async next(): Promise<T | undefined> {
 		for (;;) {
-			if (this.#rolled) throw new Rolled();
-
 			if (!this.#group) {
-				const group = await this.#recvGroup();
-				this.#pending = undefined;
+				const { group } = await this.#recvGroup();
 				if (!group) return undefined;
-				if (this.#taken) {
-					this.#rolled = true;
-					continue;
-				}
+				// The resolved `#pending` is the whole record of the failure: it is left in place, so
+				// every later read arrives back here and throws again rather than reading on.
+				if (this.#taken) throw new Rolled();
+				this.#pending = undefined;
 				this.#taken = true;
 				// Each group is its own compressed stream, so the window starts cold.
 				this.#decoder.reset();
@@ -93,15 +89,13 @@ export class Consumer<T> {
 		}
 
 		const frame = group.readFrame();
-		const winner = await Promise.race([
-			frame.then((frame) => ({ frame }) as const),
-			this.#recvGroup().then((group) => ({ group }) as const),
-		]);
+		const winner = await Promise.race([frame.then((frame) => ({ frame }) as const), this.#recvGroup()]);
 		if ("frame" in winner) return winner.frame;
 
-		this.#pending = undefined;
 		if (winner.group) {
-			this.#rolled = true;
+			// Drop the group rather than drain the rest of a log that has already lost records: the next
+			// read then waits on the track, where the second group is still resolved and throws again.
+			this.#group = undefined;
 			throw new Rolled();
 		}
 
@@ -114,8 +108,8 @@ export class Consumer<T> {
 	// Arrival order rather than sequence order, because there is only ever one group to take and a
 	// second one has to be seen whatever its sequence. The monotonic `nextGroup` would drop a late
 	// lower sequence, which is the very loss this reports.
-	#recvGroup(): Promise<Moq.Group.Consumer | undefined> {
-		this.#pending ??= this.#track.recvGroup();
+	#recvGroup(): Promise<{ group: Moq.Group.Consumer | undefined }> {
+		this.#pending ??= this.#track.recvGroup().then((group) => ({ group }));
 		return this.#pending;
 	}
 

--- a/js/json/src/stream/stream.test.ts
+++ b/js/json/src/stream/stream.test.ts
@@ -91,3 +91,17 @@ test("a second group is reported while the first is still open", async () => {
 	first.writeFrame({ payload: encode({ n: 2 }), timestamp: Time.Timestamp.now() });
 	await expect(consumer.next()).rejects.toThrow(Rolled);
 });
+
+test("a second concurrent read is refused rather than served the first one's group", async () => {
+	// Both calls would await the same in-flight `recvGroup`, and the loser would take the winner's
+	// group for a second one and fail a perfectly good log. Rust gets this from `&mut self`.
+	const track = new Track.Producer("test");
+	const producer = new Producer<Rec>(track);
+	producer.append({ n: 0 });
+	producer.finish();
+
+	const consumer = new Consumer<Rec>(track.subscribe());
+	const first = consumer.next();
+	expect(() => consumer.next()).toThrow("multiple calls to next not supported");
+	expect(await first).toEqual({ n: 0 });
+});

--- a/js/json/src/stream/stream.test.ts
+++ b/js/json/src/stream/stream.test.ts
@@ -87,6 +87,11 @@ test("a second group is reported while the first is still open", async () => {
 	expect(await consumer.next()).toEqual({ n: 0 });
 	await expect(consumer.next()).rejects.toThrow(Rolled);
 
+	// Both mirrors are released. The read that lost the race would otherwise stay registered on the
+	// first group, keeping this consumer's subscription reachable after the caller drops it.
+	expect(first.used.peek()).toBe(false);
+	expect(second.used.peek()).toBe(false);
+
 	// Sticky: a later read must not report the rest of the first group as a whole log.
 	first.writeFrame({ payload: encode({ n: 2 }), timestamp: Time.Timestamp.now() });
 	await expect(consumer.next()).rejects.toThrow(Rolled);

--- a/js/json/src/stream/stream.test.ts
+++ b/js/json/src/stream/stream.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "bun:test";
-import { Track } from "@moq/net";
-import { Consumer, Producer } from "./index.ts";
+import { Time, Track } from "@moq/net";
+import { Consumer, Producer, Rolled } from "./index.ts";
 
 type Rec = { n: number };
 
@@ -65,4 +65,29 @@ test("records with embedded newlines round-trip (JSON escapes the newline)", asy
 		out.push(record);
 	}
 	expect(out).toEqual([value, value, value, value]);
+});
+
+test("a second group is reported while the first is still open", async () => {
+	// A stream is one group. A publisher that opens a second lost whatever would have completed the
+	// first, so the read reports that rather than handing back the remainder as a continuous log.
+	// A boundary-only check would never look at the track again while the first group is open, so
+	// this parks forever without the eager check. Written by hand because this producer never rolls.
+	const track = new Track.Producer("test");
+	const encode = (record: Rec) => new TextEncoder().encode(JSON.stringify(record));
+
+	// Both groups stay open, the way a publisher writing to two at once leaves them.
+	const first = track.appendGroup();
+	first.writeFrame({ payload: encode({ n: 0 }), timestamp: Time.Timestamp.now() });
+	const second = track.appendGroup();
+	second.writeFrame({ payload: encode({ n: 1 }), timestamp: Time.Timestamp.now() });
+
+	// Ask for a replay window, so the first group is delivered rather than skipped by the
+	// subscriber's default max-age budget once a newer group exists.
+	const consumer = new Consumer<Rec>(track.subscribe({ maxAge: 30_000 }));
+	expect(await consumer.next()).toEqual({ n: 0 });
+	await expect(consumer.next()).rejects.toThrow(Rolled);
+
+	// Sticky: a later read must not report the rest of the first group as a whole log.
+	first.writeFrame({ payload: encode({ n: 2 }), timestamp: Time.Timestamp.now() });
+	await expect(consumer.next()).rejects.toThrow(Rolled);
 });

--- a/rs/moq-binary/src/stream/consumer.rs
+++ b/rs/moq-binary/src/stream/consumer.rs
@@ -33,11 +33,18 @@ impl ConsumerConfig {
 /// write ends the track instead. A second group is therefore a broken publisher, and reading it
 /// would present a gap as a continuous log, so it fails with
 /// [`Error::Rolled`](crate::Error::Rolled) rather than yielding the remainder.
+///
+/// The failure does not wait for the first group to end: whatever has already arrived in it is
+/// yielded, and the read then fails rather than blocking on a group a broken publisher may never
+/// finish.
 pub struct Consumer {
 	track: moq_net::track::Subscriber,
 	group: Option<moq_net::group::Consumer>,
 	/// Whether the log's one group has been taken, so a second is a rolled log rather than the first.
 	taken: bool,
+	/// Sticky once a second group is seen: the payloads it displaced are gone, so every later read
+	/// fails too rather than reporting the rest of the log as a whole one.
+	rolled: bool,
 	/// The DEFLATE decoder for the group, `Some` while decompressing.
 	flate: Option<moq_flate::Decoder>,
 	compression: bool,
@@ -53,6 +60,7 @@ impl Consumer {
 			track,
 			group: None,
 			taken: false,
+			rolled: false,
 			flate: None,
 			compression: config.compression,
 		}
@@ -66,24 +74,26 @@ impl Consumer {
 	/// Poll for the next payload, without blocking.
 	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<Bytes>>> {
 		loop {
+			if self.rolled {
+				return Poll::Ready(Err(crate::Error::Rolled));
+			}
+
 			let Some(group) = &mut self.group else {
 				// Arrival order rather than sequence order, because there is only ever one group to
 				// take and a second one has to be seen whatever its sequence. The monotonic
 				// `poll_next_group` would drop a late lower sequence, which is the very loss this
 				// has to report.
 				match self.track.poll_recv_group(waiter)? {
+					Poll::Ready(Some(_)) if self.taken => self.rolled = true,
 					Poll::Ready(Some(group)) => {
-						if self.taken {
-							return Poll::Ready(Err(crate::Error::Rolled));
-						}
 						self.taken = true;
 						self.flate = self.compression.then(moq_flate::Decoder::new);
 						self.group = Some(group);
-						continue;
 					}
 					Poll::Ready(None) => return Poll::Ready(Ok(None)),
 					Poll::Pending => return Poll::Pending,
 				}
+				continue;
 			};
 
 			match group.poll_read_frame(waiter)? {
@@ -93,7 +103,15 @@ impl Consumer {
 					// reports the log as complete, and so a second group is caught as `Rolled`.
 					self.group = None;
 				}
-				Poll::Pending => return Poll::Pending,
+				// Nothing more in the group yet, so ask the track before parking on it. A publisher
+				// that opens a second group and leaves the first open would otherwise hold this read
+				// open forever, on a log that already lost the payloads the second one displaced.
+				// Both polls register, so either source wakes this read.
+				Poll::Pending => match self.track.poll_recv_group(waiter)? {
+					Poll::Ready(Some(_)) => self.rolled = true,
+					// A finished track does not truncate the group in hand; its frames may still arrive.
+					Poll::Ready(None) | Poll::Pending => return Poll::Pending,
+				},
 			}
 		}
 	}

--- a/rs/moq-binary/src/stream/mod.rs
+++ b/rs/moq-binary/src/stream/mod.rs
@@ -283,6 +283,43 @@ mod test {
 		));
 	}
 
+	/// A boundary-only check would never look at the track again while a group is open, so a
+	/// publisher that opens a second group and leaves the first one running parks the read forever
+	/// on a log that already lost payloads. The payloads already in hand are still delivered.
+	#[test]
+	fn a_second_group_is_reported_while_the_first_is_open() {
+		let mut track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+		let subscriber = track.subscribe(replaying());
+
+		// Both groups stay open, the way a publisher writing to two at once leaves them.
+		let mut first = track.append_group().unwrap();
+		first.write_frame(moq_net::Timestamp::now(), &b"first"[..]).unwrap();
+		let mut second = track.append_group().unwrap();
+		second.write_frame(moq_net::Timestamp::now(), &b"second"[..]).unwrap();
+
+		let mut consumer = Consumer::new(subscriber, ConsumerConfig::default());
+		let waiter = kio::Waiter::noop();
+
+		assert!(matches!(
+			consumer.poll_next(&waiter),
+			Poll::Ready(Ok(Some(payload))) if payload == Bytes::from_static(b"first")
+		));
+		assert!(matches!(
+			consumer.poll_next(&waiter),
+			Poll::Ready(Err(crate::Error::Rolled))
+		));
+
+		// Sticky: a later read must not report the rest of the first group as a whole log.
+		first.write_frame(moq_net::Timestamp::now(), &b"more"[..]).unwrap();
+		assert!(matches!(
+			consumer.poll_next(&waiter),
+			Poll::Ready(Err(crate::Error::Rolled))
+		));
+	}
+
 	/// Groups are separate QUIC streams, so a second one can land before the first. Reading in
 	/// arrival order is what catches that: the monotonic `next_group` would skip the late lower
 	/// sequence and end the log cleanly, reporting a truncated log as a whole one.

--- a/rs/moq-json/src/stream/consumer.rs
+++ b/rs/moq-json/src/stream/consumer.rs
@@ -16,11 +16,18 @@ use crate::Result;
 /// present a gap as a continuous log, so it fails with [`Error::Rolled`](crate::Error::Rolled)
 /// rather than yielding the remainder. When something else already owns the track, use the
 /// [`Decoder`] directly.
+///
+/// The failure does not wait for the first group to end: whatever has already arrived in it is
+/// yielded, and the read then fails rather than blocking on a group a broken publisher may never
+/// finish.
 pub struct Consumer<T> {
 	track: moq_net::track::Subscriber,
 	group: Option<moq_net::group::Consumer>,
 	/// Whether the log's one group has been taken, so a second is a rolled log rather than the first.
 	taken: bool,
+	/// Sticky once a second group is seen: the records it displaced are gone, so every later read
+	/// fails too rather than reporting the rest of the log as a whole one.
+	rolled: bool,
 	decoder: Decoder<T>,
 }
 
@@ -34,6 +41,7 @@ impl<T: DeserializeOwned> Consumer<T> {
 			track,
 			group: None,
 			taken: false,
+			rolled: false,
 			decoder: Decoder::new(config),
 		}
 	}
@@ -49,24 +57,26 @@ impl<T: DeserializeOwned> Consumer<T> {
 	/// Poll for the next record, without blocking.
 	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<T>>> {
 		loop {
+			if self.rolled {
+				return Poll::Ready(Err(crate::Error::Rolled));
+			}
+
 			let Some(group) = &mut self.group else {
 				// Arrival order rather than sequence order, because there is only ever one group to
 				// take and a second one has to be seen whatever its sequence. The monotonic
 				// `poll_next_group` would drop a late lower sequence, which is the very loss this
 				// has to report.
 				match self.track.poll_recv_group(waiter)? {
+					Poll::Ready(Some(_)) if self.taken => self.rolled = true,
 					Poll::Ready(Some(group)) => {
-						if self.taken {
-							return Poll::Ready(Err(crate::Error::Rolled));
-						}
 						self.taken = true;
 						self.decoder.reset();
 						self.group = Some(group);
-						continue;
 					}
 					Poll::Ready(None) => return Poll::Ready(Ok(None)),
 					Poll::Pending => return Poll::Pending,
 				}
+				continue;
 			};
 
 			match group.poll_read_frame(waiter)? {
@@ -76,7 +86,15 @@ impl<T: DeserializeOwned> Consumer<T> {
 					// reports the log as complete, and so a second group is caught as `Rolled`.
 					self.group = None;
 				}
-				Poll::Pending => return Poll::Pending,
+				// Nothing more in the group yet, so ask the track before parking on it. A publisher
+				// that opens a second group and leaves the first open would otherwise hold this read
+				// open forever, on a log that already lost the records the second one displaced.
+				// Both polls register, so either source wakes this read.
+				Poll::Pending => match self.track.poll_recv_group(waiter)? {
+					Poll::Ready(Some(_)) => self.rolled = true,
+					// A finished track does not truncate the group in hand; its frames may still arrive.
+					Poll::Ready(None) | Poll::Pending => return Poll::Pending,
+				},
 			}
 		}
 	}

--- a/rs/moq-json/src/stream/mod.rs
+++ b/rs/moq-json/src/stream/mod.rs
@@ -251,6 +251,54 @@ mod test {
 		assert_eq!(drain(consumer(producer.consume(), true)), vec![json!({ "n": 0 })]);
 	}
 
+	/// A stream is one group. A publisher that opens a second lost whatever would have completed the
+	/// first, so the read reports that rather than handing back the remainder as a continuous log.
+	/// A boundary-only check would never look at the track again while the first group is open, so
+	/// this parks forever without the eager check. Written by hand because this producer never rolls.
+	#[test]
+	fn a_second_group_is_reported_while_the_first_is_open() {
+		let mut track = moq_net::broadcast::Info::new()
+			.produce()
+			.create_track("test", None)
+			.unwrap();
+
+		// Ask for a replay window, so the first group is delivered rather than skipped by the
+		// subscriber's default max-age budget once a newer group exists.
+		let subscription = moq_net::track::Subscription::default().with_max_age(std::time::Duration::from_secs(30));
+		let subscriber = track.subscribe(subscription);
+
+		// Both groups stay open, the way a publisher writing to two at once leaves them.
+		let mut first = track.append_group().unwrap();
+		first
+			.write_frame(moq_net::Timestamp::now(), br#"{"n":0}"#.as_slice())
+			.unwrap();
+		let mut second = track.append_group().unwrap();
+		second
+			.write_frame(moq_net::Timestamp::now(), br#"{"n":1}"#.as_slice())
+			.unwrap();
+
+		let mut consumer = consumer(subscriber, false);
+		let waiter = kio::Waiter::noop();
+
+		assert!(matches!(
+			consumer.poll_next(&waiter),
+			Poll::Ready(Ok(Some(value))) if value == json!({ "n": 0 })
+		));
+		assert!(matches!(
+			consumer.poll_next(&waiter),
+			Poll::Ready(Err(crate::Error::Rolled))
+		));
+
+		// Sticky: a later read must not report the rest of the first group as a whole log.
+		first
+			.write_frame(moq_net::Timestamp::now(), br#"{"n":2}"#.as_slice())
+			.unwrap();
+		assert!(matches!(
+			consumer.poll_next(&waiter),
+			Poll::Ready(Err(crate::Error::Rolled))
+		));
+	}
+
 	#[test]
 	fn embedded_newlines_survive() {
 		// Each record is its own frame (one JSON object), and JSON escapes control characters, so a


### PR DESCRIPTION
Closes #3260.

## Summary

- **Root cause.** A `stream` track is one group; a second group means records are missing, which all four implementations report as `Rolled` / `Stream.Rolled`. But each only asked the track for another group once the held one ended (`poll_recv_group` / `recvGroup` gated on `group.is_none()`). A publisher that opens a second group and leaves the first open (itself the same violation) therefore parked the consumer indefinitely, on a track that already carried the condition the contract says to fail on.
- The consumers now consult the track whenever the held group's read would block. A second group there fails immediately instead of waiting for a group a broken publisher may never finish. A finished track does not truncate the group in hand: its frames may still arrive, so that case keeps waiting as before.
- **Drain, then fail** (the open question in the issue). Records already received from the first group are still yielded, since they precede the gap; only a read that would actually block consults the track. That keeps the boundary-triggered behavior the existing tests pin, and keeps the four implementations agreeing on what a reader sees. Rust reads the frame first and polls the track only on `Pending`; TS drains with `tryReadFrame` (guarded by `skipped`, which is the evicted prefix `readFrame` reports as lagged) before racing the blocking read.
- The failure is now **sticky**. Previously a second `poll_next` after `Rolled` could return `Ok(None)`, which reads as a cleanly completed log.
- TS builds the raced `recvGroup` promise **once per consumer**, tagged for the race. `recvGroup` delivers each group exactly once, so a second call would take a second group off the track and lose the first; and tagging it inside the race would chain a fresh reaction onto that one pending promise for every frame the log delivers. That cached promise is also what makes the failure sticky there: a second group leaves it resolved, so dropping the held group sends every later read back to the same throw, with no flag to carry. Rust polls rather than awaits, so it keeps an explicit `rolled` flag instead.
- **A concurrent `next()` is refused**, the way `js/json/src/window/consumer.ts` already does it. Sharing the one `recvGroup` promise means two concurrent calls resolve to the same group, and the second would take the first's group for a rolled log and fail a valid one. Rust gets this from `&mut self`.
- **The failure closes both groups**: the one it abandons mid-read and the second one it rejects. The read that loses the race stays registered on the held group's signals otherwise, which keeps the group consumer, and through its expiry closure the track subscription, reachable after the caller drops the stream consumer. Closing settles that read; the mirrors are per-subscriber, so this touches neither the producer nor another subscriber.

## Public API changes

None. No `pub` / exported item added, renamed, or re-signed; `Error::Rolled` and `Rolled` already existed. Behavior only, which is why this could target `main`, except the code being changed exists only on `dev`.

## Wire behavior changes

None on the wire. What changes is when a consumer gives up on a non-conforming publisher: previously never, while the first group stayed open; now as soon as the second group is observed and the first has nothing more in hand. `drafts/draft-lcurley-moq-hang.md` is updated to require that, and to say explicitly that already-received payloads may be yielded first.

## Test plan

- One regression test per implementation (`a_second_group_is_reported_while_the_first_is_open` / "a second group is reported while the first is still open"): two groups opened, neither finished. Without the fix the Rust reads return `Pending` forever and the TS reads never settle. Each also asserts the failure is sticky, and the TS ones assert both group mirrors are released (dropping the `close()` calls turns them red).
- A concurrent-read test per TS implementation: the second call is refused rather than served the first's group.
- `cargo test -p moq-binary -p moq-json` (30 tests) and `cargo clippy -p moq-binary -p moq-json --all-targets -- -D warnings`: clean.
- `bun test js/binary/src/stream js/json/src/stream` (26 tests), `bun biome check`, and `bun run --filter=@moq/binary --filter=@moq/json check` (tsc): clean.
- Cross-Package Sync: all four implementations plus the draft are in this PR.
- Reviewed adversarially by Codex; both findings (the concurrent read, the abandoned read) are fixed above.

(Written by claude-opus-5)