### PR TITLE
fix: complete post-merge API migrations

### DIFF
--- a/go/wrapper/errors.go
+++ b/go/wrapper/errors.go
@@ -72,6 +72,8 @@ var (
 	ErrAlreadyCommitted = ffi.ErrMoqErrorAlreadyCommitted
 	// ErrInvalidRoute is returned when a route has an invalid hop ID or too many hops.
 	ErrInvalidRoute = ffi.ErrMoqErrorInvalidRoute
+	// ErrUnresolvableBroadcast is returned when a referenced sibling broadcast cannot be resolved without an origin.
+	ErrUnresolvableBroadcast = ffi.ErrMoqErrorUnresolvableBroadcast
 	// ErrLog is returned when installing or configuring the native log subscriber fails.
 	ErrLog = ffi.ErrMoqErrorLog
 )

--- a/go/wrapper/errors_test.go
+++ b/go/wrapper/errors_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	ffi "github.com/moq-dev/moq-go-ffi/moq"
-	"github.com/moq-dev/moq-go/moq"
+	"moq.dev/moq"
+	ffi "moq.dev/moq-ffi/moq"
 )
 
 func TestErrorSentinels(t *testing.T) {
@@ -37,6 +37,7 @@ func TestErrorSentinels(t *testing.T) {
 		{"NotFound", ffi.NewMoqErrorNotFound(), moq.ErrNotFound},
 		{"Unsupported", ffi.NewMoqErrorUnsupported(), moq.ErrUnsupported},
 		{"InvalidRoute", ffi.NewMoqErrorInvalidRoute(), moq.ErrInvalidRoute},
+		{"UnresolvableBroadcast", ffi.NewMoqErrorUnresolvableBroadcast(), moq.ErrUnresolvableBroadcast},
 		{"AlreadyCommitted", ffi.NewMoqErrorAlreadyCommitted(), moq.ErrAlreadyCommitted},
 		{"Log", ffi.NewMoqErrorLog(), moq.ErrLog},
 	}

--- a/py/moq-rs/tests/test_local.py
+++ b/py/moq-rs/tests/test_local.py
@@ -893,7 +893,7 @@ def test_optional_binding_records_use_none_defaults():
     assert encoder.channels is None
     assert encoder.bitrate is None
 
-    decoder = moq.AudioDecoderOutput(format=moq.AudioFormat.F32)
+    decoder = moq.AudioDecoderOutput(format=moq.AudioSampleFormat.F32)
     assert decoder.sample_rate is None
     assert decoder.channels is None
-    assert decoder.latency_max_ms is None
+    assert decoder.max_age_ms is None

--- a/rs/moq-ffi/src/media.rs
+++ b/rs/moq-ffi/src/media.rs
@@ -164,14 +164,19 @@ pub struct MoqDatagram {
 #[derive(Clone, Default, uniffi::Record)]
 pub struct MoqVideoHint {
 	/// The encoded pixel dimensions.
+	#[uniffi(default = None)]
 	pub coded: Option<MoqDimensions>,
 	/// The display aspect ratio.
+	#[uniffi(default = None)]
 	pub display_aspect: Option<MoqDimensions>,
 	/// The maximum bitrate in bits per second.
+	#[uniffi(default = None)]
 	pub bitrate: Option<u64>,
 	/// The frame rate in frames per second.
+	#[uniffi(default = None)]
 	pub framerate: Option<f64>,
 	/// Whether the decoder should optimize for latency.
+	#[uniffi(default = None)]
 	pub optimize_for_latency: Option<bool>,
 }
 

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -593,8 +593,16 @@ mod tests {
 	async fn idle_capture_publishes_a_discontinuity_before_resume() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
-		let track = broadcast.create_track("video", catalog.track_info()).unwrap();
-		let consumer = track.subscribe(None);
+		// The synthetic clock jumps ten seconds. Keep every fixture group readable until the
+		// assertion instead of letting the default five-second publisher window evict the marker.
+		let replay = std::time::Duration::from_secs(11);
+		let track = broadcast
+			.create_track(
+				"video",
+				catalog.track_info(hang::catalog::PRIORITY.video).with_max_age(replay),
+			)
+			.unwrap();
+		let consumer = track.subscribe(moq_net::track::Subscription::default().with_max_age(replay));
 
 		let mut config = Config::new(320, 240, 30);
 		config.kind = encoder::Kind::Software;


### PR DESCRIPTION
## Summary

- pass the catalog video priority in the stale `moq-video` discontinuity test
- restore UniFFI defaults for optional video hint fields that were lost when `main` merged into `dev`
- update the Python defaults regression to the renamed PCM format and max-age fields
- expose and test the Go `ErrUnresolvableBroadcast` sentinel using the current vanity module paths

The `dev` merge combined the new regression tests with older conflict resolutions in their implementations and wrappers, leaving the full-tree Check gate unable to compile or type-check.

## Public API changes

- Go adds the missing additive `ErrUnresolvableBroadcast` sentinel for the existing FFI error variant.
- UniFFI-generated constructors once again default every optional `MoqVideoHint` field to `None`, matching `main` and the intended API.

## Wire behavior changes

None.

## Test plan

- `just fix`
- `just check-all` through the final Go gate
- `just go check` after correcting the stale test import paths

Cross-package sync: Rust FFI, Python, and Go are updated together. Kotlin generation and tests passed in `check-all`; Swift was skipped locally because no Swift toolchain is available.

(written by GPT-5)