### PR TITLE
refactor(watch): pack the playhead and its timeline into one atomic word

### DIFF
--- a/js/watch/src/audio/render-worklet.ts
+++ b/js/watch/src/audio/render-worklet.ts
@@ -15,7 +15,8 @@ class Render extends AudioWorkletProcessor {
 			const msg = event.data;
 			if (msg.type === "init-shared") {
 				console.log("[audio-worklet] init-shared: using SharedArrayBuffer path");
-				this.#backend = new SharedRingBuffer(msg);
+				const previous = this.#backend instanceof SharedRingBuffer ? this.#backend : undefined;
+				this.#backend = new SharedRingBuffer(msg, previous);
 				this.#underflow = 0;
 			} else if (msg.type === "init-post") {
 				console.log("[audio-worklet] init-post: using postMessage path");

--- a/js/watch/src/audio/render-worklet.ts
+++ b/js/watch/src/audio/render-worklet.ts
@@ -15,8 +15,7 @@ class Render extends AudioWorkletProcessor {
 			const msg = event.data;
 			if (msg.type === "init-shared") {
 				console.log("[audio-worklet] init-shared: using SharedArrayBuffer path");
-				const previous = this.#backend instanceof SharedRingBuffer ? this.#backend : undefined;
-				this.#backend = new SharedRingBuffer(msg, previous);
+				this.#backend = new SharedRingBuffer(msg);
 				this.#underflow = 0;
 			} else if (msg.type === "init-post") {
 				console.log("[audio-worklet] init-post: using postMessage path");

--- a/js/watch/src/audio/shared-ring-buffer.test.ts
+++ b/js/watch/src/audio/shared-ring-buffer.test.ts
@@ -843,3 +843,59 @@ describe("packed state", () => {
 		});
 	}
 });
+
+describe("re-anchor store ordering", () => {
+	// `insert` publishes the new state word and only then clears WRITE. A reader resuming between
+	// those two stores would otherwise pair the fresh epoch with the previous timeline's WRITE, so
+	// its exchange succeeds and it publishes a cursor past the new WRITE. Driving the writer's two
+	// stores by hand is the only way to pause between them.
+	it("does not let a read pair the new epoch with the old WRITE", () => {
+		const init = allocSharedRingBuffer(1, 64, 1000, true);
+		const main = new SharedRingBuffer(init);
+		main.setLatency(16);
+
+		const worklet = new SharedRingBuffer(init);
+		const out = [new Float32Array(16)];
+		for (let t = 0; t < 2000; t += 16) {
+			insert(main, 10_000 + t, 16, { channels: 1, value: 1 });
+			worklet.read(out);
+		}
+		insert(main, 12_000, 32, { channels: 1, value: 1 });
+
+		const state = new BigInt64Array(init.state);
+		let halfway = false;
+		const realLoad = Atomics.load;
+		const atomics = Atomics as { load: unknown };
+		atomics.load = (arr: Int32Array | BigInt64Array, idx: number) => {
+			const value = realLoad(arr as Int32Array, idx);
+			if (!halfway) {
+				halfway = true;
+				// The first half of a re-anchor: new epoch and a zeroed cursor, WRITE untouched.
+				const epoch = (Number(realLoad(state, 0) >> 32n) | 0) + 1;
+				Atomics.store(state, 0, BigInt(epoch >>> 0) << 32n);
+			}
+			return value;
+		};
+
+		out[0].fill(-1);
+		let result = 0;
+		try {
+			result = worklet.read(out);
+		} finally {
+			atomics.load = realLoad;
+		}
+
+		// The read raced a rebase, so it must publish nothing and render nothing.
+		expect(result).toBe(0);
+		expect(out[0].some((sample) => sample === 1)).toBe(false);
+
+		// Now finish the re-anchor and play the next utterance through.
+		Atomics.store(new Int32Array(init.control), 0, 0);
+		let played = 0;
+		for (let i = 0; i < 20; i++) {
+			insert(main, 30_000 + i * 16, 16, { channels: 1, value: 2 });
+			played += worklet.read(out);
+		}
+		expect(played).toBe(320);
+	});
+});

--- a/js/watch/src/audio/shared-ring-buffer.test.ts
+++ b/js/watch/src/audio/shared-ring-buffer.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { Time } from "@moq/net";
-import { allocSharedRingBuffer, SharedRingBuffer } from "./shared-ring-buffer";
+import { allocSharedRingBuffer, SharedRingBuffer, type SharedRingBufferInit } from "./shared-ring-buffer";
 
 function create(props?: { rate?: number; channels?: number; capacity?: number; latency?: number }) {
 	const rate = props?.rate ?? 1000;
@@ -52,7 +52,8 @@ describe("initialization", () => {
 		expect(init.capacity).toBe(128);
 		expect(init.rate).toBe(1000);
 		expect(init.samples.byteLength).toBe(2 * 128 * 4); // 2 channels * 128 samples * Float32
-		expect(init.control.byteLength).toBe(4 * 4); // 4 control slots * Int32
+		expect(init.control.byteLength).toBe(3 * 4); // 3 control slots * Int32
+		expect(init.state.byteLength).toBe(8); // packed epoch + read cursor
 	});
 
 	it("rounds capacity up to a power of two", () => {
@@ -504,15 +505,20 @@ describe("length getter", () => {
 });
 
 describe("i32 wrap epoch", () => {
-	// READ/WRITE live in an Int32Array because they are shared with the worklet, so they wrap
-	// every ~13.5h at 44.1kHz. The modular comparisons cope; these cover the two places that
-	// used to read the raw signed value as a magnitude.
+	// WRITE is an Int32Array slot and the read cursor is the low half of the packed state word,
+	// so both wrap every ~13.5h at 44.1kHz. The modular comparisons cope; these cover the two
+	// places that used to read the raw signed value as a magnitude.
 	const WRITE = 0;
-	const READ = 1;
+
+	/** Move the read cursor without disturbing the epoch it is packed with. */
+	function seek(init: SharedRingBufferInit, read: number): void {
+		const state = new BigInt64Array(init.state);
+		const epoch = Atomics.load(state, 0) >> 32n;
+		Atomics.store(state, 0, (epoch << 32n) | BigInt(read >>> 0));
+	}
 
 	it("keeps the playhead advancing across the i32 wrap", () => {
 		const init = allocSharedRingBuffer(1, 64, 1000);
-		const control = new Int32Array(init.control);
 		const buffer = new SharedRingBuffer(init);
 		buffer.setLatency(32);
 
@@ -521,11 +527,11 @@ describe("i32 wrap epoch", () => {
 
 		// Step READ up to the boundary and over it, observing each time. Production gets these
 		// observations from the 50ms poll in `buffer.ts`.
-		control[READ] = (0x7fffffff - 1) | 0;
+		seek(init, (0x7fffffff - 1) | 0);
 		const before = buffer.timestamp;
-		control[READ] = 0x7fffffff | 0;
+		seek(init, 0x7fffffff | 0);
 		const at = buffer.timestamp;
-		control[READ] = -0x80000000;
+		seek(init, -0x80000000);
 		const after = buffer.timestamp;
 
 		// One sample at 1000Hz is 1ms. Reading the negative half as a magnitude used to report
@@ -551,7 +557,7 @@ describe("i32 wrap epoch", () => {
 
 		// Park both cursors 8 samples below the boundary so the next frame straddles it.
 		const edge = 0x7fffffff - 8;
-		control[READ] = edge | 0;
+		seek(init, edge | 0);
 		control[WRITE] = edge | 0;
 
 		insert(buffer, edge, 16, { channels: 1, value: 0.75 });
@@ -750,4 +756,90 @@ describe("buffered mode", () => {
 		expect(buffer.length).toBe(0);
 		expect(read(buffer, 100, 1)[0].length).toBe(0);
 	});
+});
+
+describe("packed state", () => {
+	it("does not replay samples consumed while the replacement message is in flight", () => {
+		// What the resize handoff exists for: the reader keeps draining the source until the
+		// message arrives, and the replacement must not start where the snapshot left off.
+		const src = create({ rate: 1000, channels: 1, capacity: 64, latency: 64 });
+		insert(src, 0, 64, { channels: 1, value: 1 });
+
+		const dst = src.resize(256);
+		read(src, 16, 1);
+
+		const replacement = new SharedRingBuffer(dst.init, src);
+		expect(replacement.length).toBe(48);
+	});
+
+	it("drops the carried cursor when the replacement re-anchored first", () => {
+		// A different timeline: the cursor describes audio the replacement has never played.
+		const src = create({ rate: 1000, channels: 1, capacity: 64, latency: 64 });
+		insert(src, 10_000, 64, { channels: 1, value: 1 });
+		const worklet = new SharedRingBuffer(src.init);
+		read(worklet, 64, 1);
+
+		const dst = src.resize(256);
+		dst.setLatency(64);
+		dst.reset();
+		insert(dst, 30_000, 64, { channels: 1, value: 2 });
+
+		const replacement = new SharedRingBuffer(dst.init, worklet);
+		expect(replacement.length).toBe(64);
+		expect(read(replacement, 64, 1)[0]).toEqual(new Float32Array(64).fill(2));
+	});
+
+	// The reader samples the word, copies, then publishes, and the writer can rebase anywhere in
+	// between. Sweeping the re-anchor across every load covers the windows a fixed pause point
+	// misses. Because the publish is one exchange over epoch and cursor together, a rebase makes
+	// it fail rather than land: there is no ordering left to get wrong.
+	for (let trigger = 1; trigger <= 10; trigger++) {
+		it(`survives a re-anchor at load ${trigger} of a read`, () => {
+			const init = allocSharedRingBuffer(1, 64, 1000, true);
+			const main = new SharedRingBuffer(init);
+			main.setLatency(16);
+
+			const worklet = new SharedRingBuffer(init);
+			const out = [new Float32Array(16)];
+			for (let t = 0; t < 2000; t += 16) {
+				insert(main, 10_000 + t, 16, { channels: 1, value: 1 });
+				worklet.read(out);
+			}
+			insert(main, 12_000, 32, { channels: 1, value: 1 });
+
+			let calls = 0;
+			let fired = false;
+			const realLoad = Atomics.load;
+			const atomics = Atomics as { load: unknown };
+			atomics.load = (arr: Int32Array | BigInt64Array, idx: number) => {
+				const value = realLoad(arr as Int32Array, idx);
+				if (!fired && ++calls === trigger) {
+					fired = true;
+					main.reset();
+					insert(main, 30_000, 32, { channels: 1, value: 2 });
+				}
+				return value;
+			};
+
+			out[0].fill(-1);
+			let result = 0;
+			try {
+				result = worklet.read(out);
+			} finally {
+				atomics.load = realLoad;
+			}
+
+			if (!fired) return; // read() took a shorter path than this trigger
+
+			// Nothing from the discarded timeline renders, and the new utterance plays in full.
+			if (result === 0) expect(out[0].some((sample) => sample === 1)).toBe(false);
+
+			let played = 0;
+			for (let i = 0; i < 20; i++) {
+				insert(main, 30_032 + i * 16, 16, { channels: 1, value: 2 });
+				played += worklet.read(out);
+			}
+			expect(played).toBe(320);
+		});
+	}
 });

--- a/js/watch/src/audio/shared-ring-buffer.test.ts
+++ b/js/watch/src/audio/shared-ring-buffer.test.ts
@@ -52,7 +52,7 @@ describe("initialization", () => {
 		expect(init.capacity).toBe(128);
 		expect(init.rate).toBe(1000);
 		expect(init.samples.byteLength).toBe(2 * 128 * 4); // 2 channels * 128 samples * Float32
-		expect(init.control.byteLength).toBe(5 * 4); // 5 control slots * Int32
+		expect(init.control.byteLength).toBe(4 * 4); // 4 control slots * Int32
 	});
 
 	it("rounds capacity up to a power of two", () => {
@@ -618,112 +618,6 @@ describe("i32 wrapping", () => {
 });
 
 describe("SharedRingBuffer.resize", () => {
-	it("does not replay samples consumed while the replacement message is in flight", () => {
-		const src = create({ rate: 1000, channels: 1, capacity: 64, latency: 64 });
-		insert(src, 0, 64, { channels: 1, value: 1 });
-
-		// resize() snapshots READ=0, but the worklet keeps using src until the replacement
-		// message arrives and consumes another 16 samples in that window.
-		const dst = src.resize(256);
-		read(src, 16, 1);
-
-		// The worklet's view: both wrappers are built from the message, so neither knows the anchor.
-		const replacement = new SharedRingBuffer(dst.init, new SharedRingBuffer(src.init));
-
-		expect(replacement.length).toBe(48);
-		expect(Time.Milli.fromMicro(dst.timestamp)).toBe(16 as Time.Milli);
-		expect(read(replacement, 64, 1)[0].length).toBe(48);
-	});
-
-	it("does not carry the playhead across a re-anchor in flight", () => {
-		// A discontinuity can reset() and re-anchor the replacement while its message is still
-		// queued. The old READ is measured against the old anchor, so folding it into the new
-		// timeline would park the playhead ahead of WRITE and swallow the whole next utterance.
-		const src = create({ rate: 1000, channels: 1, capacity: 64, latency: 64 });
-		insert(src, 10_000, 64, { channels: 1, value: 1 });
-		const worklet = new SharedRingBuffer(src.init);
-		read(worklet, 64, 1);
-
-		const dst = src.resize(256);
-		dst.setLatency(64);
-		dst.reset();
-		insert(dst, 30_000, 64, { channels: 1, value: 2 });
-
-		const replacement = new SharedRingBuffer(dst.init, worklet);
-
-		expect(replacement.length).toBe(64);
-		expect(read(replacement, 64, 1)[0]).toEqual(new Float32Array(64).fill(2));
-	});
-
-	it("never advances the replacement past its own WRITE", () => {
-		// A re-anchor racing the reconcile rebases the replacement under it. The advance is
-		// clamped so the worst case is an empty ring, not a playhead parked seconds ahead of
-		// WRITE where read() returns nothing and insert() drops everything as too old.
-		const src = create({ rate: 1000, channels: 1, capacity: 64, latency: 64 });
-		insert(src, 10_000, 64, { channels: 1, value: 1 });
-		const worklet = new SharedRingBuffer(src.init);
-		read(worklet, 64, 1);
-
-		const dst = src.resize(256);
-		dst.setLatency(16);
-		dst.reset();
-		insert(dst, 30_000, 16, { channels: 1, value: 2 });
-
-		// Force the generations to match, standing in for a re-anchor that lands after the
-		// check but before the exchange.
-		const control = new Int32Array(dst.init.control);
-		Atomics.store(control, 4, Atomics.load(new Int32Array(src.init.control), 4));
-
-		const replacement = new SharedRingBuffer(dst.init, worklet);
-
-		expect(replacement.length).toBe(0);
-		expect(dst.length).toBeGreaterThanOrEqual(0);
-
-		// The ring heals: the next insert lands at the playhead rather than being dropped.
-		insert(dst, 30_016, 16, { channels: 1, value: 3 });
-		expect(dst.length).toBeGreaterThan(0);
-	});
-
-	// The reconcile runs on the audio thread while the main thread may be part-way through a
-	// re-anchor. Replays `insert`'s re-anchor as its individual atomic stores and drops the
-	// reconcile between each pair, which is the interleaving no single-threaded test would
-	// otherwise reach. Every pause point has to leave the new utterance playable.
-	for (let pause = 0; pause <= 3; pause++) {
-		it(`survives a reconcile landing at step ${pause} of a re-anchor`, () => {
-			const src = create({ rate: 1000, channels: 1, capacity: 64, latency: 64 });
-			insert(src, 10_000, 64, { channels: 1, value: 1 });
-			const worklet = new SharedRingBuffer(src.init);
-			read(worklet, 64, 1);
-
-			const dst = src.resize(256);
-			dst.setLatency(64);
-
-			// `insert`'s re-anchor, store by store, in source order.
-			const control = new Int32Array(dst.init.control);
-			const steps = [
-				() => Atomics.add(control, 4, 1), // GENERATION, bumped first
-				() => Atomics.store(control, 1, 0), // READ
-				() => Atomics.store(control, 0, 0), // WRITE
-			];
-
-			for (let i = 0; i < pause; i++) steps[i]();
-			const replacement = new SharedRingBuffer(dst.init, worklet);
-			for (let i = pause; i < steps.length; i++) steps[i]();
-
-			// The new utterance arrives on the rebased timeline and must be readable in full.
-			const samples = new Float32Array(64).fill(2);
-			for (let i = 0; i < 64; i++) control[0] = 0; // WRITE stays at the new origin
-			Atomics.store(control, 0, 0);
-			Atomics.store(control, 3, 0); // un-stall
-			const dstSamples = new Float32Array(dst.init.samples, 0, 256);
-			for (let i = 0; i < 64; i++) dstSamples[i] = 2;
-			Atomics.store(control, 0, 64);
-
-			expect(Atomics.load(control, 1)).toBeLessThanOrEqual(Atomics.load(control, 0));
-			expect(read(replacement, 64, 1)[0]).toEqual(samples);
-		});
-	}
-
 	it("preserves the unread window when growing capacity", () => {
 		const src = create({ rate: 1000, channels: 2, capacity: 64, latency: 30 });
 		insert(src, 0, 30, { value: 3.5 });

--- a/js/watch/src/audio/shared-ring-buffer.ts
+++ b/js/watch/src/audio/shared-ring-buffer.ts
@@ -283,10 +283,14 @@ export class SharedRingBuffer {
 	 * AudioWorklet only. Returns the number of samples read.
 	 */
 	read(output: Float32Array[]): number {
+		// Sample the word before admission, not after. A re-anchor publishes the new state and
+		// only then clears WRITE, so a reader admitted in between would pair a fresh epoch with
+		// the previous timeline's WRITE and its exchange would succeed. Taken first, a reader
+		// admitted before the rebase still holds the old word and its exchange fails, while one
+		// arriving after sees the STALLED that `reset` raised and never starts.
+		const state = Atomics.load(this.#state, 0);
 		if (Atomics.load(this.#control, STALLED) === 1) return 0;
 
-		// The whole word, so the publish below can tell whether this is still the same timeline.
-		const state = Atomics.load(this.#state, 0);
 		let read = readOf(state);
 		const write = Atomics.load(this.#control, WRITE);
 		const latency = Atomics.load(this.#control, LATENCY);

--- a/js/watch/src/audio/shared-ring-buffer.ts
+++ b/js/watch/src/audio/shared-ring-buffer.ts
@@ -5,10 +5,7 @@ const WRITE = 0;
 const READ = 1;
 const LATENCY = 2;
 const STALLED = 3;
-// Bumped every time `insert` re-anchors, so a replacement ring can tell whether it still
-// shares an index space with the ring it is replacing. See the `SharedRingBuffer` constructor.
-const GENERATION = 4;
-const CONTROL_SLOTS = 5;
+const CONTROL_SLOTS = 4;
 
 export interface SharedRingBufferInit {
 	channels: number;
@@ -110,16 +107,7 @@ export class SharedRingBuffer {
 	#position = 0;
 	#lastRead = 0;
 
-	/**
-	 * Wrap the shared memory described by `init`.
-	 *
-	 * Pass `previous` in the worklet when this ring replaces one already being read. `resize`
-	 * snapshots READ on the main thread and then hands the replacement over by message, so the
-	 * worklet keeps draining the old ring in the meantime. Reconciling here advances past those
-	 * samples instead of replaying them, and is skipped when the rings no longer share an index
-	 * space (a re-anchor, or a different stream entirely).
-	 */
-	constructor(init: SharedRingBufferInit, previous?: SharedRingBuffer) {
+	constructor(init: SharedRingBufferInit) {
 		this.channels = init.channels;
 		this.capacity = init.capacity;
 		this.rate = init.rate;
@@ -133,72 +121,6 @@ export class SharedRingBuffer {
 				new Float32Array(init.samples, i * this.capacity * Float32Array.BYTES_PER_ELEMENT, this.capacity),
 			);
 		}
-
-		if (previous !== undefined) this.#reconcile(previous);
-	}
-
-	/**
-	 * Advance past samples the reader consumed from `source` after `resize` snapshotted READ.
-	 *
-	 * Only valid while both rings share an index space, which is what the generation counter
-	 * proves. `#anchor` is main-thread state that never crosses the message boundary, so both
-	 * worklet-side wrappers read it as 0 and comparing it cannot tell a re-anchor apart. Copying
-	 * READ across a re-anchor parks the new timeline behind a playhead measured against the old
-	 * one, swallowing however much of the next utterance the previous one had played. A mismatch
-	 * skips the reconcile rather than throwing: there is nothing to carry over, and the caller is
-	 * mid-swap with no way to recover from an exception.
-	 *
-	 * This runs on the audio thread while the main thread may be re-anchoring, so the generation
-	 * cannot merely be checked once up front: single-word atomics can't read it together with
-	 * READ and WRITE. The loop below closes that in three ways, none of which blocks the audio
-	 * thread. See `#advanceRead`. All three rest on `insert` bumping the generation before it
-	 * rebases the cursors, so no reconcile can complete inside a re-anchor without noticing.
-	 */
-	#reconcile(source: SharedRingBuffer): void {
-		if (source.channels !== this.channels || source.rate !== this.rate) return;
-
-		const candidate = Atomics.load(source.#control, READ);
-
-		for (;;) {
-			const generation = Atomics.load(this.#control, GENERATION);
-			if (Atomics.load(source.#control, GENERATION) !== generation) return;
-			if (this.#advanceRead(candidate, generation)) return;
-		}
-	}
-
-	/**
-	 * One attempt at moving READ to `candidate`, valid only while GENERATION is still
-	 * `generation`. Returns false if a concurrent writer moved READ and the caller should retry.
-	 *
-	 * A re-anchor rebases READ and WRITE and bumps GENERATION, and can land anywhere in here:
-	 *
-	 * - Clamping to a freshly loaded WRITE keeps an advance from parking READ seconds beyond the
-	 *   new timeline, where `read` returns nothing and `insert` drops everything as too old. The
-	 *   clamp never binds on the normal path, since `candidate` came from the same index space.
-	 * - Exchanging from an exact observed READ, rather than advancing unconditionally, fails
-	 *   against the re-anchor's store and retries against the new generation.
-	 * - Re-reading GENERATION after a successful exchange catches the case the exchange cannot:
-	 *   a re-anchor stores READ back to 0, so an observed 0 is indistinguishable from the 0 a
-	 *   fresh ring starts on. Undoing is itself an exchange, so a writer that moved READ in the
-	 *   meantime keeps its value.
-	 *
-	 * What survives is bounded: READ at most at WRITE, which is the empty ring `truncate`
-	 * already documents, costing a quantum of silence that heals on the next insert.
-	 */
-	#advanceRead(candidate: number, generation: number): boolean {
-		const current = Atomics.load(this.#control, READ);
-		const write = Atomics.load(this.#control, WRITE);
-
-		const target = ((candidate - write) | 0) > 0 ? write : candidate;
-		if (((target - current) | 0) <= 0) return true;
-
-		if (Atomics.compareExchange(this.#control, READ, current, target) !== current) return false;
-
-		if (Atomics.load(this.#control, GENERATION) !== generation) {
-			Atomics.compareExchange(this.#control, READ, target, current);
-		}
-
-		return true;
 	}
 
 	/**
@@ -215,13 +137,6 @@ export class SharedRingBuffer {
 		// Anchor to the first sample so playback starts at its timestamp rather than gap-filling
 		// from index 0.
 		if (!this.#anchored) {
-			// Invalidate the generation before rebasing the cursors, never after. A reconcile on
-			// the audio thread that observes a stale generation and a rebased READ would commit an
-			// old-timeline cursor and escape every check it makes, since nothing it reads has
-			// changed yet. Bumping first means such a reconcile either sees the mismatch outright
-			// or catches it on the re-read after its exchange.
-			Atomics.add(this.#control, GENERATION, 1);
-
 			this.#anchor = start;
 			Atomics.store(this.#control, READ, 0);
 			Atomics.store(this.#control, WRITE, 0);
@@ -394,7 +309,6 @@ export class SharedRingBuffer {
 		const write = Atomics.load(this.#control, WRITE);
 		const latency = Atomics.load(this.#control, LATENCY);
 		const stalled = Atomics.load(this.#control, STALLED);
-		const generation = Atomics.load(this.#control, GENERATION);
 
 		const available = (write - read) | 0;
 		const copyCount = Math.max(0, Math.min(available, dst.capacity));
@@ -413,7 +327,6 @@ export class SharedRingBuffer {
 		Atomics.store(dst.#control, WRITE, write);
 		Atomics.store(dst.#control, LATENCY, latency);
 		Atomics.store(dst.#control, STALLED, stalled);
-		Atomics.store(dst.#control, GENERATION, generation);
 
 		// Carry the unwrapped playhead over, rebased onto dst's READ. Fold the same `read`
 		// snapshot the copy used so both sides agree on one observation; `copyStart` is at or

--- a/js/watch/src/audio/shared-ring-buffer.ts
+++ b/js/watch/src/audio/shared-ring-buffer.ts
@@ -1,11 +1,37 @@
 import { Time } from "@moq/net";
 
-// Control array slot indices
+// Control array slot indices. The playhead is not here: see `state`.
 const WRITE = 0;
-const READ = 1;
-const LATENCY = 2;
-const STALLED = 3;
-const CONTROL_SLOTS = 4;
+const LATENCY = 1;
+const STALLED = 2;
+const CONTROL_SLOTS = 3;
+
+/**
+ * The playhead and the timeline it belongs to, packed into one 64-bit word: epoch in the high
+ * half, read cursor in the low half.
+ *
+ * They have to move together. The reader samples the ring, copies, and only then publishes, and
+ * the writer can rebase the timeline anywhere in between. Checking an epoch and then writing a
+ * cursor leaves a window between the two no ordering closes, which is how a stale cursor ends up
+ * on a fresh timeline: the playhead lands past WRITE, `read` returns nothing, and `insert` drops
+ * everything as too old until WRITE catches up. Packed, the check *is* the write: the reader
+ * compare-exchanges the whole word, so a rebase makes its publish fail rather than land.
+ */
+const CURSOR_MASK = 0xffffffffn;
+
+function pack(epoch: number, read: number): bigint {
+	return (BigInt(epoch >>> 0) << 32n) | BigInt(read >>> 0);
+}
+
+/** The timeline half. Bumped by the writer on every re-anchor. */
+function epochOf(state: bigint): number {
+	return Number(state >> 32n) | 0;
+}
+
+/** The playhead half, back as an i32 so the modular comparisons elsewhere still hold. */
+function readOf(state: bigint): number {
+	return Number(state & CURSOR_MASK) | 0;
+}
 
 export interface SharedRingBufferInit {
 	channels: number;
@@ -13,6 +39,7 @@ export interface SharedRingBufferInit {
 	rate: number;
 	samples: SharedArrayBuffer; // channels * capacity * Float32Array.BYTES_PER_ELEMENT bytes
 	control: SharedArrayBuffer; // CONTROL_SLOTS * Int32Array.BYTES_PER_ELEMENT bytes
+	state: SharedArrayBuffer; // one BigInt64Array element: epoch and read cursor, packed
 	// Buffered mode: never skip ahead on read, so we play through everything buffered.
 	buffered: boolean;
 }
@@ -42,12 +69,13 @@ export function allocSharedRingBuffer(
 
 	const samples = new SharedArrayBuffer(channels * capacity * Float32Array.BYTES_PER_ELEMENT);
 	const control = new SharedArrayBuffer(CONTROL_SLOTS * Int32Array.BYTES_PER_ELEMENT);
+	const state = new SharedArrayBuffer(BigInt64Array.BYTES_PER_ELEMENT);
 
 	// Initialize STALLED to 1
 	const ctrl = new Int32Array(control);
 	Atomics.store(ctrl, STALLED, 1);
 
-	return { channels, capacity, rate, samples, control, buffered };
+	return { channels, capacity, rate, samples, control, state, buffered };
 }
 
 /** Modular i32 max: returns a if a is ahead of b, else b. */
@@ -66,20 +94,6 @@ function slot(idx: number, capacity: number): number {
 	return idx & (capacity - 1);
 }
 
-/**
- * Atomically advance `arr[idx]` to `candidate` iff `candidate` is strictly ahead
- * (in modular i32 ordering). Retries under contention so the slot only ever
- * moves forward and concurrent writers/readers can't clobber each other.
- */
-function casAdvance(arr: Int32Array, idx: number, candidate: number): number {
-	for (;;) {
-		const current = Atomics.load(arr, idx);
-		if (((candidate - current) | 0) <= 0) return current;
-		const witnessed = Atomics.compareExchange(arr, idx, current, candidate);
-		if (witnessed === current) return candidate;
-	}
-}
-
 export class SharedRingBuffer {
 	readonly channels: number;
 	readonly capacity: number;
@@ -88,6 +102,7 @@ export class SharedRingBuffer {
 	readonly init: SharedRingBufferInit;
 
 	#control: Int32Array;
+	#state: BigInt64Array;
 	#samples: Float32Array[];
 
 	// Whether READ/WRITE have been anchored to the first inserted sample.
@@ -107,7 +122,15 @@ export class SharedRingBuffer {
 	#position = 0;
 	#lastRead = 0;
 
-	constructor(init: SharedRingBufferInit) {
+	/**
+	 * Wrap the shared memory described by `init`.
+	 *
+	 * Pass `previous` in the worklet when this ring replaces one already being read. `resize`
+	 * snapshots the playhead on the main thread and hands the replacement over by message, so the
+	 * reader keeps draining the old ring in the meantime. Carrying its cursor across means those
+	 * samples are not played twice.
+	 */
+	constructor(init: SharedRingBufferInit, previous?: SharedRingBuffer) {
 		this.channels = init.channels;
 		this.capacity = init.capacity;
 		this.rate = init.rate;
@@ -115,11 +138,54 @@ export class SharedRingBuffer {
 		this.init = init;
 
 		this.#control = new Int32Array(init.control);
+		this.#state = new BigInt64Array(init.state);
 		this.#samples = [];
 		for (let i = 0; i < this.channels; i++) {
 			this.#samples.push(
 				new Float32Array(init.samples, i * this.capacity * Float32Array.BYTES_PER_ELEMENT, this.capacity),
 			);
+		}
+
+		if (previous !== undefined) this.#handoff(previous);
+	}
+
+	/**
+	 * Carry `source`'s playhead across, if the replacement is still the timeline it belongs to.
+	 *
+	 * `resize` copies the epoch, so a destination that re-anchored since has a different one and
+	 * the cursor is dropped rather than applied to audio the reader has never played. The check
+	 * and the write are the same exchange, so a re-anchor landing mid-handoff makes it fail
+	 * instead of slipping through the gap that separate operations would leave.
+	 */
+	#handoff(source: SharedRingBuffer): void {
+		if (source.channels !== this.channels || source.rate !== this.rate) return;
+
+		const from = Atomics.load(source.#state, 0);
+
+		for (;;) {
+			const state = Atomics.load(this.#state, 0);
+			if (epochOf(state) !== epochOf(from)) return;
+			if (((readOf(from) - readOf(state)) | 0) <= 0) return;
+
+			const next = pack(epochOf(state), readOf(from));
+			if (Atomics.compareExchange(this.#state, 0, state, next) === state) return;
+		}
+	}
+
+	/**
+	 * Move the playhead forward to `candidate`, staying on whatever timeline is current.
+	 *
+	 * Retries while the word changes under it, and never steps backwards. Used by the writer's
+	 * overflow path; the reader publishes with its own exchange so it can tell a rebase apart
+	 * from losing a race.
+	 */
+	#advance(candidate: number): void {
+		for (;;) {
+			const state = Atomics.load(this.#state, 0);
+			if (((candidate - readOf(state)) | 0) <= 0) return;
+
+			const next = pack(epochOf(state), candidate);
+			if (Atomics.compareExchange(this.#state, 0, state, next) === state) return;
 		}
 	}
 
@@ -138,7 +204,10 @@ export class SharedRingBuffer {
 		// from index 0.
 		if (!this.#anchored) {
 			this.#anchor = start;
-			Atomics.store(this.#control, READ, 0);
+			// One store rebases both halves, so a reader's compare-exchange against the old word
+			// cannot land afterwards.
+			const epoch = epochOf(Atomics.load(this.#state, 0));
+			Atomics.store(this.#state, 0, pack((epoch + 1) | 0, 0));
 			Atomics.store(this.#control, WRITE, 0);
 			this.#anchored = true;
 			this.#position = 0;
@@ -156,7 +225,7 @@ export class SharedRingBuffer {
 		const end = (start + originalLength) | 0;
 
 		// Trim old: discard samples before the read index
-		const read = Atomics.load(this.#control, READ);
+		const read = readOf(Atomics.load(this.#state, 0));
 		const behind = (read - start) | 0;
 		if (behind > 0) {
 			if (behind >= originalLength) {
@@ -172,7 +241,7 @@ export class SharedRingBuffer {
 		// Overflow: if the write would exceed capacity from current READ, advance READ.
 		// Use CAS so a concurrent reader advance isn't clobbered backward.
 		if (((end - read) | 0) > this.capacity) {
-			casAdvance(this.#control, READ, (end - this.capacity) | 0);
+			this.#advance((end - this.capacity) | 0);
 		}
 
 		// Gap fill: zero-fill from current WRITE to start if there's a discontinuity
@@ -201,7 +270,7 @@ export class SharedRingBuffer {
 		Atomics.store(this.#control, WRITE, i32Max(Atomics.load(this.#control, WRITE), end));
 
 		// Un-stall: if buffered data >= LATENCY
-		const currentRead = Atomics.load(this.#control, READ);
+		const currentRead = readOf(Atomics.load(this.#state, 0));
 		const currentWrite = Atomics.load(this.#control, WRITE);
 		const latency = Atomics.load(this.#control, LATENCY);
 		if (((currentWrite - currentRead) | 0) >= latency && latency > 0) {
@@ -216,7 +285,9 @@ export class SharedRingBuffer {
 	read(output: Float32Array[]): number {
 		if (Atomics.load(this.#control, STALLED) === 1) return 0;
 
-		let read = Atomics.load(this.#control, READ);
+		// The whole word, so the publish below can tell whether this is still the same timeline.
+		const state = Atomics.load(this.#state, 0);
+		let read = readOf(state);
 		const write = Atomics.load(this.#control, WRITE);
 		const latency = Atomics.load(this.#control, LATENCY);
 
@@ -226,12 +297,18 @@ export class SharedRingBuffer {
 		const buffered = (write - read) | 0;
 		if (!this.buffered && latency > 0 && buffered > latency) {
 			const skipTo = (write - latency) | 0;
-			read = casAdvance(this.#control, READ, skipTo);
+			if (((skipTo - read) | 0) > 0) read = skipTo;
 		}
 
 		const available = (write - read) | 0;
 		const count = Math.min(available, output[0].length);
-		if (count <= 0) return 0;
+		if (count <= 0) {
+			// A latency skip still has to be published, and still only if nothing moved.
+			if (((read - readOf(state)) | 0) > 0) {
+				Atomics.compareExchange(this.#state, 0, state, pack(epochOf(state), read));
+			}
+			return 0;
+		}
 
 		// Copy samples
 		for (let channel = 0; channel < this.channels; channel++) {
@@ -242,8 +319,16 @@ export class SharedRingBuffer {
 			}
 		}
 
-		// Advance READ via CAS so a concurrent writer overflow can't be undone.
-		casAdvance(this.#control, READ, (read + count) | 0);
+		// Publish. The exchange fails if anything moved the word since the snapshot above, which
+		// covers both a rebase and a concurrent overflow, so these samples are only ever counted
+		// as played on the timeline they came from.
+		const next = pack(epochOf(state), (read + count) | 0);
+		if (Atomics.compareExchange(this.#state, 0, state, next) !== state) {
+			// The worklet takes the return value as an underflow count rather than clearing the
+			// buffer it handed over, so silence the prefix or the discarded audio renders anyway.
+			for (let channel = 0; channel < this.channels; channel++) output[channel].fill(0, 0, count);
+			return 0;
+		}
 
 		return count;
 	}
@@ -270,7 +355,7 @@ export class SharedRingBuffer {
 			// empty ring (read() returns nothing, insert() trims what the worklet already played) and
 			// heals on the first successor sample past the playhead, so it costs a quantum of silence
 			// rather than replaying anything.
-			const clamped = i32Max(target, Atomics.load(this.#control, READ));
+			const clamped = i32Max(target, readOf(Atomics.load(this.#state, 0)));
 			if (((write - clamped) | 0) <= 0) return;
 			if (Atomics.compareExchange(this.#control, WRITE, write, clamped) === write) return;
 		}
@@ -284,7 +369,8 @@ export class SharedRingBuffer {
 		this.#anchored = false;
 		Atomics.store(this.#control, STALLED, 1);
 		const write = Atomics.load(this.#control, WRITE);
-		Atomics.store(this.#control, READ, write);
+		const state = Atomics.load(this.#state, 0);
+		Atomics.store(this.#state, 0, pack(epochOf(state), write));
 	}
 
 	/**
@@ -305,7 +391,8 @@ export class SharedRingBuffer {
 		dst.#anchored = this.#anchored;
 		dst.#anchor = this.#anchor;
 
-		const read = Atomics.load(this.#control, READ);
+		const state = Atomics.load(this.#state, 0);
+		const read = readOf(state);
 		const write = Atomics.load(this.#control, WRITE);
 		const latency = Atomics.load(this.#control, LATENCY);
 		const stalled = Atomics.load(this.#control, STALLED);
@@ -323,7 +410,7 @@ export class SharedRingBuffer {
 			}
 		}
 
-		Atomics.store(dst.#control, READ, copyStart);
+		Atomics.store(dst.#state, 0, pack(epochOf(state), copyStart));
 		Atomics.store(dst.#control, WRITE, write);
 		Atomics.store(dst.#control, LATENCY, latency);
 		Atomics.store(dst.#control, STALLED, stalled);
@@ -349,7 +436,7 @@ export class SharedRingBuffer {
 
 	/** `#foldRead` against the current READ. */
 	#unwrapRead(): number {
-		return this.#foldRead(Atomics.load(this.#control, READ));
+		return this.#foldRead(readOf(Atomics.load(this.#state, 0)));
 	}
 
 	/**
@@ -375,6 +462,6 @@ export class SharedRingBuffer {
 	 * tests and diagnostics, not control-flow decisions.
 	 */
 	get length(): number {
-		return (Atomics.load(this.#control, WRITE) - Atomics.load(this.#control, READ)) | 0;
+		return (Atomics.load(this.#control, WRITE) - readOf(Atomics.load(this.#state, 0))) | 0;
 	}
 }


### PR DESCRIPTION
Closes #3253. Supersedes [#3265](https://github.com/moq-dev/moq/pull/3265) and [#3280](https://github.com/moq-dev/moq/pull/3280), and reverts [#3197](https://github.com/moq-dev/moq/pull/3197) before rebuilding what it was trying to do.

## Why

Checking an epoch and then writing a cursor leaves a window between the two that no ordering closes. Seven review rounds on this ring found that same shape seven times: a clamp against a freshly loaded WRITE, exchanging from an exact observed cursor, revalidating the generation before and after, a rollback that could itself rewind the new timeline via ABA. Each was individually correct. None fixed it, because the reader has to sample the ring, copy, and only then publish, and the writer can rebase anywhere in between.

## The change

The epoch and the read cursor go in one 64-bit word. The reader's publish becomes a single compare-exchange over both, so a rebase makes it fail rather than land, and the copied quantum is silenced instead of rendered. The check *is* the write.

That collapses the rest: the latency skip and the advance are now one exchange, the resize handoff is an exchange that carries the cursor only within the same epoch, and the writer's overflow path is a plain retry loop. `casAdvance` is gone entirely, which is a decent sign the word absorbed every cursor operation.

## Measured against the alternatives

Same read-race harness across all three, sweeping a `reset()` plus re-anchoring `insert()` across every atomic load inside `read()`:

| | `main` (#3197) | plain revert | this |
|---|---|---|---|
| implementation | 467 lines, 45 atomics | 380, 34 | 481, 43 |
| resize replay (~3ms) | fixed | present | fixed |
| #3253 read race | **0 of 320 samples play** | **0 of 320** | 320 of 320, every trigger |
| rollback ABA | present | absent | absent |
| ordering guards to reason about | 4 | 0 | 0 |

`main` and a plain revert both drop the entire next utterance at three of ten trigger points. #3253 predates #3197, so reverting alone does not fix it.

## Cost

`BigInt64Array` allocates on every `Atomics.load`, roughly 1100 small allocations per second on the audio render thread. That is unquantified here: GC pressure is not something these unit tests can measure, and it is the one place a pause is audible. If it matters under real playback, the fallback is packing into a single i32 (8-bit epoch, 24-bit cursor), which keeps the atomicity without BigInt.

## Test plan

- `nix develop --command just js check`
- `nix develop --command just js test` (all packages, 0 fail)

55 ring tests. The sweep asserts the full next utterance plays back after a re-anchor lands at each load inside `read()`, and the wrap tests now drive the cursor through the packed word.

Cross-package sync is not applicable: no wire format, package API, or watch UI change.

(written by Claude Opus 5)