### PR TITLE
fix(rs): repair the test call sites the main merge missed

### DIFF
--- a/rs/moq-rtc/src/lib.rs
+++ b/rs/moq-rtc/src/lib.rs
@@ -85,11 +85,11 @@ mod tests {
 
 	#[tokio::test]
 	async fn whip_and_whep_round_trip_opus() {
-		let source_origin = moq_net::Origin::random().produce();
+		let source_origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let source_consumer = source_origin.consume();
 		let mut announcements = source_consumer.announced();
 		let mut source = source_origin
-			.create_broadcast("source", moq_net::broadcast::Route::new().with_announce(true))
+			.create_broadcast("source")
 			.expect("create source broadcast");
 		let catalog = moq_mux::catalog::Producer::new(&mut source).expect("create source catalog");
 		let mut opus = crate::codec::opus::Bridge::new(source, catalog, 48_000, 2).expect("create Opus bridge");
@@ -101,15 +101,20 @@ mod tests {
 			},
 		)
 		.expect("publish source packet");
+
+		// Create, populate, announce: the route goes out once the tracks exist.
+		let _source_route = source_origin
+			.announce("source", moq_net::origin::Route::default())
+			.expect("announce source");
 		let announcement = tokio::time::timeout(TIMEOUT, announcements.next())
 			.await
 			.expect("source announcement timed out")
 			.expect("source origin closed");
-		assert_eq!(announcement.path.as_str(), "source");
-		assert!(announcement.broadcast.is_some(), "source was unannounced");
+		assert_eq!(announcement.prefix.as_path().as_str(), "source");
+		assert!(announcement.active, "source was unannounced");
 		drop(announcements);
 
-		let server_origin = moq_net::Origin::random().produce();
+		let server_origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let server = Server::new(
 			server::Config::default(),
 			server_origin.clone(),
@@ -131,9 +136,9 @@ mod tests {
 			.expect("WHIP negotiation timed out")
 			.expect("WHIP negotiation failed");
 
-		let output_origin = moq_net::Origin::random().produce();
+		let output_origin = moq_tokio::origin::spawn(moq_net::Hop::random());
 		let output = output_origin
-			.create_broadcast("output", moq_net::broadcast::Route::new().with_announce(true))
+			.create_broadcast("output")
 			.expect("create output broadcast");
 		let output_consumer = output.consume();
 		let whep = format!("http://{address}/whep/ingested").parse().expect("WHEP URL");

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -593,8 +593,14 @@ mod tests {
 	async fn idle_capture_publishes_a_discontinuity_before_resume() {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
-		let track = broadcast.create_track("video", catalog.track_info()).unwrap();
-		let consumer = track.subscribe(None);
+		let track = broadcast
+			.create_track("video", catalog.track_info(hang::catalog::PRIORITY.video))
+			.unwrap();
+		// The test walks the finished track after the fact, so it needs a subscriber that tolerates
+		// a backlog. The default budget is `Duration::ZERO`, which sheds the empty marker the moment
+		// the resumed group stamps its reach; a live consumer takes it as the edge instead.
+		let subscription = moq_net::track::Subscription::default().with_max_age(std::time::Duration::from_secs(60));
+		let consumer = track.subscribe(subscription);
 
 		let mut config = Config::new(320, 240, 30);
 		config.kind = encoder::Kind::Software;


### PR DESCRIPTION
## Summary

`origin/dev` at 3227c195e ("Merge main into dev") does not compile: the merge carried three tests over from `main` without updating them for dev's APIs. The first two are hard errors, and both crates are dependents of widely-used ones, so `just check` and `just test` fail for essentially every branch based on `dev` (that is how I ran into this, from #3282).

- **`moq-video`** (`encode/producer.rs`): a test called `catalog.track_info()`, but dev's `moq_mux::catalog::Producer::track_info` takes a `priority: u8` (#2854). The production call site in the same file was updated by the merge; this one was missed.
- **`moq-rtc`** (`lib.rs`): the WHIP/WHEP round-trip test built origins with `moq_net::Origin::random().produce()` and announced by passing a `Route` to `create_broadcast`. On dev an origin is `origin::Info` plus a driver (`moq_tokio::origin::spawn`, already a dev-dependency), and announcing is separate from creating: `create_broadcast(path)` then `announce(prefix, Route)`, in create-populate-announce order. The announcement assertions move from `path`/`broadcast.is_some()` to `prefix`/`active`.
- **`moq-video`** again: with the first fix in place, `idle_capture_publishes_a_discontinuity_before_resume` compiled and **failed** (`[1, 1]`, expected `[1, 0, 1]`) — a real behavior difference the compile error had been hiding.

  Root cause: the marker is still published (`container::Producer::discontinuity` appends an empty group and finishes it). What changed is delivery. A group's staleness is measured by its *reach*, which is bounded by its successor's start, so the empty group's reach is the resumed group's timestamp — equal to the live edge, and `>=` a `Duration::ZERO` budget. The default subscription therefore sheds it. That is correct for a live consumer, which takes the marker as the live edge when it arrives with no successor; it is wrong only for a test that walks the finished track afterwards. Fixed by subscribing with a replay window, the same thing the `moq-binary` / `moq-json` stream tests do for the same reason.

Test-only changes; no production code touched.

## Public API changes

None.

## Test plan

- `just check` and `just test` (diff-scoped to `moq-rtc`, `moq-video`, and their dependents): 376/376 pass. Both failed on `origin/dev` before this.
- `cargo test -p moq-rtc`: 44 pass, including `whip_and_whep_round_trip_opus`, which had not been able to run.
- A full `just check-all` / `just test all` is running; I will note anything else it turns up.

## Not fixed here

`just drafts check` fails on `draft-lcurley-moq-hang.md:425`, a `{{field-timeline}}` cross-reference with no anchor (from #3109). The `timeline` field exists on the `json` and `binary` rendition schemas, but the draft never got a `### timeline {#field-timeline}` section, and the sentence claims the field "carries the same meaning here as for a media rendition" when media renditions have no such field. Writing that section is spec authoring rather than a build repair, so it wants an author. Nothing in CI runs the drafts check, so it blocks no workflow.

(Written by claude-opus-5)