### PR TITLE
chore(quest): track the native capture follow-ups from #3244

### DIFF
--- a/quest/m0/README.md
+++ b/quest/m0/README.md
@@ -28,6 +28,10 @@ regression test per Root Cause First.
 - [#3080](/quest/m0/3080-fix-watch-audio-ring-truncate-can-race-the-worklet-reader.md) - fix(watch): audio ring truncate can race the worklet reader for one quantum
 - [#2833](/quest/m0/2833-moq-export-ts-a-rewound-timeline-stalls-the-si-table.md) - moq export ts: a rewound timeline stalls the SI table cadence until the media clock catches up
 - [#2806](/quest/m0/2806-js-net-the-draft-14-15-adapter-keeps-one-request-per.md) - js/net: the draft-14/15 adapter keeps one request per namespace, so a duplicate strands the first
+- [Windows window capture](/quest/m0/windows-window-capture-blank.md) - Windows window capture returns black pixels for GPU-composited windows
+- [Capture device loss](/quest/m0/capture-device-loss.md) - an AVFoundation camera that disappears parks the reader forever
+- [X11 window identity](/quest/m0/x11-window-identity.md) - a reused X11 window id can publish an unrelated window
+- [Window capture lifecycle](/quest/m0/capture-window-lifecycle.md) - a minimized or resizing window ends capture instead of riding it out
 - [#2799](/quest/m0/2799-moq-video-capture-negotiates-twice-so-a-window-resize.md) - moq-video: capture negotiates twice, so a window resize between the probe and the first subscriber strands consumers that fixed on the first snapshot
 - [#2813](/quest/m0/2813-capture-on-ios-is-software-only-not-hardware.md) - Capture on iOS is software only , not hardware
 - [#2847](/quest/m0/2847-the-quinn-backends-send-bandwidth-estimate-is-cwnd-rtt.md) - The quinn backend's send-bandwidth estimate is cwnd/rtt, not a rate

--- a/quest/m0/capture-device-loss.md
+++ b/quest/m0/capture-device-loss.md
@@ -1,0 +1,36 @@
+# [M] moq-video: an AVFoundation camera that disappears parks the reader forever
+
+## Goal
+
+Unplugging a camera, revoking its permission, or losing the session to a
+runtime error ends `capture::Stream::read` with a typed error instead of
+leaving it parked.
+
+## Plan
+
+Every capture backend except one reports device loss. The pump-driven backends
+(V4L2, Media Foundation, Desktop Duplication, X11, Windows GDI) surface a read
+failure, which `pump::spawn` turns into `chan.fail`. ScreenCaptureKit has
+`didStopWithError`, which does the same. AVFoundation has neither: after the
+first frame the only callback pushes samples, and nothing watches for
+`AVCaptureSessionRuntimeError`, `AVCaptureDeviceWasDisconnected`, or an
+interruption. So a camera that vanishes stops delivering frames and nobody
+closes the channel; `read` waits on a notification that never comes.
+
+`capture::Stream::read` documents `Ok(None)` as a benign stop and an error as
+terminal for that selection, and this path delivers neither. `capture_loop`
+still races the read against demand, so the publisher releases the device when
+the last viewer leaves; what it cannot do is notice that the camera went away
+while someone is watching.
+
+`SessionGuard` is the natural owner: it already ties the session's lifetime to
+the stream, so it can hold the notification observers too. Translate device
+removal and permission revocation into `chan.fail` with
+`SourceUnavailable`/`PermissionDenied`, and decide explicitly what an
+*interruption* means, since a phone call taking the camera is recoverable in a
+way that unplugging it is not.
+
+Pre-existing, not introduced by the native screen capture work; found by Codex
+while reviewing [#3244](https://github.com/moq-dev/moq/pull/3244). Verifying it
+means unplugging a real camera on a Mac, so an injectable termination hook is
+what makes a regression test possible.

--- a/quest/m0/capture-window-lifecycle.md
+++ b/quest/m0/capture-window-lifecycle.md
@@ -1,0 +1,38 @@
+# [S] moq-video: a minimized or resizing window ends capture instead of riding it out
+
+## Goal
+
+Minimizing a captured window pauses its broadcast and resumes when it is
+restored, rather than ending the publish. Dragging a window's edge produces one
+reopen once the drag settles, not one per mouse-move.
+
+## Plan
+
+Two defects in the native window backends, both reachable from an ordinary
+mouse gesture.
+
+**Minimize is fatal on Windows.** `capture/window.rs` compares `GetWindowRect`
+against the geometry captured at open. A minimized window reports an off-screen
+rect, so the size check fails and the stream ends; `capture_loop` reopens, and
+`Capture::open` then rejects it with `SourceUnavailable("window has no
+capturable area")`, which is terminal. So minimizing a window kills the
+broadcast, where macOS ScreenCaptureKit keeps working. `IsIconic` should hold
+the capture instead: sleep the frame interval and keep polling until the window
+comes back.
+
+**A drag-resize storms the reopen path.** Both `capture/window.rs` and
+`capture/x11.rs` end the stream the first frame the geometry differs. The
+publisher then drops the encoder, publishes a discontinuity, reopens the source,
+and builds a fresh encoder, all per mouse-move, and each reopen also republishes
+the catalog rendition dimensions. Settle the geometry before ending the stream:
+once a change is seen, keep polling at the frame interval and only end once the
+size has held for a beat. That also stops the encoder being rebuilt for a size
+that is about to change again.
+
+Both need a Windows host to verify the Windows half; `just rs windows` must run
+on Windows and PR CI is Linux-only.
+
+## Related
+
+- [#2799](/quest/m0/2799-moq-video-capture-negotiates-twice-so-a-window-resize.md) - the other half of the resize story, on the probe-versus-subscriber path
+- [Windows window capture](/quest/m0/windows-window-capture-blank.md) - the other defect in the same backend

--- a/quest/m0/windows-window-capture-blank.md
+++ b/quest/m0/windows-window-capture-blank.md
@@ -1,0 +1,47 @@
+# [M] moq-video: Windows window capture returns black pixels for GPU-composited windows
+
+## Goal
+
+`moq import capture --window <id>` on Windows publishes the window's real
+contents for browsers, Electron apps, and UWP apps, not a black rectangle.
+Capturing an elevated window either works or fails with a clear permission
+error, rather than failing at open because the identity marker could not be
+written.
+
+## Plan
+
+`capture/window.rs` snapshots the selected window with `BitBlt` from its window
+DC and then asks the target to repaint into our memory DC by sending `WM_PRINT`
+cross-process. Neither reaches a window that renders through DirectComposition,
+which today is Chrome, Edge, Electron, and every UWP app: the window DC holds
+nothing the compositor used, so the copy is black.
+
+`PrintWindow(hwnd, hdc, PW_RENDERFULLCONTENT)` is the supported API for exactly
+this. It marshals the DC across the process boundary itself (sending `WM_PRINT`
+by hand is not a documented cross-process contract), and `PW_RENDERFULLCONTENT`
+(Windows 8.1+) is the flag that makes a GPU-composited window render into the
+target DC at all. That is the smallest fix and should come first.
+
+Longer term, evaluate Windows.Graphics.Capture (Windows 10 1803+). WGC is the
+modern path: hardware-accelerated, captures occluded windows, handles DPI and
+per-window rounded corners, and delivers `IDirect3DSurface` frames that could
+feed the existing D3D11 surface path zero-copy instead of the current
+BGRA-to-CPU-I420 round trip. It costs a WinRT dependency and a capture-picker
+consent story, so it is a separate decision from the `PrintWindow` fix.
+
+While in here, revisit `WindowIdentity`. It calls `SetPropW` on a window owned
+by another process to detect `HWND` reuse. UIPI blocks that write for an
+elevated window, so `Capture::open` fails outright on a window that plain GDI
+capture could have read. Prefer an identity check that only reads: the owning
+process id plus its creation time is stable, cheap, and needs no write to a
+foreign window.
+
+Verification needs a Windows host: PR CI is Linux-only and `just rs windows`
+must run on Windows, so none of this code has ever been compiled by automation.
+Check the four cases by hand: a plain Win32 window, a Chrome window, an
+elevated window, and a window on a scaled display.
+
+## Related
+
+- [Window lifecycle](/quest/m0/capture-window-lifecycle.md) - the other defect in the same backend
+- [Windows capture parity](/quest/m2/capture-windows.md) - where the wider Windows.Graphics.Capture decision lives

--- a/quest/m0/x11-window-identity.md
+++ b/quest/m0/x11-window-identity.md
@@ -1,0 +1,35 @@
+# [S] moq-video: a reused X11 window id can publish an unrelated window
+
+## Goal
+
+X11 window capture stops when the selected window is destroyed, even if the X
+server hands the same id to a replacement window.
+
+## Plan
+
+`capture/x11.rs` identifies its target by XID alone and revalidates it each
+frame with `get_geometry`. A destroyed window makes that request fail, which
+correctly ends the stream. The gap is XID reuse: X clients allocate ids from
+their own range and do reuse freed ones, so a window destroyed and replaced by
+the same client can inherit the id. If the replacement's even-clamped
+dimensions match, capture continues against it and publishes a window the user
+never selected.
+
+The exposure is narrow, since all of that has to happen inside one frame
+interval, but the failure mode is publishing content nobody chose, which is the
+same class of problem as the layered-window leak fixed during
+[#3244](https://github.com/moq-dev/moq/pull/3244) review.
+
+`StructureNotify` is the fix: select for it on the target at open and drain
+events before each frame, so `DestroyNotify` ends the stream regardless of what
+happens to the id afterwards. Event masks are per-client, so this does not
+disturb the window's owner, and it is a read-only interest rather than the
+`SetPropW` marker the Windows backend writes into a foreign window.
+`ConfigureNotify` arrives on the same subscription and could later replace the
+per-frame `get_geometry` round trip.
+
+Found by Codex while reviewing #3244. Needs a real X session to verify.
+
+## Related
+
+- [X11 capture transport](/quest/m2/x11-capture-shm.md) - would consume the same event subscription to drop the per-frame geometry poll

--- a/quest/m2/README.md
+++ b/quest/m2/README.md
@@ -62,3 +62,5 @@ dashboards, fleet rollout) stay downstream.
 - [Windows capture parity](/quest/m2/capture-windows.md) - window, app, system-audio and cursor capture on Windows
 - [Linux capture parity](/quest/m2/capture-linux.md) - window capture, system audio, and a chosen display through the portal
 - [Capture ergonomics](/quest/m2/capture-ergonomics.md) - region capture, audio mixing, and validating format overrides
+- [X11 capture transport](/quest/m2/x11-capture-shm.md) - move X11 capture to shared memory and RandR events instead of a per-frame socket copy
+- [Capture frame buffers](/quest/m2/capture-frame-buffers.md) - stop rebuilding a full-frame buffer every tick in the X11 and Windows backends

--- a/quest/m2/capture-frame-buffers.md
+++ b/quest/m2/capture-frame-buffers.md
@@ -1,0 +1,30 @@
+# [S] moq-video: X11 and Windows capture rebuild their frame buffers every tick
+
+## Goal
+
+Neither native screen-capture backend allocates a full-frame buffer per frame.
+Steady-state capture reuses the same scratch memory and GDI objects.
+
+## Plan
+
+Both backends added in the native screen-capture work allocate the whole frame,
+every frame, on the pump thread.
+
+`capture/window.rs`'s `snapshot` creates a memory DC, a compatible bitmap, and a
+`vec![0u8; w * h * 4]` per call, then destroys them. At 1080p60 that is roughly
+500 MB/s of allocation plus GDI object churn for pixels whose size never changes
+while the stream is open. All three belong in `Capture`, built once at open: the
+pump thread owns the struct, so the `!Send` handles are fine where they are.
+
+`capture/x11.rs`'s `PixelFormat::rgb` allocates a `w * h * 3` `Vec` and fills it
+with three `push` calls per pixel, and `I420::from_rgb` then walks it again into
+a third buffer. Take an `&mut Vec<u8>` the `Capture` owns and `clear()` it, so
+the allocation happens once.
+
+Neither is a correctness bug, so this is a steady-state cost question: measure
+before and after rather than assuming. The X11 half compiles on Linux CI; the
+Windows half needs a Windows host (`just rs windows`).
+
+## Related
+
+- [X11 capture transport](/quest/m2/x11-capture-shm.md) - the larger X11 cost, in the same read path

--- a/quest/m2/x11-capture-shm.md
+++ b/quest/m2/x11-capture-shm.md
@@ -1,0 +1,31 @@
+# [M] moq-video: X11 capture copies the framebuffer over the socket and re-polls RandR every frame
+
+## Goal
+
+X11 display capture moves pixels through shared memory rather than the X
+connection, and learns about layout changes from RandR events rather than by
+asking every frame.
+
+## Plan
+
+`capture/x11.rs` reads pixels with `GetImage`, which serializes the whole
+requested rectangle through the X connection. On a local server that is ~8 MB
+per frame through a Unix socket at 1080p, before any conversion. MIT-SHM
+(`shm_get_image`, which `x11rb` supports) is the standard fast path: attach a
+shared segment once at open and let the server write into it directly. Fall back
+to `GetImage` when the extension is absent or the display is remote, since SHM
+is meaningless there.
+
+Separately, `Capture::read` calls `randr_get_monitors` plus a `get_atom_name`
+per monitor on every frame purely to notice a layout change, and allocates a
+`String` per monitor each time. RandR's `SCREEN_CHANGE_NOTIFY` is the intended
+mechanism: select for it once, then drain pending events between frames. Window
+capture does the same thing with a per-frame `get_geometry`, where
+`ConfigureNotify` on the window is the event equivalent.
+
+Both changes are contained to the one backend and are verifiable on a Linux
+host with a real X session; CI compiles the file but cannot run it.
+
+## Related
+
+- [Capture frame buffers](/quest/m2/capture-frame-buffers.md) - the per-frame allocations in the same read path


### PR DESCRIPTION
Six follow-ups turned up while taking over [#3244](https://github.com/moq-dev/moq/pull/3244) (native screen capture). None belong in that PR: three are in Windows code nothing in CI compiles, one is pre-existing on `main`, and two are steady-state cost rather than correctness.

**m0**

- **Windows window capture returns black for GPU-composited windows.** `BitBlt` plus a cross-process `WM_PRINT` reaches nothing rendered through DirectComposition, so `--window` is a black rectangle for Chrome, Edge, Electron, and UWP. `PrintWindow(hwnd, hdc, PW_RENDERFULLCONTENT)` is the supported API; WGC is the longer-term path. Also covers `SetPropW` on a foreign window being UIPI-blocked for elevated windows, and the timed-out `WM_PRINT` GDI hazard.
- **A minimized or resizing window ends capture instead of riding it out.** Minimizing on Windows makes `GetWindowRect` report an off-screen rect, so the reopen fails with "no capturable area" and the broadcast dies; a drag-resize rebuilds the encoder once per mouse-move.
- **An AVFoundation camera that disappears parks the reader forever.** Every other backend reports device loss; AVFoundation watches for neither a runtime error nor a disconnect, so nothing closes the channel. Pre-existing on `main`, found by Codex reviewing #3244.
- **A reused X11 window id can publish an unrelated window.** XID reuse inside one frame interval, at a matching clamped size, keeps capture running against a replacement window. `StructureNotify`/`DestroyNotify` is the fix.

**m2**

- **Both new backends rebuild a full frame buffer every tick** (a DC, a bitmap and a W*H*4 `Vec` on Windows; a W*H*3 `Vec` filled byte-by-byte on X11).
- **X11 capture copies the framebuffer over the socket every frame** and re-polls RandR to notice layout changes, where MIT-SHM and `SCREEN_CHANGE_NOTIFY` are the intended mechanisms.

Depends on #3244: four of these describe `rs/moq-video/src/capture/{window,x11}.rs`, which land there. Worth merging after it.

`quest check` passes (241 documents ok).

(written by Claude Opus 5)