### PR TITLE
fix(ci): package release assets without path collisions

### DIFF
--- a/.github/justfile
+++ b/.github/justfile
@@ -7,3 +7,4 @@ set fallback
 check:
     @if command -v actionlint >/dev/null 2>&1; then actionlint; fi
     {{ source_directory() }}/scripts/alert.sh check-coverage
+    {{ source_directory() }}/scripts/package-binary.test.sh

--- a/.github/justfile
+++ b/.github/justfile
@@ -7,4 +7,4 @@ set fallback
 check:
     @if command -v actionlint >/dev/null 2>&1; then actionlint; fi
     {{ source_directory() }}/scripts/alert.sh check-coverage
-    {{ source_directory() }}/scripts/package-binary.test.sh
+    @if command -v rustc >/dev/null 2>&1; then {{ source_directory() }}/scripts/package-binary.test.sh; fi

--- a/.github/scripts/package-binary.test.sh
+++ b/.github/scripts/package-binary.test.sh
@@ -12,7 +12,12 @@ printf '#!/usr/bin/env sh\necho test\n' >"$binary"
 chmod 0755 "$binary"
 target="$(rustc -vV | awk '/^host:/ {print $2}')"
 
-"$WORKSPACE_DIR/rs/scripts/package-binary.sh" \
+# This test covers archive staging, not the macOS Mach-O rewrite.
+mkdir "$tmp/bin"
+printf '#!/usr/bin/env sh\nprintf "Linux\\n"\n' >"$tmp/bin/uname"
+chmod 0755 "$tmp/bin/uname"
+
+PATH="$tmp/bin:$PATH" "$WORKSPACE_DIR/rs/scripts/package-binary.sh" \
     --crate moq-relay \
     --bin moq-relay \
     --binary "$binary" \

--- a/.github/scripts/package-binary.test.sh
+++ b/.github/scripts/package-binary.test.sh
@@ -13,13 +13,13 @@ chmod 0755 "$binary"
 target="$(rustc -vV | awk '/^host:/ {print $2}')"
 
 "$WORKSPACE_DIR/rs/scripts/package-binary.sh" \
-	--crate moq-relay \
-	--bin moq-relay \
-	--binary "$binary" \
-	--bare \
-	--version 0.14.13 \
-	--target "$target" \
-	--output "$tmp/dist"
+    --crate moq-relay \
+    --bin moq-relay \
+    --binary "$binary" \
+    --bare \
+    --version 0.14.13 \
+    --target "$target" \
+    --output "$tmp/dist"
 
 name="moq-relay-v0.14.13-$target"
 bare="$tmp/dist/$name"

--- a/.github/scripts/package-binary.test.sh
+++ b/.github/scripts/package-binary.test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKSPACE_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+binary="$tmp/moq-relay"
+printf '#!/usr/bin/env sh\necho test\n' >"$binary"
+chmod 0755 "$binary"
+target="$(rustc -vV | awk '/^host:/ {print $2}')"
+
+"$WORKSPACE_DIR/rs/scripts/package-binary.sh" \
+	--crate moq-relay \
+	--bin moq-relay \
+	--binary "$binary" \
+	--bare \
+	--version 0.14.13 \
+	--target "$target" \
+	--output "$tmp/dist"
+
+name="moq-relay-v0.14.13-$target"
+bare="$tmp/dist/$name"
+archive="$tmp/dist/$name.tar.gz"
+
+[[ -x "$bare" ]]
+[[ -f "$archive" ]]
+
+mkdir "$tmp/extracted"
+tar -xzf "$archive" -C "$tmp/extracted"
+[[ -x "$tmp/extracted/$name/bin/moq-relay" ]]
+[[ -f "$tmp/extracted/$name/LICENSE-MIT" ]]
+[[ -f "$tmp/extracted/$name/LICENSE-APACHE" ]]
+cmp "$binary" "$bare"
+cmp "$binary" "$tmp/extracted/$name/bin/moq-relay"
+
+echo "release assets package together without path collisions"

--- a/.github/workflows/moq-cli.yml
+++ b/.github/workflows/moq-cli.yml
@@ -54,30 +54,20 @@ jobs:
         # and AlmaLinux/RHEL/Rocky 9+ (.rpm).
         run: cargo zigbuild --locked --release --target ${{ matrix.target }}.2.34 -p moq-cli
 
-      - name: Package bare binary
-        shell: bash
-        run: |
-          # The crate is named moq-cli but its `[[bin]]` ships as `moq`.
-          version="${{ steps.parse.outputs.version }}"
-          target="${{ matrix.target }}"
-          name="moq-cli-v${version}-${target}"
-          mkdir -p dist
-          cp "target/${target}/release/moq" "dist/${name}"
-
-      - name: Package tarball (Homebrew)
+      - name: Package release assets
         shell: bash
         env:
           VERSION: ${{ steps.parse.outputs.version }}
           TARGET: ${{ matrix.target }}
         run: |
-          name="moq-cli-v${VERSION}-${TARGET}"
-          mkdir -p "dist/${name}/bin"
-          cp "target/${TARGET}/release/moq" "dist/${name}/bin/moq"
-          cp LICENSE-MIT LICENSE-APACHE "dist/${name}/"
-          if [[ -f rs/moq-cli/README.md ]]; then
-            cp rs/moq-cli/README.md "dist/${name}/"
-          fi
-          (cd dist && tar -czvf "${name}.tar.gz" "${name}" && rm -rf "${name}")
+          ./rs/scripts/package-binary.sh \
+            --crate moq-cli \
+            --bin moq \
+            --binary "target/${TARGET}/release/moq" \
+            --bare \
+            --version "$VERSION" \
+            --target "$TARGET" \
+            --output dist
 
       - name: Package .deb (Ubuntu 22.04 toolchain)
         shell: bash

--- a/.github/workflows/moq-relay.yml
+++ b/.github/workflows/moq-relay.yml
@@ -57,29 +57,20 @@ jobs:
         # and AlmaLinux/RHEL/Rocky 9+ (.rpm).
         run: cargo zigbuild --locked --release --target ${{ matrix.target }}.2.34 -p moq-relay
 
-      - name: Package bare binary
-        shell: bash
-        run: |
-          version="${{ steps.parse.outputs.version }}"
-          target="${{ matrix.target }}"
-          name="moq-relay-v${version}-${target}"
-          mkdir -p dist
-          cp "target/${target}/release/moq-relay" "dist/${name}"
-
-      - name: Package tarball (Homebrew)
+      - name: Package release assets
         shell: bash
         env:
           VERSION: ${{ steps.parse.outputs.version }}
           TARGET: ${{ matrix.target }}
         run: |
-          name="moq-relay-v${VERSION}-${TARGET}"
-          mkdir -p "dist/${name}/bin"
-          cp "target/${TARGET}/release/moq-relay" "dist/${name}/bin/moq-relay"
-          cp LICENSE-MIT LICENSE-APACHE "dist/${name}/"
-          if [[ -f rs/moq-relay/README.md ]]; then
-            cp rs/moq-relay/README.md "dist/${name}/"
-          fi
-          (cd dist && tar -czvf "${name}.tar.gz" "${name}" && rm -rf "${name}")
+          ./rs/scripts/package-binary.sh \
+            --crate moq-relay \
+            --bin moq-relay \
+            --binary "target/${TARGET}/release/moq-relay" \
+            --bare \
+            --version "$VERSION" \
+            --target "$TARGET" \
+            --output dist
 
       - name: Package .deb (Ubuntu 22.04 toolchain, glibc 2.35)
         shell: bash

--- a/.github/workflows/moq-token-cli.yml
+++ b/.github/workflows/moq-token-cli.yml
@@ -54,29 +54,20 @@ jobs:
         # and AlmaLinux/RHEL/Rocky 9+ (.rpm).
         run: cargo zigbuild --locked --release --target ${{ matrix.target }}.2.34 -p moq-token-cli
 
-      - name: Package bare binary
-        shell: bash
-        run: |
-          version="${{ steps.parse.outputs.version }}"
-          target="${{ matrix.target }}"
-          name="moq-token-cli-v${version}-${target}"
-          mkdir -p dist
-          cp "target/${target}/release/moq-token" "dist/${name}"
-
-      - name: Package tarball (Homebrew)
+      - name: Package release assets
         shell: bash
         env:
           VERSION: ${{ steps.parse.outputs.version }}
           TARGET: ${{ matrix.target }}
         run: |
-          name="moq-token-cli-v${VERSION}-${TARGET}"
-          mkdir -p "dist/${name}/bin"
-          cp "target/${TARGET}/release/moq-token" "dist/${name}/bin/moq-token"
-          cp LICENSE-MIT LICENSE-APACHE "dist/${name}/"
-          if [[ -f rs/moq-token-cli/README.md ]]; then
-            cp rs/moq-token-cli/README.md "dist/${name}/"
-          fi
-          (cd dist && tar -czvf "${name}.tar.gz" "${name}" && rm -rf "${name}")
+          ./rs/scripts/package-binary.sh \
+            --crate moq-token-cli \
+            --bin moq-token \
+            --binary "target/${TARGET}/release/moq-token" \
+            --bare \
+            --version "$VERSION" \
+            --target "$TARGET" \
+            --output dist
 
       - name: Package .deb (Ubuntu 22.04 toolchain)
         shell: bash

--- a/rs/scripts/package-binary.sh
+++ b/rs/scripts/package-binary.sh
@@ -2,16 +2,18 @@
 set -euo pipefail
 
 # Build and package a workspace binary for release.
-# Usage: ./package-binary.sh --crate CRATE [--bin NAME] [--target TARGET] [--version VERSION] [--output DIR]
+# Usage: ./package-binary.sh --crate CRATE [--bin NAME] [--binary PATH] [--bare]
+#   [--target TARGET] [--version VERSION] [--output DIR]
 #
 # --bin overrides the binary/command name when it differs from the crate (e.g.
 # the `moq-cli` crate ships its binary as `moq`); it defaults to the crate name.
 #
-# Builds via `nix build .#<crate>` against the flake-pinned toolchain so
-# artifacts are reproducible across hosts. Produces
+# Builds via `nix build .#<crate>` against the flake-pinned toolchain unless
+# --binary supplies an existing build. Produces
 # <output>/<crate>-v<version>-<target>.tar.gz, named after the release tag so
 # a URL rewritten from one tag to the next still resolves; the layout matches
-# the Homebrew tap templates in .github/homebrew/Formula/.
+# the Homebrew tap templates in .github/homebrew/Formula/. With --bare, also
+# produces an extensionless executable beside the archive.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -19,13 +21,15 @@ WORKSPACE_DIR="$(cd "$RS_DIR/.." && pwd)"
 
 CRATE=""
 BIN=""
+BINARY=""
+BARE=false
 TARGET=""
 VERSION=""
 OUTPUT_DIR="dist"
 
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --crate | --bin | --target | --version | --output)
+        --crate | --bin | --binary | --target | --version | --output)
             if [[ $# -lt 2 ]]; then
                 echo "Error: $1 requires a value" >&2
                 exit 1
@@ -33,14 +37,19 @@ while [[ $# -gt 0 ]]; do
             case $1 in
                 --crate) CRATE="$2" ;;
                 --bin) BIN="$2" ;;
+                --binary) BINARY="$2" ;;
                 --target) TARGET="$2" ;;
                 --version) VERSION="$2" ;;
                 --output) OUTPUT_DIR="$2" ;;
             esac
             shift 2
             ;;
+        --bare)
+            BARE=true
+            shift
+            ;;
         -h | --help)
-            echo "Usage: $0 --crate CRATE [--bin NAME] [--target TARGET] [--version VERSION] [--output DIR]"
+            echo "Usage: $0 --crate CRATE [--bin NAME] [--binary PATH] [--bare] [--target TARGET] [--version VERSION] [--output DIR]"
             exit 0
             ;;
         *)
@@ -82,28 +91,34 @@ if [[ "$TARGET" != "$HOST_TARGET" ]]; then
     exit 1
 fi
 
-echo "Building $CRATE for $TARGET via nix (output: $CRATE)..."
-
 BUILD_TMP="$(mktemp -d)"
 trap 'rm -rf "$BUILD_TMP"' EXIT
-RESULT_LINK="$BUILD_TMP/result"
-nix build "$WORKSPACE_DIR#$CRATE" --out-link "$RESULT_LINK"
+if [[ -n "$BINARY" ]]; then
+    BIN_FILE="$BINARY"
+    echo "Packaging prebuilt $CRATE binary for $TARGET..."
+else
+    echo "Building $CRATE for $TARGET via nix (output: $CRATE)..."
+    RESULT_LINK="$BUILD_TMP/result"
+    nix build "$WORKSPACE_DIR#$CRATE" --out-link "$RESULT_LINK"
 
-# Locate the built binary. Crane installs to result/bin/<binary>. The binary
-# name is usually the crate name; the `moq-cli` crate ships as `moq`.
-BIN_FILE="$RESULT_LINK/bin/$BIN"
+    # Crane installs to result/bin/<binary>. The binary name is usually the
+    # crate name; the `moq-cli` crate ships as `moq`.
+    BIN_FILE="$RESULT_LINK/bin/$BIN"
+fi
+
 if [[ ! -f "$BIN_FILE" ]]; then
     echo "Error: no binary found at $BIN_FILE" >&2
-    echo "Contents of $RESULT_LINK/bin:" >&2
-    ls "$RESULT_LINK/bin" >&2 || true
+    if [[ -n "${RESULT_LINK:-}" ]]; then
+        echo "Contents of $RESULT_LINK/bin:" >&2
+        ls "$RESULT_LINK/bin" >&2 || true
+    fi
     exit 1
 fi
 
 NAME="$CRATE-v$VERSION-$TARGET"
-PACKAGE_DIR="$OUTPUT_DIR/$NAME"
+PACKAGE_DIR="$BUILD_TMP/$NAME"
 
 echo "Packaging $NAME..."
-rm -rf "$PACKAGE_DIR"
 mkdir -p "$PACKAGE_DIR/bin"
 
 # Dereference the nix-store symlink and drop perms so the file is writable
@@ -138,11 +153,21 @@ fi
 cp "$WORKSPACE_DIR/LICENSE-MIT" "$PACKAGE_DIR/"
 cp "$WORKSPACE_DIR/LICENSE-APACHE" "$PACKAGE_DIR/"
 
-cd "$OUTPUT_DIR"
-ARCHIVE="$NAME.tar.gz"
-tar -czvf "$ARCHIVE" "$NAME"
-rm -rf "$NAME"
+mkdir -p "$OUTPUT_DIR"
+if [[ "$BARE" == true ]]; then
+    BARE_FILE="$OUTPUT_DIR/$NAME"
+    if [[ -d "$BARE_FILE" ]]; then
+        echo "Error: bare output path is a directory: $BARE_FILE" >&2
+        exit 1
+    fi
+    cp "$PACKAGE_DIR/bin/$BIN" "$BARE_FILE"
+fi
+
+ARCHIVE="$OUTPUT_DIR/$NAME.tar.gz"
+tar -C "$BUILD_TMP" -czvf "$ARCHIVE" "$NAME"
 
 echo ""
-echo "Created: $OUTPUT_DIR/$ARCHIVE"
-echo "$ARCHIVE"
+if [[ "$BARE" == true ]]; then
+    echo "Created: $BARE_FILE"
+fi
+echo "Created: $ARCHIVE"


### PR DESCRIPTION
## Summary

- Fix binary release jobs that created a bare executable and then reused the same path as the tarball staging directory.
- Stage archive contents in the shared binary packager's temporary directory, while emitting the bare executable and archive together.
- Apply the shared packager to moq-relay, moq-cli, and moq-token-cli, which all had the same collision.
- Add a regression test that verifies the same-stem executable and `.tar.gz` assets coexist and contain the expected files.

## Public API changes

- None.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just test`

(written by GPT-5)