### PR TITLE
fix(moq-net): walk every spliced segment when resolving the live edge

### DIFF
--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -3610,8 +3610,8 @@ struct LiveEdge {
 	/// The newest group sequence, `None` before any group exists.
 	latest: Option<u64>,
 	/// The precise Largest Object. `None` when the track is empty, or when the newest
-	/// group's frames cannot be read right now (none written yet, or a spliced track
-	/// between segments), in which case nothing is advertised and no fill is servable.
+	/// group's frames cannot be read right now, in which case nothing is advertised and
+	/// no fill is servable.
 	largest: Option<Location>,
 	/// One past the Largest Object, which is where a Next Object subscription begins.
 	/// When the edge is imprecise this falls back to the next group boundary: never below
@@ -3669,10 +3669,13 @@ fn live_edge(track: &track::Consumer) -> LiveEdge {
 }
 
 /// The last object below `sequence`: the nearest earlier cached group that has started a
-/// frame, walked in cache order so legal gaps in the group numbering are crossed. Empty
-/// groups exist for at most the instant between creation and first frame, so the walk is
-/// one step in practice. A group evicted from the cache is not visible, which is fine:
-/// Largest Object is the track from this publisher's perspective, and that is the cache.
+/// frame, walked in cache order so legal gaps in the group numbering are crossed and a
+/// spliced track's older segments are reached. Empty groups exist for at most the instant
+/// between creation and first frame, so within a segment the walk is one step in
+/// practice; a takeover is what makes it more. A group evicted from the cache is not
+/// visible, which is fine: Largest Object is the track from this publisher's perspective,
+/// and that is the cache. The newest group is never evicted, so the walk always has a
+/// floor to stop at.
 fn largest_before(track: &track::Consumer, sequence: u64) -> Option<Location> {
 	let mut sequence = sequence;
 	loop {
@@ -4061,6 +4064,73 @@ mod range_tests {
 		assert_eq!(edge.latest, Some(2));
 		assert_eq!(edge.largest, Some(Location { group: 0, object: 0 }));
 		assert_eq!(edge.next, Some(Location { group: 0, object: 1 }));
+	}
+
+	/// Build a spliced track: `old` serving up to the boundary, `new` from it on.
+	fn spliced(boundary: u64) -> (track::Producer, track::Producer, track::Consumer) {
+		let broadcast = std::sync::Arc::new(crate::broadcast::Info::default());
+		let old = track::Producer::new(broadcast.clone(), "video", None);
+		let new = track::Producer::new(broadcast, "video", None);
+
+		let mut resume = crate::model::resume::Producer::new();
+		resume.takeover(old.consume()).unwrap();
+		resume.switch(new.consume(), boundary).unwrap();
+
+		(old, new, track::Consumer::spliced("video".into(), resume.consume()))
+	}
+
+	fn write_frames(group: &mut group::Producer, count: usize) {
+		for _ in 0..count {
+			group
+				.write_frame(crate::Timestamp::from_millis(0).unwrap(), b"frame".as_slice())
+				.unwrap();
+		}
+	}
+
+	/// A takeover splices a fresh track in above the old one. Resolving the edge against
+	/// the newest segment alone reads the whole logical track as empty, and unlike an
+	/// empty newest group that lasts an instant, this lasts the entire failover window.
+	#[tokio::test]
+	async fn an_empty_spliced_segment_keeps_the_previous_edge() {
+		let (mut old, _new, track) = spliced(1);
+
+		let mut group = old.create_group(group::Info { sequence: 0 }).unwrap();
+		write_frames(&mut group, 3);
+		group.finish().unwrap();
+
+		// The new route serves from group 1 onward but hasn't produced anything yet.
+		let edge = live_edge(&track);
+		assert_eq!(edge.latest, Some(0));
+		assert_eq!(
+			edge.largest,
+			Some(Location { group: 0, object: 2 }),
+			"the previous segment's edge survives the takeover"
+		);
+		assert_eq!(edge.next, Some(Location { group: 0, object: 3 }));
+	}
+
+	/// The walkback itself has to cross the boundary: the new route's first group exists
+	/// but has no objects yet, so the largest sits in the segment below it.
+	#[tokio::test]
+	async fn the_walkback_crosses_a_spliced_segment() {
+		let (mut old, mut new, track) = spliced(1);
+
+		let mut group = old.create_group(group::Info { sequence: 0 }).unwrap();
+		write_frames(&mut group, 3);
+		group.finish().unwrap();
+
+		// Created on the new route, not yet written: the instant the walkback exists for,
+		// except the earlier group is in another segment.
+		let _open = new.create_group(group::Info { sequence: 1 }).unwrap();
+
+		let edge = live_edge(&track);
+		assert_eq!(edge.latest, Some(1));
+		assert_eq!(
+			edge.largest,
+			Some(Location { group: 0, object: 2 }),
+			"the walk crosses into the previous segment"
+		);
+		assert_eq!(edge.next, Some(Location { group: 0, object: 3 }));
 	}
 
 	/// Both ends carry through, object bounds included, so the boundary groups can be

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -57,6 +57,27 @@ impl Segment {
 			None => latest,
 		})
 	}
+
+	/// The newest cached group this segment serves below `before` (exclusive), or its
+	/// newest cached group at all when `before` is `None`.
+	///
+	/// Bounded at both ends, since a segment's track can hold groups outside the range
+	/// it serves: a fetch can backfill below `start`, and the track's own edge can race
+	/// past `end` before the next takeover splices above it. Neither belongs to this
+	/// segment, so the search is capped at `end` and anything below `start` reads as a
+	/// miss (there is nothing in range, or the caller would have found it).
+	fn peek_below(&self, before: Option<u64>) -> Option<group::Consumer> {
+		// `end` is inclusive and `peek_before` is exclusive, hence the +1.
+		let limit = min_some(before, self.end.map(|end| end.saturating_add(1)));
+		let group = match limit {
+			Some(limit) => self.track.peek_before(limit)?,
+			None => self.track.peek_latest()?,
+		};
+		if self.start.is_some_and(|start| group.sequence < start) {
+			return None;
+		}
+		Some(group)
+	}
 }
 
 /// The demand to register on an underlying track: the subscriber's own
@@ -494,11 +515,10 @@ impl Consumer {
 		self.state.read().latest()
 	}
 
-	/// The newest segment's newest cached group, resolved synchronously; see
+	/// The newest cached group across every spliced segment; see
 	/// [`track::Consumer::peek_latest`].
 	pub(crate) fn peek_latest(&self) -> Option<group::Consumer> {
-		let track = self.state.read().segments.last().map(|segment| segment.track.clone())?;
-		track.peek_latest()
+		self.peek_below(None)
 	}
 
 	/// A cached group by sequence from the newest segment; see
@@ -508,11 +528,24 @@ impl Consumer {
 		track.peek_group(sequence)
 	}
 
-	/// The nearest cached group below `sequence` in the newest segment; see
+	/// The nearest cached group below `sequence` across every spliced segment; see
 	/// [`track::Consumer::peek_before`].
 	pub(crate) fn peek_before(&self, sequence: u64) -> Option<group::Consumer> {
-		let track = self.state.read().segments.last().map(|segment| segment.track.clone())?;
-		track.peek_before(sequence)
+		self.peek_below(Some(sequence))
+	}
+
+	/// Walk the segments newest-first for the first one holding a group in range.
+	///
+	/// Every segment, not just the newest: a takeover splices in a fresh track with no
+	/// groups at all, and a peek that stopped there would read the whole logical track
+	/// as empty for the entire failover window. Ranges are disjoint and ascending, so
+	/// the first hit walking backwards is the newest.
+	///
+	/// The segment list is copied out rather than held, since resolving each candidate
+	/// takes the underlying track's own lock.
+	fn peek_below(&self, before: Option<u64>) -> Option<group::Consumer> {
+		let segments = self.state.read().segments.clone();
+		segments.iter().rev().find_map(|segment| segment.peek_below(before))
 	}
 }
 
@@ -1890,6 +1923,49 @@ mod test {
 			.now_or_never()
 			.expect("a live copy's answer must resolve immediately");
 		assert!(matches!(result, Err(Error::NotFound)));
+	}
+
+	/// A takeover splices in a track with no groups at all. A peek that stopped at the
+	/// newest segment would read the logical track as empty until the new route
+	/// produces, which is the whole failover window.
+	#[tokio::test]
+	async fn peeks_walk_past_an_empty_segment() {
+		let (mut track_a, consumer_a) = track_pair("a");
+		let (_track_b, consumer_b) = track_pair("b");
+
+		let mut producer = Producer::new();
+		producer.takeover(&consumer_a).unwrap();
+		write_group(&mut track_a, 0, "a0");
+		write_group(&mut track_a, 1, "a1");
+		producer.switch(&consumer_b, 2).unwrap();
+
+		let consumer = producer.consume();
+		assert_eq!(consumer.peek_latest().map(|group| group.sequence), Some(1));
+		assert_eq!(consumer.peek_before(1).map(|group| group.sequence), Some(0));
+		assert_eq!(consumer.peek_before(0).map(|group| group.sequence), None);
+	}
+
+	/// A segment's track can hold groups outside the range the segment serves: its own
+	/// edge can race past the cap before the next takeover splices above it. Those
+	/// belong to the newer segment's range, so a peek must not return them.
+	#[tokio::test]
+	async fn peeks_respect_segment_bounds() {
+		let (mut track_a, consumer_a) = track_pair("a");
+		let (_track_b, consumer_b) = track_pair("b");
+
+		let mut producer = Producer::new();
+		producer.takeover(&consumer_a).unwrap();
+		write_group(&mut track_a, 0, "a0");
+		// B takes over at 1, capping A at 0. A then races past its own cap.
+		producer.switch(&consumer_b, 1).unwrap();
+		write_group(&mut track_a, 5, "a5");
+
+		let consumer = producer.consume();
+		assert_eq!(
+			consumer.peek_latest().map(|group| group.sequence),
+			Some(0),
+			"group 5 is above A's cap and belongs to B's range"
+		);
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
Addresses gap 1 of #3283. Gap 2 is deliberately left open; see below.

## Root cause

`resume::Consumer`'s peeks only ever consulted `segments.last()`:

```rust
let track = self.state.read().segments.last().map(|s| s.track.clone())?;
track.peek_latest()
```

A takeover splices in a fresh track with no groups at all, so for the whole failover window `peek_latest` returned `None` and the draft-20 publisher's `live_edge` fell into its no-readable-group arm: LARGEST_OBJECT omitted, subscription floor raised to one past the previous segment's edge, and a requested fill resolving to empty. The same blind spot hid the walkback's target once the new route created its first group but hadn't written an object into it yet.

This is a window that lasts as long as the failover takes, not the instant that the within-segment walkback was written for.

## The change

Both peeks go through one `peek_below`, which walks the segments newest-first and takes the first hit. Ranges are disjoint and ascending, so the first hit walking backwards is the newest.

Each segment resolves candidates against its own bounds, since a segment's track can hold groups outside the range it serves: the search is capped at `end` (the track's own edge can race past the cap before the next takeover splices above it) and a hit below `start` reads as a miss (it belongs to an earlier segment, which the walk reaches on its own). This mirrors `Segment::produced`.

Read-side only. No change to the frame-write path.

## Why gap 2 is not addressed

The issue's second gap is eviction walking the advertised Largest Object backward. In practice the newest group is protected from eviction by construction: `insert_group` only enqueues the *previous* latest when a newer group lands, and `evict_expired` skips `Some(sequence) == self.latest_group` outright. So the gap needs the *just-demoted* group to die, and that group is `push_back`'d to an eviction queue that `pay_debt` scans from the front, carrying a fresh write stamp above the pool's access mean. It is the last thing eviction picks.

Closing it means maintaining a monotonic high-water `Location`, which means a write on every frame in a path that deliberately takes no track-level lock. That is not worth paying for a race that rare whose degradation (under-reporting by one group) is already the documented, coherent fallback. Deriving the edge from the cache also has a property the monotonic version loses: LARGEST_OBJECT stays something the publisher can actually serve a fill for, instead of naming content that has aged out and turning the fill into a stream reset.

I prototyped the monotonic version first and could not measure its cost here: on this machine `group_write_frames/single/8192` reports "+63.9% regressed, p<0.05" when compared against *itself*, so the benchmark cannot resolve an uncontended lock.

## Tests

Four regression tests, all failing before the change:

- `an_empty_spliced_segment_keeps_the_previous_edge` — a takeover with no groups yet on the new route keeps the old segment's edge instead of reading empty.
- `the_walkback_crosses_a_spliced_segment` — the new route's first group exists but has no objects, so the walk crosses the boundary.
- `peeks_walk_past_an_empty_segment` — the resume-level peeks directly.
- `peeks_respect_segment_bounds` — a segment whose track raced past its cap does not return the out-of-range group.

`just check` and `just test` pass (3020 tests, four consecutive clean runs).

## Cross-package sync

No wire format change, so no draft update. `js/net`'s IETF publisher does not compute a live edge or advertise LARGEST_OBJECT, so there is nothing to mirror.

(Written by Claude Opus 5)