### PR TITLE
feat(js/net): honor draft-20 Location Filters and serve fills

### DIFF
--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -386,9 +386,13 @@ test("a retained fetch fails on an evicted group instead of waiting", async () =
 	// once its latencyMax elapses. Subscribing prunes, so the fetch finds nothing cached.
 	const track = broadcast.createTrack("video", { latencyMax: 0 });
 
-	const group = track.appendGroup();
-	group.writeFrame({ payload: new TextEncoder().encode("gone"), timestamp: Timestamp.now() });
-	group.close();
+	// Two groups, both closed, so the target is unambiguously not the latest and the whole
+	// window is evictable however the latest group is treated.
+	for (const payload of ["gone", "also gone"]) {
+		const group = track.appendGroup();
+		group.writeFrame({ payload: new TextEncoder().encode(payload), timestamp: Timestamp.now() });
+		group.close();
+	}
 
 	// The track stays open, so a blocking fetch would wait for a sequence that has already
 	// been published and will never come round again.

--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -376,3 +376,46 @@ test("close rejects a still-pending track request so its subscriber unblocks", a
 
 	await expect(info).rejects.toThrow();
 });
+
+// A group at or below the live edge is either still retained or gone for good, so a
+// blocking fetch for an evicted one parks for the life of the track: nothing republishes
+// an old sequence, and a blocking read cannot tell "evicted" from "not published yet".
+test("a retained fetch fails on an evicted group instead of waiting", async () => {
+	const broadcast = new BroadcastProducer();
+	// A zero window evicts a group as soon as it closes, which is what a stale one hits
+	// once its latencyMax elapses. Subscribing prunes, so the fetch finds nothing cached.
+	const track = broadcast.createTrack("video", { latencyMax: 0 });
+
+	const group = track.appendGroup();
+	group.writeFrame({ payload: new TextEncoder().encode("gone"), timestamp: Timestamp.now() });
+	group.close();
+
+	// The track stays open, so a blocking fetch would wait for a sequence that has already
+	// been published and will never come round again.
+	await expect(broadcast.fetchGroup("video", 0, { retained: true })).rejects.toThrow("group not found");
+
+	broadcast.close();
+});
+
+// The waiting form is still the default: a fetch for a group that has yet to be published
+// has to park for it, which is what the consuming wire layer's coalescing relies on.
+test("a fetch without retained waits for a group still to come", async () => {
+	const broadcast = new BroadcastProducer();
+	const track = broadcast.createTrack("video");
+
+	const pending = broadcast.fetchGroup("video", 1);
+
+	const first = track.appendGroup();
+	first.writeFrame({ payload: new TextEncoder().encode("0"), timestamp: Timestamp.now() });
+	first.close();
+
+	const second = track.appendGroup();
+	second.writeFrame({ payload: new TextEncoder().encode("1"), timestamp: Timestamp.now() });
+	second.close();
+
+	const group = await pending;
+	expect(group.sequence).toBe(1);
+	expect(await group.readString()).toBe("1");
+
+	broadcast.close();
+});

--- a/js/net/src/broadcast.test.ts
+++ b/js/net/src/broadcast.test.ts
@@ -377,33 +377,10 @@ test("close rejects a still-pending track request so its subscriber unblocks", a
 	await expect(info).rejects.toThrow();
 });
 
-// A group at or below the live edge is either still retained or gone for good, so a
-// blocking fetch for an evicted one parks for the life of the track: nothing republishes
-// an old sequence, and a blocking read cannot tell "evicted" from "not published yet".
-test("a retained fetch fails on an evicted group instead of waiting", async () => {
-	const broadcast = new BroadcastProducer();
-	// A zero window evicts a group as soon as it closes, which is what a stale one hits
-	// once its latencyMax elapses. Subscribing prunes, so the fetch finds nothing cached.
-	const track = broadcast.createTrack("video", { latencyMax: 0 });
-
-	// Two groups, both closed, so the target is unambiguously not the latest and the whole
-	// window is evictable however the latest group is treated.
-	for (const payload of ["gone", "also gone"]) {
-		const group = track.appendGroup();
-		group.writeFrame({ payload: new TextEncoder().encode(payload), timestamp: Timestamp.now() });
-		group.close();
-	}
-
-	// The track stays open, so a blocking fetch would wait for a sequence that has already
-	// been published and will never come round again.
-	await expect(broadcast.fetchGroup("video", 0, { retained: true })).rejects.toThrow("group not found");
-
-	broadcast.close();
-});
-
-// The waiting form is still the default: a fetch for a group that has yet to be published
-// has to park for it, which is what the consuming wire layer's coalescing relies on.
-test("a fetch without retained waits for a group still to come", async () => {
+// A fetch parks for a group that has yet to be published, which is what the consuming wire
+// layer's coalescing relies on. The publisher's fill deliberately does not use this path: it
+// wants a group that already exists, and waiting for one that is gone would never return.
+test("a fetch waits for a group still to come", async () => {
 	const broadcast = new BroadcastProducer();
 	const track = broadcast.createTrack("video");
 

--- a/js/net/src/broadcast.ts
+++ b/js/net/src/broadcast.ts
@@ -116,10 +116,7 @@ async function fetchGroup(
 	const subscriber = subscribe(state, name, { priority: options.priority });
 	try {
 		for (;;) {
-			// A retained fetch never waits. The subscription mirrors the whole window in
-			// synchronously, so running dry means the sequence has been evicted, which a
-			// blocking read could not tell from one that has yet to be published.
-			const group = options.retained ? subscriber.tryRecvGroup() : await subscriber.recvGroup();
+			const group = await subscriber.recvGroup();
 			if (!group) throw new Error(`group not found: ${sequence}`);
 			if (group.sequence === sequence) {
 				// Close the subscription when the returned group finishes, not now: an

--- a/js/net/src/broadcast.ts
+++ b/js/net/src/broadcast.ts
@@ -116,7 +116,10 @@ async function fetchGroup(
 	const subscriber = subscribe(state, name, { priority: options.priority });
 	try {
 		for (;;) {
-			const group = await subscriber.recvGroup();
+			// A retained fetch never waits. The subscription mirrors the whole window in
+			// synchronously, so running dry means the sequence has been evicted, which a
+			// blocking read could not tell from one that has yet to be published.
+			const group = options.retained ? subscriber.tryRecvGroup() : await subscriber.recvGroup();
 			if (!group) throw new Error(`group not found: ${sequence}`);
 			if (group.sequence === sequence) {
 				// Close the subscription when the returned group finishes, not now: an

--- a/js/net/src/group.ts
+++ b/js/net/src/group.ts
@@ -127,6 +127,10 @@ export class Producer {
 		const dst = new GroupState(this.sequence);
 		for (const frame of this.#state.frames.peek()) appendFrame(dst, frame);
 		dst.offset = this.#state.offset;
+		// The replay only covers what is still buffered, so the count has to come from the
+		// source: it is what names a frame's absolute sequence, and what a publisher reads
+		// to resolve the live edge.
+		dst.total.set(this.#state.total.peek());
 
 		const closed = this.#state.closed.peek();
 		if (closed !== undefined) {
@@ -275,6 +279,16 @@ export class Consumer {
 	/** True if frames were evicted from the front of this group before being read. */
 	get skipped(): boolean {
 		return this.#state.offset > 0;
+	}
+
+	/**
+	 * How many frames the group has held, including any already read or evicted.
+	 *
+	 * It is also the next frame's sequence number, so `frameCount - 1` names the newest
+	 * frame written so far. A publisher snapshots it to resolve the track's live edge.
+	 */
+	get frameCount(): number {
+		return this.#state.total.peek();
 	}
 
 	/**

--- a/js/net/src/ietf/fetch.ts
+++ b/js/net/src/ietf/fetch.ts
@@ -3,6 +3,32 @@ import type { Reader, Writer } from "../stream.ts";
 import * as Message from "./message.ts";
 import type { IetfVersion } from "./version.ts";
 
+/**
+ * The header that begins a fetch stream (draft-20 section 11.4.4), naming the request it
+ * answers. Written by the publisher when serving a subscription's fill.
+ */
+export class FetchHeader {
+	/** The uni stream type, not a control message id. */
+	static type = 0x5;
+
+	/** The SUBSCRIBE (or FETCH) request this stream carries objects for. */
+	requestId: bigint;
+
+	constructor({ requestId }: { requestId: bigint }) {
+		this.requestId = requestId;
+	}
+
+	/** Write the header, which the stream type must already precede. */
+	async encode(w: Writer, _version: IetfVersion): Promise<void> {
+		await w.u62(this.requestId);
+	}
+
+	/** Read the header, with the stream type already consumed. */
+	static async decode(r: Reader, _version: IetfVersion): Promise<FetchHeader> {
+		return new FetchHeader({ requestId: await r.u62() });
+	}
+}
+
 export class Fetch {
 	static id = 0x16;
 

--- a/js/net/src/ietf/filter.test.ts
+++ b/js/net/src/ietf/filter.test.ts
@@ -101,7 +101,9 @@ test("draft-19 cannot bound the end object", () => {
 test("fill skips a length-prefixed range filter", () => {
 	// count=2, 0x26 len=3 AABBCC, delta 1 -> 0x27 len=1 DD
 	const encoded = new Uint8Array([0x02, 0x26, 0x03, 0xaa, 0xbb, 0xcc, 0x01, 0x01, 0xdd]);
-	expect(Filter.decodeFill(encoded, NEW)).toEqual({ kind: "unfiltered" });
+	// No LOCATION_FILTER, so the fill inherits the subscription's; a Range Filter's presence
+	// is what makes the publisher refuse it.
+	expect(Filter.decodeFill(encoded, NEW)).toEqual({ filter: undefined, rangeFilters: true });
 });
 
 test("rejects too many fields", () => {
@@ -111,20 +113,23 @@ test("rejects too many fields", () => {
 // The canonical current-group join: an empty subscription filter paired with a fill that
 // starts one group back.
 test("fill encodes the current group join", () => {
-	const encoded = Filter.encodeFill({ kind: "relative", groups: 1n }, NEW);
+	const encoded = Filter.encodeFill({ filter: { kind: "relative", groups: 1n }, rangeFilters: false }, NEW);
 	// count=1, type=0x21, len=1, StartGroup=1
 	expect([...encoded]).toEqual([0x01, 0x21, 0x01, 0x01]);
-	expect(Filter.decodeFill(encoded, NEW)).toEqual({ kind: "relative", groups: 1n });
+	expect(Filter.decodeFill(encoded, NEW)).toEqual({ filter: { kind: "relative", groups: 1n }, rangeFilters: false });
 });
 
 test("fill round trips", () => {
-	const filters: Filter.Filter[] = [
-		{ kind: "unfiltered" },
-		{ kind: "relative", groups: 3n },
-		{ kind: "absolute", startGroup: 4n, startObject: 0n, endGroup: 9n },
+	const fills: Filter.Fill[] = [
+		// An omitted filter inherits the subscription's, which is a different request from an
+		// explicit unfiltered one.
+		{ filter: undefined, rangeFilters: false },
+		{ filter: { kind: "unfiltered" }, rangeFilters: false },
+		{ filter: { kind: "relative", groups: 3n }, rangeFilters: false },
+		{ filter: { kind: "absolute", startGroup: 4n, startObject: 0n, endGroup: 9n }, rangeFilters: false },
 	];
-	for (const filter of filters) {
-		expect(Filter.decodeFill(Filter.encodeFill(filter, NEW), NEW)).toEqual(filter);
+	for (const fill of fills) {
+		expect(Filter.decodeFill(Filter.encodeFill(fill, NEW), NEW)).toEqual(fill);
 	}
 });
 
@@ -154,11 +159,11 @@ test("draft-20 uses leading-ones varints above 63", () => {
 test("fill skips a uint8 parameter whose value has a leading one", () => {
 	// count=2, 0x20 (uint8) = 0x80, delta 1 -> 0x21 len=1 StartGroup=1
 	const encoded = new Uint8Array([0x02, 0x20, 0x80, 0x01, 0x01, 0x01]);
-	expect(Filter.decodeFill(encoded, NEW)).toEqual({ kind: "relative", groups: 1n });
+	expect(Filter.decodeFill(encoded, NEW)).toEqual({ filter: { kind: "relative", groups: 1n }, rangeFilters: false });
 });
 
 test("fill skips allowed parameters it ignores", () => {
 	// count=2, 0x20 (even, one varint) = 42, delta 1 -> 0x21 (odd, length prefixed)
 	const encoded = new Uint8Array([0x02, 0x20, 0x2a, 0x01, 0x01, 0x02]);
-	expect(Filter.decodeFill(encoded, NEW)).toEqual({ kind: "relative", groups: 2n });
+	expect(Filter.decodeFill(encoded, NEW)).toEqual({ filter: { kind: "relative", groups: 2n }, rangeFilters: false });
 });

--- a/js/net/src/ietf/filter.ts
+++ b/js/net/src/ietf/filter.ts
@@ -4,6 +4,7 @@
  * @module
  */
 
+import type { Reader } from "../stream.ts";
 import * as Varint from "../varint.ts";
 import { type IetfVersion, Version } from "./version.ts";
 
@@ -206,10 +207,62 @@ function decodeTag(data: Uint8Array, version: IetfVersion): Filter {
 	}
 }
 
+/**
+ * Read the tagged filter draft-14 carries inline in a SUBSCRIBE body, where the fields
+ * following the tag have no length to delimit them.
+ *
+ * Every tag is read, including the absolute forms we do not serve. Rejecting one would tear
+ * the session down over a filter the draft lets a subscriber send; what we do with it is
+ * decided when the range is resolved.
+ */
+export async function decodeInline(r: Reader): Promise<Filter> {
+	const tag = await r.u62();
+	switch (tag) {
+		case TAG_NEXT_GROUP:
+			return { kind: "relative", groups: 0n };
+		case TAG_LARGEST_OBJECT:
+			return { kind: "nextObject" };
+		case TAG_ABSOLUTE_START:
+			return { kind: "absolute", startGroup: await r.u62(), startObject: await r.u62() };
+		case TAG_ABSOLUTE_RANGE: {
+			const startGroup = await r.u62();
+			const startObject = await r.u62();
+			const delta = await r.u62();
+			return { kind: "absolute", startGroup, startObject, endGroup: startGroup + delta };
+		}
+		default:
+			throw new Error(`unsupported filter type: ${tag}`);
+	}
+}
+
 function expectEmpty(rest: Uint8Array): void {
 	if (rest.length !== 0) {
 		throw new Error("trailing bytes in LOCATION_FILTER");
 	}
+}
+
+/**
+ * A draft-20 fill: the backfill a subscriber asks for alongside its subscription.
+ *
+ * The publisher serves one whose range resolves to a single group, straight from the group
+ * cache on a fetch stream. That covers the draft's own current-group join (a Next Object
+ * subscription plus a `StartGroup=1` fill). Anything wider is refused by resetting the
+ * fetch stream, the draft's fill-failure signal.
+ */
+export interface Fill {
+	/**
+	 * The range to fill. `undefined` means the Location Filter was omitted, which inherits
+	 * the subscription's own filter; `unfiltered` (a zero length filter) means the whole
+	 * track up to Largest Object.
+	 */
+	filter?: Filter;
+
+	/**
+	 * Whether the scope carried a Range Filter (0x25-0x28). Those narrow which objects pass,
+	 * which we do not implement, and serving the unfiltered range instead would deliver
+	 * objects the peer excluded. Never encoded; we send no range filters.
+	 */
+	rangeFilters: boolean;
 }
 
 /** LOCATION_FILTER, the only parameter we act on inside a fill. */
@@ -250,21 +303,22 @@ const FILL_ALLOWED = new Map<bigint, Framing>([
  *
  * The value is a nested parameter scope, encoded like a message's parameters.
  */
-export function encodeFill(filter: Filter, version: IetfVersion): Uint8Array {
-	if (filter.kind === "unfiltered") {
-		// An empty scope fills the whole track up to Largest Object.
+export function encodeFill(fill: Fill, version: IetfVersion): Uint8Array {
+	// An omitted filter inherits the subscription's, so the scope is empty. An explicit
+	// unfiltered still encodes, as a zero length filter meaning the whole track.
+	if (fill.filter === undefined) {
 		return varint(0n, version);
 	}
 	return concat([
 		varint(1n, version),
 		// The first type in a scope is not delta encoded, so this is the raw id.
 		varint(FILL_LOCATION_FILTER, version),
-		encodeLengthPrefixed(encode(filter, version), version),
+		encodeLengthPrefixed(encode(fill.filter, version), version),
 	]);
 }
 
 /** Decode FILL_PARAMETERS, returning the range it asks to fill. */
-export function decodeFill(data: Uint8Array, version: IetfVersion): Filter {
+export function decodeFill(data: Uint8Array, version: IetfVersion): Fill {
 	const [count, afterCount] = unvarint(data, version);
 	if (count > 64n) {
 		throw new Error("too many parameters in FILL_PARAMETERS");
@@ -272,6 +326,7 @@ export function decodeFill(data: Uint8Array, version: IetfVersion): Filter {
 
 	let rest = afterCount;
 	let filter: Filter | undefined;
+	let rangeFilters = false;
 	let prev = 0n;
 	for (let i = 0n; i < count; i++) {
 		const [delta, afterType] = unvarint(rest, version);
@@ -283,6 +338,10 @@ export function decodeFill(data: Uint8Array, version: IetfVersion): Filter {
 		if (framing === undefined) {
 			throw new Error(`parameter ${key} is not allowed inside FILL_PARAMETERS`);
 		}
+
+		// A Range Filter changes which objects the fill may contain, so its presence is
+		// recorded even though its value is not interpreted.
+		rangeFilters ||= key >= 0x25n && key <= 0x28n;
 
 		// The rest are parameters we do not act on, but their bytes still have to be
 		// consumed or the remaining keys desync.
@@ -315,7 +374,7 @@ export function decodeFill(data: Uint8Array, version: IetfVersion): Filter {
 		throw new Error("trailing bytes in FILL_PARAMETERS");
 	}
 
-	return filter ?? { kind: "unfiltered" };
+	return { filter, rangeFilters };
 }
 
 function encodeLengthPrefixed(value: Uint8Array, version: IetfVersion): Uint8Array {

--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -1529,11 +1529,28 @@ test("FetchFrame: an empty payload is a zero length, with no status byte", async
 	]);
 });
 
-// A track that declared no timescale opted out of timestamps, so the properties block is
-// present but empty rather than carrying a value in units the peer cannot read.
-test("FetchFrame: an unstamped object writes an empty properties block", async () => {
+// A track that declared no timescale opted out of timestamps, so the properties field is
+// omitted rather than carrying a value in units the peer was never told. This is what a
+// subscriber that sent INCLUDE_PROPERTIES=0 gets.
+test("FetchFrame: an unstamped object omits the properties field", async () => {
 	const frame = new FetchFrame({ payload: new Uint8Array([0x01]) });
 	const encoded = await encodeFetchFrameVersioned(frame, { group: 0, object: 0, first: false }, Version.DRAFT_20);
 
-	expect(Array.from(encoded)).toEqual([0x20, 0x00, 0x01, 0x01]);
+	// Flags 0 (subgroup zero, no fields present), then the payload.
+	expect(Array.from(encoded)).toEqual([0x00, 0x01, 0x01]);
+});
+
+// The first object still carries its absolute ids and priority; only the properties go.
+test("FetchFrame: an unstamped first object keeps its ids", async () => {
+	const frame = new FetchFrame({ payload: new Uint8Array([0x01]) });
+	const encoded = await encodeFetchFrameVersioned(frame, { group: 4, object: 2, first: true }, Version.DRAFT_20);
+
+	expect(Array.from(encoded)).toEqual([
+		0x1c, // GROUP_ID | OBJECT_ID | PRIORITY, without PROPERTIES
+		4,
+		2,
+		0,
+		0x01,
+		0x01,
+	]);
 });

--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -1077,7 +1077,7 @@ test("SubscribeOk v18: no requestId", async () => {
 // preference belongs in the DEFAULT_PUBLISHER_GROUP_ORDER track property, which shares the
 // number 0x22 in the separate property registry.
 test("SubscribeOk v18: group order is a track property, not a parameter", async () => {
-	const msg = new Subscribe.SubscribeOk({ trackAlias: 42n });
+	const msg = new Subscribe.SubscribeOk({ trackAlias: 42n, properties: { groupOrder: 0x02 } });
 
 	const encoded = await encodeVersioned(msg, Version.DRAFT_18);
 	expect(Array.from(encoded)).toEqual([
@@ -1125,7 +1125,7 @@ test("SubscribeOk v18: rejects a zero group order property", async () => {
 // Draft-15 is the one version that takes it as a message parameter, and has no track
 // properties to put it in.
 test("SubscribeOk v15: group order is a message parameter", async () => {
-	const msg = new Subscribe.SubscribeOk({ requestId: 7n, trackAlias: 42n });
+	const msg = new Subscribe.SubscribeOk({ requestId: 7n, trackAlias: 42n, properties: { groupOrder: 0x02 } });
 
 	const encoded = await encodeVersioned(msg, Version.DRAFT_15);
 	expect(Array.from(encoded)).toEqual([

--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -5,7 +5,7 @@ import { Timescale, Timestamp } from "../time.ts";
 import * as Varint from "../varint.ts";
 import * as GoAway from "./goaway.ts";
 import * as Namespace from "./namespace.ts";
-import { Frame, Group, type GroupFlags } from "./object.ts";
+import { FetchFrame, type FetchPosition, Frame, Group, type GroupFlags } from "./object.ts";
 import { Parameters, SetupOptions } from "./parameters.ts";
 import { Publish, PublishDone } from "./publish.ts";
 import * as Announce from "./publish_namespace.ts";
@@ -71,6 +71,20 @@ async function encodeFrameVersioned(
 	const { stream, written } = createTestWritableStream();
 	const writer = new Writer(stream, version);
 	await frame.encode(writer, flags, timescale, version);
+	writer.close();
+	await writer.closed;
+	return concatChunks(written);
+}
+
+async function encodeFetchFrameVersioned(
+	frame: FetchFrame,
+	position: FetchPosition,
+	version: IetfVersion,
+	timescale: Timescale = Timescale.MILLI,
+): Promise<Uint8Array> {
+	const { stream, written } = createTestWritableStream();
+	const writer = new Writer(stream, version);
+	await frame.encode(writer, position, timescale, version);
 	writer.close();
 	await writer.closed;
 	return concatChunks(written);
@@ -1456,4 +1470,70 @@ test("Frame object time: draft-16 starts delta property types", async () => {
 	);
 	expect(decoded.timestamp?.value).toBe(96_000);
 	expect(decoded.timestamp?.scale).toBe(Timescale.MILLI);
+});
+
+// A fetch stream's first object is the only one carrying absolute ids, so a wrong flag byte
+// there silently renumbers every object after it. This codec is the sole serialization path
+// for a served fill.
+test("FetchFrame: the first object carries its absolute ids and the rest inherit them", async () => {
+	const timestamp = new Timestamp(96_000, Timescale.MILLI);
+	const frame = new FetchFrame({ payload: new Uint8Array([0xaa, 0xbb]), timestamp });
+
+	const first = await encodeFetchFrameVersioned(frame, { group: 7, object: 3, first: true }, Version.DRAFT_20);
+	expect(Array.from(first)).toEqual([
+		0x3c, // GROUP_ID | OBJECT_ID | PRIORITY | PROPERTIES
+		7, // group id
+		3, // object id
+		0, // publisher priority
+		0x04, // properties length
+		0x10, // TIMESTAMP
+		0xc1,
+		0x77,
+		0x00, // 96000 as a three byte leading-ones varint
+		0x02, // payload length
+		0xaa,
+		0xbb,
+	]);
+
+	// Same group and priority, and the object id is the prior one plus one, so only the
+	// properties and the payload go on the wire.
+	const next = await encodeFetchFrameVersioned(frame, { group: 7, object: 4, first: false }, Version.DRAFT_20);
+	expect(Array.from(next)).toEqual([
+		0x20, // PROPERTIES
+		0x04,
+		0x10,
+		0xc1,
+		0x77,
+		0x00,
+		0x02,
+		0xaa,
+		0xbb,
+	]);
+});
+
+// A fetch object has no status field, unlike a subgroup object: a zero payload length is
+// simply an empty object, and writing a status after it would desync the stream.
+test("FetchFrame: an empty payload is a zero length, with no status byte", async () => {
+	const frame = new FetchFrame({ payload: new Uint8Array(), timestamp: new Timestamp(0, Timescale.MILLI) });
+	const encoded = await encodeFetchFrameVersioned(frame, { group: 1, object: 0, first: true }, Version.DRAFT_20);
+
+	expect(Array.from(encoded)).toEqual([
+		0x3c,
+		1, // group id
+		0, // object id
+		0, // publisher priority
+		0x02, // properties length
+		0x10, // TIMESTAMP
+		0x00, // 0
+		0x00, // payload length, and nothing follows
+	]);
+});
+
+// A track that declared no timescale opted out of timestamps, so the properties block is
+// present but empty rather than carrying a value in units the peer cannot read.
+test("FetchFrame: an unstamped object writes an empty properties block", async () => {
+	const frame = new FetchFrame({ payload: new Uint8Array([0x01]) });
+	const encoded = await encodeFetchFrameVersioned(frame, { group: 0, object: 0, first: false }, Version.DRAFT_20);
+
+	expect(Array.from(encoded)).toEqual([0x20, 0x00, 0x01, 0x01]);
 });

--- a/js/net/src/ietf/object.ts
+++ b/js/net/src/ietf/object.ts
@@ -268,9 +268,14 @@ export class Frame {
 		this.timestamp = timestamp;
 	}
 
-	/** Encode this frame using the group flags and negotiated IETF version. */
-	async encode(w: Writer, flags: GroupFlags, timescale: Timescale, version = w.version): Promise<void> {
-		await w.u53(0); // id_delta = 0
+	/**
+	 * Encode this frame using the group flags and negotiated IETF version.
+	 *
+	 * `idDelta` is the first object's absolute Object ID and zero for every later one, so a
+	 * group whose head was trimmed by a filter still puts the true numbering on the wire.
+	 */
+	async encode(w: Writer, flags: GroupFlags, timescale: Timescale, version = w.version, idDelta = 0): Promise<void> {
+		await w.u53(idDelta);
 
 		if (flags.hasExtensions) {
 			const extensions = await encodeObjectExtensions(this.timestamp, timescale, version);
@@ -337,5 +342,65 @@ export class Frame {
 		}
 
 		throw new Error(`Unsupported object status: ${status}`);
+	}
+}
+
+// Serialization Flags for a fetch object: the two low bits encode the subgroup (00 =
+// subgroup zero), then one presence bit per field.
+const FETCH_OBJECT_ID = 0x04;
+const FETCH_GROUP_ID = 0x08;
+const FETCH_PRIORITY = 0x10;
+const FETCH_PROPERTIES = 0x20;
+
+/** Where a {@link FetchFrame} sits in the track, and whether it opens the stream. */
+export interface FetchPosition {
+	/** The group's sequence number. */
+	group: number;
+	/** The object's id within that group. */
+	object: number;
+	/** Whether this is the stream's first object, which is what carries the absolute ids. */
+	first: boolean;
+}
+
+/**
+ * A moq-transport object inside a fetch stream, which a publisher writes to serve a fill.
+ *
+ * The first object carries its absolute Group and Object IDs plus the priority; every later
+ * one inherits them and increments the Object ID, so only the properties and the payload go
+ * on the wire. A fetch object has no status field: a zero payload length is simply an empty
+ * object.
+ */
+export class FetchFrame {
+	/** The object payload. */
+	payload: Uint8Array;
+	/** The presentation timestamp carried in object properties, when present. */
+	timestamp?: Timestamp;
+
+	constructor({ payload, timestamp }: { payload: Uint8Array; timestamp?: Timestamp }) {
+		this.payload = payload;
+		this.timestamp = timestamp;
+	}
+
+	/** Encode this object at `position`, stamping it in the track's timescale. */
+	async encode(w: Writer, position: FetchPosition, timescale: Timescale, version = w.version): Promise<void> {
+		if (position.first) {
+			// Include the priority too: "same as the prior object" has no prior to refer to.
+			await w.u53(FETCH_GROUP_ID | FETCH_OBJECT_ID | FETCH_PRIORITY | FETCH_PROPERTIES);
+			await w.u53(position.group);
+			await w.u53(position.object);
+			await w.u8(0);
+		} else {
+			// Same group and priority; the Object ID is the prior one plus one.
+			await w.u53(FETCH_PROPERTIES);
+		}
+
+		const extensions = await encodeObjectExtensions(this.timestamp, timescale, version);
+		await w.u53(extensions.byteLength);
+		await w.write(extensions);
+
+		await w.u53(this.payload.byteLength);
+		if (this.payload.byteLength > 0) {
+			await w.write(this.payload);
+		}
 	}
 }

--- a/js/net/src/ietf/object.ts
+++ b/js/net/src/ietf/object.ts
@@ -385,18 +385,23 @@ export class FetchFrame {
 	async encode(w: Writer, position: FetchPosition, timescale: Timescale, version = w.version): Promise<void> {
 		if (position.first) {
 			// Include the priority too: "same as the prior object" has no prior to refer to.
-			await w.u53(FETCH_GROUP_ID | FETCH_OBJECT_ID | FETCH_PRIORITY | FETCH_PROPERTIES);
+			const properties = this.timestamp !== undefined ? FETCH_PROPERTIES : 0;
+			await w.u53(FETCH_GROUP_ID | FETCH_OBJECT_ID | FETCH_PRIORITY | properties);
 			await w.u53(position.group);
 			await w.u53(position.object);
 			await w.u8(0);
 		} else {
 			// Same group and priority; the Object ID is the prior one plus one.
-			await w.u53(FETCH_PROPERTIES);
+			await w.u53(this.timestamp !== undefined ? FETCH_PROPERTIES : 0);
 		}
 
-		const extensions = await encodeObjectExtensions(this.timestamp, timescale, version);
-		await w.u53(extensions.byteLength);
-		await w.write(extensions);
+		// Omitted entirely rather than written empty when the object carries no timestamp:
+		// the track declared no units, so there is no property to send.
+		if (this.timestamp !== undefined) {
+			const extensions = await encodeObjectExtensions(this.timestamp, timescale, version);
+			await w.u53(extensions.byteLength);
+			await w.write(extensions);
+		}
 
 		await w.u53(this.payload.byteLength);
 		if (this.payload.byteLength > 0) {

--- a/js/net/src/ietf/parameters.ts
+++ b/js/net/src/ietf/parameters.ts
@@ -215,7 +215,8 @@ const MSG_PARAM_INCLUDE_PROPERTIES = 0x35n;
 const MSG_PARAM_HOP_PATH = 0x40b57n;
 
 type MessageParamKind = "varint" | "uint8" | "bool" | "location" | "bytes";
-type MessageLocation = { groupId: bigint; objectId: bigint };
+/** A `{Group, Object}` pair carried by a message parameter, such as LARGEST_OBJECT. */
+export type MessageLocation = { groupId: bigint; objectId: bigint };
 
 function getMessageParamKind(id: bigint): MessageParamKind {
 	switch (id) {

--- a/js/net/src/ietf/properties.ts
+++ b/js/net/src/ietf/properties.ts
@@ -13,6 +13,12 @@ const TIMESCALE = 0x08n;
 // subscriber states its own preference.
 const DEFAULT_PUBLISHER_GROUP_ORDER = 0x22n;
 
+/**
+ * DEFAULT_PUBLISHER_GROUP_ORDER's descending value: the newest group first, which is what
+ * we serve, matching moq-lite.
+ */
+export const DESCENDING = 0x02;
+
 /// The Track Properties block carried at the end of SUBSCRIBE_OK, PUBLISH, and FETCH_OK.
 export interface Properties {
 	/// The track's Timescale, which declares the units of every object Timestamp on it.

--- a/js/net/src/ietf/publisher.test.ts
+++ b/js/net/src/ietf/publisher.test.ts
@@ -810,7 +810,7 @@ test("draft-20: an empty track opens no fill stream", async () => {
 test("draft-20: an opt-out peer gets no track properties", async () => {
 	for (const propertiesWanted of [true, false]) {
 		const fx = fixture();
-		fx.broadcast.createTrack("video");
+		const track = fx.broadcast.createTrack("video");
 
 		const { client, ok } = await runSubscribe(
 			fx,
@@ -825,6 +825,24 @@ test("draft-20: an opt-out peer gets no track properties", async () => {
 
 		expect(ok.properties.timescale !== undefined).toBe(propertiesWanted);
 		expect(ok.properties.groupOrder !== undefined).toBe(propertiesWanted);
+
+		// With no TIMESCALE declared there are no units to read a timestamp in, so the objects
+		// must not carry one either: a bare value invites a peer to read it as some default.
+		writeGroup(track, 1);
+
+		const served = await nextUni(fx.uni);
+		if (!served) throw new Error("the group was never served");
+		const reader = new Reader(served, undefined, V20);
+		const header = await GroupMessage.decode(reader, V20);
+		expect(header.flags.hasExtensions).toBe(propertiesWanted);
+
+		await reader.u53(); // object id delta
+		if (propertiesWanted) {
+			const length = await reader.u53();
+			expect(length).toBeGreaterThan(0); // the properties block, carrying the timestamp
+			await reader.read(length);
+		}
+		expect(await reader.read(await reader.u53())).toEqual(new TextEncoder().encode("0.0"));
 
 		fx.close();
 		client.close();

--- a/js/net/src/ietf/publisher.test.ts
+++ b/js/net/src/ietf/publisher.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
 import { Producer as BroadcastProducer } from "../broadcast.ts";
+import { error } from "../error.ts";
 import { createMockTransportPair } from "../mock.ts";
 import { type Origin, OriginSchema } from "../origin.ts";
 import * as Path from "../path.ts";
@@ -476,8 +477,14 @@ interface ServedFill {
 	requestId?: bigint;
 	/** Each object's group, absolute id, and payload. */
 	objects: { group: number; id: number; payload: string }[];
-	/** Whether the publisher reset the stream instead of finishing it. */
-	reset: boolean;
+	/**
+	 * The error the stream ended with, when the publisher reset it instead of finishing.
+	 *
+	 * Carried rather than reduced to a flag so a test can assert *why* the publisher gave
+	 * up: a reset arrives here as the reason the publisher chose, so a decoder failure in
+	 * this helper cannot pass for one.
+	 */
+	reset?: Error;
 }
 
 /**
@@ -592,14 +599,13 @@ async function readFill(stream: ReadableStream<Uint8Array>): Promise<ServedFill>
 	let id = 0;
 
 	// Guarded on its own, so the assertion below lands outside every catch. Folding it into
-	// the object loop's would report a wrong stream type as a publisher reset, and the tests
-	// that only assert `reset` would pass on a malformed header.
+	// the object loop's would report a wrong stream type as a publisher reset.
 	let header: { type: number; requestId: bigint } | undefined;
 	try {
 		const type = await reader.u53();
 		header = { type, requestId: (await FetchHeader.decode(reader, V20)).requestId };
-	} catch {
-		return { objects, reset: true };
+	} catch (err) {
+		return { objects, reset: error(err) };
 	}
 	expect(header.type).toBe(FetchHeader.type);
 	const requestId = header.requestId;
@@ -618,11 +624,11 @@ async function readFill(stream: ReadableStream<Uint8Array>): Promise<ServedFill>
 			const payload = await reader.read(await reader.u53());
 			objects.push({ group, id, payload: new TextDecoder().decode(payload) });
 		}
-	} catch {
-		return { requestId, objects, reset: true };
+	} catch (err) {
+		return { requestId, objects, reset: error(err) };
 	}
 
-	return { requestId, objects, reset: false };
+	return { requestId, objects, reset: undefined };
 }
 
 /**
@@ -713,7 +719,7 @@ test("draft-20: a fill serves the current group's head on a fetch stream", async
 				{ group: 0, id: 0, payload: "0.0" },
 				{ group: 0, id: 1, payload: "0.1" },
 			],
-			reset: false,
+			reset: undefined,
 		});
 
 		// Everything past the snapshot belongs to the subscription, not the fill.
@@ -758,8 +764,9 @@ test("draft-20: a fill spanning several groups resets its stream", async () => {
 	try {
 		const fill = await nextUni(fx.uni);
 		if (!fill) throw new Error("a refused fill still owes the subscriber a reset stream");
+		// The reason the publisher chose, so a decode failure in readFill cannot pass for it.
 		const served = await readFill(fill);
-		expect(served.reset).toBe(true);
+		expect(served.reset?.message).toContain("several groups");
 		expect(served.objects).toEqual([]);
 	} finally {
 		fx.close();

--- a/js/net/src/ietf/publisher.test.ts
+++ b/js/net/src/ietf/publisher.test.ts
@@ -461,6 +461,9 @@ test("subscription completion sends PUBLISH_DONE on every supported draft", asyn
 /** Draft-20 is the only version whose Location Filters and fills the publisher acts on. */
 const V20 = Version.DRAFT_20;
 
+/** The PUBLISH_DONE status for a subscription the track itself ended. */
+const TRACK_ENDED_STATUS = 0x2;
+
 /** A group stream the publisher opened, decoded down to its objects. */
 interface ServedGroup {
 	/** The group's sequence number. */
@@ -861,11 +864,63 @@ test("draft-20: a clean close past a bounded filter's end still sends PUBLISH_DO
 
 		expect(await client.reader.u53()).toBe(PublishDone.id);
 		const done = await PublishDone.decode(client.reader, V20);
-		expect(done.statusCode).toBe(0x2);
+		expect(done.statusCode).toBe(TRACK_ENDED_STATUS);
 
 		// Only the in-range group was ever opened.
 		expect(await nextUni(fx.uni)).toBeUndefined();
 	} finally {
+		fx.close();
+		client.close();
+	}
+});
+
+/**
+ * An absolute fill ending below the live edge with no end object reads until its group
+ * closes, which a group still being written may never do. The subscriber leaving has to end
+ * it: watching only the fetch stream would pin the group and its cache subscription for the
+ * life of the track.
+ */
+test("draft-20: the subscriber leaving ends a fill still reading its group", async () => {
+	const fx = fixture();
+	const track = fx.broadcast.createTrack("video");
+
+	// Group 0 stays open, so a fill over it has no end of its own to wait for. Group 1 puts
+	// the live edge above it, which is what leaves the requested end object unset.
+	const open = track.appendGroup();
+	open.writeFrame({ payload: new TextEncoder().encode("0.0"), timestamp: Timestamp.now() });
+	writeGroup(track, 1);
+
+	const { client } = await runSubscribe(
+		fx,
+		new Subscribe({
+			requestId: 7n,
+			trackNamespace: Path.from("test"),
+			trackName: "video",
+			subscriberPriority: 0,
+			filter: { kind: "nextObject" },
+			fill: {
+				filter: { kind: "absolute", startGroup: 0n, startObject: 0n, endGroup: 0n },
+				rangeFilters: false,
+			},
+		}),
+	);
+
+	try {
+		const fill = await nextUni(fx.uni);
+		if (!fill) throw new Error("no fetch stream for the requested fill");
+
+		// The fill is parked on a group that is never going to close on its own, so this only
+		// settles once the subscriber leaving cancels it.
+		const reading = readFill(fill);
+		client.close();
+
+		// A reset discards what the peer has not acknowledged, so the objects already written
+		// may or may not survive it. That it ends at all, with the cancellation as its reason,
+		// is the whole point.
+		const served = await reading;
+		expect(served.reset?.message).toContain("unsubscribed");
+	} finally {
+		open.close();
 		fx.close();
 		client.close();
 	}

--- a/js/net/src/ietf/publisher.test.ts
+++ b/js/net/src/ietf/publisher.test.ts
@@ -820,3 +820,46 @@ test("draft-20: an opt-out peer gets no track properties", async () => {
 		client.close();
 	}
 });
+
+/**
+ * A bounded filter does not end the subscription (draft-20 removed that), so the publisher
+ * keeps serving until the track does. Groups published above the end are dropped rather
+ * than held: parking them would leave the serving loop waiting for a cap that never rises,
+ * and PUBLISH_DONE would never go out.
+ */
+test("draft-20: a clean close past a bounded filter's end still sends PUBLISH_DONE", async () => {
+	const fx = fixture();
+	const track = fx.broadcast.createTrack("video");
+	writeGroup(track, 1); // group 0, the whole requested range
+
+	const { client } = await runSubscribe(
+		fx,
+		new Subscribe({
+			requestId: 7n,
+			trackNamespace: Path.from("test"),
+			trackName: "video",
+			subscriberPriority: 0,
+			filter: { kind: "absolute", startGroup: 0n, startObject: 0n, endGroup: 0n },
+		}),
+	);
+
+	try {
+		const served = await nextUni(fx.uni);
+		if (!served) throw new Error("the requested group was never served");
+		expect((await readGroup(served)).sequence).toBe(0);
+
+		// Beyond the end, so it is never served, and it must not hold the subscription open.
+		writeGroup(track, 1); // group 1
+		track.close();
+
+		expect(await client.reader.u53()).toBe(PublishDone.id);
+		const done = await PublishDone.decode(client.reader, V20);
+		expect(done.statusCode).toBe(0x2);
+
+		// Only the in-range group was ever opened.
+		expect(await nextUni(fx.uni)).toBeUndefined();
+	} finally {
+		fx.close();
+		client.close();
+	}
+});

--- a/js/net/src/ietf/publisher.test.ts
+++ b/js/net/src/ietf/publisher.test.ts
@@ -588,13 +588,23 @@ async function readGroup(stream: ReadableStream<Uint8Array>): Promise<ServedGrou
 async function readFill(stream: ReadableStream<Uint8Array>): Promise<ServedFill> {
 	const reader = new Reader(stream, undefined, V20);
 	const objects: { group: number; id: number; payload: string }[] = [];
-	let requestId: bigint | undefined;
 	let group = 0;
 	let id = 0;
-	try {
-		expect(await reader.u53()).toBe(FetchHeader.type);
-		requestId = (await FetchHeader.decode(reader, V20)).requestId;
 
+	// Guarded on its own, so the assertion below lands outside every catch. Folding it into
+	// the object loop's would report a wrong stream type as a publisher reset, and the tests
+	// that only assert `reset` would pass on a malformed header.
+	let header: { type: number; requestId: bigint } | undefined;
+	try {
+		const type = await reader.u53();
+		header = { type, requestId: (await FetchHeader.decode(reader, V20)).requestId };
+	} catch {
+		return { objects, reset: true };
+	}
+	expect(header.type).toBe(FetchHeader.type);
+	const requestId = header.requestId;
+
+	try {
 		while (!(await reader.done())) {
 			const flags = await reader.u53();
 			if (flags & 0x08) group = await reader.u53();

--- a/js/net/src/ietf/publisher.test.ts
+++ b/js/net/src/ietf/publisher.test.ts
@@ -925,3 +925,58 @@ test("draft-20: the subscriber leaving ends a fill still reading its group", asy
 		client.close();
 	}
 });
+
+/**
+ * A broadcast served through `requested()` resolves its track on demand, and a dynamic serve
+ * is deliberately one request per peer subscription. Resolving the track again to read the
+ * fill's cache would mint a second producer nobody has accepted, so the fill has to read the
+ * one already serving the subscription.
+ */
+test("draft-20: a fill works on a dynamically requested track", async () => {
+	const fx = fixture();
+
+	// Answer the request the subscription raises, the way an application serving on demand
+	// does, rather than inserting the track up front.
+	const serving = (async () => {
+		const request = await fx.broadcast.requested();
+		if (!request) throw new Error("no track was requested");
+		const track = request.accept();
+		const group = track.appendGroup();
+		for (let i = 0; i < 2; i++) {
+			group.writeFrame({ payload: new TextEncoder().encode(`0.${i}`), timestamp: Timestamp.now() });
+		}
+		return group;
+	})();
+
+	const { client, ok } = await runSubscribe(
+		fx,
+		new Subscribe({
+			requestId: 7n,
+			trackNamespace: Path.from("test"),
+			trackName: "video",
+			subscriberPriority: 0,
+			filter: { kind: "nextObject" },
+			fill: { filter: { kind: "relative", groups: 1n }, rangeFilters: false },
+		}),
+	);
+	const group = await serving;
+
+	try {
+		expect(ok.largest).toEqual({ groupId: 0n, objectId: 1n });
+
+		const fill = await nextUni(fx.uni);
+		if (!fill) throw new Error("no fetch stream for the requested fill");
+		expect(await readFill(fill)).toEqual({
+			requestId: 7n,
+			objects: [
+				{ group: 0, id: 0, payload: "0.0" },
+				{ group: 0, id: 1, payload: "0.1" },
+			],
+			reset: undefined,
+		});
+	} finally {
+		group.close();
+		fx.close();
+		client.close();
+	}
+});

--- a/js/net/src/ietf/publisher.test.ts
+++ b/js/net/src/ietf/publisher.test.ts
@@ -3,9 +3,13 @@ import { Producer as BroadcastProducer } from "../broadcast.ts";
 import { createMockTransportPair } from "../mock.ts";
 import { type Origin, OriginSchema } from "../origin.ts";
 import * as Path from "../path.ts";
-import { Stream } from "../stream.ts";
+import { Reader, Stream } from "../stream.ts";
+import { Timestamp } from "../time.ts";
+import type { Producer as TrackProducer } from "../track.ts";
 import { NativeSession, type Session } from "./adapter.ts";
 import type * as Cluster from "./cluster.ts";
+import { FetchHeader } from "./fetch.ts";
+import { Group as GroupMessage } from "./object.ts";
 import { PublishDone } from "./publish.ts";
 import { PublishNamespace } from "./publish_namespace.ts";
 import { Publisher } from "./publisher.ts";
@@ -450,5 +454,359 @@ test("subscription completion sends PUBLISH_DONE on every supported draft", asyn
 			pub.close();
 			client.close();
 		}
+	}
+});
+
+/** Draft-20 is the only version whose Location Filters and fills the publisher acts on. */
+const V20 = Version.DRAFT_20;
+
+/** A group stream the publisher opened, decoded down to its objects. */
+interface ServedGroup {
+	/** The group's sequence number. */
+	sequence: number;
+	/** Whether the header claimed the stream starts at the group's first object. */
+	firstObject: boolean;
+	/** Each object's absolute id (reconstructed from its delta) and payload. */
+	objects: { id: number; payload: string }[];
+}
+
+/** A fill's fetch stream, decoded down to its objects. */
+interface ServedFill {
+	/** The request id the FETCH_HEADER named, when it survived a reset. */
+	requestId?: bigint;
+	/** Each object's group, absolute id, and payload. */
+	objects: { group: number; id: number; payload: string }[];
+	/** Whether the publisher reset the stream instead of finishing it. */
+	reset: boolean;
+}
+
+/**
+ * A publisher serving one broadcast over draft-20, with the subscribe stream already open.
+ *
+ * The uni reader is taken up front: a group stream opened before the test asks for one still
+ * queues, but taking the reader late races the publisher rather than the test.
+ */
+function fixture(): {
+	pair: ReturnType<typeof createMockTransportPair>;
+	pub: Publisher;
+	broadcast: BroadcastProducer;
+	uni: ReadableStreamDefaultReader<ReadableStream<Uint8Array>>;
+	close: () => void;
+} {
+	const pair = createMockTransportPair(ALPN.DRAFT_20);
+	const session = new NativeSession(pair.server, V20, true);
+	const pub = new Publisher({ quic: pair.server, session, requiresSolicitation: false });
+	const broadcast = new BroadcastProducer();
+	pub.publish(Path.from("test"), broadcast);
+	const uni = pair.client.incomingUnidirectionalStreams.getReader() as ReadableStreamDefaultReader<
+		ReadableStream<Uint8Array>
+	>;
+
+	return {
+		pair,
+		pub,
+		broadcast,
+		uni,
+		close: () => {
+			uni.releaseLock();
+			pub.close();
+		},
+	};
+}
+
+/** Write `frames` numbered payloads into a new closed group. */
+function writeGroup(track: TrackProducer, frames: number): void {
+	const group = track.appendGroup();
+	for (let i = 0; i < frames; i++) {
+		group.writeFrame({ payload: new TextEncoder().encode(`${group.sequence}.${i}`), timestamp: Timestamp.now() });
+	}
+	group.close();
+}
+
+/** Send `msg` on a fresh subscribe stream and read the publisher's SUBSCRIBE_OK. */
+async function runSubscribe(
+	fx: ReturnType<typeof fixture>,
+	msg: Subscribe,
+): Promise<{ client: Stream; ok: SubscribeOk }> {
+	const client = await Stream.open(fx.pair.client, { version: V20 });
+	const server = await Stream.accept(fx.pair.server, V20);
+	if (!server) throw new Error("publisher never accepted the subscribe stream");
+
+	void fx.pub.runSubscribe(msg, server);
+
+	expect(await client.reader.u53()).toBe(SubscribeOk.id);
+	return { client, ok: await SubscribeOk.decode(client.reader, V20) };
+}
+
+/** Take the next uni stream the publisher opened, or undefined if it opened none. */
+async function nextUni(
+	uni: ReadableStreamDefaultReader<ReadableStream<Uint8Array>>,
+): Promise<ReadableStream<Uint8Array> | undefined> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		const next = await Promise.race([
+			uni.read(),
+			new Promise<undefined>((resolve) => {
+				timer = setTimeout(() => resolve(undefined), STREAM_WAIT);
+			}),
+		]);
+		if (!next || next.done) return undefined;
+		return next.value;
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/** Read a group stream to its end. */
+async function readGroup(stream: ReadableStream<Uint8Array>): Promise<ServedGroup> {
+	const reader = new Reader(stream, undefined, V20);
+	const header = await GroupMessage.decode(reader, V20);
+
+	// Decoded by hand rather than through Frame: a filter that trims a group's head puts the
+	// first object's absolute id in the delta, which Frame.decode refuses on principle.
+	const objects: { id: number; payload: string }[] = [];
+	let id = 0;
+	let first = true;
+	while (!(await reader.done())) {
+		const delta = await reader.u53();
+		id = first ? delta : id + delta + 1;
+		first = false;
+		await reader.read(await reader.u53()); // object properties
+		const payload = await reader.read(await reader.u53());
+		objects.push({ id, payload: new TextDecoder().decode(payload) });
+	}
+
+	return { sequence: header.groupId, firstObject: header.flags.firstObject, objects };
+}
+
+/**
+ * Read a fill's fetch stream to its end, reporting a reset rather than throwing.
+ *
+ * A reset discards data the peer has not acknowledged, so a refused fill may lose its
+ * FETCH_HEADER along with the rest: the request id is only reported when it arrived.
+ */
+async function readFill(stream: ReadableStream<Uint8Array>): Promise<ServedFill> {
+	const reader = new Reader(stream, undefined, V20);
+	const objects: { group: number; id: number; payload: string }[] = [];
+	let requestId: bigint | undefined;
+	let group = 0;
+	let id = 0;
+	try {
+		expect(await reader.u53()).toBe(FetchHeader.type);
+		requestId = (await FetchHeader.decode(reader, V20)).requestId;
+
+		while (!(await reader.done())) {
+			const flags = await reader.u53();
+			if (flags & 0x08) group = await reader.u53();
+			if (flags & 0x04) {
+				id = await reader.u53();
+			} else {
+				id += 1;
+			}
+			if (flags & 0x10) await reader.u8();
+			if (flags & 0x20) await reader.read(await reader.u53());
+			const payload = await reader.read(await reader.u53());
+			objects.push({ group, id, payload: new TextDecoder().decode(payload) });
+		}
+	} catch {
+		return { requestId, objects, reset: true };
+	}
+
+	return { requestId, objects, reset: false };
+}
+
+/**
+ * An absolute filter names the objects it wants, so the boundary groups are trimmed to it
+ * and the groups outside it are never opened. The first object written carries its absolute
+ * id, or the subscriber would read a silently renumbered group.
+ */
+test("draft-20: an absolute filter trims the range it serves", async () => {
+	const fx = fixture();
+	const track = fx.broadcast.createTrack("video");
+	for (let i = 0; i < 4; i++) writeGroup(track, 3);
+
+	const { client } = await runSubscribe(
+		fx,
+		new Subscribe({
+			requestId: 7n,
+			trackNamespace: Path.from("test"),
+			trackName: "video",
+			subscriberPriority: 0,
+			filter: { kind: "absolute", startGroup: 1n, startObject: 1n, endGroup: 2n, endObject: 0n },
+		}),
+	);
+
+	try {
+		const first = await nextUni(fx.uni);
+		if (!first) throw new Error("the filter's start group was never served");
+		expect(await readGroup(first)).toEqual({
+			sequence: 1,
+			// The head was trimmed, so the stream does not start at the group's first object.
+			firstObject: false,
+			objects: [
+				{ id: 1, payload: "1.1" },
+				{ id: 2, payload: "1.2" },
+			],
+		});
+
+		const second = await nextUni(fx.uni);
+		if (!second) throw new Error("the filter's end group was never served");
+		expect(await readGroup(second)).toEqual({
+			sequence: 2,
+			firstObject: true,
+			objects: [{ id: 0, payload: "2.0" }],
+		});
+
+		// Groups 0 and 3 are outside the range, so nothing more is opened.
+		expect(await nextUni(fx.uni)).toBeUndefined();
+	} finally {
+		fx.close();
+		client.close();
+	}
+});
+
+/**
+ * The draft's own current-group join: a Next Object subscription for the live tail, plus a
+ * StartGroup=1 fill for the head already published. The two must meet exactly, so the head
+ * arrives once, on the fetch stream, and the subscription picks up at the next object.
+ */
+test("draft-20: a fill serves the current group's head on a fetch stream", async () => {
+	const fx = fixture();
+	const track = fx.broadcast.createTrack("video");
+
+	const group = track.appendGroup();
+	for (let i = 0; i < 2; i++) {
+		group.writeFrame({ payload: new TextEncoder().encode(`0.${i}`), timestamp: Timestamp.now() });
+	}
+
+	const { client, ok } = await runSubscribe(
+		fx,
+		new Subscribe({
+			requestId: 7n,
+			trackNamespace: Path.from("test"),
+			trackName: "video",
+			subscriberPriority: 0,
+			filter: { kind: "nextObject" },
+			fill: { filter: { kind: "relative", groups: 1n }, rangeFilters: false },
+		}),
+	);
+
+	try {
+		// A fill-requesting subscriber sizes its backfill against this.
+		expect(ok.largest).toEqual({ groupId: 0n, objectId: 1n });
+
+		const fill = await nextUni(fx.uni);
+		if (!fill) throw new Error("no fetch stream for the requested fill");
+		expect(await readFill(fill)).toEqual({
+			requestId: 7n,
+			objects: [
+				{ group: 0, id: 0, payload: "0.0" },
+				{ group: 0, id: 1, payload: "0.1" },
+			],
+			reset: false,
+		});
+
+		// Everything past the snapshot belongs to the subscription, not the fill.
+		group.writeFrame({ payload: new TextEncoder().encode("0.2"), timestamp: Timestamp.now() });
+		group.close();
+
+		const live = await nextUni(fx.uni);
+		if (!live) throw new Error("the subscription never served the live tail");
+		expect(await readGroup(live)).toEqual({
+			sequence: 0,
+			firstObject: false,
+			objects: [{ id: 2, payload: "0.2" }],
+		});
+	} finally {
+		fx.close();
+		client.close();
+	}
+});
+
+/**
+ * Multi-group fetch serialization depends on a negotiated group order we do not implement.
+ * A fill is a promise once requested, so the stream still opens and is reset right after the
+ * FETCH_HEADER, which is the draft's fill-failure signal.
+ */
+test("draft-20: a fill spanning several groups resets its stream", async () => {
+	const fx = fixture();
+	const track = fx.broadcast.createTrack("video");
+	for (let i = 0; i < 3; i++) writeGroup(track, 2);
+
+	const { client } = await runSubscribe(
+		fx,
+		new Subscribe({
+			requestId: 7n,
+			trackNamespace: Path.from("test"),
+			trackName: "video",
+			subscriberPriority: 0,
+			filter: { kind: "nextObject" },
+			fill: { filter: { kind: "relative", groups: 2n }, rangeFilters: false },
+		}),
+	);
+
+	try {
+		const fill = await nextUni(fx.uni);
+		if (!fill) throw new Error("a refused fill still owes the subscriber a reset stream");
+		const served = await readFill(fill);
+		expect(served.reset).toBe(true);
+		expect(served.objects).toEqual([]);
+	} finally {
+		fx.close();
+		client.close();
+	}
+});
+
+/** A fill against a track with nothing published has an empty range: no stream is owed. */
+test("draft-20: an empty track opens no fill stream", async () => {
+	const fx = fixture();
+	fx.broadcast.createTrack("video");
+
+	const { client, ok } = await runSubscribe(
+		fx,
+		new Subscribe({
+			requestId: 7n,
+			trackNamespace: Path.from("test"),
+			trackName: "video",
+			subscriberPriority: 0,
+			filter: { kind: "nextObject" },
+			fill: { filter: { kind: "relative", groups: 1n }, rangeFilters: false },
+		}),
+	);
+
+	try {
+		expect(ok.largest).toBeUndefined();
+		expect(await nextUni(fx.uni)).toBeUndefined();
+	} finally {
+		fx.close();
+		client.close();
+	}
+});
+
+/**
+ * INCLUDE_PROPERTIES=0 opts the response out of Track Properties, which also opts the track
+ * out of timestamps: with no declared Timescale there are no units to read one in.
+ */
+test("draft-20: an opt-out peer gets no track properties", async () => {
+	for (const propertiesWanted of [true, false]) {
+		const fx = fixture();
+		fx.broadcast.createTrack("video");
+
+		const { client, ok } = await runSubscribe(
+			fx,
+			new Subscribe({
+				requestId: 7n,
+				trackNamespace: Path.from("test"),
+				trackName: "video",
+				subscriberPriority: 0,
+				propertiesWanted,
+			}),
+		);
+
+		expect(ok.properties.timescale !== undefined).toBe(propertiesWanted);
+		expect(ok.properties.groupOrder !== undefined).toBe(propertiesWanted);
+
+		fx.close();
+		client.close();
 	}
 });

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -96,11 +96,11 @@ interface RunFill {
 	/** The range the fill resolved to. */
 	fill: FillServe;
 
-	/** The broadcast to read the cached group from. */
-	broadcast: broadcast.Producer;
-
-	/** The track the fill belongs to. */
-	trackName: string;
+	/**
+	 * An independent view of the same track, used to read the cached group without consuming
+	 * anything the subscription will deliver.
+	 */
+	cache: track.Subscriber;
 
 	/** The track's advertised timescale, applied to every frame timestamp. */
 	timescale: Timescale;
@@ -236,9 +236,12 @@ export class Publisher {
 			if (startGroup !== undefined) track.startAt(startGroup);
 
 			// A fill reads the group cache through its own consumer, independent of the
-			// subscription's cursor.
+			// subscription's cursor. Forked from this subscriber rather than resolved through
+			// the broadcast again: a dynamic serve is one request per peer subscription, so
+			// asking the broadcast would mint a second producer nobody has accepted.
 			const fill =
 				msg.fill && Filter.isDraft20(version) ? fillRange(msg.fill, msg.filter, edge.largest) : undefined;
+			const cache = fill && fill.kind !== "empty" ? track.fork({ priority }) : undefined;
 
 			// Send SUBSCRIBE_OK
 			await stream.writer.u53(SubscribeOk.id);
@@ -307,17 +310,10 @@ export class Publisher {
 
 			// The fill (when one was requested) runs alongside on its own fetch stream; its
 			// failures reset that stream and never touch the subscription.
-			const filling = fill
-				? this.#runFill({
-						requestId: msg.requestId,
-						priority,
-						fill,
-						broadcast,
-						trackName: msg.trackName,
-						timescale,
-						unsubscribed,
-					})
-				: Promise.resolve();
+			const filling =
+				fill && cache
+					? this.#runFill({ requestId: msg.requestId, priority, fill, cache, timescale, unsubscribed })
+					: Promise.resolve();
 
 			let publishError: Error | undefined;
 			try {
@@ -442,13 +438,17 @@ export class Publisher {
 	 * fill-failure signal. Nothing here touches the subscription either way.
 	 */
 	async #runFill(options: RunFill) {
-		const { requestId, fill, timescale, unsubscribed } = options;
-		if (fill.kind === "empty") return;
+		const { requestId, fill, cache, timescale, unsubscribed } = options;
+		if (fill.kind === "empty") {
+			cache.close();
+			return;
+		}
 
 		const version = this.#session.version;
 		const stream = await Writer.tryOpen(this.#quic, { cancel: unsubscribed, version });
 		if (!stream) {
 			console.debug(`fill stream failed to open: fill=${requestId}`);
+			cache.close();
 			return;
 		}
 
@@ -460,7 +460,7 @@ export class Publisher {
 				throw new Error("a fill spanning several groups is not supported");
 			}
 
-			const group = await this.#fetchFill(options, fill.sequence);
+			const group = takeGroup(cache, Number(fill.sequence));
 			try {
 				await this.#writeFillGroup(stream, group, fill, timescale, unsubscribed);
 			} finally {
@@ -473,42 +473,9 @@ export class Publisher {
 			const e = error(err);
 			console.debug(`fill failed, resetting its stream: fill=${requestId} error=${reason(e)}`);
 			stream.reset(e);
+		} finally {
+			cache.close();
 		}
-	}
-
-	/**
-	 * Read the fill's group out of the broadcast's cache.
-	 *
-	 * The group is at or below the Largest Object snapshot, so it is either still retained
-	 * or gone for good: `retained` is what makes an evicted one fail here rather than park
-	 * the fetch waiting for a sequence nothing will republish, which would leave the
-	 * subscriber with neither its fill nor the reset it is owed.
-	 *
-	 * The race only covers the subscriber leaving before the fetch settles, and closes the
-	 * group the fetch hands back afterwards so its subscription is not left behind.
-	 */
-	async #fetchFill(options: RunFill, sequence: bigint): Promise<group.Consumer> {
-		let left = false;
-		const pending = options.broadcast.fetchGroup(options.trackName, Number(sequence), {
-			priority: options.priority,
-			retained: true,
-		});
-		void pending.then(
-			(group) => {
-				if (left) group.close();
-			},
-			() => undefined,
-		);
-
-		const group = await Promise.race([
-			pending,
-			options.unsubscribed.then(() => {
-				left = true;
-				return undefined;
-			}),
-		]);
-		if (!group) throw new Error("unsubscribed before the fill's group resolved");
-		return group;
 	}
 
 	/**
@@ -1045,6 +1012,25 @@ type FillServe =
 	 * reset instead, the draft's fill-failure signal.
 	 */
 	| { kind: "unsupported" };
+
+/**
+ * Take one group out of a cache view, without waiting.
+ *
+ * A fill's group is at or below the Largest Object snapshot, so it is either still in the
+ * retained window or gone for good: nothing republishes an old sequence, and waiting for one
+ * would park for the life of the track. Scanning past it, or running dry, is a cache miss,
+ * which the caller turns into the draft's fill-failure reset.
+ */
+function takeGroup(cache: track.Subscriber, sequence: number): group.Consumer {
+	for (;;) {
+		const group = cache.tryRecvGroup();
+		if (!group) throw new Error(`group not found: ${sequence}`);
+		if (group.sequence === sequence) return group;
+
+		group.close();
+		if (group.sequence > sequence) throw new Error(`group not found: ${sequence}`);
+	}
+}
 
 /** `a - b`, saturating at zero the way the draft's unsigned arithmetic does. */
 function saturatingSub(a: bigint, b: bigint): bigint {

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -462,7 +462,7 @@ export class Publisher {
 
 			const group = await this.#fetchFill(options, fill.sequence);
 			try {
-				await this.#writeFillGroup(stream, group, fill, timescale);
+				await this.#writeFillGroup(stream, group, fill, timescale, unsubscribed);
 			} finally {
 				group.close();
 			}
@@ -517,16 +517,33 @@ export class Publisher {
 	 * The cap is the Largest Object snapshot: the group may keep growing, but everything
 	 * past the snapshot belongs to the subscription, not the fill.
 	 */
-	async #writeFillGroup(stream: Writer, group: group.Consumer, fill: FillGroup, timescale: Timescale) {
+	async #writeFillGroup(
+		stream: Writer,
+		group: group.Consumer,
+		fill: FillGroup,
+		timescale: Timescale,
+		unsubscribed: Promise<void>,
+	) {
 		let first = true;
 		let next = 0n;
+
+		// The subscriber leaving has to end the fill too. An absolute filter ending below the
+		// edge with no end object leaves `until` unset, so this reads until the group closes,
+		// which a still-open past group may never do. Watching only the fetch stream would
+		// then pin the group and the cache subscription behind it for the life of the track.
+		let left = false;
+		const cancelled = unsubscribed.then(() => {
+			left = true;
+			return undefined;
+		});
 
 		for (;;) {
 			// The group may keep growing, but everything at `until` and beyond belongs to the
 			// subscription, so stop without waiting for the group's end.
 			if (fill.until !== undefined && next >= fill.until) break;
 
-			const frame = await Promise.race([group.readFrameSequence(), stream.closed]);
+			const frame = await Promise.race([group.readFrameSequence(), stream.closed, cancelled]);
+			if (left) throw new Error("unsubscribed before the fill finished");
 			if (!frame) break;
 			next = BigInt(frame.sequence) + 1n;
 			if (fill.until !== undefined && BigInt(frame.sequence) >= fill.until) break;

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -84,7 +84,13 @@ interface RunFill {
 	/** The subscription's request ID, which the fetch stream names. */
 	requestId: bigint;
 
-	/** The subscriber's delivery priority, applied to the fetch stream. */
+	/**
+	 * The subscriber's delivery priority, applied to the cache subscription the fill reads.
+	 *
+	 * Deliberately not the fetch stream's send order: this publisher leaves its group
+	 * streams at the transport's default, so ranking the fill alone would put backfill
+	 * ahead of the live groups it is catching up to.
+	 */
 	priority: number;
 
 	/** The range the fill resolved to. */
@@ -463,14 +469,19 @@ export class Publisher {
 	/**
 	 * Read the fill's group out of the broadcast's cache.
 	 *
-	 * The group is at or below the Largest Object snapshot, so this resolves right away.
-	 * The race only covers the subscriber leaving in that window, and closes the group the
-	 * fetch hands back afterwards so its subscription is not left behind.
+	 * The group is at or below the Largest Object snapshot, so it is either still retained
+	 * or gone for good: `retained` is what makes an evicted one fail here rather than park
+	 * the fetch waiting for a sequence nothing will republish, which would leave the
+	 * subscriber with neither its fill nor the reset it is owed.
+	 *
+	 * The race only covers the subscriber leaving before the fetch settles, and closes the
+	 * group the fetch hands back afterwards so its subscription is not left behind.
 	 */
 	async #fetchFill(options: RunFill, sequence: bigint): Promise<group.Consumer> {
 		let left = false;
 		const pending = options.broadcast.fetchGroup(options.trackName, Number(sequence), {
 			priority: options.priority,
+			retained: true,
 		});
 		void pending.then(
 			(group) => {

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -5,7 +5,7 @@ import type * as group from "../group.ts";
 import * as Path from "../path.ts";
 import { type Stream, Writer } from "../stream.ts";
 import type { Timescale } from "../time.ts";
-import type * as track from "../track.ts";
+import type { Subscriber as TrackSubscriber } from "../track.ts";
 import { withTimeout } from "../util/timeout.ts";
 import type { Session } from "./adapter.ts";
 import * as Cluster from "./cluster.ts";
@@ -72,6 +72,15 @@ interface RunGroup {
 	/** The track's advertised timescale, applied to every frame timestamp. */
 	timescale: Timescale;
 
+	/**
+	 * Whether objects carry their presentation timestamp.
+	 *
+	 * False once the subscriber sends INCLUDE_PROPERTIES=0: that drops TIMESCALE from
+	 * SUBSCRIBE_OK, and a timestamp whose units were never declared is worse than none. Our
+	 * own reader discards it; another may read it as some default and time the media wrong.
+	 */
+	stamped: boolean;
+
 	/** The objects of this group the subscription's filter selects. */
 	slice: GroupSlice;
 
@@ -100,10 +109,13 @@ interface RunFill {
 	 * An independent view of the same track, used to read the cached group without consuming
 	 * anything the subscription will deliver.
 	 */
-	cache: track.Subscriber;
+	cache: TrackSubscriber;
 
 	/** The track's advertised timescale, applied to every frame timestamp. */
 	timescale: Timescale;
+
+	/** Whether objects carry their presentation timestamp; see {@link RunGroup.stamped}. */
+	stamped: boolean;
 
 	/** Settles when the subscriber leaves, releasing a fill still waiting on its group. */
 	unsubscribed: Promise<void>;
@@ -213,6 +225,10 @@ export class Publisher {
 		const priority = fromWire(msg.subscriberPriority);
 		const track = broadcast.subscribe(msg.trackName, { priority });
 
+		// Hoisted so the cleanup below reaches it: the fork happens before SUBSCRIBE_OK is
+		// written, and a write that throws must not strand the sink it attached.
+		let cache: TrackSubscriber | undefined;
+
 		try {
 			const timescale = (await track.info()).timescale;
 
@@ -241,7 +257,7 @@ export class Publisher {
 			// asking the broadcast would mint a second producer nobody has accepted.
 			const fill =
 				msg.fill && Filter.isDraft20(version) ? fillRange(msg.fill, msg.filter, edge.largest) : undefined;
-			const cache = fill && fill.kind !== "empty" ? track.fork({ priority }) : undefined;
+			cache = fill && fill.kind !== "empty" ? track.fork({ priority }) : undefined;
 
 			// Send SUBSCRIBE_OK
 			await stream.writer.u53(SubscribeOk.id);
@@ -302,6 +318,7 @@ export class Publisher {
 						requestId: msg.requestId,
 						group,
 						timescale,
+						stamped: msg.propertiesWanted,
 						slice: groupSlice(range, group.sequence),
 						unsubscribed,
 					});
@@ -312,7 +329,15 @@ export class Publisher {
 			// failures reset that stream and never touch the subscription.
 			const filling =
 				fill && cache
-					? this.#runFill({ requestId: msg.requestId, priority, fill, cache, timescale, unsubscribed })
+					? this.#runFill({
+							requestId: msg.requestId,
+							priority,
+							fill,
+							cache,
+							timescale,
+							stamped: msg.propertiesWanted,
+							unsubscribed,
+						})
 					: Promise.resolve();
 
 			let publishError: Error | undefined;
@@ -355,6 +380,9 @@ export class Publisher {
 			stream.abort(e);
 		} finally {
 			track.close();
+			// Idempotent, and the backstop for a throw between the fork and the fill starting:
+			// #runFill closes it itself on every path it reaches.
+			cache?.close();
 		}
 	}
 
@@ -362,7 +390,7 @@ export class Publisher {
 	 * Runs a group and sends its frames using ObjectStream (Subgroup delivery mode).
 	 */
 	async #runGroup(options: RunGroup) {
-		const { requestId, group, timescale, slice, unsubscribed } = options;
+		const { requestId, group, timescale, stamped, slice, unsubscribed } = options;
 		try {
 			// One stream per group is faster than a peer at its limit can retire them, so this
 			// is the one path that doesn't wait for a slot: the transport would serve the opens
@@ -384,7 +412,9 @@ export class Publisher {
 				subGroupId: 0,
 				publisherPriority: 0,
 				flags: {
-					hasExtensions: true,
+					// The object properties carry the timestamp, so there is nothing to write
+					// when the track declared no units to read one in.
+					hasExtensions: stamped,
 					hasSubgroup: false,
 					hasSubgroupObject: false,
 					hasEnd: true,
@@ -438,21 +468,21 @@ export class Publisher {
 	 * fill-failure signal. Nothing here touches the subscription either way.
 	 */
 	async #runFill(options: RunFill) {
-		const { requestId, fill, cache, timescale, unsubscribed } = options;
-		if (fill.kind === "empty") {
-			cache.close();
-			return;
-		}
-
+		const { requestId, fill, cache, timescale, stamped, unsubscribed } = options;
 		const version = this.#session.version;
-		const stream = await Writer.tryOpen(this.#quic, { cancel: unsubscribed, version });
-		if (!stream) {
-			console.debug(`fill stream failed to open: fill=${requestId}`);
-			cache.close();
-			return;
-		}
 
+		// Everything is inside the try so the cache fork is released on every path out,
+		// including a transport failure while opening the stream.
+		let stream: Writer | undefined;
 		try {
+			if (fill.kind === "empty") return;
+
+			stream = await Writer.tryOpen(this.#quic, { cancel: unsubscribed, version });
+			if (!stream) {
+				console.debug(`fill stream failed to open: fill=${requestId}`);
+				return;
+			}
+
 			await stream.u53(FetchHeader.type);
 			await new FetchHeader({ requestId }).encode(stream, version);
 
@@ -462,7 +492,7 @@ export class Publisher {
 
 			const group = takeGroup(cache, Number(fill.sequence));
 			try {
-				await this.#writeFillGroup(stream, group, fill, timescale, unsubscribed);
+				await this.#writeFillGroup(stream, group, fill, timescale, stamped, unsubscribed);
 			} finally {
 				group.close();
 			}
@@ -470,9 +500,10 @@ export class Publisher {
 			stream.close();
 			console.debug(`fill complete: fill=${requestId}`);
 		} catch (err: unknown) {
+			// A fill never fails the subscription; its own stream carries the failure.
 			const e = error(err);
 			console.debug(`fill failed, resetting its stream: fill=${requestId} error=${reason(e)}`);
-			stream.reset(e);
+			stream?.reset(e);
 		} finally {
 			cache.close();
 		}
@@ -489,6 +520,7 @@ export class Publisher {
 		group: group.Consumer,
 		fill: FillGroup,
 		timescale: Timescale,
+		stamped: boolean,
 		unsubscribed: Promise<void>,
 	) {
 		let first = true;
@@ -516,7 +548,7 @@ export class Publisher {
 			if (fill.until !== undefined && BigInt(frame.sequence) >= fill.until) break;
 			if (BigInt(frame.sequence) < fill.skip) continue;
 
-			const obj = new FetchFrame({ payload: frame.payload, timestamp: frame.timestamp });
+			const obj = new FetchFrame({ payload: frame.payload, timestamp: stamped ? frame.timestamp : undefined });
 			await obj.encode(
 				stream,
 				{ group: Number(fill.sequence), object: frame.sequence, first },
@@ -1021,7 +1053,7 @@ type FillServe =
  * would park for the life of the track. Scanning past it, or running dry, is a cache miss,
  * which the caller turns into the draft's fill-failure reset.
  */
-function takeGroup(cache: track.Subscriber, sequence: number): group.Consumer {
+function takeGroup(cache: TrackSubscriber, sequence: number): group.Consumer {
 	for (;;) {
 		const group = cache.tryRecvGroup();
 		if (!group) throw new Error(`group not found: ${sequence}`);
@@ -1038,7 +1070,7 @@ function saturatingSub(a: bigint, b: bigint): bigint {
 }
 
 /** Snapshot the live edge of a track. */
-function liveEdge(track: track.Subscriber): LiveEdge {
+function liveEdge(track: TrackSubscriber): LiveEdge {
 	const latest = track.latest();
 	if (latest === undefined) return {};
 

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -5,11 +5,15 @@ import type * as group from "../group.ts";
 import * as Path from "../path.ts";
 import { type Stream, Writer } from "../stream.ts";
 import type { Timescale } from "../time.ts";
+import type * as track from "../track.ts";
 import { withTimeout } from "../util/timeout.ts";
 import type { Session } from "./adapter.ts";
 import * as Cluster from "./cluster.ts";
-import { Frame, Group as GroupMessage } from "./object.ts";
+import { FetchHeader } from "./fetch.ts";
+import * as Filter from "./filter.ts";
+import { FetchFrame, Frame, Group as GroupMessage } from "./object.ts";
 import { fromWire } from "./priority.ts";
+import * as Properties from "./properties.ts";
 import { PublishDone } from "./publish.ts";
 import { PublishNamespace, PublishNamespaceDone, PublishNamespaceOk } from "./publish_namespace.ts";
 import { RequestError, RequestOk } from "./request.ts";
@@ -21,7 +25,7 @@ import {
 	SubscribeNamespaceOk,
 } from "./subscribe_namespace.ts";
 import { TrackStatus, type TrackStatusRequest } from "./track.ts";
-import { Version } from "./version.ts";
+import { type IetfVersion, Version } from "./version.ts";
 
 /** First wait before re-offering a namespace the peer refused or we couldn't open for. */
 const RETRY_BASE = 100;
@@ -68,7 +72,34 @@ interface RunGroup {
 	/** The track's advertised timescale, applied to every frame timestamp. */
 	timescale: Timescale;
 
+	/** The objects of this group the subscription's filter selects. */
+	slice: GroupSlice;
+
 	/** Settles when the subscriber leaves, dropping a group still queued for a stream slot. */
+	unsubscribed: Promise<void>;
+}
+
+/** What {@link Publisher.runFill} needs to serve one subscription's backfill. */
+interface RunFill {
+	/** The subscription's request ID, which the fetch stream names. */
+	requestId: bigint;
+
+	/** The subscriber's delivery priority, applied to the fetch stream. */
+	priority: number;
+
+	/** The range the fill resolved to. */
+	fill: FillServe;
+
+	/** The broadcast to read the cached group from. */
+	broadcast: broadcast.Producer;
+
+	/** The track the fill belongs to. */
+	trackName: string;
+
+	/** The track's advertised timescale, applied to every frame timestamp. */
+	timescale: Timescale;
+
+	/** Settles when the subscriber leaves, releasing a fill still waiting on its group. */
 	unsubscribed: Promise<void>;
 }
 
@@ -173,12 +204,36 @@ export class Publisher {
 			return;
 		}
 
-		const track = broadcast.subscribe(msg.trackName, { priority: fromWire(msg.subscriberPriority) });
+		const priority = fromWire(msg.subscriberPriority);
+		const track = broadcast.subscribe(msg.trackName, { priority });
 
 		try {
-			// Declaring the timescale is what opts the track into timestamps; every object
-			// Timestamp below is in these units.
 			const timescale = (await track.info()).timescale;
+
+			// The filter and any fill are relative to the live edge, so snapshot it once: the
+			// fill ends exactly where a Next Object subscription begins, which is what lets
+			// the draft's current-group join (Next Object plus a StartGroup=1 fill) cover the
+			// group with no gap and no overlap.
+			const edge = liveEdge(track);
+			const range = subscribeRange(msg, edge, version);
+
+			// The wire request tells an upstream what we need; the cursor is what actually
+			// trims this subscriber, since the producer fans every cached group out to every
+			// sink regardless. An absent start joins at the latest group, which is what
+			// moq-lite means by joining a live track.
+			track.update({
+				priority,
+				startGroup: range.start && Number(range.start.group),
+				endGroup: range.end && Number(range.end.group),
+			});
+			const startGroup = range.start ? Number(range.start.group) : track.latest();
+			if (startGroup !== undefined) track.startAt(startGroup);
+			track.endAt(range.end && Number(range.end.group));
+
+			// A fill reads the group cache through its own consumer, independent of the
+			// subscription's cursor.
+			const fill =
+				msg.fill && Filter.isDraft20(version) ? fillRange(msg.fill, msg.filter, edge.largest) : undefined;
 
 			// Send SUBSCRIBE_OK
 			await stream.writer.u53(SubscribeOk.id);
@@ -188,7 +243,17 @@ export class Publisher {
 						? msg.requestId
 						: undefined,
 				trackAlias: msg.requestId,
-				timescale,
+				// Required once the track has content; a fill-requesting subscriber sizes its
+				// backfill against this.
+				largest: edge.largest && { groupId: edge.largest.group, objectId: edge.largest.object },
+				properties: msg.propertiesWanted
+					? // Declaring the timescale is what opts the track into timestamps; every
+						// object Timestamp below is in these units. We serve the newest group
+						// first, matching moq-lite.
+						{ timescale, groupOrder: Properties.DESCENDING }
+					: // INCLUDE_PROPERTIES=0. The block stays present but empty, which also means
+						// the track opts out of timestamps for this subscriber.
+						{},
 			});
 			await ok.encode(stream.writer, version);
 			console.debug(`publish ok: broadcast=${name} track=${track.name}`);
@@ -214,13 +279,33 @@ export class Publisher {
 				for (;;) {
 					const group = await track.recvGroup();
 					if (!group) return;
-					void this.#runGroup({ requestId: msg.requestId, group, timescale, unsubscribed });
+					void this.#runGroup({
+						requestId: msg.requestId,
+						group,
+						timescale,
+						slice: groupSlice(range, group.sequence),
+						unsubscribed,
+					});
 				}
 			})();
 
+			// The fill (when one was requested) runs alongside on its own fetch stream; its
+			// failures reset that stream and never touch the subscription.
+			const filling = fill
+				? this.#runFill({
+						requestId: msg.requestId,
+						priority,
+						fill,
+						broadcast,
+						trackName: msg.trackName,
+						timescale,
+						unsubscribed,
+					})
+				: Promise.resolve();
+
 			let publishError: Error | undefined;
 			try {
-				await Promise.race([serving, stream.reader.closed]);
+				await Promise.race([Promise.all([serving, filling]), stream.reader.closed]);
 			} catch (err: unknown) {
 				publishError = error(err);
 			}
@@ -265,7 +350,7 @@ export class Publisher {
 	 * Runs a group and sends its frames using ObjectStream (Subgroup delivery mode).
 	 */
 	async #runGroup(options: RunGroup) {
-		const { requestId, group, timescale, unsubscribed } = options;
+		const { requestId, group, timescale, slice, unsubscribed } = options;
 		try {
 			// One stream per group is faster than a peer at its limit can retire them, so this
 			// is the one path that doesn't wait for a slot: the transport would serve the opens
@@ -292,19 +377,35 @@ export class Publisher {
 					hasSubgroupObject: false,
 					hasEnd: true,
 					hasPriority: true,
-					firstObject: true,
+					// Only honest when the stream really starts at the group's first object;
+					// a trimmed head starts partway through.
+					firstObject: slice.skip === 0,
 				},
 			});
 
 			await header.encode(stream, this.#session.version);
 
 			try {
+				// The first written object goes on the wire as its absolute id, so a trimmed
+				// head shows the true numbering rather than a silently renumbered group.
+				let first = true;
+				let next = 0;
+
 				for (;;) {
-					const frame = await Promise.race([group.readFrame(), stream.closed]);
+					// The filter ends inside this group: everything at `until` and beyond is
+					// outside the requested range, so stop without waiting for the group's end.
+					if (slice.until !== undefined && next >= slice.until) break;
+
+					const frame = await Promise.race([group.readFrameSequence(), stream.closed]);
 					if (!frame) break;
+					next = frame.sequence + 1;
+					if (slice.until !== undefined && frame.sequence >= slice.until) break;
+					if (frame.sequence < slice.skip) continue;
 
 					const obj = new Frame({ payload: frame.payload, timestamp: frame.timestamp });
-					await obj.encode(stream, header.flags, timescale, this.#session.version);
+					const delta = first ? frame.sequence : 0;
+					first = false;
+					await obj.encode(stream, header.flags, timescale, this.#session.version, delta);
 				}
 
 				stream.close();
@@ -313,6 +414,111 @@ export class Publisher {
 			}
 		} finally {
 			group.close();
+		}
+	}
+
+	/**
+	 * Serve a draft-20 fill on its own fetch stream: the requested range, read from the
+	 * group cache, capped at the Largest Object snapshot.
+	 *
+	 * A fill is a promise once requested. An empty range opens no stream, but a range we
+	 * cannot serve still opens one and resets it right after the FETCH_HEADER, the draft's
+	 * fill-failure signal. Nothing here touches the subscription either way.
+	 */
+	async #runFill(options: RunFill) {
+		const { requestId, fill, timescale, unsubscribed } = options;
+		if (fill.kind === "empty") return;
+
+		const version = this.#session.version;
+		const stream = await Writer.tryOpen(this.#quic, { cancel: unsubscribed, version });
+		if (!stream) {
+			console.debug(`fill stream failed to open: fill=${requestId}`);
+			return;
+		}
+
+		try {
+			await stream.u53(FetchHeader.type);
+			await new FetchHeader({ requestId }).encode(stream, version);
+
+			if (fill.kind !== "group") {
+				throw new Error("a fill spanning several groups is not supported");
+			}
+
+			const group = await this.#fetchFill(options, fill.sequence);
+			try {
+				await this.#writeFillGroup(stream, group, fill, timescale);
+			} finally {
+				group.close();
+			}
+
+			stream.close();
+			console.debug(`fill complete: fill=${requestId}`);
+		} catch (err: unknown) {
+			const e = error(err);
+			console.debug(`fill failed, resetting its stream: fill=${requestId} error=${reason(e)}`);
+			stream.reset(e);
+		}
+	}
+
+	/**
+	 * Read the fill's group out of the broadcast's cache.
+	 *
+	 * The group is at or below the Largest Object snapshot, so this resolves right away.
+	 * The race only covers the subscriber leaving in that window, and closes the group the
+	 * fetch hands back afterwards so its subscription is not left behind.
+	 */
+	async #fetchFill(options: RunFill, sequence: bigint): Promise<group.Consumer> {
+		let left = false;
+		const pending = options.broadcast.fetchGroup(options.trackName, Number(sequence), {
+			priority: options.priority,
+		});
+		void pending.then(
+			(group) => {
+				if (left) group.close();
+			},
+			() => undefined,
+		);
+
+		const group = await Promise.race([
+			pending,
+			options.unsubscribed.then(() => {
+				left = true;
+				return undefined;
+			}),
+		]);
+		if (!group) throw new Error("unsubscribed before the fill's group resolved");
+		return group;
+	}
+
+	/**
+	 * Write one cached group's frames as draft-20 fetch objects.
+	 *
+	 * The cap is the Largest Object snapshot: the group may keep growing, but everything
+	 * past the snapshot belongs to the subscription, not the fill.
+	 */
+	async #writeFillGroup(stream: Writer, group: group.Consumer, fill: FillGroup, timescale: Timescale) {
+		let first = true;
+		let next = 0n;
+
+		for (;;) {
+			// The group may keep growing, but everything at `until` and beyond belongs to the
+			// subscription, so stop without waiting for the group's end.
+			if (fill.until !== undefined && next >= fill.until) break;
+
+			const frame = await Promise.race([group.readFrameSequence(), stream.closed]);
+			if (!frame) break;
+			next = BigInt(frame.sequence) + 1n;
+			if (fill.until !== undefined && BigInt(frame.sequence) >= fill.until) break;
+			if (BigInt(frame.sequence) < fill.skip) continue;
+
+			const obj = new FetchFrame({ payload: frame.payload, timestamp: frame.timestamp });
+			await obj.encode(
+				stream,
+				{ group: Number(fill.sequence), object: frame.sequence, first },
+				timescale,
+				this.#session.version,
+			);
+			first = false;
 		}
 	}
 
@@ -718,4 +924,221 @@ export class Publisher {
 			return undefined;
 		});
 	}
+}
+
+/** A `{group, object}` position, in the Location Filter's own units. */
+interface Location {
+	/** The group's sequence number. */
+	group: bigint;
+	/** The object's id within that group. */
+	object: bigint;
+}
+
+/** Where a range ends, inclusive. An absent `object` includes the whole end group. */
+interface EndLocation {
+	/** The last group to serve. */
+	group: bigint;
+	/** The last object within it, or the whole group when absent. */
+	object?: bigint;
+}
+
+/**
+ * The live edge a SUBSCRIBE resolves against, snapshotted once so the subscription floor,
+ * the fill cap, and the advertised LARGEST_OBJECT all agree on where it is.
+ */
+interface LiveEdge {
+	/** The newest group sequence, absent before any group exists. */
+	latest?: bigint;
+
+	/**
+	 * The precise Largest Object. Absent when the track has no readable frame, in which case
+	 * nothing is advertised and no fill is servable.
+	 */
+	largest?: Location;
+
+	/**
+	 * One past the Largest Object, which is where a Next Object subscription begins. With no
+	 * readable object anywhere this falls back to the newest group's start, which excludes
+	 * nothing the cache can still name.
+	 */
+	next?: Location;
+}
+
+/** The Locations a SUBSCRIBE's Location Filter selects, resolved against the live edge. */
+interface ServeRange {
+	/** The first Location to serve, or the start of the latest group when absent. */
+	start?: Location;
+
+	/**
+	 * Where the range ends, inclusive, or open ended when absent. The subscription stays open
+	 * once the range is exhausted; draft-20 removed the notion of a filter ending one.
+	 */
+	end?: EndLocation;
+}
+
+/** The slice of one group a subscription's {@link ServeRange} selects. */
+interface GroupSlice {
+	/** Objects dropped from the front; also the first written object's absolute id. */
+	skip: number;
+
+	/** One past the last object to write, when the filter ends inside this group. */
+	until?: number;
+}
+
+/** A fill resolved to a single group of the cache. */
+interface FillGroup {
+	kind: "group";
+	/** The group to serve. */
+	sequence: bigint;
+	/** Objects dropped from the front. */
+	skip: bigint;
+	/** One past the last object to write, capping the fill at the Largest Object snapshot. */
+	until?: bigint;
+}
+
+/** What a draft-20 fill request resolves to. */
+type FillServe =
+	/** The range is empty, so no fetch stream is opened at all. */
+	| { kind: "empty" }
+	| FillGroup
+	/**
+	 * A range spanning several groups, which we do not serve: multi-group fetch
+	 * serialization depends on a negotiated group order we do not implement, so the stream is
+	 * reset instead, the draft's fill-failure signal.
+	 */
+	| { kind: "unsupported" };
+
+/** `a - b`, saturating at zero the way the draft's unsigned arithmetic does. */
+function saturatingSub(a: bigint, b: bigint): bigint {
+	return a > b ? a - b : 0n;
+}
+
+/** Snapshot the live edge of a track. */
+function liveEdge(track: track.Subscriber): LiveEdge {
+	const latest = track.latest();
+	if (latest === undefined) return {};
+
+	const largest = track.largest();
+	if (!largest) return { latest: BigInt(latest), next: { group: BigInt(latest), object: 0n } };
+
+	const group = BigInt(largest.group);
+	const object = BigInt(largest.frame);
+	return { latest: BigInt(latest), largest: { group, object }, next: { group, object: object + 1n } };
+}
+
+/**
+ * Resolve a SUBSCRIBE's Location Filter into the range to serve.
+ *
+ * Only draft-20 is honored. Earlier drafts have a Filter Type tag whose absolute forms we
+ * never served, and starting to interpret them now would change what an existing peer
+ * receives; draft-20 is also the first version whose relative forms can name a past group
+ * without the subscriber knowing Largest Object.
+ */
+function subscribeRange(msg: Subscribe, edge: LiveEdge, version: IetfVersion): ServeRange {
+	if (!Filter.isDraft20(version)) {
+		if (msg.filter.kind !== "nextObject" && msg.filter.kind !== "unfiltered") {
+			console.warn(`filter not supported before draft-20, ignoring: ${msg.filter.kind}`);
+		}
+		return {};
+	}
+
+	return filterRange(msg.filter, edge);
+}
+
+/** The Locations a single Location Filter selects, resolved against the live edge. */
+function filterRange(filter: Filter.Filter, edge: LiveEdge): ServeRange {
+	switch (filter.kind) {
+		// No restriction. moq-lite starts at the beginning of the latest group, which is the
+		// join point it is built around; a subscription passes objects as they are published,
+		// so an absent filter is not a request to replay history.
+		case "unfiltered":
+			return {};
+		// `{Largest.Group, Largest.Object + 1}`. Everything below it, including the already
+		// published head of the current group, is outside the requested range, so the join is
+		// mid-group by construction. The draft pairs this with a fill when the subscriber
+		// wants the head; see {@link Publisher.runFill}.
+		case "nextObject":
+			return { start: edge.next };
+		// `{Largest.Group + 1 - groups, 0}`: 0 is the next group and 1 is the current one.
+		// Counted from `Largest.Group`, which sits below the newest group while that group has
+		// no objects yet; only with no largest at all does the newest group stand in for it.
+		case "relative": {
+			const base = edge.largest?.group ?? edge.latest;
+			if (base === undefined) return {};
+			return { start: { group: saturatingSub(base + 1n, filter.groups), object: 0n } };
+		}
+		case "absolute":
+			return {
+				start: { group: filter.startGroup, object: filter.startObject },
+				end: filter.endGroup === undefined ? undefined : { group: filter.endGroup, object: filter.endObject },
+			};
+	}
+}
+
+/**
+ * Trim a group to the filter's object bounds, so nothing outside the requested range is
+ * sent. Interior groups are served whole.
+ */
+function groupSlice(range: ServeRange, sequence: number): GroupSlice {
+	const at = BigInt(sequence);
+	return {
+		skip: range.start?.group === at ? Number(range.start.object) : 0,
+		until: range.end?.group === at && range.end.object !== undefined ? Number(range.end.object) + 1 : undefined,
+	};
+}
+
+/**
+ * Resolve a fill request using the Fetch rules: relative to Largest Object and never
+ * extending beyond it. An omitted Location Filter inherits the subscription's.
+ */
+function fillRange(fill: Filter.Fill, subscription: Filter.Filter, largest?: Location): FillServe {
+	// A Range Filter narrows which objects pass, which we do not implement; serving the
+	// unfiltered range instead would deliver objects the peer excluded, so refuse it.
+	if (fill.rangeFilters) return { kind: "unsupported" };
+	const filter = fill.filter ?? subscription;
+
+	// Nothing published (or no precise edge to cap at) means no fill is servable; an empty
+	// range opens no stream.
+	if (!largest) return { kind: "empty" };
+
+	let start: Location;
+	switch (filter.kind) {
+		// A Fetch without a filter is the whole track up to Largest Object.
+		case "unfiltered":
+			start = { group: 0n, object: 0n };
+			break;
+		// One past the edge, which for a Fetch is always empty.
+		case "nextObject":
+			return { kind: "empty" };
+		case "relative":
+			start = { group: saturatingSub(largest.group + 1n, filter.groups), object: 0n };
+			break;
+		case "absolute":
+			start = { group: filter.startGroup, object: filter.startObject };
+			break;
+	}
+
+	// Cap the requested end at Largest Object.
+	let end: EndLocation = { group: largest.group, object: largest.object };
+	if (filter.kind === "absolute" && filter.endGroup !== undefined) {
+		const below =
+			filter.endGroup < largest.group ||
+			(filter.endGroup === largest.group && filter.endObject !== undefined && filter.endObject < largest.object);
+		if (below) end = { group: filter.endGroup, object: filter.endObject };
+	}
+
+	if (
+		start.group > end.group ||
+		(start.group === end.group && end.object !== undefined && end.object < start.object)
+	) {
+		return { kind: "empty" };
+	}
+	if (start.group !== end.group) return { kind: "unsupported" };
+
+	return {
+		kind: "group",
+		sequence: start.group,
+		skip: start.object,
+		until: end.object === undefined ? undefined : end.object + 1n,
+	};
 }

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -234,7 +234,6 @@ export class Publisher {
 			});
 			const startGroup = range.start ? Number(range.start.group) : track.latest();
 			if (startGroup !== undefined) track.startAt(startGroup);
-			track.endAt(range.end && Number(range.end.group));
 
 			// A fill reads the group cache through its own consumer, independent of the
 			// subscription's cursor.
@@ -285,6 +284,17 @@ export class Publisher {
 				for (;;) {
 					const group = await track.recvGroup();
 					if (!group) return;
+
+					// Past the filter's end. Dropped here rather than through `endAt`, which
+					// parks a capped group instead: this range is fixed for the life of the
+					// subscription, so a group above it is never coming back in, and holding
+					// one keeps the loop from ever ending. A producer that publishes beyond
+					// the end and then closes would otherwise strand PUBLISH_DONE.
+					if (range.end !== undefined && BigInt(group.sequence) > range.end.group) {
+						group.close();
+						continue;
+					}
+
 					void this.#runGroup({
 						requestId: msg.requestId,
 						group,

--- a/js/net/src/ietf/subscribe.ts
+++ b/js/net/src/ietf/subscribe.ts
@@ -1,15 +1,25 @@
 import type * as Path from "../path.ts";
 import type { Reader, Writer } from "../stream.ts";
-import type { Timescale } from "../time.ts";
 import * as Filter from "./filter.ts";
 import * as Message from "./message.ts";
 import * as Namespace from "./namespace.ts";
-import { Parameters } from "./parameters.ts";
+import { type MessageLocation, Parameters } from "./parameters.ts";
 import * as Properties from "./properties.ts";
 import { type IetfVersion, Version } from "./version.ts";
 
 // we only support Group Order descending
 const GROUP_ORDER = 0x02;
+
+/**
+ * The filter this implementation joins a live track with.
+ *
+ * moq-lite joins at the start of the current group, which is a decodable point, and
+ * draft-20's relative form is the first that can name it without knowing Largest Object.
+ * Earlier drafts only get the next Object after the live edge, which begins mid-group.
+ */
+export function joinFilter(version: IetfVersion): Filter.Filter {
+	return Filter.isDraft20(version) ? { kind: "relative", groups: 1n } : { kind: "nextObject" };
+}
 
 export class Subscribe {
 	static id = 0x03;
@@ -19,21 +29,39 @@ export class Subscribe {
 	trackName: string;
 	subscriberPriority: number;
 
+	/** Which Objects the subscription delivers, resolved by the publisher against the live edge. */
+	filter: Filter.Filter;
+
+	/** The draft-20 backfill requested alongside it, or `undefined` for none. */
+	fill?: Filter.Fill;
+
+	/** Whether the subscriber wants Track Properties on the response (INCLUDE_PROPERTIES). */
+	propertiesWanted: boolean;
+
 	constructor({
 		requestId,
 		trackNamespace,
 		trackName,
 		subscriberPriority,
+		filter,
+		fill,
+		propertiesWanted,
 	}: {
 		requestId: bigint;
 		trackNamespace: Path.Valid;
 		trackName: string;
 		subscriberPriority: number;
+		filter?: Filter.Filter;
+		fill?: Filter.Fill;
+		propertiesWanted?: boolean;
 	}) {
 		this.requestId = requestId;
 		this.trackNamespace = trackNamespace;
 		this.trackName = trackName;
 		this.subscriberPriority = subscriberPriority;
+		this.filter = filter ?? { kind: "unfiltered" };
+		this.fill = fill;
+		this.propertiesWanted = propertiesWanted ?? true;
 	}
 
 	async #encode(w: Writer, version: IetfVersion): Promise<void> {
@@ -48,7 +76,7 @@ export class Subscribe {
 			await w.u8(this.subscriberPriority);
 			await w.u8(GROUP_ORDER);
 			await w.bool(true); // forward = true
-			await w.u53(0x2); // filter type = LargestObject
+			await w.write(Filter.encode(this.filter, version));
 			await w.u53(0); // no parameters
 		} else {
 			// v15+: fields moved into parameters
@@ -56,17 +84,21 @@ export class Subscribe {
 			params.subscriberPriority = this.subscriberPriority;
 			params.groupOrder = GROUP_ORDER;
 			params.forward = true;
-			// moq-lite joins a track at the start of the current group, which is a decodable
-			// point, and draft-20's relative form is the first that can name it without
-			// knowing Largest Object. No fill is requested: the fill's fetch stream and the
-			// live subscription split the group across two streams, and this subscriber does
-			// not reassemble them into one group yet. A lenient publisher (like ours)
-			// replays the whole in-range group on the subscription instead; a strict one
-			// only delivers from the next published object, and that mid-group stream is
-			// dropped, degrading the join to the next group boundary.
-			params.subscriptionFilter = Filter.isDraft20(version)
-				? Filter.encode({ kind: "relative", groups: 1n }, version)
-				: Filter.encode({ kind: "nextObject" }, version);
+			params.subscriptionFilter = Filter.encode(this.filter, version);
+
+			// FILL_PARAMETERS and INCLUDE_PROPERTIES arrived in draft-20. An older peer reads
+			// either as an unknown parameter, which is a protocol violation, so they are
+			// dropped rather than downgraded.
+			if (Filter.isDraft20(version)) {
+				if (this.fill) {
+					params.fillParameters = Filter.encodeFill(this.fill, version);
+				}
+				// The default is 1, so only the opt-out is worth bytes.
+				if (!this.propertiesWanted) {
+					params.includeProperties = false;
+				}
+			}
+
 			await params.encode(w, version);
 		}
 	}
@@ -103,14 +135,11 @@ export class Subscribe {
 				throw new Error(`unsupported forward value: ${forward}`);
 			}
 
-			const filterType = await r.u53();
-			if (filterType !== 0x1 && filterType !== 0x2) {
-				throw new Error(`unsupported filter type: ${filterType}`);
-			}
+			const filter = await Filter.decodeInline(r);
 
 			await Parameters.decode(r, version); // ignore parameters
 
-			return new Subscribe({ requestId, trackNamespace, trackName, subscriberPriority });
+			return new Subscribe({ requestId, trackNamespace, trackName, subscriberPriority, filter });
 		}
 		// v15+: fields are in parameters
 		const params = await Parameters.decode(r, version);
@@ -128,18 +157,30 @@ export class Subscribe {
 			throw new Error(`unsupported forward value: ${forward}`);
 		}
 
-		// Parsed to reject a malformed filter, then dropped: this side always serves from
-		// the live edge, so the range does not change what it sends.
-		const filter = params.subscriptionFilter;
-		if (filter !== undefined) {
-			Filter.decode(filter, version);
-		}
-		const fill = params.fillParameters;
-		if (fill !== undefined) {
-			Filter.decodeFill(fill, version);
+		// FILL_PARAMETERS and INCLUDE_PROPERTIES are draft-20 additions. An unknown message
+		// parameter is a protocol violation, so they stay rejected on the drafts that predate
+		// them rather than being quietly tolerated.
+		const draft20 = Filter.isDraft20(version);
+		if ((params.fillParameters !== undefined || params.includeProperties !== undefined) && !draft20) {
+			throw new Error("FILL_PARAMETERS and INCLUDE_PROPERTIES need draft-20");
 		}
 
-		return new Subscribe({ requestId, trackNamespace, trackName, subscriberPriority });
+		// An absent LOCATION_FILTER means the subscription is unfiltered.
+		const raw = params.subscriptionFilter;
+		const filter = raw !== undefined ? Filter.decode(raw, version) : { kind: "unfiltered" as const };
+		const rawFill = params.fillParameters;
+		const fill = rawFill !== undefined ? Filter.decodeFill(rawFill, version) : undefined;
+
+		return new Subscribe({
+			requestId,
+			trackNamespace,
+			trackName,
+			subscriberPriority,
+			filter,
+			fill,
+			// Defaults to 1, so an absent parameter means the subscriber wants them.
+			propertiesWanted: params.includeProperties ?? true,
+		});
 	}
 }
 
@@ -150,24 +191,39 @@ export class SubscribeOk {
 	trackAlias: bigint;
 
 	/**
-	 * The track's Timescale, sent as a Track Property (draft-17+).
+	 * The largest Location in the track (LARGEST_OBJECT), which the draft requires once the
+	 * track has content. It is what a subscriber sizes a fill against.
 	 *
-	 * `undefined` declares no timeline, so the subscriber times objects by arrival.
+	 * Encoded on draft-20 only: the parameter is legal on earlier drafts too, but peers built
+	 * before we sent it reject an unexpected SUBSCRIBE_OK parameter by closing the session,
+	 * so emitting it there would break existing deployments over a hint.
 	 */
-	timescale: Timescale | undefined;
+	largest: MessageLocation | undefined;
+
+	/**
+	 * The Track Properties to send (draft-17+): the track's Timescale and our group order.
+	 *
+	 * Empty opts the response out of properties entirely, which is what a peer that sent
+	 * INCLUDE_PROPERTIES=0 asked for; declaring no Timescale also opts the track out of
+	 * timestamps, so the subscriber times objects by arrival.
+	 */
+	properties: Properties.Properties;
 
 	constructor({
 		requestId,
 		trackAlias,
-		timescale,
+		largest,
+		properties,
 	}: {
 		requestId?: bigint;
 		trackAlias: bigint;
-		timescale?: Timescale;
+		largest?: MessageLocation;
+		properties?: Properties.Properties;
 	}) {
 		this.requestId = requestId;
 		this.trackAlias = trackAlias;
-		this.timescale = timescale;
+		this.largest = largest;
+		this.properties = properties ?? {};
 	}
 
 	async #encode(w: Writer, version: IetfVersion): Promise<void> {
@@ -179,7 +235,7 @@ export class SubscribeOk {
 
 		if (version === Version.DRAFT_14) {
 			await w.u62(0n); // expires = 0
-			await w.u8(GROUP_ORDER);
+			await w.u8(this.properties.groupOrder ?? GROUP_ORDER);
 			await w.bool(false); // content exists = false
 			await w.u53(0); // no parameters
 		} else {
@@ -189,13 +245,17 @@ export class SubscribeOk {
 			// closes the session with PROTOCOL_VIOLATION when it sees one. The publisher's
 			// preference is a DEFAULT_PUBLISHER_GROUP_ORDER track property instead, which we
 			// write from draft-17 on. Draft-16 gets neither form; see Properties.encode.
-			if (version === Version.DRAFT_15) {
-				params.groupOrder = GROUP_ORDER;
+			if (version === Version.DRAFT_15 && this.properties.groupOrder !== undefined) {
+				params.groupOrder = this.properties.groupOrder;
+			}
+			// See the field doc for why LARGEST_OBJECT stays draft-20 only.
+			if (this.largest !== undefined && Filter.isDraft20(version)) {
+				params.largest = this.largest;
 			}
 			await params.encode(w, version);
 
 			// Track Properties are the final field, so nothing may follow.
-			await Properties.encode(w, { timescale: this.timescale, groupOrder: GROUP_ORDER }, version);
+			await Properties.encode(w, this.properties, version);
 		}
 	}
 
@@ -213,7 +273,8 @@ export class SubscribeOk {
 				? await r.u62()
 				: undefined;
 		const trackAlias = await r.u62();
-		let timescale: Timescale | undefined;
+		let largest: MessageLocation | undefined;
+		let properties: Properties.Properties = {};
 
 		if (version === Version.DRAFT_14) {
 			const expires = await r.u62();
@@ -225,19 +286,21 @@ export class SubscribeOk {
 
 			const contentExists = await r.bool();
 			if (contentExists) {
-				// Ignore largest group/object
-				await r.u62();
-				await r.u62();
+				const groupId = await r.u62();
+				const objectId = await r.u62();
+				largest = { groupId, objectId };
 			}
 
 			await Parameters.decode(r, version); // ignore parameters
 		} else {
-			// v15+: parameters followed by Track Properties (draft-17+)
-			await Parameters.decode(r, version);
-			timescale = (await Properties.decode(r, version)).timescale;
+			// v15+: parameters followed by Track Properties (draft-17+). LARGEST_OBJECT is
+			// required on every draft once the track has content, so rejecting it would tear
+			// down a session over a parameter compliant publishers must send.
+			largest = (await Parameters.decode(r, version)).largest;
+			properties = await Properties.decode(r, version);
 		}
 
-		return new SubscribeOk({ requestId, trackAlias, timescale });
+		return new SubscribeOk({ requestId, trackAlias, largest, properties });
 	}
 }
 

--- a/js/net/src/ietf/subscriber.ts
+++ b/js/net/src/ietf/subscriber.ts
@@ -21,7 +21,7 @@ import {
 	PublishNamespaceOk,
 } from "./publish_namespace.ts";
 import { RequestError, RequestOk } from "./request.ts";
-import { Subscribe, SubscribeError, SubscribeOk, Unsubscribe } from "./subscribe.ts";
+import { joinFilter, Subscribe, SubscribeError, SubscribeOk, Unsubscribe } from "./subscribe.ts";
 import {
 	PublishBlocked,
 	SubscribeNamespace,
@@ -583,6 +583,13 @@ export class Subscriber {
 			trackNamespace: broadcast,
 			trackName: request.name,
 			subscriberPriority: toWire(request.priority),
+			// No fill is requested: the fill's fetch stream and the live subscription split
+			// the group across two streams, and this subscriber does not reassemble them into
+			// one group yet. A lenient publisher (like ours) replays the whole in-range group
+			// on the subscription instead; a strict one only delivers from the next published
+			// object, and that mid-group stream is dropped, degrading the join to the next
+			// group boundary.
+			filter: joinFilter(version),
 		});
 		await msg.encode(state.stream.writer, version);
 		state.sent = true;
@@ -615,8 +622,9 @@ export class Subscriber {
 
 		try {
 			this.#aliases.set(ok.trackAlias, producer, { broadcast, name: request.name });
-			if (ok.timescale !== undefined) {
-				this.#timescales.set(ok.trackAlias, ok.timescale);
+			const timescale = ok.properties.timescale;
+			if (timescale !== undefined) {
+				this.#timescales.set(ok.trackAlias, timescale);
 			}
 		} catch (err) {
 			// Only one alias naming two different tracks is the session's problem. A publisher

--- a/js/net/src/track.test.ts
+++ b/js/net/src/track.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { Producer as GroupProducer } from "./group.ts";
+import { Producer as GroupProducer, MAX_GROUP_FRAMES } from "./group.ts";
 import { Timestamp } from "./time.ts";
 import { Producer as TrackProducer } from "./track.ts";
 
@@ -442,6 +442,28 @@ test("largest names the newest frame written", async () => {
 	// Reading a group does not move the edge: it is what the track produced, not what is left.
 	await subscriber.recvGroup();
 	expect(subscriber.largest()).toEqual({ group: 1, frame: 0 });
+
+	producer.close();
+});
+
+// A subscriber that arrives after the frames were written reads mirrors, and a mirror only
+// replays what is still buffered. Once a group has evicted from its front, a replay-local
+// count would put the edge below the frames actually written.
+test("largest survives a mirror replay of an evicted group", async () => {
+	const producer = new TrackProducer("test").accept();
+
+	// Overflow the group's frame cap so the front is evicted, which is the only case where
+	// the replayed frames and the frames ever written disagree.
+	const written = MAX_GROUP_FRAMES + 5;
+	const group = producer.appendGroup();
+	for (let i = 0; i < written; i++) {
+		group.writeFrame({ payload: enc.encode(`${i}`), timestamp: Timestamp.now() });
+	}
+	group.close();
+
+	// Subscribing now replays the retained window into a fresh sink.
+	const late = producer.subscribe();
+	expect(late.largest()).toEqual({ group: 0, frame: written - 1 });
 
 	producer.close();
 });

--- a/js/net/src/track.test.ts
+++ b/js/net/src/track.test.ts
@@ -414,3 +414,34 @@ test("readFrame does not livelock when a sole group finishes before the next arr
 
 	expect(await track.readString()).toBe("hello");
 }, 2000);
+
+// The IETF publisher resolves Largest Object from this, so it has to name a frame, not just
+// a group: a filter is applied down to the object.
+test("largest names the newest frame written", async () => {
+	const producer = new TrackProducer("test").accept();
+	const subscriber = producer.subscribe();
+
+	// Nothing published yet.
+	expect(subscriber.largest()).toBeUndefined();
+
+	const first = producer.appendGroup();
+	first.writeFrame({ payload: enc.encode("a"), timestamp: Timestamp.now() });
+	first.writeFrame({ payload: enc.encode("b"), timestamp: Timestamp.now() });
+	expect(subscriber.largest()).toEqual({ group: 0, frame: 1 });
+	first.close();
+
+	// A group with no frames yet has no object of its own, so the edge stays in the group
+	// before it rather than reading as an empty track.
+	const second = producer.appendGroup();
+	expect(subscriber.largest()).toEqual({ group: 0, frame: 1 });
+
+	second.writeFrame({ payload: enc.encode("c"), timestamp: Timestamp.now() });
+	expect(subscriber.largest()).toEqual({ group: 1, frame: 0 });
+	second.close();
+
+	// Reading a group does not move the edge: it is what the track produced, not what is left.
+	await subscriber.recvGroup();
+	expect(subscriber.largest()).toEqual({ group: 1, frame: 0 });
+
+	producer.close();
+});

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -191,6 +191,16 @@ export class Request {
 export interface FetchGroupOptions {
 	/** Delivery priority for the fetch stream. Defaults to `0`. */
 	priority?: number;
+
+	/**
+	 * Fail instead of waiting when the group is not in the retained window right now.
+	 *
+	 * A group at or below the live edge is either still retained or gone for good, because
+	 * nothing republishes an old sequence. Set this when fetching one: without it, a group
+	 * that has already been evicted parks the fetch for the life of the track, since a
+	 * fetch cannot otherwise tell "evicted" from "not published yet".
+	 */
+	retained?: boolean;
 }
 
 /**
@@ -760,26 +770,42 @@ export class Subscriber {
 	 */
 	async recvGroup(): Promise<GroupConsumer | undefined> {
 		for (;;) {
-			const groups = this.#state.groups.peek();
-			const { start, end } = this.#cursor.peek();
-			while (groups.length > 0 && groups[0].sequence < start) groups.shift()?.close();
-
-			// The buffer is sequence-sorted, so an in-range group that arrives behind a
-			// beyond-cap one sorts in front of it and is never blocked by it.
-			const group = groups[0];
-			if (group && (end === undefined || group.sequence <= end)) {
-				groups.shift();
-				return group;
-			}
+			const group = this.tryRecvGroup();
+			if (group) return group;
 
 			const closed = this.#state.closed.peek();
 			if (closed instanceof Error) throw closed;
 			// A group beyond the cap outlives a clean close: it becomes deliverable if
 			// the cap rises, so the track isn't over while any are held.
-			if (closed !== undefined && !group) return undefined;
+			if (closed !== undefined && !this.#state.groups.peek()[0]) return undefined;
 
 			await Signal.race(this.#state.groups, this.#cursor, this.#state.closed);
 		}
+	}
+
+	/**
+	 * Take the next buffered group without blocking, honoring the same cursor bounds as
+	 * {@link recvGroup}.
+	 *
+	 * Returns `undefined` when nothing is deliverable right now, which is not by itself the
+	 * end of the track: a group may still arrive, or one may be parked beyond the
+	 * {@link endAt} cap. Use it to drain what the retained window already holds, where
+	 * waiting for a sequence nothing will republish would park forever.
+	 */
+	tryRecvGroup(): GroupConsumer | undefined {
+		const groups = this.#state.groups.peek();
+		const { start, end } = this.#cursor.peek();
+		while (groups.length > 0 && groups[0].sequence < start) groups.shift()?.close();
+
+		// The buffer is sequence-sorted, so an in-range group that arrives behind a
+		// beyond-cap one sorts in front of it and is never blocked by it.
+		const group = groups[0];
+		if (group && (end === undefined || group.sequence <= end)) {
+			groups.shift();
+			return group;
+		}
+
+		return undefined;
 	}
 
 	/**

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -191,16 +191,6 @@ export class Request {
 export interface FetchGroupOptions {
 	/** Delivery priority for the fetch stream. Defaults to `0`. */
 	priority?: number;
-
-	/**
-	 * Fail instead of waiting when the group is not in the retained window right now.
-	 *
-	 * A group at or below the live edge is either still retained or gone for good, because
-	 * nothing republishes an old sequence. Set this when fetching one: without it, a group
-	 * that has already been evicted parks the fetch for the life of the track, since a
-	 * fetch cannot otherwise tell "evicted" from "not published yet".
-	 */
-	retained?: boolean;
 }
 
 /**
@@ -254,6 +244,8 @@ export class Consumer {
 // The shared state behind a Producer / Subscriber pair. Package-internal
 // wiring, unexported so it never appears in the published type declarations.
 class TrackState {
+	/** The producer fanning into this sink, so a subscriber can mint a sibling of itself. */
+	producer?: Producer;
 	groups = new Signal<GroupConsumer[]>([]);
 	/** Best-effort datagram channel, parallel to {@link groups}; an age-evicted send buffer per subscriber. */
 	datagrams = new Signal<BufferedDatagram[]>([]);
@@ -420,6 +412,7 @@ export class Producer {
 	// the track is open) mirror future groups into it. A late subscriber to a closed
 	// track still drains the buffered groups before seeing the end.
 	#addSink(sink: TrackState): void {
+		sink.producer = this;
 		const info = this.#state.info.peek();
 		if (info) sink.info.set(info);
 
@@ -727,6 +720,23 @@ export class Subscriber {
 			if (count > 0) return { group: groups[i].sequence, frame: count - 1 };
 		}
 		return undefined;
+	}
+
+	/**
+	 * An independent subscriber to the same track, with its own cursor and its own replay of
+	 * the retained window.
+	 *
+	 * Reads here do not consume anything this one would deliver, which is what lets a
+	 * publisher read the cache alongside the cursor it is serving from. Resolving the track
+	 * again through the broadcast would not do: a dynamic serve is one request per peer
+	 * subscription, so that mints a second producer the application has to answer separately.
+	 *
+	 * @internal Wire layers only.
+	 */
+	fork(options?: Subscription): Subscriber {
+		const producer = this.#state.producer;
+		if (!producer) throw new Error("track has no producer to fork from");
+		return producer.subscribe(options);
 	}
 
 	/** Start this subscriber's local read cursor at `sequence`, without changing its wire request. */

--- a/js/net/src/track.ts
+++ b/js/net/src/track.ts
@@ -33,6 +33,14 @@ type BufferedDatagram = { datagram: Datagram; time: number };
  */
 const MAX_DATAGRAM_BYTES = 65535;
 
+/** A position within a track: a group's sequence and a frame's index inside it. */
+export interface Location {
+	/** The group's sequence number within the track. */
+	group: number;
+	/** The frame's index within that group. */
+	frame: number;
+}
+
 /**
  * A track's immutable publisher properties, fixed for the lifetime of the track.
  *
@@ -686,6 +694,29 @@ export class Subscriber {
 	/** Return the latest group sequence observed on this track, if any. */
 	latest(): number | undefined {
 		return this.#state.latest;
+	}
+
+	/**
+	 * The newest frame this track has produced, or `undefined` while it has none.
+	 *
+	 * Read from the groups buffered for this subscriber, so nothing is consumed. A newest
+	 * group that has no frames yet falls back to the newest older group that does. It
+	 * reads as `undefined` once the newest group has been evicted or received: what is
+	 * left can no longer say where the edge is.
+	 */
+	largest(): Location | undefined {
+		const latest = this.#state.latest;
+		if (latest === undefined) return undefined;
+
+		const groups = this.#state.groups.peek();
+		const newest = groups[groups.length - 1];
+		if (!newest || newest.sequence !== latest) return undefined;
+
+		for (let i = groups.length - 1; i >= 0; i--) {
+			const count = groups[i].frameCount;
+			if (count > 0) return { group: groups[i].sequence, frame: count - 1 };
+		}
+		return undefined;
 	}
 
 	/** Start this subscriber's local read cursor at `sequence`, without changing its wire request. */


### PR DESCRIPTION
The JS IETF publisher decoded a draft-20 subscription's delivery selectors and then
threw them away. It served the retained cache plus every future group regardless of the
requested range, owed a fill-requesting subscriber neither a fetch stream nor the
fill-failure reset, and sent Track Properties to a peer that had explicitly opted out.
This brings `js/net/src/ietf/publisher.ts` to parity with the Rust publisher (#3255),
which is the model it mirrors throughout.

Closes #3281.

## What changed

**Location Filters are honored.** The filter is resolved against a live edge snapshotted
once (`liveEdge`), so the subscription floor, the fill cap, and the advertised
`LARGEST_OBJECT` all agree on where the edge is. Boundary groups are trimmed to the
filter's *object* bounds rather than just its group bounds, and a group whose head was
trimmed puts the first object's absolute id in its id delta (and clears `FIRST_OBJECT`)
instead of silently renumbering the group.

**Fills are served.** A requested fill goes out on its own `FETCH_HEADER` stream: a
single group read from the cache and capped at the Largest Object snapshot. That cap is
exactly where a Next Object subscription begins, which is what lets the draft's own
current-group join (Next Object plus a `StartGroup=1` fill) cover the group with no gap
and no overlap. A range we will not serve (one spanning several groups, or one narrowed
by a Range Filter) opens the stream and resets it right after the `FETCH_HEADER`, the
draft's fill-failure signal. An empty range opens nothing.

**`LARGEST_OBJECT` is advertised** in `SUBSCRIBE_OK` once the track has content, which is
what a fill-requesting subscriber sizes its backfill against. Draft-20 only: the
parameter is legal earlier, but peers built before we sent it close the session over an
unexpected `SUBSCRIBE_OK` parameter.

**`INCLUDE_PROPERTIES=0` reaches `SubscribeOk`,** which then sends an empty Track
Properties block instead of the timescale and group order.

Only draft-20 is honored. Earlier drafts carry a Filter Type tag whose absolute forms we
never served, and starting to interpret them now would change what an existing peer
receives; draft-20 is also the first version whose relative forms can name a past group
without the subscriber knowing Largest Object.

## Supporting changes

- **`Track.Subscriber.largest()` and `Group.Consumer.frameCount`** (`js/net/src/track.ts`,
  `group.ts`). The publisher previously had no way to name a *frame*, only a group
  sequence, so it could not resolve Largest Object at all. Both are additive.
- **`Group.Producer.mirror()` now carries the source's frame count.** It replayed only the
  still-buffered frames, so a mirror of a group that had evicted any reported a count too
  low. That count is what names a frame's absolute sequence, so the bug would have
  understated the live edge.
- **`Filter.Fill`** distinguishes an omitted Location Filter (inherit the subscription's)
  from an explicit unfiltered one, matching Rust's `Fill`, and records whether a Range
  Filter was present.
- **`Subscribe` carries its filter, fill, and properties opt-out as fields,** so the
  subscriber picks the join filter (`joinFilter`) rather than the encoder hardcoding it.
  The bytes the subscriber puts on the wire are unchanged on every draft.

## Reviewer notes

- **`SubscribeOk.timescale` became `SubscribeOk.properties`,** so the opt-out is
  expressible at all (an empty block, mirroring Rust's `Properties::default()`).
  `js/net/src/ietf/` is not re-exported from the package entrypoint, so this is not a
  break in `@moq/net`'s published surface. Hence `main` rather than `dev`.
- **Draft-14's inline filter decode used to reject the absolute tags (0x3/0x4).** Once
  `Subscribe` encodes its own `filter` field, that made our own round-trip fail. It now
  reads all four tags (`Filter.decodeInline`) and ignores what it will not serve, which is
  what Rust does: rejecting one would tear the session down over a filter the draft
  permits.
- **`Frame.decode` still refuses a non-zero object id delta,** so our own JS subscriber
  cannot read a group whose head was trimmed. That is safe only because neither the JS nor
  the Rust subscriber ever sends an absolute filter. Worth knowing if that changes.
- **The `liveEdge` snapshot must be taken before the serving loop starts.**
  `Subscriber.largest()` reads the sink's buffered group mirrors, so it goes `undefined`
  once the newest group has been handed out by `recvGroup()`.

## Testing

Six new publisher tests at draft-20 (`js/net/src/ietf/publisher.test.ts`): absolute-range
trimming across two boundary groups, the current-group join checked across both the fill's
fetch stream and the live tail, the refused multi-group fill's reset, an empty track owing
no stream, and the properties opt-out. Plus a `largest()` test in `track.test.ts` covering
the empty-newest-group walk-back.

`just check` and `just test` both pass. The diff is JS-only, so the Rust and Python halves
skip.

## Out of scope

The other half of #3281: neither subscriber *requests* a fill yet, so joining a strict
draft-20 publisher still starts at the next group boundary. That needs the fill's fetch
stream and the live tail stitched into one group producer, which is its own change.

(Written by Claude Opus 5)
