### PR TITLE
fix: repair draft-20 merge regressions

### DIFF
--- a/js/net/src/connection/accept.ts
+++ b/js/net/src/connection/accept.ts
@@ -60,7 +60,7 @@ async function acceptInner(transport: WebTransport, url: URL, props?: AcceptProp
 	};
 
 	if (protocol === Ietf.ALPN.DRAFT_20) {
-		return acceptAlpn(transport, url, Ietf.Version.DRAFT_20, discovery);
+		return acceptAlpn(transport, url, Ietf.Version.DRAFT_20, wiring);
 	}
 	if (protocol === Ietf.ALPN.DRAFT_19) {
 		return acceptAlpn(transport, url, Ietf.Version.DRAFT_19, wiring);

--- a/rs/moq-tokio/src/connect.rs
+++ b/rs/moq-tokio/src/connect.rs
@@ -150,7 +150,8 @@ pub(crate) struct Legacy {
 			"moq-transport-16",
 			"moq-transport-17",
 			"moq-transport-18",
-			"moq-transport-19"
+			"moq-transport-19",
+			"moq-transport-20"
 		),
 		hide = true
 	)]
@@ -487,7 +488,8 @@ pub struct Config {
 			"moq-transport-16",
 			"moq-transport-17",
 			"moq-transport-18",
-			"moq-transport-19"
+			"moq-transport-19",
+			"moq-transport-20"
 		)
 	)]
 	pub version: Vec<moq_net::Version>,

--- a/rs/moq-tokio/src/listen.rs
+++ b/rs/moq-tokio/src/listen.rs
@@ -66,7 +66,8 @@ pub struct Config {
 			"moq-transport-16",
 			"moq-transport-17",
 			"moq-transport-18",
-			"moq-transport-19"
+			"moq-transport-19",
+			"moq-transport-20"
 		)
 	)]
 	pub version: Vec<moq_net::Version>,
@@ -184,7 +185,8 @@ pub(crate) struct Legacy {
 			"moq-transport-16",
 			"moq-transport-17",
 			"moq-transport-18",
-			"moq-transport-19"
+			"moq-transport-19",
+			"moq-transport-20"
 		),
 		hide = true
 	)]


### PR DESCRIPTION
## Summary

- Add moq-transport-20 to the static connect and listen version choices. The draft-20 parser support was merged without updating these copied lists, so the existing synchronization test failed.
- Pass the dev branch session wiring into the draft-20 JavaScript accept path. The main-to-dev merge retained the old discovery identifier after the sibling paths migrated to SessionProps.

## Public API changes

None.

## Wire behavior changes

None.

## Test plan

- MOQ_STRICT=1 just check origin/dev
- MOQ_STRICT=1 just test default origin/dev (2,332 passed, 2 skipped)
- just test wasm (9/9 browser cases passed)

(written by GPT-5)