### PR TITLE
chore(quest): reconcile the capture parity quests with #3244

### DIFF
--- a/quest/m2/capture-linux.md
+++ b/quest/m2/capture-linux.md
@@ -2,31 +2,38 @@
 
 ## Goal
 
-Window capture and system audio work on Linux, and a chosen display can be
-captured without a human at the picker.
+Window capture and system audio work on a Wayland desktop, and app capture has
+a stated answer rather than a runtime error.
 
 ## Plan
 
-The xdg-desktop-portal owns source selection, which is what makes this
-different from the other platforms rather than merely unimplemented:
+X11 answered half of this already: `capture/x11.rs` enumerates monitors and
+windows with stable `x11:<id>` selectors, captures either natively, composites
+the XFixes cursor, and is the default when no Wayland session is running. So
+scripted capture of a chosen monitor *is* expressible on X11, and XWayland
+windows are reachable by explicit id even under Wayland.
 
-- **Windows** are not offered at all: the portal is asked for
+The portal path is what is left, and it is different in kind rather than merely
+unimplemented, because xdg-desktop-portal owns source selection:
+
+- **Windows are not offered** on Wayland: the portal is asked for
   `SourceType::Monitor` only, so the picker never shows one. Adding
   `SourceType::Window` is the change, but the portal still owns which window
-  the user picks.
-- **Display selection is not expressible.** The device selector is explicitly
-  ignored, so scripted or headless capture of a chosen monitor cannot be
-  written. Either the restore-token flow lets a previously-approved source be
-  reused without the picker, or this stays a documented limitation of the
-  portal path and the X11/DRM direct path is what answers it.
-- **System audio** needs a PipeWire monitor node, which is independent of the
-  screencast portal.
-
-App capture (every window of one process) has no portal concept behind it, so
-decide explicitly whether Linux offers it rather than leaving it as an
-unimplemented variant that errors at runtime.
+  the user picks, so there is no id to hand back.
+- **Display selection stays picker-driven.** An unqualified `--display` still
+  goes to the portal and ignores the selector. Either the restore-token flow
+  lets a previously-approved source be reused without the picker, or this stays
+  a documented limitation answered by the X11 path.
+- **System audio** needs a PipeWire monitor node.
+  `moq_audio::capture::Source::System` exists but is macOS-only and returns
+  `Unsupported` elsewhere. This is independent of the screencast portal.
+- **Applications** have no portal concept behind them, so decide explicitly
+  whether Linux offers app capture rather than leaving a variant that errors at
+  runtime.
 
 ## Related
 
 - [Windows capture parity](/quest/m2/capture-windows.md) - the same gaps,
   through Windows.Graphics.Capture and WASAPI
+- [X11 capture transport](/quest/m2/x11-capture-shm.md) - making the X11 half
+  that landed cheap enough for a full-screen share

--- a/quest/m2/capture-windows.md
+++ b/quest/m2/capture-windows.md
@@ -2,32 +2,40 @@
 
 ## Goal
 
-Window capture, app capture, system audio, and cursor capture work on Windows.
-Each landed on macOS only.
+App capture, system audio, and whole-screen cursor capture work on Windows.
+Window capture landed with the native screen capture work; these are what it
+left behind.
 
 ## Plan
 
-`capture::Source::{Window, App}` are documented "macOS only", and
-`moq_audio::capture::Source::System` likewise. Windows needs a different API
-for each:
+Window capture and its cursor now exist: `capture/window.rs` enumerates
+top-level windows, captures the selected one through GDI, composites the cursor
+when `config.cursor` asks for it, and surfaces the ids through `moq devices`.
+What remains:
 
-- **Windows and apps** need `Windows.Graphics.Capture`. Desktop Duplication is
-  whole-monitor by construction, so this is a second capture backend beside
-  the existing one rather than a flag on it. App capture (every window of a
-  process, including ones that open later) has no direct equivalent the way
-  `SCShareableContent` gives it on macOS, so it needs per-window composition
-  or an explicit decision that Windows offers window capture only.
-- **System audio** needs WASAPI loopback. Unlike macOS, this does not go
-  through the screen-capture API, so it is an independent path and does not
-  inherit the Screen Recording permission coupling.
-- **The cursor** is not captured at all today: the Desktop Duplication backend
-  handles neither `PointerShape` nor `PointerPosition`, so `config.cursor` has
-  nothing to control. macOS and Linux both honor it.
+- **Applications** (every window of a process, including ones that open later)
+  are still `Unsupported` outside macOS, where `SCShareableContent` gives it
+  almost free. Windows has no direct equivalent, so this needs per-window
+  composition or an explicit decision that Windows offers window capture only.
+  Decide that rather than leaving a variant that errors at runtime.
+- **System audio** needs WASAPI loopback. `moq_audio::capture::Source::System`
+  exists but is macOS-only and returns `Unsupported` elsewhere. Unlike macOS
+  this does not go through the screen-capture API, so it is an independent path
+  and does not inherit the Screen Recording permission coupling.
+- **The cursor on whole-screen capture** is still missing: the Desktop
+  Duplication backend handles neither `PointerShape` nor `PointerPosition`, so
+  `config.cursor` controls nothing there. Window capture and both other
+  platforms honor it, which makes this the odd one out.
 
-Also surface whatever these enumerate through `moq devices`, so a window or
-app id is discoverable rather than something the caller must already know.
+Note that the window capture that landed is GDI, which is why
+[the black-frame quest](/quest/m0/windows-window-capture-blank.md) exists: it
+reaches nothing rendered through DirectComposition. If that quest moves to
+Windows.Graphics.Capture, WGC also answers app capture and the cursor, so weigh
+these three against doing that once.
 
 ## Related
 
 - [Linux capture parity](/quest/m2/capture-linux.md) - the same gaps, through
   the portal and PipeWire
+- [Windows window capture](/quest/m0/windows-window-capture-blank.md) - the GDI
+  backend's blank output, and the WGC decision that would subsume much of this


### PR DESCRIPTION
`capture-windows.md` and `capture-linux.md` were written before [#3244](https://github.com/moq-dev/moq/pull/3244) landed native window capture, so both listed work that now exists. Verified each claim against `main` rather than assuming.

**Now done, removed from the quests**

- Windows window capture and its cursor (`capture/window.rs`), with ids surfaced through `moq devices`.
- X11 monitor and window enumeration, native capture of either, the XFixes cursor, and stable `x11:<id>` selectors. Scripted capture of a chosen monitor *is* expressible on X11, so the Linux quest no longer claims otherwise; XWayland windows are reachable by explicit id even under Wayland.

**Still open, kept**

- App capture on both platforms. Still `Unsupported` off macOS, and neither has a direct `SCShareableContent` equivalent, so the quests now ask for an explicit decision rather than leaving a variant that errors at runtime.
- System audio on both. `moq_audio::capture::Source::System` exists but is macOS-only; Windows needs WASAPI loopback and Linux a PipeWire monitor node.
- The cursor on Windows whole-screen capture. Desktop Duplication still handles neither `PointerShape` nor `PointerPosition`, which now makes it the only backend ignoring `config.cursor`.
- Portal window capture on Wayland. Still `SourceType::Monitor` only, so the picker never offers a window.

The Windows quest now points at [`windows-window-capture-blank`](https://github.com/moq-dev/moq/blob/main/quest/m0/windows-window-capture-blank.md): the window capture that landed is GDI, and if that quest moves the backend to Windows.Graphics.Capture, WGC answers app capture and the cursor too. Worth weighing those three against doing it once.

(written by Claude Opus 5)