### PR TITLE
refactor(rs): simplify poll propagation

### DIFF
--- a/rs/CLAUDE.md
+++ b/rs/CLAUDE.md
@@ -74,7 +74,7 @@ Two ways to drive things, both backed by `kio`:
 
 Sessions are caller-driven: `Client::connect` / `Server::accept` return a `(Session, Driver)` pair; nothing is spawned behind the caller's back. The `Session` is the handle, with the library's usual refcount lifecycle (clones share the connection, transport closes when the last clone drops, `abort(err)` closes explicitly). The `Driver` is the future running the protocol work: spawn it, await it in place, or step `Driver::poll(&kio::Waiter)` from another poll function. The invariant that keeps close-on-last-drop honest: **the `Driver` holds no `Session` clone**, so handing it to an executor never keeps the session alive (`moq-net/src/session.rs`). moq-native's `connect`/`ok` spawn the driver on tokio and return the plain `moq_net::Session`.
 
-Follow the root `poll_*` conventions: collapse `Poll::Pending => Poll::Pending` with `ready!(...)`, and prefer `Ok(x?)` over `.map_err(Into::into)` so a fallible poll reads `let v = ready!(inner.poll_next(cx))?;`. Representative `ready!` sites: `moq-mux/src/container/consumer.rs`, `moq-net/src/model/group.rs`.
+Follow the root `poll_*` conventions: use `ready!(...)` instead of matching `Poll::Pending => return Poll::Pending`. Both `Result<T, E>` and `Poll<Result<T, E>>` support `?` in a function returning `Poll<Result<_, _>>`; use `ready!(poll())?` when pending returns from the function, or `match poll()?` when pending needs a local arm. Prefer `Ok(x?)` over `.map_err(Into::into)`. Representative sites: `moq-mux/src/container/source.rs`, `moq-mux/src/container/ts/export.rs`.
 
 ## Version matching
 

--- a/rs/CLAUDE.md
+++ b/rs/CLAUDE.md
@@ -74,7 +74,7 @@ Two ways to drive things, both backed by `kio`:
 
 Sessions are caller-driven: `Client::connect` / `Server::accept` return a `(Session, Driver)` pair; nothing is spawned behind the caller's back. The `Session` is the handle, with the library's usual refcount lifecycle (clones share the connection, transport closes when the last clone drops, `abort(err)` closes explicitly). The `Driver` is the future running the protocol work: spawn it, await it in place, or step `Driver::poll(&kio::Waiter)` from another poll function. The invariant that keeps close-on-last-drop honest: **the `Driver` holds no `Session` clone**, so handing it to an executor never keeps the session alive (`moq-net/src/session.rs`). moq-native's `connect`/`ok` spawn the driver on tokio and return the plain `moq_net::Session`.
 
-Follow the root `poll_*` conventions: use `ready!(...)` instead of matching `Poll::Pending => return Poll::Pending`. Both `Result<T, E>` and `Poll<Result<T, E>>` support `?` in a function returning `Poll<Result<_, _>>`; use `ready!(poll())?` when pending returns from the function, or `match poll()?` when pending needs a local arm. Prefer `Ok(x?)` over `.map_err(Into::into)`. Representative sites: `moq-mux/src/container/source.rs`, `moq-mux/src/container/ts/export.rs`.
+Follow the root `poll_*` conventions: use `ready!(...)` instead of matching `Poll::Pending => return Poll::Pending`. Both `Result<T, E>` and `Poll<Result<T, E>>` support `?` in a function returning `Poll<Result<_, _>>`; use `ready!(poll())?` when pending returns from the function, or `match poll()?` when pending needs a local arm. Prefer `Ok(x?)` over `.map_err(Into::into)`.
 
 ## Version matching
 

--- a/rs/libmoq/src/consume.rs
+++ b/rs/libmoq/src/consume.rs
@@ -1,4 +1,9 @@
-use std::{ffi::c_char, future::Future, pin::Pin, task::Poll};
+use std::{
+	ffi::c_char,
+	future::Future,
+	pin::Pin,
+	task::{Poll, ready},
+};
 use tokio::sync::{mpsc, oneshot};
 
 use crate::ffi::OnStatus;
@@ -581,11 +586,9 @@ impl Consume {
 					if Self::poll_raw_control(&mut close, &mut updates, &mut track, waiter) {
 						return Poll::Ready(Ok(RawStep::Stop));
 					}
-					match track.poll_next_group(waiter) {
-						Poll::Ready(Ok(Some(group))) => Poll::Ready(Ok(RawStep::Item(group))),
-						Poll::Ready(Ok(None)) => Poll::Ready(Ok(RawStep::End)),
-						Poll::Ready(Err(err)) => Poll::Ready(Err(err.into())),
-						Poll::Pending => Poll::Pending,
+					match ready!(track.poll_next_group(waiter))? {
+						Some(group) => Poll::Ready(Ok(RawStep::Item(group))),
+						None => Poll::Ready(Ok(RawStep::End)),
 					}
 				})
 				.await?
@@ -600,11 +603,9 @@ impl Consume {
 					if Self::poll_raw_control(&mut close, &mut updates, &mut track, waiter) {
 						return Poll::Ready(Ok(RawStep::Stop));
 					}
-					match group.poll_read_frame(waiter) {
-						Poll::Ready(Ok(Some(frame))) => Poll::Ready(Ok(RawStep::Item(frame))),
-						Poll::Ready(Ok(None)) => Poll::Ready(Ok(RawStep::End)),
-						Poll::Ready(Err(err)) => Poll::Ready(Err(err.into())),
-						Poll::Pending => Poll::Pending,
+					match ready!(group.poll_read_frame(waiter))? {
+						Some(frame) => Poll::Ready(Ok(RawStep::Item(frame))),
+						None => Poll::Ready(Ok(RawStep::End)),
 					}
 				})
 				.await?

--- a/rs/moq-json/src/stream/consumer.rs
+++ b/rs/moq-json/src/stream/consumer.rs
@@ -1,6 +1,6 @@
 //! Consuming an ordered log from a track: a [`Decoder`] plus the track it reads from.
 
-use std::task::Poll;
+use std::task::{Poll, ready};
 
 use serde::de::DeserializeOwned;
 
@@ -45,26 +45,24 @@ impl<T: DeserializeOwned> Consumer<T> {
 	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<T>>> {
 		loop {
 			let Some(group) = &mut self.group else {
-				match self.track.poll_next_group(waiter)? {
-					Poll::Ready(Some(group)) => {
+				match ready!(self.track.poll_next_group(waiter)?) {
+					Some(group) => {
 						// Each group is its own compressed stream, so the window starts cold.
 						self.decoder.reset();
 						self.group = Some(group);
 						continue;
 					}
-					Poll::Ready(None) => return Poll::Ready(Ok(None)),
-					Poll::Pending => return Poll::Pending,
+					None => return Poll::Ready(Ok(None)),
 				}
 			};
 
-			match group.poll_read_frame(waiter)? {
-				Poll::Ready(Some(frame)) => return Poll::Ready(Ok(Some(self.decoder.decode(&frame.payload)?))),
-				Poll::Ready(None) => {
+			match ready!(group.poll_read_frame(waiter)?) {
+				Some(frame) => return Poll::Ready(Ok(Some(self.decoder.decode(&frame.payload)?))),
+				None => {
 					// This group is exhausted. Clear it and poll for a later one, which starts its own
 					// window; the stream ends only when the track does.
 					self.group = None;
 				}
-				Poll::Pending => return Poll::Pending,
 			}
 		}
 	}

--- a/rs/moq-json/src/window/consumer.rs
+++ b/rs/moq-json/src/window/consumer.rs
@@ -1,6 +1,6 @@
 //! Consuming a window from a track: a [`Decoder`] plus the track it reads from.
 
-use std::task::Poll;
+use std::task::{Poll, ready};
 
 use serde::de::DeserializeOwned;
 
@@ -57,29 +57,27 @@ impl<T: DeserializeOwned> Consumer<T> {
 			}
 
 			let Some(group) = &mut self.group else {
-				match self.track.poll_next_group(waiter)? {
-					Poll::Ready(Some(group)) => {
+				match ready!(self.track.poll_next_group(waiter)?) {
+					Some(group) => {
 						self.codec = Some(Codec::new());
 						self.group = Some(group);
 						continue;
 					}
-					Poll::Ready(None) => return Poll::Ready(Ok(None)),
-					Poll::Pending => return Poll::Pending,
+					None => return Poll::Ready(Ok(None)),
 				}
 			};
 
-			match group.poll_read_frame(waiter)? {
-				Poll::Ready(Some(frame)) => {
+			match ready!(group.poll_read_frame(waiter)?) {
+				Some(frame) => {
 					let codec = self.codec.as_mut().expect("an open MoQ group has a window codec");
 					self.decoder.decode(codec, &frame.payload)?;
 				}
-				Poll::Ready(None) => {
+				None => {
 					// This group is exhausted. Clear it and poll for a later one, which restates the
 					// window; the stream ends only when the track does.
 					self.group = None;
 					self.codec = None;
 				}
-				Poll::Pending => return Poll::Pending,
 			}
 		}
 	}

--- a/rs/moq-mux/src/catalog/consumer.rs
+++ b/rs/moq-mux/src/catalog/consumer.rs
@@ -60,10 +60,7 @@ impl<E: CatalogExt> Stream for Consumer<E> {
 			Self::Hang(c) => c.poll_next(waiter),
 			Self::Msf(c) => {
 				// MSF carries only the media sections, so the extension defaults.
-				let media = match ready!(c.poll_next(waiter)) {
-					Ok(media) => media,
-					Err(err) => return Poll::Ready(Err(err)),
-				};
+				let media = ready!(c.poll_next(waiter))?;
 				Poll::Ready(Ok(media.map(|m| Catalog::<E> {
 					video: m.video,
 					audio: m.audio,

--- a/rs/moq-mux/src/catalog/hang/consumer.rs
+++ b/rs/moq-mux/src/catalog/hang/consumer.rs
@@ -35,8 +35,7 @@ impl<E: CatalogExt> Consumer<E> {
 
 	/// Poll for the next catalog update.
 	pub fn poll_next(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<Catalog<E>>>> {
-		let result = ready!(self.inner.poll_next(waiter));
-		Poll::Ready(result.map_err(Into::into))
+		Poll::Ready(Ok(ready!(self.inner.poll_next(waiter))?))
 	}
 
 	/// Get the next catalog update.

--- a/rs/moq-mux/src/catalog/hang/container.rs
+++ b/rs/moq-mux/src/catalog/hang/container.rs
@@ -1,4 +1,4 @@
-use std::task::Poll;
+use std::task::{Poll, ready};
 
 use crate::container::{Container as ContainerTrait, Frame, fmp4, legacy, loc};
 
@@ -72,7 +72,7 @@ impl ContainerTrait for Container {
 	) -> Poll<Result<Option<Vec<Frame>>, Self::Error>> {
 		match self {
 			Self::Legacy => legacy::Wire.poll_read(group, waiter),
-			Self::Cmaf(cmaf) => cmaf.poll_read(group, waiter).map(|r| r.map_err(Into::into)),
+			Self::Cmaf(cmaf) => Poll::Ready(Ok(ready!(cmaf.poll_read(group, waiter))?)),
 			Self::Loc => loc::Wire.poll_read(group, waiter),
 		}
 	}

--- a/rs/moq-mux/src/catalog/msf/consumer.rs
+++ b/rs/moq-mux/src/catalog/msf/consumer.rs
@@ -1,5 +1,5 @@
 use std::str::FromStr;
-use std::task::Poll;
+use std::task::{Poll, ready};
 
 use base64::Engine;
 use hang::catalog::{AudioCodec, AudioConfig, Container, VideoCodec, VideoConfig};
@@ -39,8 +39,8 @@ impl Consumer {
 		};
 
 		if let Some(group) = &mut self.group {
-			match group.poll_read_frame(waiter)? {
-				Poll::Ready(Some(frame)) => {
+			match ready!(group.poll_read_frame(waiter)?) {
+				Some(frame) => {
 					self.group = None;
 					let json = std::str::from_utf8(&frame.payload).map_err(|_| Error::InvalidUtf8)?;
 					let msf = match moq_msf::Catalog::from_str(json) {
@@ -53,8 +53,7 @@ impl Consumer {
 					let catalog = from_msf(&msf)?;
 					return Poll::Ready(Ok(Some(catalog)));
 				}
-				Poll::Ready(None) => self.group = None,
-				Poll::Pending => return Poll::Pending,
+				None => self.group = None,
 			}
 		}
 

--- a/rs/moq-mux/src/codec/h264/export.rs
+++ b/rs/moq-mux/src/codec/h264/export.rs
@@ -12,7 +12,7 @@
 //!   Length prefixes are replaced with `00 00 00 01` start codes; SPS/PPS
 //!   extracted from the avcC are injected ahead of every keyframe.
 
-use std::task::Poll;
+use std::task::{Poll, ready};
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -96,8 +96,8 @@ impl<S: Stream> Export<S> {
 				return Poll::Pending;
 			};
 
-			match track.source.poll_read(waiter) {
-				Poll::Ready(Ok(Some(frame))) => {
+			match ready!(track.source.poll_read(waiter))? {
+				Some(frame) => {
 					let bytes = match &track.convert {
 						None => frame.payload,
 						Some(convert) => {
@@ -110,12 +110,10 @@ impl<S: Stream> Export<S> {
 					}
 					return Poll::Ready(Ok(Some(bytes)));
 				}
-				Poll::Ready(Ok(None)) => {
+				None => {
 					self.track = None;
 					continue;
 				}
-				Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-				Poll::Pending => return Poll::Pending,
 			}
 		}
 	}

--- a/rs/moq-mux/src/codec/h265/export.rs
+++ b/rs/moq-mux/src/codec/h265/export.rs
@@ -5,7 +5,7 @@
 //! hvcC) source and emits a raw Annex-B elementary stream. Timestamps are
 //! dropped.
 
-use std::task::Poll;
+use std::task::{Poll, ready};
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -88,8 +88,8 @@ impl<S: Stream> Export<S> {
 				return Poll::Pending;
 			};
 
-			match track.source.poll_read(waiter) {
-				Poll::Ready(Ok(Some(frame))) => {
+			match ready!(track.source.poll_read(waiter))? {
+				Some(frame) => {
 					let bytes = match &track.convert {
 						None => frame.payload,
 						Some(convert) => {
@@ -102,12 +102,10 @@ impl<S: Stream> Export<S> {
 					}
 					return Poll::Ready(Ok(Some(bytes)));
 				}
-				Poll::Ready(Ok(None)) => {
+				None => {
 					self.track = None;
 					continue;
 				}
-				Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-				Poll::Pending => return Poll::Pending,
 			}
 		}
 	}

--- a/rs/moq-mux/src/container/consumer.rs
+++ b/rs/moq-mux/src/container/consumer.rs
@@ -390,10 +390,8 @@ impl<F: Container> Consumer<F> {
 				let mut discontinuities = 0;
 				if self.rewind.live_edge.is_some() {
 					for group in self.pending.iter_mut().take(new_idx) {
-						match group.poll_empty(waiter) {
-							Poll::Ready(true) => discontinuities += 1,
-							Poll::Ready(false) => {}
-							Poll::Pending => return Poll::Pending,
+						if ready!(group.poll_empty(waiter)) {
+							discontinuities += 1;
 						}
 					}
 				}

--- a/rs/moq-mux/src/container/flv/export.rs
+++ b/rs/moq-mux/src/container/flv/export.rs
@@ -235,19 +235,18 @@ impl Export {
 				continue;
 			}
 			loop {
-				match track.source.poll_read(waiter) {
-					Poll::Ready(Ok(Some(frame))) => {
+				match track.source.poll_read(waiter)? {
+					Poll::Ready(Some(frame)) => {
 						if waiting_for_header && !track.source.header_ready() {
 							continue;
 						}
 						track.pending = Some(frame);
 						break;
 					}
-					Poll::Ready(Ok(None)) => {
+					Poll::Ready(None) => {
 						track.finished = true;
 						break;
 					}
-					Poll::Ready(Err(e)) => return Poll::Ready(Err(e.into())),
 					Poll::Pending => break,
 				}
 			}

--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -194,8 +194,8 @@ impl<S: Stream> Export<S> {
 				continue;
 			}
 			loop {
-				match track.source.poll_read(waiter) {
-					Poll::Ready(Ok(Some(frame))) => {
+				match track.source.poll_read(waiter)? {
+					Poll::Ready(Some(frame)) => {
 						let geometry_ready = !track.is_video
 							|| self
 								.catalog_snapshot
@@ -211,11 +211,10 @@ impl<S: Stream> Export<S> {
 						track.pending = Some(frame);
 						break;
 					}
-					Poll::Ready(Ok(None)) => {
+					Poll::Ready(None) => {
 						track.finished = true;
 						break;
 					}
-					Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
 					Poll::Pending => break,
 				}
 			}

--- a/rs/moq-mux/src/container/mkv/export.rs
+++ b/rs/moq-mux/src/container/mkv/export.rs
@@ -224,8 +224,8 @@ impl<S: Stream> Export<S> {
 				continue;
 			}
 			loop {
-				match track.source.poll_read(waiter) {
-					Poll::Ready(Ok(Some(frame))) => {
+				match track.source.poll_read(waiter)? {
+					Poll::Ready(Some(frame)) => {
 						let geometry_ready = track.kind == TrackKind::Audio
 							|| self
 								.catalog_snapshot
@@ -239,11 +239,10 @@ impl<S: Stream> Export<S> {
 						track.pending = Some(frame);
 						break;
 					}
-					Poll::Ready(Ok(None)) => {
+					Poll::Ready(None) => {
 						track.finished = true;
 						break;
 					}
-					Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
 					Poll::Pending => break,
 				}
 			}

--- a/rs/moq-mux/src/container/source.rs
+++ b/rs/moq-mux/src/container/source.rs
@@ -13,7 +13,7 @@
 //! existing `description` (for already-out-of-band sources) or the synthesized
 //! avcC/hvcC (for Annex-B sources).
 
-use std::task::Poll;
+use std::task::{Poll, ready};
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -212,11 +212,7 @@ impl ExportSource {
 				let SourceState::Requesting(pending, name) = &self.state else {
 					unreachable!("just matched Requesting");
 				};
-				match pending.poll_ok(waiter) {
-					Poll::Ready(Ok(broadcast)) => (broadcast, name.clone()),
-					Poll::Ready(Err(e)) => return Poll::Ready(Err(e.into())),
-					Poll::Pending => return Poll::Pending,
-				}
+				(ready!(pending.poll_ok(waiter))?, name.clone())
 			};
 			self.state = SourceState::Subscribing(broadcast.track(&name)?.subscribe(None));
 		}
@@ -228,11 +224,7 @@ impl ExportSource {
 				let SourceState::Subscribing(pending) = &self.state else {
 					unreachable!("just matched Subscribing");
 				};
-				match pending.poll_ok(waiter) {
-					Poll::Ready(Ok(track)) => track,
-					Poll::Ready(Err(e)) => return Poll::Ready(Err(e.into())),
-					Poll::Pending => return Poll::Pending,
-				}
+				ready!(pending.poll_ok(waiter))?
 			};
 			let media = self
 				.media
@@ -248,12 +240,10 @@ impl ExportSource {
 				let SourceState::Active(consumer) = &mut self.state else {
 					unreachable!("subscription resolved into an Active consumer");
 				};
-				match consumer.poll_read(waiter) {
-					Poll::Ready(Ok(Some(f))) => f,
-					Poll::Ready(Ok(None)) => return Poll::Ready(Ok(None)),
-					Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
-					Poll::Pending => return Poll::Pending,
-				}
+				let Some(frame) = ready!(consumer.poll_read(waiter))? else {
+					return Poll::Ready(Ok(None));
+				};
+				frame
 			};
 
 			let Some(transform) = self.transform.as_mut() else {

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -270,8 +270,8 @@ impl<E: catalog::Catalog> Export<E> {
 			}
 			let is_video = matches!(track.kind, Kind::Video(_));
 			loop {
-				match track.source.poll_read(waiter) {
-					Poll::Ready(Ok(Some(frame))) => {
+				match track.source.poll_read(waiter)? {
+					Poll::Ready(Some(frame)) => {
 						if waiting_for_header && !track.source.header_ready() {
 							continue;
 						}
@@ -285,11 +285,10 @@ impl<E: catalog::Catalog> Export<E> {
 						track.pending = Some(frame);
 						break;
 					}
-					Poll::Ready(Ok(None)) => {
+					Poll::Ready(None) => {
 						track.finished = true;
 						break;
 					}
-					Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
 					Poll::Pending => break,
 				}
 			}

--- a/rs/moq-net/src/lite/publisher.rs
+++ b/rs/moq-net/src/lite/publisher.rs
@@ -1932,18 +1932,16 @@ fn poll_recv_next(
 ) -> Poll<Result<Recv, Error>> {
 	{
 		let mut groups_finished = false;
-		match track.poll_recv_group(waiter) {
-			Poll::Ready(Ok(Some(group))) => return Poll::Ready(Ok(Recv::Group(group))),
-			Poll::Ready(Ok(None)) => groups_finished = true,
-			Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+		match track.poll_recv_group(waiter)? {
+			Poll::Ready(Some(group)) => return Poll::Ready(Ok(Recv::Group(group))),
+			Poll::Ready(None) => groups_finished = true,
 			Poll::Pending => {}
 		}
 		if datagrams {
-			match track.poll_recv_datagram(waiter) {
-				Poll::Ready(Ok(Some(datagram))) => return Poll::Ready(Ok(Recv::Datagram(datagram))),
+			match track.poll_recv_datagram(waiter)? {
+				Poll::Ready(Some(datagram)) => return Poll::Ready(Ok(Recv::Datagram(datagram))),
 				// Datagram side finished but groups are still paused/pending: keep waiting on groups.
-				Poll::Ready(Ok(None)) => {}
-				Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+				Poll::Ready(None) => {}
 				Poll::Pending => {}
 			}
 		}

--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -442,7 +442,7 @@ impl Consumer {
 	/// serving session may not have accepted it yet).
 	pub fn poll_info(&self, waiter: &kio::Waiter) -> Poll<Result<track::Info>> {
 		// Wait for the first segment (or a terminal state), then poll its info.
-		let track = match self.state.poll(waiter, |state| {
+		let track = match ready!(self.state.poll(waiter, |state| {
 			if state.abort.is_some() || !state.segments.is_empty() {
 				Poll::Ready(
 					state
@@ -453,15 +453,14 @@ impl Consumer {
 			} else {
 				Poll::Pending
 			}
-		}) {
-			Poll::Ready(Ok(res)) => res?,
-			Poll::Ready(Err(state)) => match (&state.abort, state.segments.first()) {
+		})) {
+			Ok(res) => res?,
+			Err(state) => match (&state.abort, state.segments.first()) {
 				(Some(err), _) => return Poll::Ready(Err(err.clone())),
 				(None, Some(segment)) => segment.track.clone(),
 				// Closed without ever getting a segment: nothing will resolve this.
 				(None, None) => return Poll::Ready(Err(Error::Dropped)),
 			},
-			Poll::Pending => return Poll::Pending,
 		};
 
 		track.info().poll_ok(waiter)
@@ -865,8 +864,8 @@ impl Subscriber {
 	/// error). Never consumes groups, so terminal-state pollers can share it.
 	fn poll_activate(seg: &mut SegmentSub, prefs: &Subscription, min_sequence: u64, waiter: &kio::Waiter) -> Poll<()> {
 		if let SubState::Pending(pending) = &mut seg.sub {
-			match pending.poll_ok(waiter) {
-				Poll::Ready(Ok(mut sub)) => {
+			match ready!(pending.poll_ok(waiter)) {
+				Ok(mut sub) => {
 					// Enforce the floor on the read cursor, and re-slice demand in
 					// case a boundary moved while the subscription was pending. The
 					// upper bounds (segment boundary and `end_at` cap) are enforced by
@@ -877,8 +876,7 @@ impl Subscriber {
 					seg.sub = SubState::Active(sub);
 				}
 				// The underlying track was rejected or closed: stall, not error.
-				Poll::Ready(Err(_)) => seg.sub = SubState::Done(None),
-				Poll::Pending => return Poll::Pending,
+				Err(_) => seg.sub = SubState::Done(None),
 			}
 		}
 		Poll::Ready(())
@@ -897,8 +895,8 @@ impl Subscriber {
 				SubState::Pending(_) => {
 					ready!(Self::poll_activate(seg, prefs, min_sequence, waiter));
 				}
-				SubState::Active(sub) => match sub.poll_recv_group(waiter) {
-					Poll::Ready(Ok(Some(group))) => {
+				SubState::Active(sub) => match ready!(sub.poll_recv_group(waiter)) {
+					Ok(Some(group)) => {
 						// `start_at` already floors the cursor; enforce the cap here since
 						// arrival-order reads don't honor `end_at`.
 						if let Some(end) = seg.end
@@ -908,7 +906,7 @@ impl Subscriber {
 						}
 						return Poll::Ready(Some(group));
 					}
-					Poll::Ready(Ok(None)) => {
+					Ok(None) => {
 						let count = sub.poll_finished(waiter).map(|res| res.ok());
 						let count = match count {
 							Poll::Ready(count) => count,
@@ -919,11 +917,10 @@ impl Subscriber {
 					}
 					// A dead segment stalls the logical track rather than erroring;
 					// the next switch resumes it.
-					Poll::Ready(Err(_)) => {
+					Err(_) => {
 						seg.sub = SubState::Done(None);
 						return Poll::Ready(None);
 					}
-					Poll::Pending => return Poll::Pending,
 				},
 				SubState::Done(_) => return Poll::Ready(None),
 			}
@@ -1060,14 +1057,13 @@ impl Subscriber {
 	pub fn poll_read_frame(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<frame::Frame>>> {
 		loop {
 			if let Some(group) = &mut self.reading {
-				match group.poll_read_frame(waiter) {
-					Poll::Ready(Ok(Some(frame))) => {
+				match ready!(group.poll_read_frame(waiter)) {
+					Ok(Some(frame)) => {
 						self.reading = None;
 						return Poll::Ready(Ok(Some(frame)));
 					}
 					// An empty or broken group is skipped like a gap.
-					Poll::Ready(_) => self.reading = None,
-					Poll::Pending => return Poll::Pending,
+					_ => self.reading = None,
 				}
 				continue;
 			}
@@ -1097,13 +1093,10 @@ impl Subscriber {
 		if let Some(seg) = self.segments.last_mut() {
 			if Self::poll_activate(seg, &self.last_prefs, self.min_sequence, waiter).is_pending() {
 				pending_activation = true;
-			} else if let SubState::Active(sub) = &mut seg.sub {
-				match sub.poll_recv_datagram(waiter) {
-					Poll::Ready(Ok(Some(datagram))) => return Poll::Ready(Ok(Some(datagram))),
-					// Terminal states fall through to the logical checks below.
-					Poll::Ready(_) => {}
-					Poll::Pending => return Poll::Pending,
-				}
+			} else if let SubState::Active(sub) = &mut seg.sub
+				&& let Ok(Some(datagram)) = ready!(sub.poll_recv_datagram(waiter))
+			{
+				return Poll::Ready(Ok(Some(datagram)));
 			}
 		}
 

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1235,7 +1235,7 @@ impl Producer {
 
 		let prev = &self.prev_subscription;
 		let mut combined = None;
-		let mut guard = match subs.poll(waiter, |subs| {
+		let mut guard = ready!(subs.poll(waiter, |subs| {
 			let next = combined_subscription(subs, bound, waiter);
 			if &next == prev {
 				Poll::Pending
@@ -1243,10 +1243,7 @@ impl Producer {
 				combined = next;
 				Poll::Ready(())
 			}
-		}) {
-			Poll::Ready(guard) => guard,
-			Poll::Pending => return Poll::Pending,
-		};
+		}));
 		// The aggregate changed: prune any closed subscribers now that we hold the lock.
 		guard.retain(|sub| !sub.is_closed());
 		drop(guard);

--- a/rs/moq-net/src/session.rs
+++ b/rs/moq-net/src/session.rs
@@ -2,7 +2,7 @@ use std::{
 	future::Future,
 	pin::Pin,
 	sync::Arc,
-	task::{Context, Poll},
+	task::{Context, Poll, ready},
 	time::Duration,
 };
 
@@ -310,11 +310,9 @@ impl<S: web_transport_trait::Session> SendBandwidth<S> {
 		loop {
 			match &mut self.mode {
 				SendBandwidthMode::Idle => {
-					match self.producer.poll_used(waiter) {
-						// A consumer appeared: sample immediately, then on the interval.
-						Poll::Ready(Ok(())) => {}
-						Poll::Ready(Err(_)) => return Poll::Ready(()),
-						Poll::Pending => return Poll::Pending,
+					// A consumer appeared: sample immediately, then on the interval.
+					if ready!(self.producer.poll_used(waiter)).is_err() {
+						return Poll::Ready(());
 					}
 					if self.sample().is_err() {
 						return Poll::Ready(());


### PR DESCRIPTION
## Summary

- Replace manual Pending propagation with std::task::ready!.
- Propagate fallible poll results with ? while preserving local Pending handling and custom error semantics.
- Document both poll patterns in the Rust workspace guide.

## Public API changes

- None.

## Test plan

- just fix
- just check
- just test (3,023 passed, 1 skipped)

## Cross-package sync

- Not applicable. This is an internal refactor with no wire, format, or public API changes.

(written by GPT-5)