### PR TITLE
fix(obs): format macOS package template

### DIFF
--- a/cpp/obs/cmake/macos/resources/create-package.cmake.in
+++ b/cpp/obs/cmake/macos/resources/create-package.cmake.in
@@ -1,12 +1,36 @@
 make_directory("$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/package/Library/Application Support/obs-studio/plugins")
 
-if(EXISTS "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.plugin" AND NOT IS_SYMLINK "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.plugin")
-  file(INSTALL DESTINATION "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/package/Library/Application Support/obs-studio/plugins"
-    TYPE DIRECTORY FILES "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.plugin" USE_SOURCE_PERMISSIONS)
+if(
+  EXISTS "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.plugin"
+  AND NOT IS_SYMLINK "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.plugin"
+)
+  file(
+    INSTALL
+    DESTINATION "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/package/Library/Application Support/obs-studio/plugins"
+    TYPE
+    DIRECTORY
+    FILES
+    "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.plugin"
+    USE_SOURCE_PERMISSIONS
+  )
 
-  if(CMAKE_INSTALL_CONFIG_NAME MATCHES "^([Rr][Ee][Ll][Ee][Aa][Ss][Ee])$" OR CMAKE_INSTALL_CONFIG_NAME MATCHES "^([Mm][Ii][Nn][Ss][Ii][Zz][Ee][Rr][Ee][Ll])$")
-    if(EXISTS "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.plugin.dSYM" AND NOT IS_SYMLINK "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.plugin.dSYM")
-      file(INSTALL DESTINATION "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/package/Library/Application Support/obs-studio/plugins" TYPE DIRECTORY FILES "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.plugin.dSYM" USE_SOURCE_PERMISSIONS)
+  if(
+    CMAKE_INSTALL_CONFIG_NAME MATCHES "^([Rr][Ee][Ll][Ee][Aa][Ss][Ee])$"
+    OR CMAKE_INSTALL_CONFIG_NAME MATCHES "^([Mm][Ii][Nn][Ss][Ii][Zz][Ee][Rr][Ee][Ll])$"
+  )
+    if(
+      EXISTS "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.plugin.dSYM"
+      AND NOT IS_SYMLINK "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.plugin.dSYM"
+    )
+      file(
+        INSTALL
+        DESTINATION "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/package/Library/Application Support/obs-studio/plugins"
+        TYPE
+        DIRECTORY
+        FILES
+        "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.plugin.dSYM"
+        USE_SOURCE_PERMISSIONS
+      )
     endif()
   endif()
 endif()
@@ -14,20 +38,18 @@ endif()
 make_directory("$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/temp")
 
 execute_process(
-  COMMAND /usr/bin/pkgbuild
-    --identifier '@MACOS_BUNDLEID@'
-    --version '@CMAKE_PROJECT_VERSION@'
-    --root "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/package"
-    "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/temp/@CMAKE_PROJECT_NAME@.pkg"
-    COMMAND_ERROR_IS_FATAL ANY
-  )
+  COMMAND
+    /usr/bin/pkgbuild --identifier '@MACOS_BUNDLEID@' --version '@CMAKE_PROJECT_VERSION@' --root
+    "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/package" "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/temp/@CMAKE_PROJECT_NAME@.pkg"
+  COMMAND_ERROR_IS_FATAL ANY
+)
 
 execute_process(
-  COMMAND /usr/bin/productbuild
-    --distribution "@CMAKE_CURRENT_BINARY_DIR@/distribution"
-    --package-path "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/temp"
-    "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.pkg"
-    COMMAND_ERROR_IS_FATAL ANY)
+  COMMAND
+    /usr/bin/productbuild --distribution "@CMAKE_CURRENT_BINARY_DIR@/distribution" --package-path
+    "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/temp" "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.pkg"
+  COMMAND_ERROR_IS_FATAL ANY
+)
 
 if(EXISTS "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@CMAKE_PROJECT_NAME@.pkg")
   file(REMOVE_RECURSE "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/temp")


### PR DESCRIPTION
## Summary

- format the macOS package template with the pinned gersemi version
- restore the cache workflow on both runner architectures

## Root cause

The flake.lock update changed gersemi formatting behavior. Its scoped checks did not include OBS, so the stale template reached main and the next full cache warm exposed it.

## Testing

- nix develop --command just obs check
- nix develop --command just check origin/main

(written by GPT-5)