### PR TITLE
fix(js/net): serve the rest of a group whose front evicted

### DIFF
--- a/js/net/src/group.test.ts
+++ b/js/net/src/group.test.ts
@@ -88,6 +88,34 @@ test("reading a group whose frames were evicted throws Lagged", async () => {
 	expect(consumer.readFrame()).rejects.toBeInstanceOf(Lagged);
 });
 
+test("a read that starts above the eviction window skips the gap instead of throwing", async () => {
+	const { producer, consumer } = pair(0);
+
+	// Overflow the frame cap without reading, evicting frames 0 through `extra - 1`.
+	const extra = 100;
+	for (let i = 0; i < MAX_GROUP_FRAMES + extra; i++) {
+		producer.writeFrame({ payload: new Uint8Array([i & 0xff]), timestamp: Timestamp.now() });
+	}
+
+	// `extra - 1` was the last frame evicted, so a reader that wanted it still has a gap; one
+	// above it is the lowest start that stays clear. Both are taken before the reads below,
+	// which drain the buffer a consume() handle shares with the producer.
+	const lagged = producer.mirror();
+	const clear = producer.mirror();
+
+	// Nothing at or above `from` was evicted, so the reader lost nothing it asked for and the
+	// frames below it are dropped rather than returned.
+	const from = 200;
+	expect(await consumer.readFrameSequence({ from })).toMatchObject({
+		sequence: from,
+		payload: new Uint8Array([from & 0xff]),
+	});
+	expect(await consumer.readFrameSequence({ from })).toMatchObject({ sequence: from + 1 });
+
+	await expect(lagged.readFrameSequence({ from: extra - 1 })).rejects.toBeInstanceOf(Lagged);
+	await expect(clear.readFrameSequence({ from: extra })).resolves.toMatchObject({ sequence: extra });
+});
+
 test("a group with no eviction reads every frame without error", async () => {
 	const { producer, consumer } = pair(0);
 	producer.writeFrame({ payload: new Uint8Array([1]), timestamp: Timestamp.now() });

--- a/js/net/src/group.ts
+++ b/js/net/src/group.ts
@@ -28,6 +28,18 @@ export interface Frame {
 	timestamp: Timestamp;
 }
 
+/** Options for a sequence-aware frame read. */
+export interface ReadOptions {
+	/**
+	 * The lowest sequence number the caller wants; defaults to the whole group.
+	 *
+	 * Frames below it are discarded instead of returned, and frames evicted below it are not
+	 * a gap: the read resumes at the next retained frame rather than throwing {@link Lagged}.
+	 * An eviction at or above it still throws, because the caller asked for that frame.
+	 */
+	from?: number;
+}
+
 /** Immutable group metadata. */
 export interface Info {
 	/** Sequence number of this group within its track. */
@@ -52,9 +64,16 @@ class GroupState {
 	closed = new Once<Error | null>();
 	total = new Signal<number>(0); // The total number of frames in the group thus far
 
-	// Frames evicted from the front by the cache cap. A reader that had not consumed
-	// them has a gap, so its next read throws Lagged rather than skipping silently.
-	offset = 0;
+	// Absolute sequence of the frame at the front of `frames`, advanced by a read and by an
+	// eviction alike: the sequence the next read returns.
+	start = 0;
+
+	// One past the newest frame the cache cap evicted before it could be read, or 0 when
+	// none was. A read that wanted a frame below it has a gap, so it throws Lagged rather
+	// than skipping silently; a read that starts above it never asked for the missing
+	// frames, so it proceeds.
+	evicted = 0;
+
 	cacheBytes = 0;
 
 	constructor(sequence: number) {
@@ -73,7 +92,8 @@ function appendFrame(state: GroupState, frame: Frame) {
 			const evicted = frames.shift();
 			if (!evicted) break;
 			state.cacheBytes -= evicted.payload.byteLength;
-			state.offset++;
+			state.start++;
+			state.evicted = state.start;
 		}
 	});
 
@@ -126,7 +146,8 @@ export class Producer {
 	mirror(): Consumer {
 		const dst = new GroupState(this.sequence);
 		for (const frame of this.#state.frames.peek()) appendFrame(dst, frame);
-		dst.offset = this.#state.offset;
+		dst.start = this.#state.start;
+		dst.evicted = this.#state.evicted;
 		// The replay only covers what is still buffered, so the count has to come from the
 		// source: it is what names a frame's absolute sequence, and what a publisher reads
 		// to resolve the live edge.
@@ -263,7 +284,7 @@ export class Consumer {
 		if (!frame) return undefined;
 
 		this.#state.cacheBytes -= frame.payload.byteLength;
-		return { sequence: this.#state.total.peek() - frames.length - 1, frame };
+		return { sequence: this.#state.start++, frame };
 	}
 
 	/** True once no further frames can be read: the group has closed and every buffered frame is read. */
@@ -278,7 +299,7 @@ export class Consumer {
 
 	/** True if frames were evicted from the front of this group before being read. */
 	get skipped(): boolean {
-		return this.#state.offset > 0;
+		return this.#state.evicted > 0;
 	}
 
 	/**
@@ -325,7 +346,7 @@ export class Consumer {
 	 */
 	async readFrame(): Promise<Frame | undefined> {
 		for (;;) {
-			if (this.#state.offset > 0) throw new Lagged();
+			if (this.#state.evicted > 0) throw new Lagged();
 
 			const read = this.#readBufferedFrame();
 			if (read) return read.frame;
@@ -342,12 +363,17 @@ export class Consumer {
 	 * Reads the next frame along with its sequence number within the group.
 	 * Treat the returned frame bytes as read-only; they are shared with other consumers.
 	 */
-	async readFrameSequence(): Promise<({ sequence: number } & Frame) | undefined> {
+	async readFrameSequence(options?: ReadOptions): Promise<({ sequence: number } & Frame) | undefined> {
+		const from = options?.from ?? 0;
+
 		for (;;) {
-			if (this.#state.offset > 0) throw new Lagged();
+			if (this.#state.evicted > from) throw new Lagged();
 
 			const read = this.#readBufferedFrame();
-			if (read) return { sequence: read.sequence, payload: read.frame.payload, timestamp: read.frame.timestamp };
+			if (read) {
+				if (read.sequence < from) continue;
+				return { sequence: read.sequence, payload: read.frame.payload, timestamp: read.frame.timestamp };
+			}
 
 			const closed = this.#state.closed.peek();
 			if (closed instanceof Error) throw closed;

--- a/js/net/src/ietf/publisher.test.ts
+++ b/js/net/src/ietf/publisher.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import { Producer as BroadcastProducer } from "../broadcast.ts";
 import { error } from "../error.ts";
+import { MAX_GROUP_FRAMES } from "../group.ts";
 import { createMockTransportPair } from "../mock.ts";
 import { type Origin, OriginSchema } from "../origin.ts";
 import * as Path from "../path.ts";
@@ -735,6 +736,53 @@ test("draft-20: a fill serves the current group's head on a fetch stream", async
 			sequence: 0,
 			firstObject: false,
 			objects: [{ id: 2, payload: "0.2" }],
+		});
+	} finally {
+		fx.close();
+		client.close();
+	}
+});
+
+/**
+ * A group that outgrows its cache evicts its own front, which used to fail the serving loop
+ * and forfeit every remaining object in it. A Next Object subscriber joins above the evicted
+ * prefix, so nothing it asked for was lost and the live tail is still served.
+ */
+test("draft-20: an open group that outgrew its cache still serves the live tail", async () => {
+	const fx = fixture();
+	const track = fx.broadcast.createTrack("video");
+
+	// Past the frame cap, so the oldest objects are gone before anyone subscribes.
+	const group = track.appendGroup();
+	const published = MAX_GROUP_FRAMES + 10;
+	for (let i = 0; i < published; i++) {
+		group.writeFrame({ payload: new TextEncoder().encode(`0.${i}`), timestamp: Timestamp.now() });
+	}
+
+	const { client, ok } = await runSubscribe(
+		fx,
+		new Subscribe({
+			requestId: 7n,
+			trackNamespace: Path.from("test"),
+			trackName: "video",
+			subscriberPriority: 0,
+			filter: { kind: "nextObject" },
+		}),
+	);
+
+	try {
+		expect(ok.largest).toEqual({ groupId: 0n, objectId: BigInt(published - 1) });
+
+		group.writeFrame({ payload: new TextEncoder().encode(`0.${published}`), timestamp: Timestamp.now() });
+		group.close();
+
+		const live = await nextUni(fx.uni);
+		if (!live) throw new Error("the subscription never served the live tail");
+		expect(await readGroup(live)).toEqual({
+			sequence: 0,
+			// The join is mid-group, so the stream does not start at the group's first object.
+			firstObject: false,
+			objects: [{ id: published, payload: `0.${published}` }],
 		});
 	} finally {
 		fx.close();

--- a/js/net/src/ietf/publisher.test.ts
+++ b/js/net/src/ietf/publisher.test.ts
@@ -744,9 +744,9 @@ test("draft-20: a fill serves the current group's head on a fetch stream", async
 });
 
 /**
- * A group that outgrows its cache evicts its own front, which used to fail the serving loop
- * and forfeit every remaining object in it. A Next Object subscriber joins above the evicted
- * prefix, so nothing it asked for was lost and the live tail is still served.
+ * A group that outgrows its cache evicts its own front. A Next Object subscriber joins above
+ * that evicted prefix, so it lost nothing it asked for: evicting objects the filter already
+ * excludes must not forfeit the live tail it did request.
  */
 test("draft-20: an open group that outgrew its cache still serves the live tail", async () => {
 	const fx = fixture();
@@ -784,6 +784,42 @@ test("draft-20: an open group that outgrew its cache still serves the live tail"
 			firstObject: false,
 			objects: [{ id: published, payload: `0.${published}` }],
 		});
+	} finally {
+		fx.close();
+		client.close();
+	}
+});
+
+/**
+ * An absolute filter naming one group with `startObject` above `endObject` selects nothing.
+ * Nothing rejects it on the wire, so the serving loop has to recognize the empty range and
+ * end the stream, rather than waiting on a start object the range itself excludes.
+ */
+test("draft-20: a backwards range within one group serves nothing and ends the stream", async () => {
+	const fx = fixture();
+	const track = fx.broadcast.createTrack("video");
+
+	// Deliberately left open: a hang here would outlive the group rather than end with it.
+	const group = track.appendGroup();
+	for (let i = 0; i < 3; i++) {
+		group.writeFrame({ payload: new TextEncoder().encode(`0.${i}`), timestamp: Timestamp.now() });
+	}
+
+	const { client } = await runSubscribe(
+		fx,
+		new Subscribe({
+			requestId: 7n,
+			trackNamespace: Path.from("test"),
+			trackName: "video",
+			subscriberPriority: 0,
+			filter: { kind: "absolute", startGroup: 0n, startObject: 5n, endGroup: 0n, endObject: 2n },
+		}),
+	);
+
+	try {
+		const served = await nextUni(fx.uni);
+		if (!served) throw new Error("the group stream never opened");
+		expect(await readGroup(served)).toEqual({ sequence: 0, firstObject: false, objects: [] });
 	} finally {
 		fx.close();
 		client.close();

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -431,7 +431,11 @@ export class Publisher {
 				// The first written object goes on the wire as its absolute id, so a trimmed
 				// head shows the true numbering rather than a silently renumbered group.
 				let first = true;
-				let next = 0;
+				// The next object id that could be written, which starts at the filter rather
+				// than at zero. A backwards range (`startObject` above `endObject` in the same
+				// group) is empty, and starting here is what lets the check below see that
+				// before the read parks on an object the range already excludes.
+				let next = slice.skip;
 
 				for (;;) {
 					// The filter ends inside this group: everything at `until` and beyond is

--- a/js/net/src/ietf/publisher.ts
+++ b/js/net/src/ietf/publisher.ts
@@ -438,11 +438,14 @@ export class Publisher {
 					// outside the requested range, so stop without waiting for the group's end.
 					if (slice.until !== undefined && next >= slice.until) break;
 
-					const frame = await Promise.race([group.readFrameSequence(), stream.closed]);
+					// Reading from the filter's start drops the objects below it, including any the
+					// group's cache evicted: they are outside the requested range, so losing them is
+					// not the gap that would otherwise reset this stream and forfeit the rest of the
+					// group. An eviction at or above the start is a real gap and still throws.
+					const frame = await Promise.race([group.readFrameSequence({ from: slice.skip }), stream.closed]);
 					if (!frame) break;
 					next = frame.sequence + 1;
 					if (slice.until !== undefined && frame.sequence >= slice.until) break;
-					if (frame.sequence < slice.skip) continue;
 
 					const obj = new Frame({ payload: frame.payload, timestamp: frame.timestamp });
 					const delta = first ? frame.sequence : 0;
@@ -541,12 +544,17 @@ export class Publisher {
 			// subscription, so stop without waiting for the group's end.
 			if (fill.until !== undefined && next >= fill.until) break;
 
-			const frame = await Promise.race([group.readFrameSequence(), stream.closed, cancelled]);
+			// Reading from the fill's start drops everything below it, evicted objects included;
+			// see the same read in #runGroup.
+			const frame = await Promise.race([
+				group.readFrameSequence({ from: Number(fill.skip) }),
+				stream.closed,
+				cancelled,
+			]);
 			if (left) throw new Error("unsubscribed before the fill finished");
 			if (!frame) break;
 			next = BigInt(frame.sequence) + 1n;
 			if (fill.until !== undefined && BigInt(frame.sequence) >= fill.until) break;
-			if (BigInt(frame.sequence) < fill.skip) continue;
 
 			const obj = new FetchFrame({ payload: frame.payload, timestamp: stamped ? frame.timestamp : undefined });
 			await obj.encode(


### PR DESCRIPTION
## Summary

A group evicts from its front once it passes `MAX_GROUP_FRAMES` (1024) or `MAX_GROUP_CACHE_BYTES` (32 MiB), which any long-lived or high-bitrate open group does.

**Root cause:** `Group.Consumer` tracked evictions as a *count* (`offset`), which is unqualified — it says frames went missing but not *which* sequences, because reads and evictions both pop the same front. So `readFrameSequence()` threw `Lagged` before returning anything, the IETF publisher's `#runGroup` reset that group's stream, and the subscriber lost every **future** object in the group, not just the evicted prefix. The filter's own `slice.skip` comparison was unreachable because `Lagged` threw first.

That is plainly wrong for a subscriber that asked for a sub-range. A draft-20 Next Object subscriber joins at `{Largest.Group, Largest.Object + 1}`, above everything buffered, so the evicted objects are ones it explicitly excluded — and it still lost the group.

**Fix:**
- `GroupState` tracks positions instead of a count: `start` (absolute sequence at the front of the buffer) and `evicted` (one past the newest unread-evicted frame).
- `readFrameSequence` takes an optional `from` floor. Frames below it are dropped, and an eviction below it is not a gap. An eviction at or above it still throws, so `Lagged` remains the default for a reader that wanted the whole group.
- `#runGroup` and `#writeFillGroup` pass the filter's / fill's start, which subsumes the `if (frame.sequence < skip) continue` both loops did by hand.

**The delivered group is still contiguous and in order.** The check is `evicted > from`, and evictions always pop at or after the reader's cursor, so any eviction once the reader has passed `from` throws. A served stream is therefore always first-object-absolute-id then strictly +1; a hole can never be emitted mid-stream, it becomes a stream reset. This keeps `#runGroup`'s `delta = first ? frame.sequence : 0` encoding correct.

`firstObject` needed no change: a tolerated eviction implies a non-zero start, which already reports `false`.

## Scope

This only affects `slice.skip > 0`, i.e. a peer that explicitly sent `nextObject` or an absolute filter with a non-zero `startObject`. For `relative groups=1` (what our own subscriber sends on draft-20), `unfiltered`, and all of moq-lite, `skip` is 0 and an oversized evicted group is still lost — deliberately. Without object 0 there is nothing decodable to send, so resetting and resyncing at the next group is the honest signal.

Issue #3304 is titled as though that broader case were the defect; it isn't, and the issue text should be read with this scope in mind.

## Public API changes

`js/net`, additive only (hence `main`):

- **New:** `Group.ReadOptions` interface, with one optional `from` field.
- **Changed (source-compatible):** `Group.Consumer.readFrameSequence()` gains an optional `options?: ReadOptions` parameter. Existing callers are unaffected.

No wire format change, so no `drafts/` update. Nothing else in the Cross-Package Sync table applies (the `rs/moq-net` row covers wire/API changes flowing to `js/net`, not the reverse).

## Test plan

- New unit test in `group.test.ts`: a read above the eviction window returns the retained frames and drops those below the floor, plus the exact boundary (`from = evicted` is clear, `from = evicted - 1` still throws `Lagged`).
- New integration test `draft-20: an open group that outgrew its cache still serves the live tail` in `ietf/publisher.test.ts`. Verified it fails without the fix, with `Lagged` thrown from `#runGroup`.
- `nix develop --command just check` — pass.
- `nix develop --command just test` — pass.
- `nix develop --command just fix` — no changes.

## Follow-ups (not in this PR)

- **`rs/moq-net` has the same defect.** `model/group.rs` evicts on the same 32 MiB cap and `poll_read_frame` returns `Error::Lagged` when `index < state.offset`, while `ietf/publisher.rs` does the identical `if index < slice.skip { drain }` dance. Needs its own API decision on the Rust side.
- **We serve a shape we refuse to read.** `Frame.decode` rejects *any* non-zero object-id delta, including the legal first-object case, so if our subscriber ever sent `startObject > 0` it could not read the answer. The correct rule is: accept a non-zero delta on the first object (a trimmed head), reject it on every later one (a hole or an out-of-order fill).
- **`#runFill` is the out-of-order path.** It serves a group's head on a fetch stream while the subscription serves the tail, requiring the peer to reassemble two streams into one group. Our own subscriber deliberately does not.

Fixes #3304

(Written by Claude Opus 5)