### PR TITLE
chore(quest): track the priority queue follow-ups from #3298

### DIFF
--- a/quest/m1/perf/README.md
+++ b/quest/m1/perf/README.md
@@ -51,6 +51,8 @@ measured and scoped to the quiche backend we ship today.
 - [#3202](/quest/m1/perf/3202-moq-uring-use-fixed-file-slots-for-worker-udp-sockets.md) - moq-uring: use fixed-file slots for worker UDP sockets
 - [#3204](/quest/m1/perf/3204-moq-uring-register-tx-pool-buffers-for-zero-copy-sends.md) - moq-uring: register TX-pool buffers for zero-copy sends
 - [Session micro](/quest/m1/perf/session-micro.md) - per-datagram route lookups and per-chunk stats bumps get amortized
+- [Send order width](/quest/m1/perf/send-order-width.md) - a wider transport send order lets a group rank itself instead of taking the queue lock
+- [Priority set_track wakes](/quest/m1/perf/priority-set-track-wakes.md) - a track priority change stops waking groups that end up where they started
 - [tokio local](/quest/m1/perf/tokio-local.md) - moq-tokio's pinned workers accept !Send futures like the io_uring workers do
 - [#3203](/quest/m1/perf/3203-moq-uring-add-opt-in-napi-busy-polling.md) - moq-uring: add opt-in NAPI busy polling
 - [#3205](/quest/m1/perf/3205-moq-uring-register-reusable-io-uring-enter-wait-arguments.md) - moq-uring: register reusable io_uring_enter wait arguments

--- a/quest/m1/perf/priority-set-track-wakes.md
+++ b/quest/m1/perf/priority-set-track-wakes.md
@@ -1,0 +1,41 @@
+# [S] Stop set_track waking groups that end up where they started
+
+## Goal
+
+`lite::priority`'s `set_track` re-ranks an item as `extract` then `place`. The
+extract shifts every following vec entry up one and the place shifts them back
+down, so an entry whose rank does not net-change is still woken: the shift up
+takes its parked waker, and the shift back finds nothing left to restore.
+
+A track priority change should wake only the groups whose rank actually moved.
+
+## Plan
+
+The insert and remove paths are already exact, because each performs a single
+monotone shift where every touched entry genuinely moves by one. Only the
+double mutation in `set_track` can cancel itself out.
+
+Two shapes, cheapest first:
+
+- Defer the reconcile. Have `update_location` record the touched id and leave
+  `PriorityEntry::rank` holding the last *published* rank, then compare once at
+  the end of the mutation and wake only the net movers. Simple and total, but it
+  adds a second slab lookup per shifted entry to the insert hot path, so measure
+  it against `priority_queue_insert_front` before taking it.
+- Rotate instead of remove-and-reinsert. Moving an item within the sorted vec
+  only shifts the entries strictly between its old and new index, so computing
+  that range directly is both exact and less work than the two full shifts. It
+  has to keep the vec/overflow boundary in `place` intact, including the case
+  where the re-ranked item crosses it.
+
+This predates the queue rework in #3298 and is not a regression from it; the
+wake count on this path is unchanged. It is a cold path (a SUBSCRIBE_UPDATE
+priority change), never group open or close.
+
+Acceptance: a test that parks each handle on its own waiter, calls `set_track`
+on the front entry within a range where it stays first, and asserts no other
+handle woke. No regression on the `priority_queue_insert_front` benches.
+
+## Related
+
+- [Send order width](/quest/m1/perf/send-order-width.md) - makes this moot if the queue goes away

--- a/quest/m1/perf/send-order-width.md
+++ b/quest/m1/perf/send-order-width.md
@@ -1,0 +1,60 @@
+# [L] Widen the transport send order so groups stop needing a queue
+
+## Goal
+
+`web_transport_trait::SendStream::set_priority` takes a `u8`, and that single
+signature is why the Lite publisher carries a `PriorityQueue` at all. The queue
+exists to compress an unbounded total order over live group streams,
+`(track desc, subscribe asc, group desc)`, into 256 dense ranks, which costs a
+session-wide lock, a vec shift, and a wake per reordered group.
+
+Widen the send order and most of that disappears for the backends that can
+carry it: the rank becomes a value each group computes for itself.
+
+## Plan
+
+What each backend takes natively today:
+
+- quinn: `i32`, narrowed by the trait and widened straight back.
+- browser: `sendOrder`, `long long` in the W3C spec; `web-transport-wasm` takes
+  an `i32`.
+- quiche: `stream_priority(id, urgency: u8, incremental)`, lower urgency first.
+  A real cap, not an artifact.
+- qmux: `u8`, into its own bucketed scheduler.
+
+So the split is quinn and browsers on one side, quiche and qmux on the other.
+Both sides are defaults somewhere: quiche for moq-uring, quinn for moq-tokio.
+
+An exact order-preserving pack of the full key needs 136 bits, so this only
+works because exactness is only required among *live* streams:
+
+- `group` needs no structure at all. "Newest first" is "most recently opened
+  first", so a per-subscription counter bumped at group open already ranks them.
+- `subscribe` cannot be truncated, because a session-old subscription and a
+  fresh one span an arbitrary id gap. It needs a rank among live subscriptions,
+  but that table is per-subscription rather than per-group, so it changes orders
+  of magnitude less often than the queue does today.
+
+An `i64` layout of `[track: 8][subscribe_rank: 16][group_ordinal: 39]` makes the
+per-group path a counter bump: no lock, no shift, no wake, and `GroupServe`
+loses its `poll_next` priority arm.
+
+Open question for the narrow backends. quiche's 256 urgency levels fit `track`
+exactly, and `incremental: true` would round-robin within a track, which is what
+`lite::priority`'s standing round-robin TODO wants. But it drops "newest group
+first", which is what makes a congested track shed its backlog instead of its
+live edge. Decide that before assuming quiche can drop the queue too; the
+fallback is keeping the queue on the narrow backends only, at the cost of two
+scheduling paths to hold consistent.
+
+Entry cost is a breaking `web-transport-trait` release, rippling through
+web-transport-quinn, web-transport-wasm, qmux, iroh, and moq-net's own
+`transport::poll::SendStream`.
+
+Acceptance: the wide backends open and close a group without touching a shared
+lock, the existing send-order and ordering tests pass unmodified, and `just
+bench BASE` shows no relay regression on the narrow path.
+
+## Related
+
+- [Priority set_track wakes](/quest/m1/perf/priority-set-track-wakes.md) - dead if the queue goes away

--- a/quest/m1/perf/send-order-width.md
+++ b/quest/m1/perf/send-order-width.md
@@ -26,14 +26,25 @@ So the split is quinn and browsers on one side, quiche and qmux on the other.
 Both sides are defaults somewhere: quiche for moq-uring, quinn for moq-tokio.
 
 An exact order-preserving pack of the full key needs 136 bits, so this only
-works because exactness is only required among *live* streams:
+works because exactness is only required among *live* streams. The asymmetry
+between the two unbounded fields is direction, not size:
 
-- `group` needs no structure at all. "Newest first" is "most recently opened
-  first", so a per-subscription counter bumped at group open already ranks them.
-- `subscribe` cannot be truncated, because a session-old subscription and a
-  fresh one span an arbitrary id gap. It needs a rank among live subscriptions,
-  but that table is per-subscription rather than per-group, so it changes orders
-  of magnitude less often than the queue does today.
+- `group` maps ascending to ascending. Newest first means a higher sequence
+  wants a higher send order, so it is the identity and only has to fit. Rebase
+  it per subscription as `group - base`, where base is the first sequence that
+  subscription served, saturating at zero below (ancient backlog belongs last
+  anyway) and at the field width above. 39 bits is centuries at any real group
+  rate, and nothing needs tracking beyond one `u64` per subscription.
+- `subscribe` maps ascending to descending. The lowest id wants the highest send
+  order, and inverting needs an upper bound the session does not have, since
+  subscription ids grow forever. That one needs a rank among live subscriptions.
+  The table is per-subscription rather than per-group, so it changes orders of
+  magnitude less often than the queue does today.
+
+Do not substitute a counter bumped at group open for the rebased sequence. Open
+order and sequence order diverge whenever groups arrive reordered at a relay,
+when a `Group Start` backfills, and on a FETCH range, and `Priority` orders on
+the sequence.
 
 An `i64` layout of `[track: 8][subscribe_rank: 16][group_ordinal: 39]` makes the
 per-group path a counter bump: no lock, no shift, no wake, and `GroupServe`


### PR DESCRIPTION
## Summary

Two follow-ups the priority queue rework in #3298 surfaced but did not fit.

- **[Send order width](/quest/m1/perf/send-order-width.md)** — the send order is a `u8` only because `web_transport_trait::SendStream::set_priority` is. quinn (`i32`) and browsers (`sendOrder`, `long long`) carry a wider value natively and get narrowed on the way through. With a wider one, a group can compute its own rank from a per-subscription counter instead of taking the session-wide queue lock, which would delete most of `lite::priority` and drop `GroupServe`'s `poll_next` priority arm. quiche (`urgency: u8`) and qmux (`u8`) are genuinely narrow, so whether they can follow is an open question about round-robin within a track versus newest-group-first.
- **[Priority set_track wakes](/quest/m1/perf/priority-set-track-wakes.md)** — `set_track` re-ranks as `extract` then `place`, so an entry shifted away and back is woken despite not net-moving. Found by Codex reviewing #3298; it predates that PR and the wake count on this path is unchanged by it. Cold path: a SUBSCRIBE_UPDATE priority change, never group open or close.

The second is moot if the first lands, which is why they are linked rather than blocked.

## Test plan

- `cargo run --package quest -- check` (243 documents ok)

(written by Claude Opus 5)