### PR TITLE
chore(quest): truncate the group send order instead of rebasing it

### DIFF
--- a/quest/m1/perf/send-order-width.md
+++ b/quest/m1/perf/send-order-width.md
@@ -30,25 +30,41 @@ works because exactness is only required among *live* streams. The asymmetry
 between the two unbounded fields is direction, not size:
 
 - `group` maps ascending to ascending. Newest first means a higher sequence
-  wants a higher send order, so it is the identity and only has to fit. Rebase
-  it per subscription as `group - base`, where base is the first sequence that
-  subscription served, saturating at zero below (ancient backlog belongs last
-  anyway) and at the field width above. 39 bits is centuries at any real group
-  rate, and nothing needs tracking beyond one `u64` per subscription.
+  wants a higher send order, so it is the identity and only has to fit.
+  Truncate it, `group & (WIDTH - 1)`, with no per-subscription state at all.
+  Do not rebase to the subscription's first sequence: that looks tidier but
+  collapses every group backfilled below the base onto one ordinal, losing
+  their order against each other, while truncation ranks any two groups within
+  WIDTH correctly whichever side of the start they fall on.
+
+  The cost is the wrap. When a subscription's live window straddles a boundary
+  the newest group truncates low and briefly sorts under the backlog it should
+  preempt, which is the one situation newest-first exists for. Taken
+  deliberately: it is seconds of one track being mis-ordered, it clears as the
+  window advances, and nothing downstream breaks. `append_group` advances by
+  one, so on a 39-bit field it is unreachable; it only becomes routine if the
+  field is squeezed or a producer picks sparse sequences.
 - `subscribe` maps ascending to descending. The lowest id wants the highest send
   order, and inverting needs an upper bound the session does not have, since
   subscription ids grow forever. That one needs a rank among live subscriptions.
   The table is per-subscription rather than per-group, so it changes orders of
   magnitude less often than the queue does today.
 
-Do not substitute a counter bumped at group open for the rebased sequence. Open
-order and sequence order diverge whenever groups arrive reordered at a relay,
-when a `Group Start` backfills, and on a FETCH range, and `Priority` orders on
-the sequence.
+Truncate the sequence itself; do not substitute a counter bumped at group open.
+Open order and sequence order diverge whenever groups arrive reordered at a
+relay, when a `Group Start` backfills, and on a FETCH range, and `Priority`
+orders on the sequence.
 
-An `i64` layout of `[track: 8][subscribe_rank: 16][group_ordinal: 39]` makes the
-per-group path a counter bump: no lock, no shift, no wake, and `GroupServe`
-loses its `poll_next` priority arm.
+An `i64` layout of `[track: 8][subscribe_rank: 16][group: 39]` makes the
+per-group path arithmetic over values the group already carries: no lock, no
+shift, no wake, and `GroupServe` loses its `poll_next` priority arm.
+
+Width is a real parameter rather than a free choice, because it sets how often
+that field wraps. Browsers have room to spare, but quinn caps at `i32`, so the
+same layout there is nearer `[8][8][15]` and wraps every 32k groups, which at a
+one-second GoP is every nine hours rather than never. Spend spare bits on
+`group` instead of `subscribe_rank`; live subscriptions per session number in
+the tens, so 8 bits is already generous.
 
 Open question for the narrow backends. quiche's 256 urgency levels fit `track`
 exactly, and `incremental: true` would round-robin within a track, which is what


### PR DESCRIPTION
## Summary

Follow-up to [#3318](https://github.com/moq-dev/moq/pull/3318), settling how the `group` component of a packed send order is derived.

Rebasing to the subscription's first sequence (`group - base`, saturating) reads tidier, but it collapses every group backfilled *below* that base onto ordinal 0, so they lose their order against each other. That is reachable through a `Group Start` or a FETCH. Plain truncation has no such case, ranks any two groups within the field width correctly on either side of the subscription's start, and needs no per-subscription state.

Truncation's own failure is a wrap: while a subscription's live window straddles a boundary, the newest group truncates low and briefly sorts under the backlog it should preempt. Taken deliberately, and written down as such: it clears as the window advances, and `append_group` advances the sequence by one, so a 39-bit field never reaches it.

Also records that the field width is a real parameter rather than a free choice, since it sets the wrap period. quinn caps at `i32`, which leaves `group` near 15 bits and wraps every 32k groups, so roughly every nine hours at a one-second GoP rather than never. Spare bits belong on `group`, not `subscribe_rank`.

## Test plan

- `cargo run --package quest -- check` (242 documents ok)

(written by Claude Opus 5)