### PR TITLE
chore(quest): settle the send order scalar, split out the scheduler

### DIFF
--- a/quest/m1/perf/README.md
+++ b/quest/m1/perf/README.md
@@ -51,6 +51,7 @@ measured and scoped to the quiche backend we ship today.
 - [#3204](/quest/m1/perf/3204-moq-uring-register-tx-pool-buffers-for-zero-copy-sends.md) - moq-uring: register TX-pool buffers for zero-copy sends
 - [Session micro](/quest/m1/perf/session-micro.md) - per-datagram route lookups and per-chunk stats bumps get amortized
 - [Send order width](/quest/m1/perf/send-order-width.md) - a wider transport send order lets a group rank itself instead of taking the queue lock
+- [Stream scheduler](/quest/m1/perf/stream-scheduler.md) - round-robin between equal-priority subscriptions, prototyped in a QUIC stack we own
 - [Priority set_track wakes](/quest/m1/perf/priority-set-track-wakes.md) - a track priority change stops waking groups that end up where they started
 - [tokio local](/quest/m1/perf/tokio-local.md) - moq-tokio's pinned workers accept !Send futures like the io_uring workers do
 - [#3203](/quest/m1/perf/3203-moq-uring-add-opt-in-napi-busy-polling.md) - moq-uring: add opt-in NAPI busy polling

--- a/quest/m1/perf/README.md
+++ b/quest/m1/perf/README.md
@@ -51,7 +51,7 @@ measured and scoped to the quiche backend we ship today.
 - [#3204](/quest/m1/perf/3204-moq-uring-register-tx-pool-buffers-for-zero-copy-sends.md) - moq-uring: register TX-pool buffers for zero-copy sends
 - [Session micro](/quest/m1/perf/session-micro.md) - per-datagram route lookups and per-chunk stats bumps get amortized
 - [Send order width](/quest/m1/perf/send-order-width.md) - a wider transport send order lets a group rank itself instead of taking the queue lock
-- [Stream scheduler](/quest/m1/perf/stream-scheduler.md) - round-robin between equal-priority subscriptions, prototyped in a QUIC stack we own
+- [Stream scheduler](/quest/m1/perf/stream-scheduler.md) - round-robin between equal-priority subscriptions, prototyped as a quinn patch
 - [Priority set_track wakes](/quest/m1/perf/priority-set-track-wakes.md) - a track priority change stops waking groups that end up where they started
 - [tokio local](/quest/m1/perf/tokio-local.md) - moq-tokio's pinned workers accept !Send futures like the io_uring workers do
 - [#3203](/quest/m1/perf/3203-moq-uring-add-opt-in-napi-busy-polling.md) - moq-uring: add opt-in NAPI busy polling

--- a/quest/m1/perf/send-order-width.md
+++ b/quest/m1/perf/send-order-width.md
@@ -8,8 +8,10 @@ exists to compress an unbounded total order over live group streams,
 `(track desc, subscribe asc, group desc)`, into 256 dense ranks, which costs a
 session-wide lock, a vec shift, and a wake per reordered group.
 
-Widen the send order and most of that disappears for the backends that can
-carry it: the rank becomes a value each group computes for itself.
+Widen the send order and the queue goes away on the backends that can carry it:
+each group packs its own rank from values it already holds. Ordering between
+subscriptions at the same track priority becomes undefined, deliberately, and
+fairness moves to the transport scheduler where round-robin is expressible.
 
 ## Plan
 
@@ -25,96 +27,76 @@ What each backend takes natively today:
 So the split is quinn and browsers on one side, quiche and qmux on the other.
 Both sides are defaults somewhere: quiche for moq-uring, quinn for moq-tokio.
 
-An exact order-preserving pack of the full key needs 136 bits, so this only
-works because exactness is only required among *live* streams. The asymmetry
-between the two unbounded fields is direction, not size:
+An exact order-preserving pack of the full key needs 136 bits, but the key does
+not have to survive intact. Only two of its three terms are worth carrying.
 
-- `group` maps ascending to ascending. Newest first means a higher sequence
-  wants a higher send order, so it is the identity and only has to fit.
-  Truncate it, `group & (WIDTH - 1)`, with no per-subscription state at all.
-  Do not rebase to the subscription's first sequence: that looks tidier but
-  collapses every group backfilled below the base onto one ordinal, losing
-  their order against each other, while truncation ranks any two groups within
-  WIDTH correctly whichever side of the start they fall on.
+`group` maps ascending to ascending. Newest first means a higher sequence wants
+a higher send order, so it is the identity and only has to fit. Truncate it,
+`group & (WIDTH - 1)`, with no per-subscription state at all. Do not rebase to
+the subscription's first sequence: that looks tidier but collapses every group
+backfilled below the base onto one ordinal, losing their order against each
+other, while truncation ranks any two groups within WIDTH correctly whichever
+side of the start they fall on. Truncate the sequence itself, and do not
+substitute a counter bumped at group open: open order and sequence order diverge
+whenever groups arrive reordered at a relay, when a `Group Start` backfills, and
+on a FETCH range, and `Priority` orders on the sequence.
 
-  The cost is the wrap. When a subscription's live window straddles a boundary
-  the newest group truncates low and briefly sorts under the backlog it should
-  preempt, which is the one situation newest-first exists for. Taken
-  deliberately: it is seconds of one track being mis-ordered, it clears as the
-  window advances, and nothing downstream breaks. `append_group` advances by
-  one, so on a 33-bit field it is unreachable; it only becomes routine if the
-  field is squeezed or a producer picks sparse sequences.
-- `subscribe` does not need to be ordered at all, only *present*. `Priority`
-  already declares which subscription wins a tie arbitrary, requiring only that
-  it is stable and independent of either side's direction. The field earns its
-  place by sitting above `group` in the key, which is what stops group sequence
-  from deciding between tracks.
+The cost is the wrap, when a subscription's live window straddles a boundary and
+the newest group truncates low, briefly sorting under the backlog it should
+preempt. At the widths below it is centuries away, since `append_group` advances
+by one.
 
-  So do not rank it. A rank is what would force a live-subscription table,
-  saturation handling, and a sizing argument; a mask, `subscribe & (K - 1)`, is
-  stable and direction-independent with no state whatsoever. Subscription ids
-  are sequential, so K consecutive subscriptions stay distinct and a collision
-  needs one still open K ids later. A colliding pair falls back to comparing by
-  group, so size K to make that rare, not impossible.
+`subscribe` is dropped, and same-priority ordering becomes explicitly undefined.
+A flat total order cannot express round-robin: whatever occupies that field
+picks a winner, and the winner then takes strict precedence. The current
+tie-break only reads as fair because each subscription usually has one live
+group, so they alternate as groups complete; under congestion the favoured
+subscription's backlog starves the other outright. Any packed variant inherits
+that, and a group-sequence tie-break inherits worse, because cadence decides it:
+audio at a 20ms cadence outruns video's sequence numbers by an order of
+magnitude regardless of which matters more. Promising fairness here and
+delivering precedence is worse than declaring it undefined.
 
-Truncate the sequence itself; do not substitute a counter bumped at group open.
-Open order and sequence order diverge whenever groups arrive reordered at a
-relay, when a `Group Start` backfills, and on a FETCH range, and `Priority`
-orders on the sequence.
+That leaves `[track: 8][group: rest]`.
 
-An `i64` layout of `[track: 8][subscribe: 12][group: 33]` makes the
-per-group path arithmetic over values the group already carries: no lock, no
-shift, no wake, and `GroupServe` loses its `poll_next` priority arm.
+Fairness between equal-priority subscriptions belongs in the transport
+scheduler, which is the only layer that can round-robin. The W3C primitive is
+[`sendGroup`](https://www.w3.org/TR/webtransport/#sendGroup): streams sharing a
+send group are strictly ordered by `sendOrder`, and bandwidth is allocated
+equally between send groups. One send group per subscription with
+`sendOrder = [track][group]` is the shape we want, with one catch worth knowing
+before designing around it: send groups carry no priority relative to each
+other, so a send group per subscription also flattens track priority across
+subscriptions. `sendGroup` is the tool for the equal-priority case, not a
+replacement for `sendOrder`.
 
-`track` is fixed at 8: it is a `u8` on the wire and every level is meaningful.
-So the whole budget question is how to split what is left between the other two,
-and that split is not free, because bits taken from the subscribe field lengthen
-the `group` wrap period and vice versa.
+Natively there is no equivalent. quinn schedules on a single `i32`, so
+round-robin there needs a fork or an upstream change. quiche's `incremental`
+flag round-robins within one urgency level, which is the same idea with one bit
+instead of a group id, so it cannot both round-robin between subscriptions and
+keep newest-first inside one.
 
-Do not size the subscribe field from `initial_max_streams_bidi`, which is what
-bounds live subscriptions (every control stream is bidi: `Stream::open` ->
-`open_bi`, driven here by one `max_streams` knob shared with uni streams, 1024
-in moq-tokio and 10,000 in moq-relay). That cap is the wrong input twice over:
-uni streams are one per group and dominate the budget, so subscriptions sit far
-below it, and a mask need not cover the population anyway, only keep collisions
-rare among the handful live at once. A player holds single digits. Four bits is
-likely enough and buys `group` a great deal; settle it against a real
-subscription-count distribution.
+Bit budgets, which are looser than the field types suggest:
 
-Dropping the field entirely is the one option to rule out. It looks like it
-merely leaves same-priority ordering undefined, but it does not: two such tracks
-would then compare by raw group sequence, so a long-running track sitting at
-sequence 50,000 beats one that started a minute ago at sequence 10, every time,
-until its backlog drains. That is precedence, not a tie-break, and it is exactly
-the failure the scoping exists to prevent.
-
-That makes three tiers, not two:
-
-- Browsers, 53 bits. `sendOrder` is IDL `long long`, but WebIDL converts to it
-  through `ToNumber`, so the value crosses as a double and only integers below
-  2^53 survive exactly. Past that, distinct orders round together into a silent
-  tie rather than an error, and because rounding drops the low bits it is
-  `group` that loses resolution first. A BigInt is not a way out: `ToNumber` on
-  one throws. `[8][12][33]` fits under the limit and still puts the wrap
-  centuries away. web-transport-wasm's own `set_priority` takes an `i32` today,
-  so it needs widening too, just not as far as the IDL suggests.
-- quinn, 31 bits, and `i32` is quinn's own API rather than something the trait
-  imposes, so widening `web-transport-trait` does not lift it. 31 bits are
-  usable rather than 32, and after `track` there are 23 to divide, so the mask
-  and the wrap period trade directly: `[8][8][15]` wraps every 32k groups, about
-  nine hours at a one-second GoP, while `[8][4][19]` buys six days at a 16-value
-  mask. The small end is likely fine for a player and tighter for a relay mesh
-  link; settle it against a real subscription-count distribution.
-- quiche and qmux, 8 bits. Not enough for a packed key at all; see the
-  round-robin question above.
-
-Open question for the narrow backends. quiche's 256 urgency levels fit `track`
-exactly, and `incremental: true` would round-robin within a track, which is what
-`lite::priority`'s standing round-robin TODO wants. But it drops "newest group
-first", which is what makes a congested track shed its backlog instead of its
-live edge. Decide that before assuming quiche can drop the queue too; the
-fallback is keeping the queue on the narrow backends only, at the cost of two
-scheduling paths to hold consistent.
+- quinn, 32 bits. The full `i32` range is usable, negatives included, as long as
+  the pack preserves order: build the key unsigned and store
+  `(key ^ 0x8000_0000) as i32`, so unsigned order maps onto signed order. That
+  gives `[8][24]`, and 24 bits is 16.7M groups, about 194 days at a one-second
+  GoP. `i32` is quinn's own API rather than something the trait imposes, so
+  widening `web-transport-trait` does not lift it, but at this layout it does
+  not need lifting.
+- Browsers, about 54 bits. `sendOrder` is IDL `long long`, but WebIDL converts
+  to it through `ToNumber`, so the value crosses as a double and only integers
+  within +/-(2^53 - 1) survive exactly. Past that, distinct orders round
+  together into a silent tie rather than an error, and because rounding drops
+  the low bits it is `group` that loses resolution first. A BigInt is not a way
+  out: `ToNumber` on one throws. web-transport-wasm's own `set_priority` takes
+  an `i32` today, so it needs widening too, just not as far as the IDL suggests.
+- quiche and qmux, 8 bits. `track` alone fills the alphabet, leaving nothing for
+  `group`, so these keep a queue or accept `incremental` round-robin in place of
+  newest-first. Decide that before assuming they can drop the queue; the
+  fallback is keeping the queue on the narrow backends only, at the cost of two
+  scheduling paths to hold consistent.
 
 Entry cost is a breaking `web-transport-trait` release, rippling through
 web-transport-quinn, web-transport-wasm, qmux, iroh, and moq-net's own

--- a/quest/m1/perf/send-order-width.md
+++ b/quest/m1/perf/send-order-width.md
@@ -55,7 +55,7 @@ Open order and sequence order diverge whenever groups arrive reordered at a
 relay, when a `Group Start` backfills, and on a FETCH range, and `Priority`
 orders on the sequence.
 
-An `i64` layout of `[track: 8][subscribe_rank: 12][group: 43]` makes the
+An `i64` layout of `[track: 8][subscribe_rank: 12][group: 33]` makes the
 per-group path arithmetic over values the group already carries: no lock, no
 shift, no wake, and `GroupServe` loses its `poll_next` priority arm.
 
@@ -76,9 +76,16 @@ the tie-break to a subscription exists to prevent.
 
 That makes three tiers, not two:
 
-- Browsers, 63 bits. `[8][12][43]` is comfortable, and the wrap is unreachable.
+- Browsers, 53 bits. `sendOrder` is IDL `long long`, but WebIDL converts to it
+  through `ToNumber`, so the value crosses as a double and only integers below
+  2^53 survive exactly. Past that, distinct orders round together into a silent
+  tie rather than an error, and because rounding drops the low bits it is
+  `group` that loses resolution first. A BigInt is not a way out: `ToNumber` on
+  one throws. `[8][12][33]` fits under the limit and still puts the wrap
+  centuries away. web-transport-wasm's own `set_priority` takes an `i32` today,
+  so it needs widening too, just not as far as the IDL suggests.
 - quinn, 31 bits, and `i32` is quinn's own API rather than something the trait
-  imposes. After `track` there are 23 bits to divide, so `subscribe_rank` and
+  imposes, so widening `web-transport-trait` does not lift it. After `track` there are 23 bits to divide, so `subscribe_rank` and
   the wrap period trade directly: `[8][8][15]` wraps every 32k groups, about
   nine hours at a one-second GoP, while `[8][4][19]` buys six days at 16
   subscriptions. Neither is obviously right, and a relay mesh session may hold

--- a/quest/m1/perf/send-order-width.md
+++ b/quest/m1/perf/send-order-width.md
@@ -41,10 +41,20 @@ substitute a counter bumped at group open: open order and sequence order diverge
 whenever groups arrive reordered at a relay, when a `Group Start` backfills, and
 on a FETCH range, and `Priority` orders on the sequence.
 
-The cost is the wrap, when a subscription's live window straddles a boundary and
-the newest group truncates low, briefly sorting under the backlog it should
-preempt. At the widths below it is centuries away, since `append_group` advances
-by one.
+The cost is a live window sorting under its own backlog rather than above it,
+which two cases produce and neither is remote. The wrap: 24 bits is 194 days at
+a one-second GoP but about 4 days at the 20ms audio cadence this plan uses
+elsewhere, so a long-lived dense publisher crosses a boundary regularly. And
+sparse sequences, which need no wrap at all: `append_group` advances by one, but
+`track::Producer::create_group` takes a caller-chosen `u64` and a relay
+preserves upstream numbering, so two live groups can start out more than the
+field apart.
+
+Both are bounded the same way, at one live window each time, so treat them as a
+stated boundary rather than a reason to rebase. Rebasing to the subscription's
+first sequence trades a bounded, occasional inversion for an unbounded one:
+every group backfilled below the base collapses onto a single ordinal and loses
+its order against the others permanently.
 
 `subscribe` is dropped, and same-priority ordering becomes explicitly undefined.
 A flat total order cannot express round-robin: whatever occupies that field
@@ -74,10 +84,10 @@ Bit budgets, which are looser than the field types suggest:
 - quinn, 32 bits. The full `i32` range is usable, negatives included, as long as
   the pack preserves order: build the key unsigned and store
   `(key ^ 0x8000_0000) as i32`, so unsigned order maps onto signed order. That
-  gives `[8][24]`, and 24 bits is 16.7M groups, about 194 days at a one-second
-  GoP. `i32` is quinn's own API rather than something the trait imposes, so
-  widening `web-transport-trait` does not lift it, but at this layout it does
-  not need lifting.
+  gives `[8][24]`, and 24 bits is 16.7M groups. `i32` is quinn's own API rather
+  than something the trait imposes, so widening `web-transport-trait` does not
+  lift it, and 32 bits is the whole budget: `track` is a `u8` on the wire, so
+  the 8 it takes are not negotiable and `group` gets the rest.
 - Browsers, about 54 bits. `sendOrder` is IDL `long long`, but WebIDL converts
   to it through `ToNumber`, so the value crosses as a double and only integers
   within +/-(2^53 - 1) survive exactly. Past that, distinct orders round

--- a/quest/m1/perf/send-order-width.md
+++ b/quest/m1/perf/send-order-width.md
@@ -55,16 +55,37 @@ Open order and sequence order diverge whenever groups arrive reordered at a
 relay, when a `Group Start` backfills, and on a FETCH range, and `Priority`
 orders on the sequence.
 
-An `i64` layout of `[track: 8][subscribe_rank: 16][group: 39]` makes the
+An `i64` layout of `[track: 8][subscribe_rank: 12][group: 43]` makes the
 per-group path arithmetic over values the group already carries: no lock, no
 shift, no wake, and `GroupServe` loses its `poll_next` priority arm.
 
-Width is a real parameter rather than a free choice, because it sets how often
-that field wraps. Browsers have room to spare, but quinn caps at `i32`, so the
-same layout there is nearer `[8][8][15]` and wraps every 32k groups, which at a
-one-second GoP is every nine hours rather than never. Spend spare bits on
-`group` instead of `subscribe_rank`; live subscriptions per session number in
-the tens, so 8 bits is already generous.
+`track` is fixed at 8: it is a `u8` on the wire and every level is meaningful.
+So the whole budget question is how to split what is left between the other two,
+and that split is not free, because bits taken from `subscribe_rank` lengthen
+the `group` wrap period and vice versa.
+
+`subscribe_rank` is bounded by `initial_max_streams_bidi`, since every control
+stream is a bidi stream (`Stream::open` -> `open_bi`). This repo drives that from
+one `max_streams` knob shared with uni streams: 1024 in moq-tokio, 10,000 in
+moq-relay. Uni streams are one per group and dominate that budget, so live
+subscriptions sit far below the cap. 12 bits covers 4096 with saturation beyond,
+which no real session reaches. Saturating is not free either, so size it to
+avoid: colliding ranks make two subscriptions tie, and the tie-break then falls
+through to `group`, which is exactly the cross-track interleaving that scoping
+the tie-break to a subscription exists to prevent.
+
+That makes three tiers, not two:
+
+- Browsers, 63 bits. `[8][12][43]` is comfortable, and the wrap is unreachable.
+- quinn, 31 bits, and `i32` is quinn's own API rather than something the trait
+  imposes. After `track` there are 23 bits to divide, so `subscribe_rank` and
+  the wrap period trade directly: `[8][8][15]` wraps every 32k groups, about
+  nine hours at a one-second GoP, while `[8][4][19]` buys six days at 16
+  subscriptions. Neither is obviously right, and a relay mesh session may hold
+  more subscriptions than the small end allows. Decide this with a real
+  subscription-count distribution, not from the cap.
+- quiche and qmux, 8 bits. Not enough for a packed key at all; see the
+  round-robin question above.
 
 Open question for the narrow backends. quiche's 256 urgency levels fit `track`
 exactly, and `incremental: true` would round-robin within a track, which is what

--- a/quest/m1/perf/send-order-width.md
+++ b/quest/m1/perf/send-order-width.md
@@ -42,37 +42,51 @@ between the two unbounded fields is direction, not size:
   preempt, which is the one situation newest-first exists for. Taken
   deliberately: it is seconds of one track being mis-ordered, it clears as the
   window advances, and nothing downstream breaks. `append_group` advances by
-  one, so on a 39-bit field it is unreachable; it only becomes routine if the
+  one, so on a 33-bit field it is unreachable; it only becomes routine if the
   field is squeezed or a producer picks sparse sequences.
-- `subscribe` maps ascending to descending. The lowest id wants the highest send
-  order, and inverting needs an upper bound the session does not have, since
-  subscription ids grow forever. That one needs a rank among live subscriptions.
-  The table is per-subscription rather than per-group, so it changes orders of
-  magnitude less often than the queue does today.
+- `subscribe` does not need to be ordered at all, only *present*. `Priority`
+  already declares which subscription wins a tie arbitrary, requiring only that
+  it is stable and independent of either side's direction. The field earns its
+  place by sitting above `group` in the key, which is what stops group sequence
+  from deciding between tracks.
+
+  So do not rank it. A rank is what would force a live-subscription table,
+  saturation handling, and a sizing argument; a mask, `subscribe & (K - 1)`, is
+  stable and direction-independent with no state whatsoever. Subscription ids
+  are sequential, so K consecutive subscriptions stay distinct and a collision
+  needs one still open K ids later. A colliding pair falls back to comparing by
+  group, so size K to make that rare, not impossible.
 
 Truncate the sequence itself; do not substitute a counter bumped at group open.
 Open order and sequence order diverge whenever groups arrive reordered at a
 relay, when a `Group Start` backfills, and on a FETCH range, and `Priority`
 orders on the sequence.
 
-An `i64` layout of `[track: 8][subscribe_rank: 12][group: 33]` makes the
+An `i64` layout of `[track: 8][subscribe: 12][group: 33]` makes the
 per-group path arithmetic over values the group already carries: no lock, no
 shift, no wake, and `GroupServe` loses its `poll_next` priority arm.
 
 `track` is fixed at 8: it is a `u8` on the wire and every level is meaningful.
 So the whole budget question is how to split what is left between the other two,
-and that split is not free, because bits taken from `subscribe_rank` lengthen
+and that split is not free, because bits taken from the subscribe field lengthen
 the `group` wrap period and vice versa.
 
-`subscribe_rank` is bounded by `initial_max_streams_bidi`, since every control
-stream is a bidi stream (`Stream::open` -> `open_bi`). This repo drives that from
-one `max_streams` knob shared with uni streams: 1024 in moq-tokio, 10,000 in
-moq-relay. Uni streams are one per group and dominate that budget, so live
-subscriptions sit far below the cap. 12 bits covers 4096 with saturation beyond,
-which no real session reaches. Saturating is not free either, so size it to
-avoid: colliding ranks make two subscriptions tie, and the tie-break then falls
-through to `group`, which is exactly the cross-track interleaving that scoping
-the tie-break to a subscription exists to prevent.
+Do not size the subscribe field from `initial_max_streams_bidi`, which is what
+bounds live subscriptions (every control stream is bidi: `Stream::open` ->
+`open_bi`, driven here by one `max_streams` knob shared with uni streams, 1024
+in moq-tokio and 10,000 in moq-relay). That cap is the wrong input twice over:
+uni streams are one per group and dominate the budget, so subscriptions sit far
+below it, and a mask need not cover the population anyway, only keep collisions
+rare among the handful live at once. A player holds single digits. Four bits is
+likely enough and buys `group` a great deal; settle it against a real
+subscription-count distribution.
+
+Dropping the field entirely is the one option to rule out. It looks like it
+merely leaves same-priority ordering undefined, but it does not: two such tracks
+would then compare by raw group sequence, so a long-running track sitting at
+sequence 50,000 beats one that started a minute ago at sequence 10, every time,
+until its backlog drains. That is precedence, not a tie-break, and it is exactly
+the failure the scoping exists to prevent.
 
 That makes three tiers, not two:
 
@@ -85,12 +99,12 @@ That makes three tiers, not two:
   centuries away. web-transport-wasm's own `set_priority` takes an `i32` today,
   so it needs widening too, just not as far as the IDL suggests.
 - quinn, 31 bits, and `i32` is quinn's own API rather than something the trait
-  imposes, so widening `web-transport-trait` does not lift it. After `track` there are 23 bits to divide, so `subscribe_rank` and
-  the wrap period trade directly: `[8][8][15]` wraps every 32k groups, about
-  nine hours at a one-second GoP, while `[8][4][19]` buys six days at 16
-  subscriptions. Neither is obviously right, and a relay mesh session may hold
-  more subscriptions than the small end allows. Decide this with a real
-  subscription-count distribution, not from the cap.
+  imposes, so widening `web-transport-trait` does not lift it. 31 bits are
+  usable rather than 32, and after `track` there are 23 to divide, so the mask
+  and the wrap period trade directly: `[8][8][15]` wraps every 32k groups, about
+  nine hours at a one-second GoP, while `[8][4][19]` buys six days at a 16-value
+  mask. The small end is likely fine for a player and tighter for a relay mesh
+  link; settle it against a real subscription-count distribution.
 - quiche and qmux, 8 bits. Not enough for a packed key at all; see the
   round-robin question above.
 

--- a/quest/m1/perf/send-order-width.md
+++ b/quest/m1/perf/send-order-width.md
@@ -60,21 +60,14 @@ delivering precedence is worse than declaring it undefined.
 That leaves `[track: 8][group: rest]`.
 
 Fairness between equal-priority subscriptions belongs in the transport
-scheduler, which is the only layer that can round-robin. The W3C primitive is
-[`sendGroup`](https://www.w3.org/TR/webtransport/#sendGroup): streams sharing a
-send group are strictly ordered by `sendOrder`, and bandwidth is allocated
-equally between send groups. One send group per subscription with
-`sendOrder = [track][group]` is the shape we want, with one catch worth knowing
-before designing around it: send groups carry no priority relative to each
-other, so a send group per subscription also flattens track priority across
-subscriptions. `sendGroup` is the tool for the equal-priority case, not a
-replacement for `sendOrder`.
+scheduler, which is the only layer that can round-robin, and is out of scope
+here. See [Stream scheduler](/quest/m1/perf/stream-scheduler.md); this quest
+deliberately gives up that level to get the queue off the hot path first.
 
-Natively there is no equivalent. quinn schedules on a single `i32`, so
-round-robin there needs a fork or an upstream change. quiche's `incremental`
-flag round-robins within one urgency level, which is the same idea with one bit
-instead of a group id, so it cannot both round-robin between subscriptions and
-keep newest-first inside one.
+Backends that cannot carry a 32-bit scalar compress it themselves rather than
+making moq-net keep two paths. That is where a queue belongs anyway: quiche's
+adapter owns its send loop, so it can rank lazily at send time and needs none of
+the waker plumbing the current queue exists to drive.
 
 Bit budgets, which are looser than the field types suggest:
 

--- a/quest/m1/perf/stream-scheduler.md
+++ b/quest/m1/perf/stream-scheduler.md
@@ -1,0 +1,64 @@
+# [L] Prototype a three-level stream scheduler in our own QUIC stack
+
+## Goal
+
+MoQ wants three scheduling levels: strict by track priority, round-robin between
+subscriptions at equal track priority, then strict newest-group-first within a
+subscription. Nothing available offers all three, and a scalar send order cannot
+express the middle one at all, since any total order picks a winner and that
+winner takes strict precedence.
+
+Prototype the real shape in a QUIC stack we own, where the send loop is ours,
+rather than negotiating it into someone else's scheduler first.
+
+## Plan
+
+What exists today, which is more than it looks:
+
+- quinn is already strict-priority then round-robin. `PendingStream` is ordered
+  `(priority, recency, id)` in a max-heap, where `recency` is a monotonically
+  decreasing counter that requeues a stream behind its equal-priority peers once
+  it writes, and `TransportConfig::send_fairness` defaults to true. That is
+  levels one and two.
+- quiche is the same two levels: `urgency` strict, `incremental` round-robin
+  within an urgency.
+- W3C [`sendGroup`](https://www.w3.org/TR/webtransport/#sendGroup) is levels two
+  and three, the other pair: equal allocation between send groups, strict
+  `sendOrder` within one. Send groups carry no priority relative to each other,
+  so it cannot also carry track priority.
+
+So both native backends already give the top two levels, `sendGroup` gives the
+bottom two, and nothing gives three. MoQ currently sees none of the round-robin
+because it hands every stream a distinct priority, which means no two streams are
+ever equal and the fairness never engages. We pay for a queue to defeat a
+scheduler already doing half the job.
+
+The missing piece is one field, not a scheduler. quinn's ordering key wants to
+become `(priority, bucket_recency, order, id)`: `priority` strict for track,
+buckets round-robin against each other reusing the existing recency counter,
+`order` strict within a bucket for group sequence. That is `sendGroup` semantics
+plus the priority dimension `sendGroup` lacks.
+
+Prototype it in moq-uring's own stack rather than as a quinn fork. We own that
+send loop, the ordering key is ours to shape, and it avoids carrying a fork
+before the semantics are settled. If it works, that is the evidence for an
+upstream quinn change or a spec issue, and the fallback stays a fork.
+
+Measure against the two points reachable without any of this, both of which are
+real options rather than strawmen: a scalar send order of `[track][group]`, which
+buys strict priority and newest-first while giving up fairness (see [Send order
+width](/quest/m1/perf/send-order-width.md)), and a scalar of `track` alone, which
+lets quinn's existing fairness through and gives up newest-first instead.
+
+Acceptance: a congested session carrying two equal-priority tracks of different
+group cadence, audio against video, keeps both progressing rather than draining
+one, while a higher-priority track still preempts both and newest-first still
+sheds backlog within a track. Compare all three configurations on the same shape.
+
+## Required
+
+- [Send order width](/quest/m1/perf/send-order-width.md) - the scalar lands first
+
+## Related
+
+- [Priority set_track wakes](/quest/m1/perf/priority-set-track-wakes.md) - dead once the queue goes

--- a/quest/m1/perf/stream-scheduler.md
+++ b/quest/m1/perf/stream-scheduler.md
@@ -1,4 +1,4 @@
-# [L] Prototype a three-level stream scheduler in our own QUIC stack
+# [L] Prototype a three-level stream scheduler as a quinn patch
 
 ## Goal
 
@@ -8,8 +8,9 @@ subscription. Nothing available offers all three, and a scalar send order cannot
 express the middle one at all, since any total order picks a winner and that
 winner takes strict precedence.
 
-Prototype the real shape in a QUIC stack we own, where the send loop is ours,
-rather than negotiating it into someone else's scheduler first.
+Prototype the real shape against quinn's scheduler, which already has two of the
+three levels and the counter the third one needs, rather than designing it in
+the abstract.
 
 ## Plan
 
@@ -39,10 +40,21 @@ buckets round-robin against each other reusing the existing recency counter,
 `order` strict within a bucket for group sequence. That is `sendGroup` semantics
 plus the priority dimension `sendGroup` lacks.
 
-Prototype it in moq-uring's own stack rather than as a quinn fork. We own that
-send loop, the ordering key is ours to shape, and it avoids carrying a fork
-before the semantics are settled. If it works, that is the evidence for an
-upstream quinn change or a spec issue, and the fallback stays a fork.
+That field lives in the QUIC stack, not above it, and moq-uring does not change
+that. Its quinn path hands stream selection to `poll_transmit` and its quiche
+path to `Connection::send`, so what moq-uring owns is the UDP path, not the
+ordering key. Either backend means a fork or an upstream patch; there is no
+third option to reach for first.
+
+Take quinn, and carry it as a patch rather than a fork. Its key is already
+`(priority, recency, id)` with the recency counter this needs, so the change is
+one field in one struct and a `SendStream` setter to reach it, which is also the
+smallest thing to keep rebased and the most likely to be acceptable upstream.
+Run it under moq-uring's quinn backend, which is where the relay workload is,
+and treat a working prototype as the evidence for the upstream PR or a spec
+issue. quiche stays out of scope: reproducing the result there is a second
+fork's worth of work, and its `urgency` plus `incremental` already give the same
+top two levels, so it tells us nothing new about whether the third one helps.
 
 Measure against the two points reachable without any of this, both of which are
 real options rather than strawmen: a scalar send order of `[track][group]`, which


### PR DESCRIPTION
## Summary

Settles the send-order design and splits it into two quests, replacing the layout guesswork in [#3319](https://github.com/moq-dev/moq/pull/3319).

### [Send order width](/quest/m1/perf/send-order-width.md) — land the scalar first

**Same-priority ordering becomes explicitly undefined.** A flat total order cannot express round-robin: whatever occupies the `subscribe` field picks a winner, and that winner takes strict precedence. The current tie-break only *reads* as fair because each subscription usually has one live group, so they alternate as groups complete — under congestion the favoured subscription's backlog starves the other. A group-sequence tie-break is worse, since cadence decides it: audio at 20ms outruns video's sequence numbers regardless of which matters more. Promising fairness and delivering precedence is worse than saying undefined.

That leaves `[track: 8][group: 24]`, and drops the live-subscription table, the mask, and the sizing argument with it.

**`i32` gives 32 bits, not 31.** Negatives are usable as long as the pack preserves order: build the key unsigned and store `(key ^ 0x8000_0000) as i32`. That leaves 24 bits of group, and 32 bits is the whole budget: `track` is a `u8` on the wire, and `i32` is quinn's own API rather than something the trait imposes.

The wrap is *not* remote, which an earlier revision of this claimed. 16.7M groups is 194 days at a 1s GoP but ~4 days at the 20ms audio cadence this plan uses as its own fairness example, and sparse sequences need no wrap at all (`create_group` takes a caller-chosen `u64` that relays preserve from upstream). Both are bounded at one live window sorting under its own backlog, which is what makes them a stated boundary rather than a reason to rebase: rebasing to the subscription's first sequence trades a bounded, occasional inversion for an unbounded, permanent one.

**Narrow backends compress the scalar themselves** rather than making moq-net keep two paths — which is where a queue belongs anyway, since quiche's adapter owns its send loop and can rank lazily without any of the waker plumbing the current queue exists to drive.

### [Stream scheduler](/quest/m1/perf/stream-scheduler.md) — the round-robin, blocked on the above

Corrects a claim in #3319 that was wrong: **quinn is already strict-priority then round-robin.** `PendingStream` sorts on `(priority, recency, id)` with `recency` requeueing a stream behind its equal-priority peers, and `send_fairness` defaults to `true`. quiche's `urgency` + `incremental` are the same two levels.

| primitive | levels | |
|---|---|---|
| quinn, quiche | strict → equal | MoQ's **top two** |
| W3C `sendGroup` | equal → strict | MoQ's **bottom two** |

Nothing gives three, and MoQ sees none of the round-robin only because a distinct priority per stream means no two streams are ever equal, so we pay for a queue to defeat a scheduler already doing half the job. The missing piece is one field, not a scheduler: quinn's key wants to become `(priority, bucket_recency, order, id)`.

That field lives inside the QUIC stack, and moq-uring does not change that: its quinn path delegates stream selection to `poll_transmit` and its quiche path to `Connection::send`, so what moq-uring owns is the UDP path, not the ordering key. The quest is therefore scoped to a **quinn patch** rather than to moq-uring's stack. quinn's key already carries the recency counter the third level needs, so it is one field plus a setter, which is both the smallest thing to keep rebased and the most plausible upstream PR. quiche stays out of scope: a second fork's work for the same two levels it already has.

## Test plan

- `cargo run --package quest -- check` (243 documents ok)

## Review

Three Codex findings were confirmed against the code and fixed in cbe1bdea4: the wrap estimate, sparse sequences, and the layer the scheduler prototype belongs in. Three earlier ones (uni/bidi budgets, browser safe-integer precision, subscribe-mask churn) were already moot, since later commits deleted the mask and the sizing table and corrected the browser budget to 53 bits.

(written by Claude Opus 5)

