### PR TITLE
fix(net): stamp the parallel write clock after the writers are ready

### DIFF
--- a/rs/moq-net/benches/track.rs
+++ b/rs/moq-net/benches/track.rs
@@ -109,6 +109,8 @@ fn parallel_write(pool: &cache::Pool, writers: usize, iterations: u64) -> Durati
 					let mut broadcast = broadcast::Producer::new(info);
 					let mut track = broadcast.create_track("bench", None).unwrap();
 					let payload = Bytes::from_static(&[0; PAYLOAD]);
+					// Arrive once setup is done, then park until the main thread has stamped the clock.
+					barrier.wait();
 					barrier.wait();
 					for _ in 0..iterations {
 						let mut group = track.append_group().unwrap();
@@ -119,8 +121,11 @@ fn parallel_write(pool: &cache::Pool, writers: usize, iterations: u64) -> Durati
 			})
 			.collect();
 
+		// The first wait returns once every writer has built its producer, keeping setup out
+		// of the interval. The second releases them, so no write lands before the stamp.
 		barrier.wait();
 		let start = Instant::now();
+		barrier.wait();
 		for handle in handles {
 			handle.join().unwrap();
 		}


### PR DESCRIPTION
Follow-up to review feedback on #3296 ([discussion](https://github.com/moq-dev/moq/pull/3296#discussion_r3909995978)).

## Root cause

`parallel_write` in `rs/moq-net/benches/track.rs` released the worker barrier and *then* recorded `start`. `Barrier::wait()` unblocks every waiter as soon as the last one (the main thread) arrives, so a worker that gets scheduled before the main thread returns from its own `wait()` can complete frame writes before the clock starts.

The bench is driven by `iter_custom`, so Criterion's short calibration runs are exactly where this bites: a few dozen iterations spread over many writers means a material share of the work can land outside the measured interval, and the reported per-frame time ends up a function of scheduler timing rather than of the code under test.

Simply hoisting the stamp above `barrier.wait()` trades one bias for another. The main thread reaches the barrier immediately after spawning, so a stamp there lands while the workers are still being scheduled and still constructing their `broadcast::Producer` and track. That setup cost then sits *inside* the interval, and it grows with the writer count.

## Fix

Split the single barrier into a two-phase handshake. Each writer arrives once its producer and track exist, so the main thread's first `wait()` returns only after every writer is parked with setup complete. It then stamps the clock and arrives a second time to open the gate.

Both ends are now tight: no write can land before the stamp, because nothing passes the second phase until the main thread arrives at it; and no thread spawn or producer construction is inside the interval, because the first phase already drained it. The only measured overhead is the barrier release itself, which is unavoidable in any design that starts N threads from one clock.

## Testing

`just check` passes. Bench-only change, no library code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 5)