### PR TITLE
chore(quest): prefer quests over issues, and add the group-overflow quest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,8 +98,10 @@ This root file holds only cross-cutting rules that apply everywhere (writing sty
 History belongs in commits and PRs; pending work belongs in a quest. Read
 [`quest/AGENTS.md`](quest/AGENTS.md) whenever work mentions a quest or
 questline, and use the `$plan-quest` or `$start-quest` skills when available.
-GitHub issues remain the public front door, while quests carry durable plans
-and dependency edges alongside the code.
+GitHub issues remain the public front door for outside reports, but for
+follow-up work discovered here, prefer creating a quest over filing an issue:
+quests carry durable plans and dependency edges alongside the code, and land
+reviewed.
 
 ## Dependencies
 

--- a/quest/m1/README.md
+++ b/quest/m1/README.md
@@ -29,6 +29,7 @@ with the current dev tree before starting.
 - [#2624](/quest/m1/2624-moq-native-goaway-redirect-guard-classifies-hosts-by-name.md) - moq-native: GOAWAY redirect guard classifies hosts by name, not by resolved address
 - [#3086](/quest/m1/3086-refactor-net-make-group-delivery-order-a-handle-and-move.md) - refactor(net): make group delivery order a handle, and move timestamp-based skipping into moq-net
 - [#3161](/quest/m1/3161-retention-should-reclaim-idle-open-groups-now-that-expiry.md) - Retention should reclaim idle open groups now that expiry is timestamp-only
+- [Group overflow](/quest/m1/group-overflow-abort.md) - an oversized open group aborts for every reader instead of shedding its head
 - [#699](/quest/m1/699-better-prioritize-ties.md) - Better prioritize ties
 - [#2895](/quest/m1/2895-add-an-atomic-readiness-gate-for-origin-broadcasts.md) - Add an atomic readiness gate for Origin broadcasts
 - [#2985](/quest/m1/2985-js-net-path-keyed-publisher-state-goes-stale-when-a.md) - js/net: path-keyed publisher state goes stale when a broadcast is replaced

--- a/quest/m1/group-overflow-abort.md
+++ b/quest/m1/group-overflow-abort.md
@@ -1,0 +1,47 @@
+# [M] Abort an oversized open group instead of shedding its head
+
+## Goal
+
+An open group that outgrows its cache budget errors for every reader instead
+of evicting frames from its front. One consistent failure replaces today's
+split, where a reader that kept up streams the whole group while a late or new
+one gets `Lagged`, and the head-shedding machinery becomes dead code to
+delete. Decide first: this is a semantics change to the model in both
+languages, not a bug fix.
+
+## Plan
+
+Today `rs/moq-net` (`model/group.rs`, `MAX_CACHE_BYTES`) and `js/net`
+(`group.ts`, `MAX_GROUP_CACHE_BYTES` plus `MAX_GROUP_FRAMES`) evict from the
+front of an open group once it passes the cap, and a reader positioned below
+the eviction fails with `Lagged`. Readers at or above it keep going, which the
+IETF publishers use to serve a draft-20 filter whose range excludes the
+evicted prefix (`group::Consumer::skip_to` in Rust, `Group.ReadOptions.from`
+in JS).
+
+Aborting the group at the cap instead:
+
+- keeps the memory bound, and the group also stops growing,
+- gives every reader the same terminal error at the same point, instead of
+  punishing only whoever subscribed late,
+- deletes the per-reader eviction floors and the eviction bookkeeping
+  (`offset` in Rust, `start`/`evicted` in JS) outright,
+- costs little in practice: a group near 32 MiB is pathological (hang groups
+  are GOP-sized), and shedding already denies the whole group to every new
+  subscriber anyway.
+
+Open questions to settle before implementing:
+
+- The abort error code: `Lagged` blames the reader for the writer's overrun;
+  the existing oversized-single-frame rejection (a write error) is the closer
+  precedent, and the writer should learn about it too.
+- Whether the JS frame-count cap (1024) aborts as well or simply goes away;
+  Rust has only the byte budget.
+- Pool-level eviction of whole idle groups is untouched; only per-group
+  front-shedding changes.
+
+## Related
+
+- [#3123](/quest/m0/3123-moq-bench-a-lagged-group-permanently-ends-the.md) - how a subscriber should react to a lagged group
+- [Group charge](/quest/m0/group-charge.md) - pool-level budget accounting, unaffected by this change
+- [#3161](/quest/m1/3161-retention-should-reclaim-idle-open-groups-now-that-expiry.md) - open-group lifecycle work in the same area


### PR DESCRIPTION
Adds the quest capturing the open design decision from the moq-transport-20 consolidation (#3283/#3304/#3300 triage): whether an oversized open group should abort for every reader instead of shedding its front. Today a reader that kept up streams the whole group while a late or new one gets `Lagged`; aborting at the cap keeps the memory bound, treats every reader the same, and deletes the per-reader eviction floors. Filed as a quest rather than an issue, ranked next to the adjacent open-group lifecycle work (#3161).

Also states the standing preference in CLAUDE.md: GitHub issues stay the public front door for outside reports, but follow-up work discovered in-repo prefers a quest, matching what quest/AGENTS.md already says.

No code changes; `just check` passes (quest: 249 documents ok).

(Written by Claude Fable 5)