### PR TITLE
fix(moq-net): serve the rest of a group whose front evicted

### DIFF
--- a/rs/moq-net/src/ietf/publisher.rs
+++ b/rs/moq-net/src/ietf/publisher.rs
@@ -862,10 +862,13 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 
 		stream.encode(&msg).await?;
 
-		// The next object id to read. Ids below `slice.skip` are consumed without being
-		// written, and the first written id goes on the wire as its absolute delta, so
-		// the peer sees the true numbering rather than a silently renumbered group.
-		let mut index: u64 = 0;
+		// Ids below `slice.skip` are outside the requested range: the cursor starts above
+		// them, so an eviction confined to that excluded prefix is not a gap and the rest
+		// of the group is still served. The first written id goes on the wire as its
+		// absolute delta, so the peer sees the true numbering rather than a silently
+		// renumbered group.
+		group.skip_to(slice.skip);
+		let mut index: u64 = slice.skip;
 		let mut first_written = true;
 
 		// A subscriber catching up on a cached group takes the whole backlog under one
@@ -902,16 +905,14 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 							break 'serve;
 						}
 						let frame = buf.filled()[i].clone();
-						if index >= slice.skip {
-							let delta = if std::mem::take(&mut first_written) { index } else { 0 };
-							Self::write_object_header(&mut stream, delta, frame.timestamp, timescale, version).await?;
-							stream.encode(&(frame.payload.len() as u64)).await?;
-							if frame.payload.is_empty() {
-								// Have to write the object status too.
-								stream.encode(&0u8).await?;
-							} else {
-								stream.write_chunk(frame.payload).await?;
-							}
+						let delta = if std::mem::take(&mut first_written) { index } else { 0 };
+						Self::write_object_header(&mut stream, delta, frame.timestamp, timescale, version).await?;
+						stream.encode(&(frame.payload.len() as u64)).await?;
+						if frame.payload.is_empty() {
+							// Have to write the object status too.
+							stream.encode(&0u8).await?;
+						} else {
+							stream.write_chunk(frame.payload).await?;
 						}
 						index += 1;
 						// The fill stamped the group once. A flow-controlled peer can
@@ -921,27 +922,6 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 					}
 				}
 				Step::Partial(mut frame) => {
-					if index < slice.skip {
-						// A skipped frame still has to be drained to advance the cursor.
-						loop {
-							let chunk = {
-								let mut closed = std::pin::pin!(stream.closed());
-								kio::wait(|waiter| {
-									if waiter.poll_future(closed.as_mut()).is_ready() {
-										return Poll::Ready(Err(Error::Cancel));
-									}
-									frame.poll_read_chunk(waiter)
-								})
-								.await
-							};
-							if chunk?.is_none() {
-								break;
-							}
-						}
-						index += 1;
-						continue;
-					}
-
 					let delta = if std::mem::take(&mut first_written) { index } else { 0 };
 					Self::write_object_header(&mut stream, delta, frame.timestamp, timescale, version).await?;
 					index += 1;
@@ -1090,7 +1070,10 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 		version: Version,
 	) -> Result<(), Error> {
 		let GroupSlice { skip, until } = slice;
-		let mut index: u64 = 0;
+		// The fill's range starts at `skip`: the cursor starts above the excluded prefix,
+		// so an eviction confined to it is not a gap.
+		group.skip_to(skip);
+		let mut index: u64 = skip;
 		let mut first = true;
 
 		let mut buf: frame::Buffer = frame::Buffer::new();
@@ -1124,48 +1107,25 @@ impl<S: web_transport_trait::Session> Publisher<S> {
 							break 'serve;
 						}
 						let frame = buf.filled()[i].clone();
-						if index >= skip {
-							Self::write_fill_object(
-								stream,
-								sequence,
-								index,
-								std::mem::take(&mut first),
-								frame.timestamp,
-								timescale,
-								version,
-							)
-							.await?;
-							stream.encode(&(frame.payload.len() as u64)).await?;
-							if !frame.payload.is_empty() {
-								stream.write_chunk(frame.payload).await?;
-							}
+						Self::write_fill_object(
+							stream,
+							sequence,
+							index,
+							std::mem::take(&mut first),
+							frame.timestamp,
+							timescale,
+							version,
+						)
+						.await?;
+						stream.encode(&(frame.payload.len() as u64)).await?;
+						if !frame.payload.is_empty() {
+							stream.write_chunk(frame.payload).await?;
 						}
 						index += 1;
 						group.keep_alive();
 					}
 				}
 				Step::Partial(mut frame) => {
-					if index < skip {
-						// A skipped frame still has to be drained to advance the cursor.
-						loop {
-							let chunk = {
-								let mut closed = std::pin::pin!(stream.closed());
-								kio::wait(|waiter| {
-									if waiter.poll_future(closed.as_mut()).is_ready() {
-										return Poll::Ready(Err(Error::Cancel));
-									}
-									frame.poll_read_chunk(waiter)
-								})
-								.await
-							};
-							if chunk?.is_none() {
-								break;
-							}
-						}
-						index += 1;
-						continue;
-					}
-
 					Self::write_fill_object(
 						stream,
 						sequence,
@@ -2609,6 +2569,56 @@ mod serve_tests {
 			0,
 			"the cap excludes cc"
 		);
+	}
+
+	/// An open group sheds its front once it outgrows the cache budget. A subscriber whose
+	/// filter already excludes the evicted prefix still gets the tail it asked for; one
+	/// whose range reaches into the gap is the reader that actually lost something, so it
+	/// still fails with Lagged.
+	#[tokio::test]
+	async fn run_group_serves_the_tail_of_an_evicted_head() {
+		fn header() -> ietf::GroupHeader {
+			ietf::GroupHeader {
+				track_alias: 0,
+				group_id: 0,
+				sub_group_id: 0,
+				publisher_priority: 0,
+				flags: ietf::GroupFlags {
+					first_object: false,
+					..Default::default()
+				},
+			}
+		}
+
+		async fn serve_evicted(slice: GroupSlice) -> Result<Vec<u8>, Error> {
+			let log = Log::default();
+			let session = SinkSession::new(log.clone());
+			let mut track = track::Producer::new(std::sync::Arc::new(crate::broadcast::Info::default()), "test", None);
+			let mut group = track.create_group(group::Info { sequence: 0 }).unwrap();
+
+			// Two oversized frames overflow the budget once the small frames land:
+			// objects 0 and 1 evict, 2 and 3 are retained.
+			let big = vec![0u8; group::MAX_CACHE_BYTES as usize];
+			group.write_frame(timestamp(), big.as_slice()).unwrap();
+			group.write_frame(timestamp(), big.as_slice()).unwrap();
+			for payload in [b"cc", b"dd"] {
+				group.write_frame(timestamp(), payload.as_slice()).unwrap();
+			}
+			let consumer = group.consume();
+			group.finish().unwrap();
+
+			Publisher::<SinkSession>::run_group(session, header(), 0, consumer, None, Version::Draft20, slice).await?;
+			Ok(log.writes.lock().unwrap().clone())
+		}
+
+		let served = serve_evicted(GroupSlice { skip: 2, until: None }).await.unwrap();
+		assert!(
+			served.ends_with(&[0x02, 0x02, b'c', b'c', 0x00, 0x02, b'd', b'd']),
+			"expected delta 2 then cc, delta 0 then dd, got {served:x?}"
+		);
+
+		let lagged = serve_evicted(GroupSlice { skip: 1, until: None }).await;
+		assert!(matches!(lagged, Err(Error::Lagged)));
 	}
 }
 

--- a/rs/moq-net/src/model/group.rs
+++ b/rs/moq-net/src/model/group.rs
@@ -725,6 +725,17 @@ impl Consumer {
 			.unwrap_or(state.offset + state.frames.len() + state.partial.is_some() as usize)
 	}
 
+	/// Advance the read cursor to `sequence`, skipping every frame below it.
+	///
+	/// Skipped frames are never returned, and an eviction confined to them is not a gap:
+	/// reads resume at the cursor instead of failing with [`Error::Lagged`]. An eviction at
+	/// or above the cursor still fails, because the caller asked for that frame. The cursor
+	/// only moves forward; a `sequence` at or below it is a no-op.
+	pub fn skip_to(&mut self, sequence: u64) {
+		let sequence = usize::try_from(sequence).unwrap_or(usize::MAX);
+		self.index = self.index.max(sequence);
+	}
+
 	// A helper to automatically apply Dropped if the state is closed without an error.
 	fn poll<F, R>(&self, waiter: &kio::Waiter, f: F) -> Poll<Result<R>>
 	where
@@ -1504,6 +1515,33 @@ mod test {
 		let mut consumer = producer.consume();
 		// First frame was evicted, next_frame should return Lagged.
 		let result = consumer.next_frame().now_or_never().unwrap();
+		assert!(matches!(result, Err(crate::Error::Lagged)));
+	}
+
+	/// A cursor at the eviction boundary never asked for the missing frames, so the read
+	/// proceeds at the retained tail; a cursor one below it has a gap and lags.
+	#[test]
+	fn skip_to_tolerates_an_eviction_below_it() {
+		let mut producer = Info { sequence: 0 }.produce();
+
+		// Two oversized frames overflow the budget once the small frame lands: frames 0
+		// and 1 evict, frame 2 is retained.
+		let big = Bytes::from(vec![0u8; MAX_CACHE_BYTES as usize]);
+		producer.write_frame(Timestamp::ZERO, big.clone()).unwrap();
+		producer.write_frame(Timestamp::ZERO, big).unwrap();
+		producer
+			.write_frame(Timestamp::ZERO, Bytes::from_static(b"tail"))
+			.unwrap();
+		assert_eq!(producer.state.read().offset, 2);
+
+		let mut reader = producer.consume();
+		reader.skip_to(2);
+		let frame = reader.next_frame().now_or_never().unwrap().unwrap().unwrap();
+		assert_eq!(frame.size, 4);
+
+		let mut behind = producer.consume();
+		behind.skip_to(1);
+		let result = behind.next_frame().now_or_never().unwrap();
 		assert!(matches!(result, Err(crate::Error::Lagged)));
 	}
 


### PR DESCRIPTION
The Rust half of #3314, which fixed the same defect in `js/net`.

## Root cause

An open group sheds its front once it passes the 32 MiB cache budget (`MAX_CACHE_BYTES`, `GroupState::evict`). The IETF publisher's serve loops started every reader at index 0, so the first `poll_read_frames` hit `Error::Lagged` and reset the stream even when the filter's `skip` sat entirely above the evicted prefix. A draft-20 Next Object subscriber joins at `{Largest.Group, Largest.Object + 1}`, above everything buffered, so the evicted objects are ones it explicitly excluded, and it still lost the group. The `index < slice.skip` drain loops were unreachable for the evicted prefix because `Lagged` fired first, and they also read every excluded frame's payload just to throw it away.

## Fix

- `group::Consumer::skip_to(sequence)` advances the per-reader cursor. Frames below it are never requested, so an eviction confined to them is not a gap; an eviction at or above it still fails with `Lagged`, because the caller asked for that frame. The existing `index < offset` check provides exactly these semantics once the cursor starts at the floor, so no eviction bookkeeping changed. (Rust needs no `start`/`evicted` split like the JS fix: the cache is shared and the cursor is per-reader, so `offset` already distinguishes the two.)
- `run_group` and `write_fill_group` seek to the slice's `skip` instead of draining excluded frames by hand, which deletes both drain loops and stops reading excluded payloads at all.

## Scope

Only `slice.skip > 0` readers are affected, i.e. a draft-20 peer that sent Next Object or an absolute filter with a non-zero start object. Unfiltered subscribers, `Relative`, and all of moq-lite have `skip = 0` and still lose an oversized evicted group to `Lagged`, deliberately: without object 0 there is nothing decodable to send. Whether that case should abort the group for every reader instead of shedding the head is `quest/m1/group-overflow-abort.md` (#3322).

## Public API changes

Additive only, hence `main`: `group::Consumer::skip_to`, mirroring `Group.ReadOptions.from` on the JS side.

## Test plan

- `model::group::test::skip_to_tolerates_an_eviction_below_it`: a cursor at the eviction boundary reads the retained tail; one below it still gets `Lagged`.
- `ietf::publisher::serve_tests::run_group_serves_the_tail_of_an_evicted_head`: a group whose objects 0-1 evicted serves objects 2-3 (absolute first delta) to a `skip: 2` subscriber, and still fails with `Lagged` for `skip: 1`. Verified it fails without the fix (`Lagged` from the first read).
- `cargo test -p moq-net --lib`: 914 passed. `cargo clippy -p moq-net --all-targets` and `cargo fmt --check` clean.

No wire change, so no `drafts/` update; the JS side already landed as #3314.

(Written by Claude Fable 5)
