### PR TITLE
feat(moq-audio)!: reach devices through PipeWire or PulseAudio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,6 +1504,7 @@ dependencies = [
  "block2 0.6.2",
  "coreaudio-rs",
  "dasp_sample",
+ "futures",
  "jni 0.22.4",
  "js-sys",
  "libc",
@@ -1519,6 +1520,9 @@ dependencies = [
  "objc2-core-audio-types",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
+ "pipewire",
+ "portable-atomic",
+ "pulseaudio",
  "web-sys",
  "windows",
  "windows-core",
@@ -2350,6 +2354,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.4",
+]
+
+[[package]]
+name = "enum-primitive-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba7795da175654fe16979af73f81f26a8ea27638d8d9823d317016888a63dc4c"
+dependencies = [
+ "num-traits",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7276,6 +7291,22 @@ dependencies = [
  "bitflags 2.13.1",
  "memchr",
  "unicase",
+]
+
+[[package]]
+name = "pulseaudio"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d70623bd7967a9ca4c2ae0e807fc380b291f98480fc037042305ec643a4d3373"
+dependencies = [
+ "bitflags 2.13.1",
+ "byteorder",
+ "enum-primitive-derive",
+ "futures",
+ "log",
+ "mio",
+ "num-traits",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/rs/moq-audio/Cargo.toml
+++ b/rs/moq-audio/Cargo.toml
@@ -46,6 +46,11 @@ capture = [
 # `capture`: a consumer that only encodes shouldn't pull cpal, or the ALSA build
 # dependency on Linux.
 playback = ["dep:cpal", "dep:fixed-resample", "dep:tokio", "dep:tracing"]
+# Reach devices through the Linux sound server rather than its ALSA plugin, for
+# the server's own device names and routing. cpal picks the host at runtime, so
+# these only cost a link against the client library.
+pipewire = ["cpal/pipewire"]
+pulseaudio = ["cpal/pulseaudio"]
 # Acoustic echo cancellation: subtract what `playback` is playing from what
 # `capture` hears, so a speakerphone doesn't send its own output back. Needs
 # both halves, since the canceller taps the output mix as its reference.

--- a/rs/moq-audio/src/capture.rs
+++ b/rs/moq-audio/src/capture.rs
@@ -465,7 +465,15 @@ pub struct Device {
 	/// Human-readable name, e.g. "MacBook Pro Microphone".
 	pub name: String,
 	/// Whether this is the system default input.
+	///
+	/// True for at most one device: the preferred host's default. Another host's
+	/// default is that host's, not the system's.
 	pub default: bool,
+	/// The host API this device is reached through, e.g. "PipeWire" or "ALSA".
+	///
+	/// The same hardware is usually reachable through several, so a caller that
+	/// offers a choice groups by this.
+	pub host: String,
 }
 
 impl Device {
@@ -482,21 +490,39 @@ pub async fn devices() -> Result<Vec<Device>, Error> {
 
 /// The blocking half of [`devices`].
 fn list() -> Result<Vec<Device>, Error> {
-	let host = cpal::default_host();
-	let default = host.default_input_device().and_then(|device| device.id().ok());
-	Ok(host
-		.input_devices()
-		.map_err(capture_err)?
-		// A device being reconfigured can fail `id`/`description` on its own, so
-		// skip it rather than losing every other input from the listing.
-		.filter_map(|device| match describe(&device, default.as_ref()) {
-			Ok(device) => Some(device),
-			Err(err) => {
-				tracing::debug!(error = %err, "skipping an input device that could not be described");
-				None
+	// Every host, not just the preferred one, matching the output side. The same
+	// hardware appears under each, and which one a caller wants is its decision:
+	// PipeWire and PulseAudio carry the server's own names and routing, ALSA
+	// reaches a device directly. `Device::host` is what lets a caller group them.
+	let preferred = cpal::default_host().id();
+	let mut devices = Vec::new();
+	// A sound server reports one id per stream, not per device, so a client with
+	// several open would otherwise appear once per stream.
+	let mut seen = std::collections::HashSet::new();
+
+	for id in cpal::available_hosts() {
+		let Ok(host) = cpal::host_from_id(id) else { continue };
+		let default = host.default_input_device().and_then(|device| device.id().ok());
+
+		let Ok(inputs) = host.input_devices() else { continue };
+		for device in inputs {
+			let Ok(device_id) = device.id() else { continue };
+			if !seen.insert(device_id.to_string()) {
+				continue;
 			}
-		})
-		.collect())
+			// Only the preferred host's default is the system default; the others
+			// are that host's idea of one.
+			let is_default = id == preferred && Some(&device_id) == default.as_ref();
+			match describe(&device, is_default, id.name()) {
+				Ok(device) => devices.push(device),
+				Err(err) => {
+					tracing::debug!(error = %err, "skipping an input device that could not be described");
+				}
+			}
+		}
+	}
+
+	Ok(devices)
 }
 
 /// Run blocking cpal host I/O off the runtime's worker threads.
@@ -526,6 +552,11 @@ fn resolve(
 					"{selector:?} is not an input device id; run `devices` to list them: {err}"
 				)))
 			})?;
+			// Ids are host-qualified, so route to the host that issued this one
+			// rather than searching the preferred host alone: `devices` lists
+			// every host, and a device it named has to be openable.
+			let host = cpal::host_from_id(wanted.host())
+				.map_err(|err| Failure::fatal(Error::Device(format!("{selector:?}: {err}"))))?;
 			host.input_devices()
 				.map_err(Failure::cpal)?
 				.find(|device| device.id().ok().as_ref() == Some(&wanted))
@@ -535,7 +566,9 @@ fn resolve(
 			.default_input_device()
 			.ok_or_else(|| Failure::retry(Error::Device("no default input device".into())))?,
 	};
-	let current = describe(&device, default.as_ref()).map_err(Failure::cpal)?;
+	let is_default = device.id().ok().as_ref() == default.as_ref();
+	let host_name = device.id().map(|id| id.host().name().to_string()).unwrap_or_default();
+	let current = describe(&device, is_default, &host_name).map_err(Failure::cpal)?;
 
 	let supported = device.default_input_config().map_err(Failure::cpal)?;
 	let sample_format = supported.sample_format();
@@ -549,13 +582,14 @@ fn resolve(
 	Ok((device, current, sample_format, stream_config))
 }
 
-fn describe(device: &cpal::Device, default: Option<&cpal::DeviceId>) -> Result<Device, cpal::Error> {
+fn describe(device: &cpal::Device, default: bool, host: &str) -> Result<Device, cpal::Error> {
 	let id = device.id()?;
 	let description = device.description()?;
 	Ok(Device {
-		default: Some(&id) == default,
+		default,
 		id: id.to_string(),
 		name: description.name().into(),
+		host: host.to_string(),
 	})
 }
 

--- a/rs/moq-audio/src/capture.rs
+++ b/rs/moq-audio/src/capture.rs
@@ -501,19 +501,39 @@ fn list() -> Result<Vec<Device>, Error> {
 	let mut seen = std::collections::HashSet::new();
 
 	for id in cpal::available_hosts() {
-		let Ok(host) = cpal::host_from_id(id) else { continue };
+		// A host that will not open takes every device on it with it, so say so:
+		// the symptom is a device missing from the listing with no other trace.
+		let host = match cpal::host_from_id(id) {
+			Ok(host) => host,
+			Err(err) => {
+				tracing::debug!(host = id.name(), error = %err, "skipping an audio host that would not open");
+				continue;
+			}
+		};
 		let default = host.default_input_device().and_then(|device| device.id().ok());
 
-		let Ok(inputs) = host.input_devices() else { continue };
+		let inputs = match host.input_devices() {
+			Ok(inputs) => inputs,
+			Err(err) => {
+				tracing::debug!(host = id.name(), error = %err, "skipping a host that would not list its inputs");
+				continue;
+			}
+		};
 		for device in inputs {
-			let Ok(device_id) = device.id() else { continue };
+			let device_id = match device.id() {
+				Ok(device_id) => device_id,
+				Err(err) => {
+					tracing::debug!(host = id.name(), error = %err, "skipping an input device with no id");
+					continue;
+				}
+			};
 			if !seen.insert(device_id.to_string()) {
 				continue;
 			}
 			// Only the preferred host's default is the system default; the others
 			// are that host's idea of one.
 			let is_default = id == preferred && Some(&device_id) == default.as_ref();
-			match describe(&device, is_default, id.name()) {
+			match describe(&device, &device_id, is_default) {
 				Ok(device) => devices.push(device),
 				Err(err) => {
 					tracing::debug!(error = %err, "skipping an input device that could not be described");
@@ -566,9 +586,10 @@ fn resolve(
 			.default_input_device()
 			.ok_or_else(|| Failure::retry(Error::Device("no default input device".into())))?,
 	};
-	let is_default = device.id().ok().as_ref() == default.as_ref();
-	let host_name = device.id().map(|id| id.host().name().to_string()).unwrap_or_default();
-	let current = describe(&device, is_default, &host_name).map_err(Failure::cpal)?;
+	// One `id` call rather than three: it is fallible, and a device that cannot
+	// name itself has nothing the caller could select it by later.
+	let id = device.id().map_err(Failure::cpal)?;
+	let current = describe(&device, &id, Some(&id) == default.as_ref()).map_err(Failure::cpal)?;
 
 	let supported = device.default_input_config().map_err(Failure::cpal)?;
 	let sample_format = supported.sample_format();
@@ -582,14 +603,13 @@ fn resolve(
 	Ok((device, current, sample_format, stream_config))
 }
 
-fn describe(device: &cpal::Device, default: bool, host: &str) -> Result<Device, cpal::Error> {
-	let id = device.id()?;
-	let description = device.description()?;
+/// Build the listing entry for `device`, whose id the caller has already read.
+fn describe(device: &cpal::Device, id: &cpal::DeviceId, default: bool) -> Result<Device, cpal::Error> {
 	Ok(Device {
 		default,
+		name: device.description()?.name().into(),
+		host: id.host().name().to_string(),
 		id: id.to_string(),
-		name: description.name().into(),
-		host: host.to_string(),
 	})
 }
 

--- a/rs/moq-audio/src/capture.rs
+++ b/rs/moq-audio/src/capture.rs
@@ -563,7 +563,7 @@ fn resolve(
 ) -> Result<(cpal::Device, Device, cpal::SampleFormat, cpal::StreamConfig), Failure> {
 	let host = cpal::default_host();
 	let default = host.default_input_device().and_then(|device| device.id().ok());
-	let device = match selector {
+	let (device, id) = match selector {
 		// `Host::device_by_id` searches outputs too, so match against the inputs
 		// ourselves: an output id must not resolve as a microphone.
 		Some(selector) => {
@@ -577,18 +577,21 @@ fn resolve(
 			// every host, and a device it named has to be openable.
 			let host = cpal::host_from_id(wanted.host())
 				.map_err(|err| Failure::fatal(Error::Device(format!("{selector:?}: {err}"))))?;
-			host.input_devices()
+			let device = host
+				.input_devices()
 				.map_err(Failure::cpal)?
 				.find(|device| device.id().ok().as_ref() == Some(&wanted))
-				.ok_or_else(|| Failure::retry(Error::Device(format!("input device {selector:?} not found"))))?
+				.ok_or_else(|| Failure::retry(Error::Device(format!("input device {selector:?} not found"))))?;
+			(device, wanted)
 		}
-		None => host
-			.default_input_device()
-			.ok_or_else(|| Failure::retry(Error::Device("no default input device".into())))?,
+		None => {
+			let device = host
+				.default_input_device()
+				.ok_or_else(|| Failure::retry(Error::Device("no default input device".into())))?;
+			let id = device.id().map_err(Failure::cpal)?;
+			(device, id)
+		}
 	};
-	// One `id` call rather than three: it is fallible, and a device that cannot
-	// name itself has nothing the caller could select it by later.
-	let id = device.id().map_err(Failure::cpal)?;
 	let current = describe(&device, &id, Some(&id) == default.as_ref()).map_err(Failure::cpal)?;
 
 	let supported = device.default_input_config().map_err(Failure::cpal)?;

--- a/rs/moq-audio/src/encode/capture.rs
+++ b/rs/moq-audio/src/encode/capture.rs
@@ -1247,6 +1247,7 @@ mod tests {
 			id: name.into(),
 			name: name.into(),
 			default: false,
+			host: "test".into(),
 		}
 	}
 

--- a/rs/moq-audio/src/playback/device.rs
+++ b/rs/moq-audio/src/playback/device.rs
@@ -65,12 +65,29 @@ fn list() -> Result<Vec<Device>, Error> {
 	let mut seen = std::collections::HashSet::new();
 
 	for id in cpal::available_hosts() {
-		let Ok(host) = cpal::host_from_id(id) else { continue };
+		// A host that will not open takes every device on it with it, so say so:
+		// the symptom is a device missing from the listing with no other trace.
+		let host = match cpal::host_from_id(id) {
+			Ok(host) => host,
+			Err(err) => {
+				tracing::debug!(host = id.name(), error = %err, "skipping an audio host that would not open");
+				continue;
+			}
+		};
 		let default = host.default_output_device().and_then(|d| d.id().ok());
 
-		let Ok(outputs) = host.output_devices() else { continue };
+		let outputs = match host.output_devices() {
+			Ok(outputs) => outputs,
+			Err(err) => {
+				tracing::debug!(host = id.name(), error = %err, "skipping a host that would not list its outputs");
+				continue;
+			}
+		};
 		for device in outputs {
-			let Ok(device_id) = device.id() else { continue };
+			let Ok(device_id) = device.id() else {
+				tracing::debug!(host = id.name(), "skipping an output device with no id");
+				continue;
+			};
 			// A sound server reports one id per stream, not per device.
 			if !seen.insert(device_id.to_string()) {
 				continue;

--- a/rs/moq-audio/src/playback/device.rs
+++ b/rs/moq-audio/src/playback/device.rs
@@ -35,7 +35,15 @@ pub struct Device {
 	/// Human-readable name, e.g. "Built-in Output".
 	pub name: String,
 	/// Whether this is the system default output.
+	///
+	/// True for at most one device: the preferred host's default. Another host's
+	/// default is that host's, not the system's.
 	pub default: bool,
+	/// The host API this device is reached through, e.g. "PipeWire" or "ALSA".
+	///
+	/// The same hardware is usually reachable through several, so a caller that
+	/// offers a choice groups by this.
+	pub host: String,
 }
 
 /// List the audio outputs, across every host API the platform offers.
@@ -48,19 +56,32 @@ pub async fn devices() -> Result<Vec<Device>, Error> {
 }
 
 fn list() -> Result<Vec<Device>, Error> {
+	// Every host, not just the preferred one. The same hardware appears under
+	// each, and which one a caller wants is its decision: PipeWire and PulseAudio
+	// carry the server's own names and routing, ALSA reaches a device directly.
+	// `Device::host` is what lets a caller group or filter them.
+	let preferred = cpal::default_host().id();
 	let mut devices = Vec::new();
+	let mut seen = std::collections::HashSet::new();
 
 	for id in cpal::available_hosts() {
 		let Ok(host) = cpal::host_from_id(id) else { continue };
 		let default = host.default_output_device().and_then(|d| d.id().ok());
-		let Ok(outputs) = host.output_devices() else { continue };
 
+		let Ok(outputs) = host.output_devices() else { continue };
 		for device in outputs {
-			let Ok(id) = device.id() else { continue };
+			let Ok(device_id) = device.id() else { continue };
+			// A sound server reports one id per stream, not per device.
+			if !seen.insert(device_id.to_string()) {
+				continue;
+			}
 			devices.push(Device {
-				default: Some(&id) == default.as_ref(),
-				name: describe(&device, &id),
-				id: id.to_string(),
+				// Only the preferred host's default is the system default; the
+				// others are that host's idea of one.
+				default: id == preferred && Some(&device_id) == default.as_ref(),
+				name: describe(&device, &device_id),
+				host: id.name().to_string(),
+				id: device_id.to_string(),
 			});
 		}
 	}

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -66,7 +66,13 @@ vaapi = ["moq-video?/vaapi", "moq-transcode?/vaapi"]
 # Screen capture for `capture --display` on Linux (xdg-desktop-portal + PipeWire),
 # on by default like the hardware codecs above and trimmable the same way. Only
 # bites when `capture` pulls in moq-video; links libpipewire-0.3 at build time.
-pipewire = ["moq-video?/pipewire"]
+# Also reaches audio, so `devices`, microphone capture and playback go through
+# the sound server rather than its ALSA plugin on a machine running one.
+pipewire = ["moq-video?/pipewire", "moq-audio?/pipewire"]
+# The other Linux sound server. Off by default, unlike `pipewire`: PulseAudio is
+# what a machine runs when it is not running PipeWire, so enabling both by
+# default would link a client library most builds never reach for.
+pulseaudio = ["moq-audio?/pulseaudio"]
 
 [dependencies]
 anyhow = { workspace = true, features = ["backtrace"] }


### PR DESCRIPTION
Adds optional `pipewire` and `pulseaudio` features, so devices can be reached through the Linux sound server as well as through its ALSA compatibility plugin. A second commit lists devices from every host and says which host each one is on.

*This PR is part of a series to update iroh-live to latest moq, see n0-computer/iroh-live#45. The code and below description was written by Claude Code*

Both hosts already exist in cpal behind features, and `default_host` already prefers PipeWire, then PulseAudio, then ALSA. Each check happens at runtime, so a build with these features on still runs on a host that has neither.

They are off by default because each links its client library at build time, which is the same reason `capture` and `playback` are opt-in.

What they buy is the sound server's own view of the hardware. Through the ALSA compatibility plugin a card's subdevices are enumerated many times over under a single description, and an application's stream appears under the plugin's name rather than its own.

## Listing every host

The same hardware is reachable through several hosts at once, and which one a caller wants is its decision. The servers carry their own names and per-application routing; ALSA reaches a device directly, which is what someone bypassing the server wants.

The output side already enumerated every host and the input side did not, so this settles the pair on the wider behaviour rather than the narrower one. `Device` carries the host's name now, so a caller offering a choice can group or filter without parsing ids. Only the preferred host's default is reported as the system default; another host's default is that host's idea of one.

Capture also gained the other half of the pair. It resolved a selector against the preferred host alone, so an id from any other host could be listed and then refused on open. It routes by the id's own host now, which is what the output side already did.

Entries are deduplicated by id, which the sound-server hosts make necessary: a server names its streams as well as its devices, so a client with several streams open reports the same id once per stream.

## Verified

On Intel Meteor Lake with PipeWire, PulseAudio and ALSA all present. Listing outputs reports all three, and every entry carries its host:

```
hosts: ["ALSA", "PipeWire", "PulseAudio"]
  [PipeWire] pipewire:output_default  default_output (default)
  [PipeWire] pipewire:alsa_output...HiFi__Speaker__sink  ... Speaker
  [PulseAudio] pulseaudio:alsa_output...HiFi__Speaker__sink  ... Speaker
  [ALSA] alsa:pipewire  PipeWire Sound Server
  [ALSA] alsa:hdmi:CARD=sofhdadsp,DEV=0  sof-hda-dsp, HDMI 1
```

The same speaker appears three times, once per host, which is the point: a caller can offer the choice. Playback through the PipeWire host was confirmed at 48 kHz stereo. 134 tests pass, and clippy is clean with and without the two features.

## Review round

Listing walks every host now, and three of its error paths dropped a whole host or a device without a word. A host that fails to open takes every device on it, and the only symptom is one missing from the listing, which is hard to chase from the other end. Each skip now says which host and why, at debug. `resolve` also called the fallible `Device::id` three times for one device and fell back to an empty host name on a path where the next call would have failed anyway.
