### PR TITLE
feat(moq-net): expose broadcast demand on the read handle

### DIFF
--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -1058,7 +1058,13 @@ impl Consumer {
 	}
 
 	/// A watch-only handle to the broadcast's demand. See [`Demand`].
-	pub(crate) fn demand(&self) -> Demand {
+	///
+	/// The consumer-side sibling of [`Producer::demand`], for a holder that has
+	/// only a read handle: a relay pulling a broadcast from upstream owns no
+	/// producer for it (the ingesting session does), yet the question it has to
+	/// answer is whether anything downstream is still reading. Holding this
+	/// handle, or the [`Consumer`] it came from, is not itself demand.
+	pub fn demand(&self) -> Demand {
 		Demand {
 			alive: self.alive.weak(),
 			state: self.state.clone(),
@@ -1164,7 +1170,8 @@ impl super::WeakEntry for WeakConsumer {
 
 /// A cloneable, watch-only handle to a broadcast's subscriber demand.
 ///
-/// Obtained from [`Producer::demand`]; the broadcast-level sibling of
+/// Obtained from [`Producer::demand`] or [`Consumer::demand`]; the
+/// broadcast-level sibling of
 /// [`track::Demand`](crate::track::Demand). Demand means live interest in the
 /// broadcast's content: a subscribed spliced track on a route-fed broadcast, or
 /// a pending track request / a consumed track on an ordinary one. A publisher
@@ -1302,16 +1309,23 @@ mod test {
 		let producer = Producer::new_spliced(Info::new());
 		let consumer = producer.consume();
 		let demand = producer.demand();
+		// The read handle answers the same question, which is all a relay
+		// holding a pulled broadcast has.
+		let watched = consumer.demand();
 
 		assert!(!demand.is_used());
+		assert!(!watched.is_used());
 		let track = consumer.track("video").unwrap();
 		assert!(demand.is_used());
+		assert!(watched.is_used());
 
 		// Dropping the only consumer wakes a parked `unused`, even though the
-		// logical track itself stays cached in the broadcast.
-		let (unused, ()) = tokio::join!(expect(demand.unused()), async { drop(track) });
+		// logical track itself stays cached in the broadcast. Parked on the read
+		// handle: that edge is what tells a relay its pull has no readers left.
+		let (unused, ()) = tokio::join!(expect(watched.unused()), async { drop(track) });
 		unused.unwrap();
 		assert!(!demand.is_used());
+		assert!(!watched.is_used());
 
 		// A repeat consumer for the cached track counts again.
 		let _track = consumer.track("video").unwrap();

--- a/rs/moq-net/src/model/broadcast.rs
+++ b/rs/moq-net/src/model/broadcast.rs
@@ -1064,6 +1064,11 @@ impl Consumer {
 	/// producer for it (the ingesting session does), yet the question it has to
 	/// answer is whether anything downstream is still reading. Holding this
 	/// handle, or the [`Consumer`] it came from, is not itself demand.
+	///
+	/// Two endings a caller has to tell apart. Demand going away is
+	/// [`Demand::unused`] resolving, and means nobody downstream is reading.
+	/// The broadcast going away is [`Error::Dropped`], and here that is the
+	/// upstream producer, not the readers.
 	pub fn demand(&self) -> Demand {
 		Demand {
 			alive: self.alive.weak(),
@@ -1170,9 +1175,8 @@ impl super::WeakEntry for WeakConsumer {
 
 /// A cloneable, watch-only handle to a broadcast's subscriber demand.
 ///
-/// Obtained from [`Producer::demand`] or [`Consumer::demand`]; the
-/// broadcast-level sibling of
-/// [`track::Demand`](crate::track::Demand). Demand means live interest in the
+/// Obtained from [`Producer::demand`] or [`Consumer::demand`]; the broadcast-level
+/// sibling of [`track::Demand`](crate::track::Demand). Demand means live interest in the
 /// broadcast's content: a subscribed spliced track on a route-fed broadcast, or
 /// a pending track request / a consumed track on an ordinary one. A publisher
 /// uses it to run expensive work only while someone is watching, and routing
@@ -1330,6 +1334,35 @@ mod test {
 		// A repeat consumer for the cached track counts again.
 		let _track = consumer.track("video").unwrap();
 		assert!(demand.is_used());
+	}
+
+	/// A read handle's demand reports the producer going away as `Dropped`,
+	/// distinct from its readers going away.
+	///
+	/// The distinction a relay has to act on: no readers means stop pulling,
+	/// while an upstream that vanished means the pull is over. Both arrive on
+	/// the same handle, so the two have to be told apart by their result rather
+	/// than by which one resolved.
+	#[tokio::test]
+	async fn a_read_handle_reports_a_dropped_producer_apart_from_lost_demand() {
+		let producer = Producer::new_spliced(Info::new());
+		let consumer = producer.consume();
+		let watched = consumer.demand();
+
+		let track = consumer.track("video").unwrap();
+		assert!(watched.is_used());
+
+		// Readers go, the broadcast stays: demand ends, and the handle keeps
+		// answering.
+		let (unused, ()) = tokio::join!(expect(watched.unused()), async { drop(track) });
+		unused.unwrap();
+
+		// The producer goes: the same handle now refuses rather than reporting
+		// no demand, which is what stops a relay retrying a pull that has no
+		// source left.
+		drop(producer);
+		assert!(matches!(watched.used().await, Err(Error::Dropped)));
+		assert!(matches!(watched.unused().await, Err(Error::Dropped)));
 	}
 
 	/// Subscribe and assert the result hasn't resolved yet (it stays pending until


### PR DESCRIPTION
`broadcast::Consumer::demand` was `pub(crate)`. Making it public gives a holder that has only a read handle the same answer `Producer::demand` gives a writer: whether anything downstream is still reading.

*This PR is part of a series to update iroh-live to latest moq, see n0-computer/iroh-live#45. The code and below description was written by Claude Code*

The case that wants it is a relay that pulls a broadcast from upstream. The ingesting session owns the producer, so the puller holds only a consumer, and the question it has to answer is whether any local subscriber is still reading what it mirrors. Without this it has no signal at all, and a transport-level one cannot substitute: keep-alives move every byte counter on a connection nobody reads.

For a route-fed front, `demand` reports whether any spliced logical track has a live consumer, which is exactly the question. Holding the handle, or the `Consumer` it came from, is not itself demand.

No behaviour changes. The visibility widens, the docs say what the consumer side is for, and the existing spliced-demand test now parks on the read handle for the unused edge, since that is the transition a puller acts on.

## Verified

914 moq-net tests pass. Clippy clean for moq-net and moq-relay.

Downstream, this is what lets iroh-live's relay retire a pulled session once nothing reads it, with a test that fails when the call is stubbed out to return nothing.

## Overlap with `dev`

`dev` already has `pub fn demand()`, but on `Producer` only. This is the consumer-side sibling, so the two do not collide, though it is worth knowing that the branches have converged on the same idea from different ends.

## Review round

A relay watching a pulled broadcast has two endings to act on and one handle to learn both from: readers going away is `unused` resolving, while the upstream producer going away is `Error::Dropped`. That distinction is now on `Consumer::demand` rather than only on `Demand`, and in a test.


## Cross-package sync

The table in `AGENTS.md` asks for a matching `js/net` update on an `rs/moq-net` API change, and this one skips that row deliberately.

Broadcast-level demand has no JavaScript surface today: `js/net/src/broadcast.ts` exports `Producer` and `Consumer` with no `demand`, `used` or `unused` on either, and the demand that does exist in JS is per-track and per-group (`track.Producer.used`, and the group mirror counting in `group.ts`). So this is not a Rust-only API being introduced; it is one method reaching the read handle of a concept that was already Rust-only on both sides. Adding a JS broadcast-demand observer is worth doing, but it is the producer half's job as much as this one's, and it belongs in a change that designs the whole surface rather than in a one-method PR.

`doc/concept` likewise documents demand at the track level, and nothing there becomes wrong.
