### PR TITLE
feat(moq-video): add the VAAPI H.264 decoder and import its pictures zero-copy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5182,8 +5182,7 @@ dependencies = [
 [[package]]
 name = "moq-vaapi"
 version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4209e5f9401f2ed76eb5a82c807966be235c483a6932777623cec30950ba7d4"
+source = "git+https://github.com/Frando/vaapi?branch=pr%2Fdecode#b2550c8f63a7a982e607dc482a5131457f9dd5d2"
 dependencies = [
  "anyhow",
  "bindgen 0.70.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5182,7 +5182,7 @@ dependencies = [
 [[package]]
 name = "moq-vaapi"
 version = "0.0.3"
-source = "git+https://github.com/Frando/vaapi?branch=pr%2Fdecode#857d1be88168941bdbf2713379a2cfe5426b74b3"
+source = "git+https://github.com/Frando/vaapi?branch=pr%2Fdecode#4c618d1ff129fc421400d98dc3efa076eb3de627"
 dependencies = [
  "anyhow",
  "bindgen 0.70.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5182,7 +5182,7 @@ dependencies = [
 [[package]]
 name = "moq-vaapi"
 version = "0.0.3"
-source = "git+https://github.com/Frando/vaapi?branch=pr%2Fdecode#b2550c8f63a7a982e607dc482a5131457f9dd5d2"
+source = "git+https://github.com/Frando/vaapi?branch=pr%2Fdecode#857d1be88168941bdbf2713379a2cfe5426b74b3"
 dependencies = [
  "anyhow",
  "bindgen 0.70.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5181,8 +5181,9 @@ dependencies = [
 
 [[package]]
 name = "moq-vaapi"
-version = "0.0.3"
-source = "git+https://github.com/Frando/vaapi?branch=pr%2Fdecode#4c618d1ff129fc421400d98dc3efa076eb3de627"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "091df44de531fc6e5346da91f2dd7d1ebbb4a2e741ddadaf49aef017e659cb57"
 dependencies = [
  "anyhow",
  "bindgen 0.70.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,9 +135,7 @@ moq-token-cli = { version = "0.5.46", path = "rs/moq-token-cli" }
 moq-transcode = { version = "0.0.16", path = "rs/moq-transcode", default-features = false }
 # Standalone crate (moq-dev/vaapi); vendored from cros-libva + cros-codecs.
 # dlopen's libva at runtime (no libva-dev at build, no NEEDED libva in the binary).
-# The decoder this crate's VAAPI backend calls is not in 0.0.3 yet; see
-# moq-dev/vaapi#2. Point this back at a release once one carries `decode`.
-moq-vaapi = { git = "https://github.com/Frando/vaapi", branch = "pr/decode" }
+moq-vaapi = "0.0.4"
 # `default-features = false` is here for `capture` (V4L2, libclang), which the
 # cross-compiled Python, Swift, Kotlin, and Go builds have no use for: adding
 # `features = ["capture"]` to a consumer that ships in those bindings pulls the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,9 @@ moq-token-cli = { version = "0.5.46", path = "rs/moq-token-cli" }
 moq-transcode = { version = "0.0.16", path = "rs/moq-transcode", default-features = false }
 # Standalone crate (moq-dev/vaapi); vendored from cros-libva + cros-codecs.
 # dlopen's libva at runtime (no libva-dev at build, no NEEDED libva in the binary).
-moq-vaapi = "0.0.3"
+# The decoder this crate's VAAPI backend calls is not in 0.0.3 yet; see
+# moq-dev/vaapi#2. Point this back at a release once one carries `decode`.
+moq-vaapi = { git = "https://github.com/Frando/vaapi", branch = "pr/decode" }
 # `default-features = false` is here for `capture` (V4L2, libclang), which the
 # cross-compiled Python, Swift, Kotlin, and Go builds have no use for: adding
 # `features = ["capture"]` to a consumer that ships in those bindings pulls the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,8 +130,8 @@ moq-token-cli = { version = "0.5.46", path = "rs/moq-token-cli" }
 # default-features off (the NVIDIA hardware codecs) on moq-transcode and
 # moq-video so each consumer opts in. Binaries enable them, but a self-compiler
 # can leave them off to drop the CUDA dependencies. Both crates still default
-# them on when depended on directly. VAAPI is opt-in everywhere, since that
-# backend has never been validated on real hardware.
+# them on when depended on directly. VAAPI is opt-in everywhere; its decoder is
+# hardware-validated, while its encoder is not yet.
 moq-transcode = { version = "0.0.16", path = "rs/moq-transcode", default-features = false }
 # Standalone crate (moq-dev/vaapi); vendored from cros-libva + cros-codecs.
 # dlopen's libva at runtime (no libva-dev at build, no NEEDED libva in the binary).

--- a/doc/lib/rs/moq-video.md
+++ b/doc/lib/rs/moq-video.md
@@ -15,7 +15,7 @@ ffmpeg, no GStreamer, no system codec to install.
 | --- | --- | --- |
 | `capture` | Camera, display, window, or application frames | AVFoundation + ScreenCaptureKit (macOS), V4L2 + X11/portal + PipeWire (Linux), Media Foundation + DXGI (Windows) |
 | `encode` | Frames to H.264/H.265, published as a hang track | VideoToolbox, Media Foundation, NVENC, VAAPI, V4L2 M2M, MediaCodec (Android), openh264 |
-| `decode` | A subscribed track back to frames | VideoToolbox, Media Foundation/DXVA, NVDEC, V4L2 M2M, MediaCodec (Android), openh264 |
+| `decode` | A subscribed track back to frames | VideoToolbox, Media Foundation/DXVA, NVDEC, VAAPI, V4L2 M2M, MediaCodec (Android), openh264 |
 | `render` | A frame as a `wgpu` texture | wgpu, with zero-copy Metal and Vulkan imports |
 
 Highlights:
@@ -45,3 +45,7 @@ Android floor at API 24 instead of MediaCodec's API 26 entry points.
 
 API: [docs.rs/moq-video](https://docs.rs/moq-video). Pair with
 [`moq-audio`](/lib/rs/moq-audio).
+
+VAAPI downloads to CPU I420 by default. Set `decode::Config::gpu_frames` before
+opening the consumer to receive DMA-BUF surfaces for zero-copy rendering. These
+surfaces still support `Surface::into_i420()` for consumers that need bytes.

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -592,6 +592,94 @@ mod tests {
 		moq_video::decode::Decoder::new(&video, &decode).is_ok()
 	}
 
+	#[cfg(feature = "vaapi")]
+	fn vaapi_decoder_available() -> bool {
+		let video = hang::catalog::VideoConfig::new(hang::catalog::H264 {
+			inline: true,
+			profile: 0x42,
+			constraints: 0,
+			level: 30,
+		});
+		let mut decode = moq_video::decode::Config::new();
+		decode.kind = moq_video::decode::Kind::Named("vaapi".to_string());
+		moq_video::decode::Decoder::new(&video, &decode).is_ok()
+	}
+
+	/// A fetched group drains VAAPI before finishing, so its buffered tail is
+	/// encoded into that group rather than dropped with the decoder.
+	#[cfg(feature = "vaapi")]
+	#[tokio::test]
+	async fn vaapi_fetch_keeps_the_buffered_tail() {
+		let source = source_broadcast(1, 5);
+		let config = Config {
+			rungs: vec![Rung::new(120, 100_000)],
+			encoder: moq_video::encode::Kind::Software,
+			decoder: moq_video::decode::Kind::Named("vaapi".to_string()),
+			source: None,
+			..Default::default()
+		};
+
+		if !vaapi_decoder_available() {
+			eprintln!("skipping: no VA-API H.264 decoder");
+			return;
+		}
+		let output = moq_net::broadcast::Info::default().produce();
+		let consumer = output.consume();
+		let transcoder = tokio::spawn(run(source.broadcast.consume(), output, config));
+
+		let track = loop {
+			match consumer.track("video/120p") {
+				Ok(track) => break track,
+				Err(moq_net::Error::NotFound) => tokio::task::yield_now().await,
+				Err(err) => panic!("rung track: {err}"),
+			}
+		};
+		let mut fetched = track.fetch_group(0, None).await.unwrap();
+		let total = fetched.finished().await.unwrap();
+		assert_eq!(total, 5, "VAAPI dropped the fetched group's buffered tail");
+
+		transcoder.abort();
+	}
+
+	/// A live group drains VAAPI before its end marker, so its buffered tail does
+	/// not move past the boundary into the next group.
+	#[cfg(feature = "vaapi")]
+	#[tokio::test]
+	async fn vaapi_live_keeps_the_buffered_tail_in_its_group() {
+		if !vaapi_decoder_available() {
+			eprintln!("skipping: no VA-API H.264 decoder");
+			return;
+		}
+
+		let (source, producer_task) = source_broadcast_live(1, 5);
+		let config = Config {
+			rungs: vec![Rung::new(120, 100_000)],
+			encoder: moq_video::encode::Kind::Software,
+			decoder: moq_video::decode::Kind::Named("vaapi".to_string()),
+			source: None,
+			..Default::default()
+		};
+
+		let output = moq_net::broadcast::Info::default().produce();
+		let consumer = output.consume();
+		let transcoder = tokio::spawn(run(source.broadcast.consume(), output, config));
+
+		let track = loop {
+			match consumer.track("video/120p") {
+				Ok(track) => break track,
+				Err(moq_net::Error::NotFound) => tokio::task::yield_now().await,
+				Err(err) => panic!("rung track: {err}"),
+			}
+		};
+		let mut subscriber = track.subscribe(None).await.unwrap();
+		let mut group = subscriber.next_group().await.unwrap().unwrap();
+		let total = group.finished().await.unwrap();
+		assert_eq!(total, 5, "VAAPI moved the live group's buffered tail past its end");
+
+		producer_task.abort();
+		transcoder.abort();
+	}
+
 	/// The GPU pipeline end to end: hardware decode (NVDEC, scaling in the
 	/// decoder) into hardware encode (NVENC, consuming the CUDA frame in place).
 	/// Skips on machines without both; on a Linux + NVIDIA box this is the

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -612,7 +612,7 @@ mod tests {
 	async fn vaapi_fetch_keeps_the_buffered_tail() {
 		let source = source_broadcast(1, 5);
 		let config = Config {
-			rungs: vec![Rung::new(120, 100_000)],
+			ladder: Ladder::new([Rung::new(120, 100_000)]).unwrap(),
 			encoder: moq_video::encode::Kind::Software,
 			decoder: moq_video::decode::Kind::Named("vaapi".to_string()),
 			source: None,
@@ -653,7 +653,7 @@ mod tests {
 
 		let (source, producer_task) = source_broadcast_live(1, 5);
 		let config = Config {
-			rungs: vec![Rung::new(120, 100_000)],
+			ladder: Ladder::new([Rung::new(120, 100_000)]).unwrap(),
 			encoder: moq_video::encode::Kind::Software,
 			decoder: moq_video::decode::Kind::Named("vaapi".to_string()),
 			source: None,

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -42,11 +42,10 @@ nvidia = ["dep:cudarc", "dep:moq-nvenc", "dep:libloading"]
 # feature tables name only `nvidia`.
 nvenc = ["nvidia"]
 nvdec = ["nvidia"]
-# Intel/AMD VAAPI hardware encoder (Linux). moq-vaapi dlopen's libva, so the
-# build needs no libva and still starts on a libva-less host, where automatic
-# backend selection falls back to the next encoder like the NVENC backend does.
-# The backend has not been validated on real hardware yet; `Kind::Named`
-# ("openh264") sidesteps it if it misbehaves.
+# Intel/AMD VAAPI hardware codecs (Linux): the H.264 encoder and decoder.
+# moq-vaapi dlopen's libva, so the build needs no libva and still starts on a
+# libva-less host, where automatic backend selection falls back to the next
+# candidate. The decoder is hardware-validated, while the encoder is not yet.
 vaapi = ["dmabuf", "dep:moq-vaapi"]
 # The V4L2 stateful memory-to-memory hardware codecs on Linux: the H.264 encoder
 # and decoder most ARM SoCs expose (a Raspberry Pi's VideoCore, and the
@@ -155,11 +154,11 @@ libloading = { workspace = true, optional = true }
 # Architecture-correct DMA_BUF_IOCTL_SYNC request values for CPU access.
 linux-raw-sys = { workspace = true, optional = true }
 moq-nvenc = { workspace = true, optional = true }
-# Intel/AMD VAAPI hardware encoder, behind the opt-in `vaapi` feature. As of
-# moq-vaapi 0.0.3 libva is dlopen'd at runtime, so the binary carries no NEEDED
-# libva: the build needs no libva-dev, and a libva-less host still loads. Automatic
-# backend selection then falls back to the next encoder instead of failing at load,
-# matching the NVENC backend.
+# Intel/AMD VAAPI hardware H.264 encoder and decoder, behind the opt-in `vaapi`
+# feature. As of moq-vaapi 0.0.3 libva is dlopen'd at runtime, so the binary carries
+# no NEEDED libva: the build needs no libva-dev, and a libva-less host still loads.
+# Automatic backend selection then falls back to the next candidate instead of
+# failing at load, matching the NVENC and NVDEC backends.
 moq-vaapi = { workspace = true, optional = true }
 # PipeWire video stream for the portal's node, behind the `pipewire` feature.
 # Links libpipewire-0.3 via pkg-config at build time; bindgen needs libclang.

--- a/rs/moq-video/README.md
+++ b/rs/moq-video/README.md
@@ -116,7 +116,7 @@ Backends are tried hardware-first, like encode:
 
 | Codec | Software | macOS | Windows | Linux | Android |
 |---|---|---|---|---|---|
-| H.264 | openh264 (vendored, static) | VideoToolbox | Media Foundation (DXVA) | NVDEC (feature `nvidia`) | MediaCodec (feature `mediacodec`, API 26+) |
+| H.264 | openh264 (vendored, static) | VideoToolbox | Media Foundation (DXVA) | NVDEC (feature `nvidia`), VAAPI (feature `vaapi`) | MediaCodec (feature `mediacodec`, API 26+) |
 | H.265 | none | VideoToolbox | Media Foundation (DXVA) | NVDEC (feature `nvidia`) | MediaCodec (feature `mediacodec`, API 26+) |
 | AV1 | none | none | none | NVDEC (feature `nvidia`) | MediaCodec (feature `mediacodec`, when the device provides it) |
 
@@ -128,5 +128,7 @@ Direct3D11 device bound to it, so the decode happens on the GPU through DXVA
 no software decoder, so it needs the GPU path (on Windows, an HEVC decoder MFT:
 the inbox HEVC Video Extensions or a vendor one). On Linux, NVDEC decodes H.264,
 H.265, and 8-bit 4:2:0 AV1 to CUDA NV12 frames; AV1 is decode-only and is useful
-for AV1 source to H.264/H.265 transcode rungs. A non-H.264/H.265/AV1 rendition
-yields `Error::UnsupportedCodec`.
+for AV1 source to H.264/H.265 transcode rungs. VAAPI decodes H.264 to CPU I420 by
+default; set `decode::Config::gpu_frames` to receive DMA-BUF surfaces that the
+renderer can import without a download. A non-H.264/H.265/AV1 rendition yields
+`Error::UnsupportedCodec`.

--- a/rs/moq-video/src/decode/backend/mod.rs
+++ b/rs/moq-video/src/decode/backend/mod.rs
@@ -8,7 +8,7 @@
 //!
 //! [`open`] picks the best backend for a [`Codec`] and [`Config`], trying
 //! hardware candidates (platform-gated: VideoToolbox on macOS, Media Foundation
-//! / DXVA on Windows, MediaCodec on Android, NVDEC then V4L2 on Linux) before
+//! / DXVA on Windows, MediaCodec on Android, NVDEC, VAAPI, then V4L2 on Linux) before
 //! the openh264 software fallback, exactly like the encode side. Only backends
 //! that support the requested codec are considered: there is no software H.265
 //! or AV1 decoder, so those tracks have no fallback below the hardware path.
@@ -35,6 +35,9 @@ mod mediacodec;
 
 #[cfg(all(target_os = "linux", feature = "nvidia"))]
 mod nvdec;
+
+#[cfg(all(target_os = "linux", feature = "vaapi"))]
+mod vaapi;
 
 #[cfg(all(target_os = "linux", feature = "v4l2"))]
 mod v4l2;
@@ -117,6 +120,12 @@ const HARDWARE: &[Candidate] = &[
 		name: nvdec::NAME,
 		supports: |c| matches!(c, Codec::H264 | Codec::H265 | Codec::Av1),
 		open: nvdec::Nvdec::open,
+	},
+	#[cfg(all(target_os = "linux", feature = "vaapi"))]
+	Candidate {
+		name: vaapi::NAME,
+		supports: |c| matches!(c, Codec::H264),
+		open: vaapi::Vaapi::open,
 	},
 	// Last of the Linux hardware decoders, for the same reason as its encode
 	// counterpart: the SoC blocks it drives are the only hardware on a board that

--- a/rs/moq-video/src/decode/backend/mod.rs
+++ b/rs/moq-video/src/decode/backend/mod.rs
@@ -37,7 +37,7 @@ mod mediacodec;
 mod nvdec;
 
 #[cfg(all(target_os = "linux", feature = "vaapi"))]
-mod vaapi;
+pub(crate) mod vaapi;
 
 #[cfg(all(target_os = "linux", feature = "v4l2"))]
 mod v4l2;

--- a/rs/moq-video/src/decode/backend/vaapi.rs
+++ b/rs/moq-video/src/decode/backend/vaapi.rs
@@ -19,9 +19,13 @@
 //! error rather than wrong pixels.
 //!
 //! Unlike NVDEC, which cuvid lets us pin to zero display delay, output trails the
-//! input by one picture even without B-frames: H.264's DPB releases a picture only
-//! once a later one needs its slot. The decoded frames still carry their own
-//! timestamps, so nothing downstream has to know.
+//! input even without B-frames: H.264's DPB releases a picture only once a later
+//! one needs its slot, and the slot count comes from the sequence's reference and
+//! reorder limits rather than the reorder depth actually used. A stream coded with
+//! three reference frames therefore keeps three pictures in hand, which is why
+//! this backend implements [`Backend::flush`] and the layers above call it when
+//! the track ends. The decoded frames carry their own timestamps, so the delay
+//! itself needs nothing downstream.
 //!
 //! The output is CPU I420 rather than a zero-copy [`Surface::DmaBuf`]: VA-API
 //! decode targets on Intel come back Y-tiled (DRM modifier `0x100000000000002`),
@@ -74,19 +78,37 @@ impl Backend for Vaapi {
 			.decode(&access_unit, timestamp.as_micros() as u64)
 			.map_err(|e| Error::Codec(anyhow::anyhow!("VAAPI decode: {e:?}")))?;
 
-		decoded
-			.into_iter()
-			.map(|frame| {
-				let i420 = I420::from_nv12(&frame.data, frame.width, frame.height)?;
-				let timestamp = Timestamp::from_micros(frame.timestamp).unwrap_or(Timestamp::ZERO);
-				Ok(Frame::new(Surface::I420(i420), timestamp))
-			})
-			.collect()
+		convert(decoded)
+	}
+
+	/// The tail of the stream, which is why this backend overrides the trait's
+	/// no-op: the DPB is holding as many pictures as the sequence's reference and
+	/// reorder limits allow, and nothing else will ever ask for them.
+	fn flush(&mut self) -> Result<Vec<Frame>, Error> {
+		let decoded = self
+			.decoder
+			.flush()
+			.map_err(|e| Error::Codec(anyhow::anyhow!("VAAPI flush: {e:?}")))?;
+
+		convert(decoded)
 	}
 
 	fn name(&self) -> &str {
 		NAME
 	}
+}
+
+/// Deinterleave each decoded picture's NV12 into the CPU I420 the rest of the
+/// crate speaks, keeping the timestamp the picture was coded with.
+fn convert(decoded: Vec<moq_vaapi::decode::Frame>) -> Result<Vec<Frame>, Error> {
+	decoded
+		.into_iter()
+		.map(|frame| {
+			let i420 = I420::from_nv12(&frame.data, frame.width, frame.height)?;
+			let timestamp = Timestamp::from_micros(frame.timestamp).unwrap_or(Timestamp::ZERO);
+			Ok(Frame::new(Surface::I420(i420), timestamp))
+		})
+		.collect()
 }
 
 #[cfg(test)]
@@ -188,5 +210,60 @@ mod tests {
 			assert!(mae(i420.u(), expected.u()) < 8, "U plane corrupt");
 			assert!(mae(i420.v(), expected.v()) < 8, "V plane corrupt");
 		}
+	}
+
+	/// Regression: every picture fed in comes back out, which needs the flush.
+	///
+	/// H.264 releases a picture from the DPB only once a later one needs its slot,
+	/// so a stream simply stopping leaves its tail there. How many depends on the
+	/// sequence's reference and reorder limits, not on the reorder depth the
+	/// stream used: openh264 codes one reference frame and loses the last picture,
+	/// x264's default three loses three. The `decode` half of the assertion is
+	/// what keeps this honest, since a decoder that held nothing back would pass
+	/// the rest of it without a flush ever running.
+	#[test]
+	fn flushing_returns_the_tail_the_dpb_holds() {
+		if !hw_available() {
+			return;
+		}
+		const FRAMES: u64 = 5;
+		let (w, h) = (320u32, 240u32);
+		let rgba = gradient_rgba(w, h);
+
+		let mut encoder = Encoder::new(&EncodeConfig {
+			kind: EncodeKind::Software,
+			..EncodeConfig::new(w, h, 30)
+		})
+		.unwrap();
+		let mut decoder = Vaapi::open(Codec::H264, &decode_config()).expect("VAAPI H.264 decoder");
+
+		let mut streamed = Vec::new();
+		for i in 0..FRAMES {
+			if i == 0 {
+				encoder.keyframe();
+			}
+			let surface = Surface::rgba(&rgba, crate::Size::new(w, h)).unwrap();
+			let frame = Frame::new(surface, Timestamp::from_micros(i * 33_333).unwrap());
+			for encoded in encoder.encode(&frame).unwrap() {
+				streamed.extend(decoder.decode(encoded.payload, encoded.timestamp, i == 0).unwrap());
+			}
+		}
+		assert!(
+			(streamed.len() as u64) < FRAMES,
+			"the DPB held nothing back, so this test proves nothing"
+		);
+
+		let flushed = decoder.flush().unwrap();
+		let timestamps: Vec<u128> = streamed
+			.iter()
+			.chain(&flushed)
+			.map(|frame| frame.timestamp.as_micros())
+			.collect();
+		let expected: Vec<u128> = (0..FRAMES as u128).map(|i| i * 33_333).collect();
+		assert_eq!(timestamps, expected, "the stream lost pictures at its end");
+
+		// A second flush has nothing left to hand back, so the drain is idempotent
+		// and a caller that flushes twice does not see a picture twice.
+		assert!(decoder.flush().unwrap().is_empty());
 	}
 }

--- a/rs/moq-video/src/decode/backend/vaapi.rs
+++ b/rs/moq-video/src/decode/backend/vaapi.rs
@@ -31,7 +31,7 @@
 //! case each picture comes back as the zero-copy [`Surface::DmaBuf`] the
 //! hardware decoded it into. Measured on Intel Meteor Lake with iHD, a decode
 //! target exports at modifier `0x100000000000009`, and the renderer imports that
-//! per memory plane with no re-tile, so the pixels reach a texture untouched
+//! a memory plane at a time, so the pixels reach a texture untouched
 //! (`decoded_frames_reach_the_gpu_without_a_download` in
 //! [`render`](crate::render) draws them).
 //!
@@ -48,7 +48,6 @@
 use std::os::fd::{AsFd, OwnedFd};
 use std::sync::{Arc, Mutex};
 
-use anyhow::Context as _;
 use bytes::Bytes;
 use moq_net::Timestamp;
 use moq_vaapi::decode::{Config as VaapiConfig, Decoder, ExportedFrame};
@@ -66,11 +65,16 @@ pub(crate) struct Vaapi {
 	/// a host that decodes but cannot share what it decoded loses the fast path
 	/// rather than the stream.
 	gpu_frames: bool,
+	/// Whether a picture has ever come back as a descriptor, which is what
+	/// settles the question above. See [`Vaapi::exported`].
+	has_exported: bool,
 }
 
-// The decoder is `!Send` (libva uses `Rc` internally) but is created, used, and
-// dropped only on the dedicated decode thread (see `decode::sink`); the `Send`
-// impl just lets the boxed trait object satisfy `Backend: Send`.
+// SAFETY: the decoder is `!Send` (libva uses `Rc` internally) but is created,
+// used, and dropped only on the dedicated decode thread (see `decode::sink`);
+// the `Send` impl just lets the boxed trait object satisfy `Backend: Send`.
+// None of the `Rc`s escape with a picture either: an exported one holds its own
+// `Arc<Display>` and a surface id, and is `Send` and `Sync` on its own terms.
 unsafe impl Send for Vaapi {}
 
 impl Vaapi {
@@ -90,48 +94,61 @@ impl Vaapi {
 		Ok(Box::new(Self {
 			decoder,
 			gpu_frames: config.gpu_frames,
+			has_exported: false,
 		}))
 	}
 
 	/// Decodes one access unit into GPU-resident frames, or `None` once the
 	/// driver has shown it will not export.
-	///
-	/// A driver can decode without being able to share what it decoded, and the
-	/// caller only asked for GPU frames as an optimization. Losing the pictures
-	/// of the one call that discovers this beats losing the stream, and the DPB
-	/// is untouched by it: those pictures had already been bumped out of it.
-	fn decode_shared(&mut self, access_unit: &Bytes, timestamp: u64) -> Option<Vec<Frame>> {
+	fn decode_shared(&mut self, access_unit: &Bytes, timestamp: u64) -> Option<Result<Vec<Frame>, Error>> {
 		if !self.gpu_frames {
 			return None;
 		}
 
-		Some(
-			match self.decoder.decode_exported(access_unit, timestamp).and_then(share) {
-				Ok(frames) => frames,
-				Err(err) => self.cannot_share(&err),
-			},
-		)
+		let exported = self.decoder.decode_exported(access_unit, timestamp).and_then(share);
+		Some(self.exported(exported))
 	}
 
 	/// The same for the stream's tail, so a track that ends does not switch to
 	/// downloading for its last few pictures.
-	fn flush_shared(&mut self) -> Option<Vec<Frame>> {
+	fn flush_shared(&mut self) -> Option<Result<Vec<Frame>, Error>> {
 		if !self.gpu_frames {
 			return None;
 		}
 
-		Some(match self.decoder.flush_exported().and_then(share) {
-			Ok(frames) => frames,
-			Err(err) => self.cannot_share(&err),
-		})
+		let exported = self.decoder.flush_exported().and_then(share);
+		Some(self.exported(exported))
 	}
 
-	/// Records that this driver will not share what it decoded, and gives up the
-	/// pictures of the call that found out.
-	fn cannot_share(&mut self, err: &anyhow::Error) -> Vec<Frame> {
-		tracing::warn!(%err, "VAAPI cannot hand out decoded surfaces; downloading them instead");
-		self.gpu_frames = false;
-		Vec::new()
+	/// Hands back the pictures a shared decode produced, and decides what a
+	/// failure to produce any means.
+	///
+	/// A driver can decode without being able to share what it decoded, and the
+	/// caller only asked for GPU frames as an optimization, so until one picture
+	/// has come back that way a failure is read as this driver answering the
+	/// question. Losing the pictures of the call that found out beats losing the
+	/// stream, and the DPB is untouched by it: those pictures had already been
+	/// bumped out of it.
+	///
+	/// Once a picture has come back the question is settled, and a later failure
+	/// is a decode error rather than a verdict on the driver. Reporting it as
+	/// one keeps a corrupt access unit from silently costing the rest of the
+	/// session its fast path.
+	fn exported(&mut self, exported: anyhow::Result<Vec<Frame>>) -> Result<Vec<Frame>, Error> {
+		match exported {
+			Ok(frames) => {
+				// An access unit whose pictures are all still in the DPB proves
+				// nothing about exporting, so only a non-empty answer counts.
+				self.has_exported |= !frames.is_empty();
+				Ok(frames)
+			}
+			Err(err) if self.has_exported => Err(Error::Codec(err.context("VAAPI decode to a shared surface"))),
+			Err(err) => {
+				tracing::warn!(%err, "VAAPI cannot hand out decoded surfaces; downloading them instead");
+				self.gpu_frames = false;
+				Ok(Vec::new())
+			}
+		}
 	}
 }
 
@@ -141,7 +158,7 @@ impl Backend for Vaapi {
 		// survives the DPB reordering a stream with B-frames goes through.
 		let timestamp = timestamp.as_micros() as u64;
 		if let Some(frames) = self.decode_shared(&access_unit, timestamp) {
-			return Ok(frames);
+			return frames;
 		}
 
 		let decoded = self
@@ -157,7 +174,7 @@ impl Backend for Vaapi {
 	/// reorder limits allow, and nothing else will ever ask for them.
 	fn flush(&mut self) -> Result<Vec<Frame>, Error> {
 		if let Some(frames) = self.flush_shared() {
-			return Ok(frames);
+			return frames;
 		}
 
 		let decoded = self
@@ -205,25 +222,48 @@ fn share(exported: Vec<ExportedFrame>) -> anyhow::Result<Vec<Frame>> {
 /// which is the driver's padded allocation. Neither the pitches nor the offsets
 /// follow from the visible size, which is exactly why they are read off the
 /// export rather than computed from it.
+///
+/// # Errors
+///
+/// When the export is not the one shape a [`DmaBuf`] can describe: a single NV12
+/// layer whose planes all live in a single object. The Intel and AMD drivers
+/// export exactly that, and the alternatives are refused rather than guessed at,
+/// because every one of them draws as a plausible-looking picture made of the
+/// wrong bytes.
 fn adopt(frame: ExportedFrame) -> anyhow::Result<DmaBuf> {
 	let (width, height) = (frame.width, frame.height);
-	let layer = frame
-		.descriptor
-		.layers
-		.first()
-		.context("the VA-API export carries no layer")?;
+	// One object, because a consumer imports every plane from the one descriptor
+	// `Exported::export` hands out, and one layer, because the planes are read
+	// off it as a group. Both are what `VA_EXPORT_SURFACE_COMPOSED_LAYERS` asks
+	// for; neither is what it guarantees.
+	let [object] = frame.descriptor.objects.as_slice() else {
+		anyhow::bail!(
+			"VA-API exported {} objects, expected one holding every plane",
+			frame.descriptor.objects.len()
+		);
+	};
+	let [layer] = frame.descriptor.layers.as_slice() else {
+		anyhow::bail!(
+			"VA-API exported {} layers, expected one composed layer",
+			frame.descriptor.layers.len()
+		);
+	};
 	if layer.drm_format != DrmFormat::NV12.as_raw() {
 		anyhow::bail!("VA-API exported DRM format {:#x}, expected NV12", layer.drm_format);
 	}
-	let planes = (0..layer.num_planes as usize)
+
+	// `num_planes` and the arrays it indexes both come from the driver, and only
+	// the arrays are bounded, so indexing on the count would panic rather than
+	// fail.
+	let count = layer.num_planes as usize;
+	anyhow::ensure!(
+		count <= layer.offset.len(),
+		"VA-API exported {count} planes, more than a PRIME descriptor holds"
+	);
+	let planes = (0..count)
 		.map(|plane| DmaBufPlane::new(layer.offset[plane], layer.pitch[plane]))
 		.collect();
-	let modifier = frame
-		.descriptor
-		.objects
-		.first()
-		.context("the VA-API export carries no object")?
-		.drm_format_modifier;
+	let modifier = object.drm_format_modifier;
 
 	// A decode target names no color space, so the renderer infers one from the
 	// frame size exactly as it does for a downloaded picture.

--- a/rs/moq-video/src/decode/backend/vaapi.rs
+++ b/rs/moq-video/src/decode/backend/vaapi.rs
@@ -27,10 +27,21 @@
 //! the track ends. The decoded frames carry their own timestamps, so the delay
 //! itself needs nothing downstream.
 //!
-//! The output is CPU I420 rather than a zero-copy [`Surface::DmaBuf`]: VA-API
-//! decode targets on Intel come back Y-tiled (DRM modifier `0x100000000000002`),
-//! a modifier the Vulkan renderer cannot import, so a DMA-BUF here would only move
-//! the download somewhere less convenient.
+//! The output is CPU I420 rather than a zero-copy [`Surface::DmaBuf`], which is
+//! now a question of plumbing rather than of capability. It used to be the
+//! latter: a decode target was believed to be a modifier the renderer could not
+//! import. Measured on Intel Meteor Lake with iHD, a decode target exports at
+//! `0x100000000000009`, and the renderer imports that per memory plane with no
+//! re-tile, so the pixels do reach a texture untouched
+//! (`decoded_frames_reach_the_gpu_without_a_download` in
+//! [`render`](crate::render) draws them).
+//!
+//! What stands in the way of making it the default is
+//! [`Surface::into_i420`](crate::Surface::into_i420): a CPU consumer of an
+//! exported surface has nowhere to read it back from, since the frame outlives
+//! the decoder that could map it, and the buffer is tiled so mapping it as rows
+//! would be wrong anyway. Handing out GPU frames therefore has to be something a
+//! caller asks for, knowing what it will do with them.
 
 use bytes::Bytes;
 use moq_net::Timestamp;

--- a/rs/moq-video/src/decode/backend/vaapi.rs
+++ b/rs/moq-video/src/decode/backend/vaapi.rs
@@ -1,0 +1,192 @@
+//! Intel/AMD VAAPI hardware H.264 decode via the opt-in `moq-vaapi` crate on Linux.
+//!
+//! The decode half of [`encode::backend::vaapi`](crate::encode). `moq-vaapi` is a
+//! focused VA-API H.264 codec vendored and trimmed from cros-libva +
+//! discord/cros-codecs. Its decoder takes one Annex-B access unit with the
+//! parameter sets inline and hands back tightly-packed NV12, which this
+//! deinterleaves to the CPU I420 the rest of the crate speaks.
+//!
+//! libva is `dlopen`'d at runtime, so a VAAPI-enabled build needs no libva at
+//! build time and the binary carries no `NEEDED libva`. A libva-less host, a
+//! missing render node, or a driver with no H.264 decode entrypoint makes
+//! `Decoder::new` return an error; under automatic selection
+//! [`backend::open`](super::open) then moves on to the next candidate, like the
+//! NVDEC backend.
+//!
+//! Progressive 8-bit 4:2:0 only, which is everything a browser's `VideoEncoder`,
+//! WebRTC, or this crate's own encoders emit. The decoder rejects an interlaced or
+//! high-bit-depth sequence at its first SPS, which surfaces here as a decode
+//! error rather than wrong pixels.
+//!
+//! Unlike NVDEC, which cuvid lets us pin to zero display delay, output trails the
+//! input by one picture even without B-frames: H.264's DPB releases a picture only
+//! once a later one needs its slot. The decoded frames still carry their own
+//! timestamps, so nothing downstream has to know.
+//!
+//! The output is CPU I420 rather than a zero-copy [`Surface::DmaBuf`]: VA-API
+//! decode targets on Intel come back Y-tiled (DRM modifier `0x100000000000002`),
+//! a modifier the Vulkan renderer cannot import, so a DMA-BUF here would only move
+//! the download somewhere less convenient.
+
+use bytes::Bytes;
+use moq_net::Timestamp;
+use moq_vaapi::decode::{Config as VaapiConfig, Decoder};
+
+use super::{Backend, Codec, Config};
+use crate::frame::{I420, Surface};
+use crate::{Error, Frame};
+
+pub(crate) const NAME: &str = "vaapi";
+
+pub(crate) struct Vaapi {
+	decoder: Decoder,
+}
+
+// The decoder is `!Send` (libva uses `Rc` internally) but is created, used, and
+// dropped only on the dedicated decode thread (see `decode::sink`); the `Send`
+// impl just lets the boxed trait object satisfy `Backend: Send`.
+unsafe impl Send for Vaapi {}
+
+impl Vaapi {
+	/// VA-API H.265 and AV1 decode exist but are not wired up in `moq-vaapi`, so
+	/// this handles H.264 only. `config` carries no hardware scaler request we can
+	/// honor: VA-API's scaler is a separate VPP pipeline, so callers scale the
+	/// frames themselves.
+	pub(crate) fn open(codec: Codec, _config: &Config) -> Result<Box<dyn Backend>, Error> {
+		if codec != Codec::H264 {
+			return Err(Error::Codec(anyhow::anyhow!("VAAPI cannot decode {}", codec.label())));
+		}
+
+		let decoder =
+			Decoder::new(VaapiConfig::new()).map_err(|e| Error::Codec(anyhow::anyhow!("VAAPI decoder init: {e:?}")))?;
+
+		tracing::info!(decoder = NAME, "opened H.264 decoder");
+		Ok(Box::new(Self { decoder }))
+	}
+}
+
+impl Backend for Vaapi {
+	fn decode(&mut self, access_unit: Bytes, timestamp: Timestamp, _keyframe: bool) -> Result<Vec<Frame>, Error> {
+		// The timestamp rides through the decoder with the picture, so it
+		// survives the DPB reordering a stream with B-frames goes through.
+		let decoded = self
+			.decoder
+			.decode(&access_unit, timestamp.as_micros() as u64)
+			.map_err(|e| Error::Codec(anyhow::anyhow!("VAAPI decode: {e:?}")))?;
+
+		decoded
+			.into_iter()
+			.map(|frame| {
+				let i420 = I420::from_nv12(&frame.data, frame.width, frame.height)?;
+				let timestamp = Timestamp::from_micros(frame.timestamp).unwrap_or(Timestamp::ZERO);
+				Ok(Frame::new(Surface::I420(i420), timestamp))
+			})
+			.collect()
+	}
+
+	fn name(&self) -> &str {
+		NAME
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::decode::{Config as DecodeConfig, Kind as DecodeKind};
+	use crate::encode::{Config as EncodeConfig, Encoder, Kind as EncodeKind};
+
+	/// Real hardware only: skip on a box with no libva or no VA-API H.264 decode
+	/// entrypoint, so these are no-ops on CI and validate on an Intel or AMD box.
+	fn hw_available() -> bool {
+		Decoder::new(VaapiConfig::new()).is_ok()
+	}
+
+	fn decode_config() -> DecodeConfig {
+		DecodeConfig {
+			kind: DecodeKind::Named(NAME.into()),
+			..DecodeConfig::new()
+		}
+	}
+
+	/// On a host with no usable VA stack, opening must return an `Err` (so
+	/// `Kind::Auto` falls through to openh264) rather than panicking inside libva.
+	/// A no-op on a box that does have one.
+	#[test]
+	fn missing_driver_errors_instead_of_panicking() {
+		if hw_available() {
+			return;
+		}
+		assert!(Vaapi::open(Codec::H264, &decode_config()).is_err());
+	}
+
+	/// A static RGBA gradient that varies in both axes, so the chroma planes have
+	/// spatial structure and a pitch or plane-split bug corrupts the picture.
+	fn gradient_rgba(width: u32, height: u32) -> Vec<u8> {
+		let (w, h) = (width as usize, height as usize);
+		let mut buf = vec![0u8; w * h * 4];
+		for y in 0..h {
+			for x in 0..w {
+				let i = (y * w + x) * 4;
+				buf[i] = (x * 255 / w) as u8;
+				buf[i + 1] = (y * 255 / h) as u8;
+				buf[i + 2] = ((x + y) * 255 / (w + h)) as u8;
+				buf[i + 3] = 255;
+			}
+		}
+		buf
+	}
+
+	/// Mean absolute error between two equal-length planes.
+	fn mae(a: &[u8], b: &[u8]) -> u64 {
+		assert_eq!(a.len(), b.len());
+		a.iter().zip(b).map(|(x, y)| x.abs_diff(*y) as u64).sum::<u64>() / a.len() as u64
+	}
+
+	/// H.264 through the real hardware: openh264 encodes a gradient (Annex-B with
+	/// inline SPS/PPS) and VA-API decodes it. Asserts the downloaded picture
+	/// matches the input, which a plane split or stride bug would shear, and that
+	/// the timestamp rides through with its picture.
+	#[test]
+	fn vaapi_h264_round_trip() {
+		if !hw_available() {
+			return;
+		}
+		let (w, h) = (320u32, 240u32);
+		let rgba = gradient_rgba(w, h);
+		let expected = I420::from_rgba(&rgba, w * 4, w, h).unwrap();
+
+		let mut encoder = Encoder::new(&EncodeConfig {
+			kind: EncodeKind::Software,
+			..EncodeConfig::new(w, h, 30)
+		})
+		.unwrap();
+		let mut decoder = Vaapi::open(Codec::H264, &decode_config()).expect("VAAPI H.264 decoder");
+
+		let mut decoded = Vec::new();
+		for i in 0..10u64 {
+			if i == 0 {
+				encoder.keyframe();
+			}
+			let surface = Surface::rgba(&rgba, crate::Size::new(w, h)).unwrap();
+			let frame = Frame::new(surface, Timestamp::from_micros(i * 33_333).unwrap());
+			for encoded in encoder.encode(&frame).unwrap() {
+				decoded.extend(decoder.decode(encoded.payload, encoded.timestamp, i == 0).unwrap());
+			}
+		}
+
+		assert!(!decoded.is_empty(), "VAAPI produced no frames");
+		for (i, frame) in decoded.iter().enumerate() {
+			// openh264 encodes IPPP, so the pictures come back in feed order.
+			assert_eq!(
+				frame.timestamp.as_micros(),
+				i as u128 * 33_333,
+				"timestamp did not ride the picture"
+			);
+			let i420 = frame.surface.to_i420().unwrap();
+			assert_eq!((i420.width(), i420.height()), (w, h));
+			assert!(mae(i420.y(), expected.y()) < 8, "Y plane corrupt");
+			assert!(mae(i420.u(), expected.u()) < 8, "U plane corrupt");
+			assert!(mae(i420.v(), expected.v()) < 8, "V plane corrupt");
+		}
+	}
+}

--- a/rs/moq-video/src/decode/backend/vaapi.rs
+++ b/rs/moq-video/src/decode/backend/vaapi.rs
@@ -27,34 +27,45 @@
 //! the track ends. The decoded frames carry their own timestamps, so the delay
 //! itself needs nothing downstream.
 //!
-//! The output is CPU I420 rather than a zero-copy [`Surface::DmaBuf`], which is
-//! now a question of plumbing rather than of capability. It used to be the
-//! latter: a decode target was believed to be a modifier the renderer could not
-//! import. Measured on Intel Meteor Lake with iHD, a decode target exports at
-//! `0x100000000000009`, and the renderer imports that per memory plane with no
-//! re-tile, so the pixels do reach a texture untouched
+//! The output is CPU I420 unless [`Config::gpu_frames`] asks otherwise, in which
+//! case each picture comes back as the zero-copy [`Surface::DmaBuf`] the
+//! hardware decoded it into. Measured on Intel Meteor Lake with iHD, a decode
+//! target exports at modifier `0x100000000000009`, and the renderer imports that
+//! per memory plane with no re-tile, so the pixels reach a texture untouched
 //! (`decoded_frames_reach_the_gpu_without_a_download` in
 //! [`render`](crate::render) draws them).
 //!
-//! What stands in the way of making it the default is
-//! [`Surface::into_i420`](crate::Surface::into_i420): a CPU consumer of an
-//! exported surface has nowhere to read it back from, since the frame outlives
-//! the decoder that could map it, and the buffer is tiled so mapping it as rows
-//! would be wrong anyway. Handing out GPU frames therefore has to be something a
-//! caller asks for, knowing what it will do with them.
+//! Opt-in rather than the default because it is not free to a consumer that does
+//! not draw. Exporting a surface retires it from the decoder's recycling pool,
+//! since a later picture decoded over it would corrupt one the consumer still
+//! holds, so it trades an allocation per picture for a download that a CPU
+//! consumer would have to pay anyway. Such a consumer is not stranded either:
+//! [`Surface::into_i420`](crate::Surface::into_i420) still answers, because
+//! `moq-vaapi` keeps the retired surface alongside the descriptor and reads it
+//! back through `vaDeriveImage` rather than trying to read a tiled buffer as
+//! rows.
 
+use std::os::fd::{AsFd, OwnedFd};
+use std::sync::{Arc, Mutex};
+
+use anyhow::Context as _;
 use bytes::Bytes;
 use moq_net::Timestamp;
-use moq_vaapi::decode::{Config as VaapiConfig, Decoder};
+use moq_vaapi::decode::{Config as VaapiConfig, Decoder, ExportedFrame};
 
 use super::{Backend, Codec, Config};
-use crate::frame::{I420, Surface};
+use crate::frame::{DmaBuf, DmaBufFrame, DmaBufPlane, DrmFormat, I420, Surface};
 use crate::{Error, Frame};
 
 pub(crate) const NAME: &str = "vaapi";
 
 pub(crate) struct Vaapi {
 	decoder: Decoder,
+	/// Whether pictures are handed out as DMA-BUFs rather than downloaded, from
+	/// [`Config::gpu_frames`]. Cleared if the driver turns out not to export, so
+	/// a host that decodes but cannot share what it decoded loses the fast path
+	/// rather than the stream.
+	gpu_frames: bool,
 }
 
 // The decoder is `!Send` (libva uses `Rc` internally) but is created, used, and
@@ -67,7 +78,7 @@ impl Vaapi {
 	/// this handles H.264 only. `config` carries no hardware scaler request we can
 	/// honor: VA-API's scaler is a separate VPP pipeline, so callers scale the
 	/// frames themselves.
-	pub(crate) fn open(codec: Codec, _config: &Config) -> Result<Box<dyn Backend>, Error> {
+	pub(crate) fn open(codec: Codec, config: &Config) -> Result<Box<dyn Backend>, Error> {
 		if codec != Codec::H264 {
 			return Err(Error::Codec(anyhow::anyhow!("VAAPI cannot decode {}", codec.label())));
 		}
@@ -75,8 +86,52 @@ impl Vaapi {
 		let decoder =
 			Decoder::new(VaapiConfig::new()).map_err(|e| Error::Codec(anyhow::anyhow!("VAAPI decoder init: {e:?}")))?;
 
-		tracing::info!(decoder = NAME, "opened H.264 decoder");
-		Ok(Box::new(Self { decoder }))
+		tracing::info!(decoder = NAME, gpu_frames = config.gpu_frames, "opened H.264 decoder");
+		Ok(Box::new(Self {
+			decoder,
+			gpu_frames: config.gpu_frames,
+		}))
+	}
+
+	/// Decodes one access unit into GPU-resident frames, or `None` once the
+	/// driver has shown it will not export.
+	///
+	/// A driver can decode without being able to share what it decoded, and the
+	/// caller only asked for GPU frames as an optimization. Losing the pictures
+	/// of the one call that discovers this beats losing the stream, and the DPB
+	/// is untouched by it: those pictures had already been bumped out of it.
+	fn decode_shared(&mut self, access_unit: &Bytes, timestamp: u64) -> Option<Vec<Frame>> {
+		if !self.gpu_frames {
+			return None;
+		}
+
+		Some(
+			match self.decoder.decode_exported(access_unit, timestamp).and_then(share) {
+				Ok(frames) => frames,
+				Err(err) => self.cannot_share(&err),
+			},
+		)
+	}
+
+	/// The same for the stream's tail, so a track that ends does not switch to
+	/// downloading for its last few pictures.
+	fn flush_shared(&mut self) -> Option<Vec<Frame>> {
+		if !self.gpu_frames {
+			return None;
+		}
+
+		Some(match self.decoder.flush_exported().and_then(share) {
+			Ok(frames) => frames,
+			Err(err) => self.cannot_share(&err),
+		})
+	}
+
+	/// Records that this driver will not share what it decoded, and gives up the
+	/// pictures of the call that found out.
+	fn cannot_share(&mut self, err: &anyhow::Error) -> Vec<Frame> {
+		tracing::warn!(%err, "VAAPI cannot hand out decoded surfaces; downloading them instead");
+		self.gpu_frames = false;
+		Vec::new()
 	}
 }
 
@@ -84,9 +139,14 @@ impl Backend for Vaapi {
 	fn decode(&mut self, access_unit: Bytes, timestamp: Timestamp, _keyframe: bool) -> Result<Vec<Frame>, Error> {
 		// The timestamp rides through the decoder with the picture, so it
 		// survives the DPB reordering a stream with B-frames goes through.
+		let timestamp = timestamp.as_micros() as u64;
+		if let Some(frames) = self.decode_shared(&access_unit, timestamp) {
+			return Ok(frames);
+		}
+
 		let decoded = self
 			.decoder
-			.decode(&access_unit, timestamp.as_micros() as u64)
+			.decode(&access_unit, timestamp)
 			.map_err(|e| Error::Codec(anyhow::anyhow!("VAAPI decode: {e:?}")))?;
 
 		convert(decoded)
@@ -96,6 +156,10 @@ impl Backend for Vaapi {
 	/// no-op: the DPB is holding as many pictures as the sequence's reference and
 	/// reorder limits allow, and nothing else will ever ask for them.
 	fn flush(&mut self) -> Result<Vec<Frame>, Error> {
+		if let Some(frames) = self.flush_shared() {
+			return Ok(frames);
+		}
+
 		let decoded = self
 			.decoder
 			.flush()
@@ -122,6 +186,106 @@ fn convert(decoded: Vec<moq_vaapi::decode::Frame>) -> Result<Vec<Frame>, Error> 
 		.collect()
 }
 
+/// Wrap each exported picture as the DMA-BUF surface a renderer imports, keeping
+/// the timestamp the picture was coded with.
+fn share(exported: Vec<ExportedFrame>) -> anyhow::Result<Vec<Frame>> {
+	exported
+		.into_iter()
+		.map(|frame| {
+			let timestamp = Timestamp::from_micros(frame.timestamp).unwrap_or(Timestamp::ZERO);
+			Ok(Frame::new(Surface::DmaBuf(adopt(frame)?), timestamp))
+		})
+		.collect()
+}
+
+/// Describe an exported picture as a [`DmaBuf`]: the driver's format modifier,
+/// and the offset and pitch of each of its memory planes.
+///
+/// The width and height are the visible frame rather than the exported extent,
+/// which is the driver's padded allocation. Neither the pitches nor the offsets
+/// follow from the visible size, which is exactly why they are read off the
+/// export rather than computed from it.
+fn adopt(frame: ExportedFrame) -> anyhow::Result<DmaBuf> {
+	let (width, height) = (frame.width, frame.height);
+	let layer = frame
+		.descriptor
+		.layers
+		.first()
+		.context("the VA-API export carries no layer")?;
+	if layer.drm_format != DrmFormat::NV12.as_raw() {
+		anyhow::bail!("VA-API exported DRM format {:#x}, expected NV12", layer.drm_format);
+	}
+	let planes = (0..layer.num_planes as usize)
+		.map(|plane| DmaBufPlane::new(layer.offset[plane], layer.pitch[plane]))
+		.collect();
+	let modifier = frame
+		.descriptor
+		.objects
+		.first()
+		.context("the VA-API export carries no object")?
+		.drm_format_modifier;
+
+	// A decode target names no color space, so the renderer infers one from the
+	// frame size exactly as it does for a downloaded picture.
+	DmaBuf::new(
+		DrmFormat::NV12,
+		modifier,
+		width,
+		height,
+		planes,
+		None,
+		Arc::new(Exported::new(frame)),
+	)
+	.map_err(|e| anyhow::anyhow!("{e}"))
+}
+
+/// A decoded picture the consumer holds as a DMA-BUF.
+///
+/// Both of the things a consumer can do with one: hand a descriptor to a
+/// graphics API, or give up on drawing it and read the pixels back. Dropping the
+/// last clone destroys the surface, which is what returns its allocation to the
+/// driver.
+struct Exported {
+	/// Locked because [`DmaBufFrame`] hands out `&self` while what is behind it
+	/// is a single libva surface: `download_i420` maps that surface, and two
+	/// threads doing so at once is more than libva promises to serialize. The
+	/// frame is [`Send`] on its own, so a lock is enough and no `unsafe impl` is
+	/// involved.
+	frame: Mutex<ExportedFrame>,
+}
+
+impl Exported {
+	fn new(frame: ExportedFrame) -> Self {
+		Self {
+			frame: Mutex::new(frame),
+		}
+	}
+}
+
+impl DmaBufFrame for Exported {
+	/// Vulkan takes ownership of an imported descriptor on success and closes it
+	/// on failure, so every import needs one of its own and the original stays
+	/// with the picture.
+	fn export(&self) -> std::io::Result<OwnedFd> {
+		let frame = self.frame.lock().expect("poisoned");
+		let object = frame.descriptor.objects.first().ok_or_else(|| {
+			std::io::Error::new(std::io::ErrorKind::InvalidData, "the VA-API export carries no object")
+		})?;
+		object.fd.as_fd().try_clone_to_owned()
+	}
+
+	/// Read the picture back through the retained surface rather than the
+	/// descriptor: a decode target is tiled, so mapping the file descriptor as
+	/// rows would be wrong.
+	fn download_i420(&self) -> Result<I420, Error> {
+		let frame = self.frame.lock().expect("poisoned");
+		let nv12 = frame
+			.download()
+			.map_err(|e| Error::Codec(anyhow::anyhow!("read a VA-API decode surface back: {e:?}")))?;
+		I420::from_nv12(&nv12.data, nv12.width, nv12.height)
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -138,6 +302,13 @@ mod tests {
 		DecodeConfig {
 			kind: DecodeKind::Named(NAME.into()),
 			..DecodeConfig::new()
+		}
+	}
+
+	fn gpu_decode_config() -> DecodeConfig {
+		DecodeConfig {
+			gpu_frames: true,
+			..decode_config()
 		}
 	}
 
@@ -223,6 +394,81 @@ mod tests {
 		}
 	}
 
+	/// `gpu_frames` hands out DMA-BUFs, and a CPU consumer of one gets the same
+	/// pixels it would have got without asking for them.
+	///
+	/// The bargain the knob rests on: a caller opting into GPU-resident output
+	/// does not take `Surface::into_i420` away from whatever it hands the frames
+	/// to. Byte-exact rather than approximate, because both sides are the same
+	/// hardware decoding the same units, and the read-back goes through the same
+	/// `vaDeriveImage` path the download does.
+	///
+	/// Needs no GPU beyond the VA-API device: this is about what a picture on the
+	/// GPU can still do for a consumer that is not on one.
+	#[test]
+	fn gpu_frames_still_answer_into_i420() {
+		if !hw_available() {
+			return;
+		}
+		let (w, h) = (320u32, 240u32);
+		let rgba = gradient_rgba(w, h);
+
+		let mut encoder = Encoder::new(&EncodeConfig {
+			kind: EncodeKind::Software,
+			..EncodeConfig::new(w, h, 30)
+		})
+		.unwrap();
+		let mut exporting = Vaapi::open(Codec::H264, &gpu_decode_config()).expect("VAAPI H.264 decoder");
+		let mut downloading = Vaapi::open(Codec::H264, &decode_config()).expect("a second decoder");
+
+		let mut exported = Vec::new();
+		let mut downloaded = Vec::new();
+		for i in 0..10u64 {
+			if i == 0 {
+				encoder.keyframe();
+			}
+			let surface = Surface::rgba(&rgba, crate::Size::new(w, h)).unwrap();
+			let frame = Frame::new(surface, Timestamp::from_micros(i * 33_333).unwrap());
+			for encoded in encoder.encode(&frame).unwrap() {
+				let (payload, timestamp) = (encoded.payload, encoded.timestamp);
+				exported.extend(exporting.decode(payload.clone(), timestamp, i == 0).unwrap());
+				downloaded.extend(downloading.decode(payload, timestamp, i == 0).unwrap());
+			}
+		}
+		assert!(!exported.is_empty(), "VAAPI produced no frames");
+		assert_eq!(exported.len(), downloaded.len(), "the two decoders disagreed");
+
+		for (i, (gpu, cpu)) in exported.iter().zip(&downloaded).enumerate() {
+			let Surface::DmaBuf(buffer) = &gpu.surface else {
+				panic!("frame {i} did not come back GPU-resident");
+			};
+			assert_eq!(buffer.format(), crate::DrmFormat::NV12);
+			assert_eq!((buffer.width(), buffer.height()), (w, h));
+			assert_eq!(gpu.timestamp, cpu.timestamp, "frame {i} lost its timestamp");
+
+			let Surface::I420(reference) = &cpu.surface else {
+				panic!("frame {i} came back GPU-resident without gpu_frames");
+			};
+			let read_back = gpu.surface.to_i420().expect("read the decoded surface back");
+			assert_eq!(
+				(read_back.width(), read_back.height()),
+				(reference.width(), reference.height())
+			);
+			assert!(
+				read_back.y() == reference.y(),
+				"frame {i} read back a different Y plane"
+			);
+			assert!(
+				read_back.u() == reference.u(),
+				"frame {i} read back a different U plane"
+			);
+			assert!(
+				read_back.v() == reference.v(),
+				"frame {i} read back a different V plane"
+			);
+		}
+	}
+
 	/// Regression: every picture fed in comes back out, which needs the flush.
 	///
 	/// H.264 releases a picture from the DPB only once a later one needs its slot,
@@ -237,6 +483,22 @@ mod tests {
 		if !hw_available() {
 			return;
 		}
+		flushing_returns_the_tail(&decode_config());
+	}
+
+	/// The same for GPU-resident output, which drains through `flush_exported`
+	/// rather than `flush`. Without its own case it would be the one path where a
+	/// track's last pictures go missing, since the two drains are separate calls
+	/// into `moq-vaapi` and only one of them is on the default path.
+	#[test]
+	fn flushing_returns_the_tail_of_a_gpu_stream() {
+		if !hw_available() {
+			return;
+		}
+		flushing_returns_the_tail(&gpu_decode_config());
+	}
+
+	fn flushing_returns_the_tail(config: &DecodeConfig) {
 		const FRAMES: u64 = 5;
 		let (w, h) = (320u32, 240u32);
 		let rgba = gradient_rgba(w, h);
@@ -246,7 +508,7 @@ mod tests {
 			..EncodeConfig::new(w, h, 30)
 		})
 		.unwrap();
-		let mut decoder = Vaapi::open(Codec::H264, &decode_config()).expect("VAAPI H.264 decoder");
+		let mut decoder = Vaapi::open(Codec::H264, config).expect("VAAPI H.264 decoder");
 
 		let mut streamed = Vec::new();
 		for i in 0..FRAMES {

--- a/rs/moq-video/src/decode/backend/vaapi.rs
+++ b/rs/moq-video/src/decode/backend/vaapi.rs
@@ -16,7 +16,7 @@
 //! Progressive 8-bit 4:2:0 only, which is everything a browser's `VideoEncoder`,
 //! WebRTC, or this crate's own encoders emit. The decoder rejects an interlaced or
 //! high-bit-depth sequence at its first SPS, which surfaces here as a decode
-//! error rather than wrong pixels.
+//! error rather than wrong pixels. Left and top cropping are also rejected.
 //!
 //! Unlike NVDEC, which cuvid lets us pin to zero display delay, output trails the
 //! input even without B-frames: H.264's DPB releases a picture only once a later
@@ -33,7 +33,7 @@
 //! target exports at modifier `0x100000000000009`, and the renderer imports that
 //! a memory plane at a time, so the pixels reach a texture untouched
 //! (`decoded_frames_reach_the_gpu_without_a_download` in
-//! [`render`](crate::render) draws them).
+//! the render module draws them).
 //!
 //! Opt-in rather than the default because it is not free to a consumer that does
 //! not draw. Exporting a surface retires it from the decoder's recycling pool,
@@ -169,9 +169,7 @@ impl Backend for Vaapi {
 		convert(decoded)
 	}
 
-	/// The tail of the stream, which is why this backend overrides the trait's
-	/// no-op: the DPB is holding as many pictures as the sequence's reference and
-	/// reorder limits allow, and nothing else will ever ask for them.
+	/// Return the tail held by the DPB at the end of the stream.
 	fn flush(&mut self) -> Result<Vec<Frame>, Error> {
 		if let Some(frames) = self.flush_shared() {
 			return frames;

--- a/rs/moq-video/src/decode/consumer.rs
+++ b/rs/moq-video/src/decode/consumer.rs
@@ -336,4 +336,63 @@ mod tests {
 		};
 		assert!(err.to_string().contains("cancelled call"), "unexpected error: {err}");
 	}
+
+	/// VAAPI returns its buffered tail before the consumer reports track end.
+	#[cfg(all(target_os = "linux", feature = "vaapi"))]
+	#[tokio::test]
+	async fn the_track_ending_drains_the_decoder() {
+		const FRAMES: u64 = 5;
+		let config = EncodeConfig {
+			kind: EncodeKind::Software,
+			..EncodeConfig::new(320, 240, 30)
+		};
+		let catalog = config.probe().await.expect("probe the software encoder");
+
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let track = broadcast.create_track("video", hang::container::track_info()).unwrap();
+		let subscriber = broadcast.consume();
+		let mut producer = moq_mux::container::Producer::new(track, moq_mux::catalog::hang::Container::Legacy);
+
+		let mut encoder = Encoder::new(&config).unwrap();
+		let rgba = vec![0x80u8; 320 * 240 * 4];
+		for index in 0..FRAMES {
+			if index == 0 {
+				encoder.keyframe();
+			}
+			let surface = crate::Surface::rgba(&rgba, crate::Size::new(320, 240)).unwrap();
+			let frame = crate::Frame::new(surface, moq_net::Timestamp::from_micros(index * 33_333).unwrap());
+			for encoded in encoder.encode(&frame).unwrap() {
+				producer
+					.write(moq_mux::container::Frame {
+						timestamp: encoded.timestamp,
+						duration: None,
+						payload: encoded.payload,
+						keyframe: index == 0,
+					})
+					.unwrap();
+			}
+		}
+		producer.finish().unwrap();
+
+		let decode = Config {
+			kind: Kind::Named("vaapi".into()),
+			..Config::new()
+		};
+		// The hardware gate: no libva, no render node, or no H.264 decode
+		// entrypoint and the named backend refuses to open.
+		let Ok(mut consumer) = Consumer::new(&subscriber, &catalog, "video", decode).await else {
+			return;
+		};
+
+		let mut timestamps = Vec::new();
+		while let Some(frame) = consumer.read().await.unwrap() {
+			timestamps.push(frame.timestamp.as_micros());
+		}
+		let expected: Vec<u128> = (0..FRAMES as u128).map(|index| index * 33_333).collect();
+		assert_eq!(timestamps, expected, "the track ended before the stream did");
+
+		// The end stays the end: the drain runs once, so a caller that keeps
+		// reading past it does not get the tail a second time.
+		assert!(consumer.read().await.unwrap().is_none());
+	}
 }

--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -61,6 +61,23 @@ pub struct Config {
 	/// Check each [`Frame`](crate::Frame)'s dimensions and scale the remainder
 	/// yourself.
 	pub resize: Option<Size>,
+	/// Ask the decoder to leave each picture on the GPU, as the surface the
+	/// hardware decoded it into, rather than downloading it to CPU memory.
+	///
+	/// For a consumer that draws the frames: [`render::Renderer`](crate::render)
+	/// imports such a surface directly, so the picture never touches system
+	/// memory. Off by default because it is not free to a consumer that does not
+	/// draw: handing a surface out retires it from the decoder's recycling pool,
+	/// which costs an allocation per picture, and a CPU consumer then pays the
+	/// download it would have paid anyway.
+	///
+	/// Best effort, like [`resize`](Self::resize): only the VAAPI backend honors
+	/// it today and the others ignore it, so match on each
+	/// [`Frame`](crate::Frame)'s surface rather than assuming. A frame that does
+	/// come back GPU-resident still answers
+	/// [`Surface::into_i420`](crate::Surface::into_i420), so nothing downstream
+	/// breaks on it.
+	pub gpu_frames: bool,
 }
 
 impl Config {

--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -38,7 +38,7 @@ pub enum Kind {
 	/// Software (openh264) only.
 	Software,
 	/// A specific backend by name, e.g. `"videotoolbox"`, `"mediacodec"`,
-	/// `"nvdec"`, `"v4l2"`, or `"openh264"`.
+	/// `"nvdec"`, `"vaapi"`, `"v4l2"`, or `"openh264"`.
 	Named(String),
 }
 
@@ -64,12 +64,12 @@ pub struct Config {
 	/// Ask the decoder to leave each picture on the GPU, as the surface the
 	/// hardware decoded it into, rather than downloading it to CPU memory.
 	///
-	/// For a consumer that draws the frames: [`render::Renderer`](crate::render)
-	/// imports such a surface directly, so the picture never touches system
-	/// memory. Off by default because it is not free to a consumer that does not
-	/// draw: handing a surface out retires it from the decoder's recycling pool,
-	/// which costs an allocation per picture, and a CPU consumer then pays the
-	/// download it would have paid anyway.
+	/// For a consumer that draws the frames, `render::Renderer` imports such a
+	/// surface directly, so the picture never touches system memory. Off by
+	/// default because it is not free to a consumer that does not draw: handing a
+	/// surface out retires it from the decoder's recycling pool, which costs an
+	/// allocation per picture, and a CPU consumer then pays the download it would
+	/// have paid anyway.
 	///
 	/// Best effort, like [`resize`](Self::resize): only the VAAPI backend honors
 	/// it today and the others ignore it, so match on each

--- a/rs/moq-video/src/decode/mod.rs
+++ b/rs/moq-video/src/decode/mod.rs
@@ -3,8 +3,8 @@
 //! The decode counterpart to [`encode`](crate::encode), and the mirror of
 //! `moq_audio::decode::Consumer`. [`Consumer`] subscribes to a moq-mux video
 //! track and hands back decoded [`Frame`](crate::Frame)s; a native backend does the work
-//! (VideoToolbox on macOS, Media Foundation / DXVA on Windows, NVDEC on Linux,
-//! openh264 everywhere as the software fallback for H.264).
+//! (VideoToolbox on macOS, Media Foundation / DXVA on Windows, NVDEC or VAAPI
+//! on Linux, openh264 everywhere as the software fallback for H.264).
 //!
 //! H.264 and H.265 are supported, symmetric with what [`encode`](crate::encode)
 //! produces. AV1 is decode-only on NVDEC. H.265 and AV1 are hardware-only (no

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -276,7 +276,9 @@ impl std::fmt::Debug for DmaBuf {
 
 #[cfg(all(target_os = "linux", feature = "dmabuf"))]
 impl DmaBuf {
-	#[cfg(any(feature = "pipewire", feature = "vaapi"))]
+	// PipeWire capture builds these for real; the render importer's tests build
+	// them from a VA-API allocation, with no producer behind them.
+	#[cfg(any(feature = "pipewire", all(feature = "vaapi", test)))]
 	pub(crate) fn new(
 		format: DrmFormat,
 		modifier: u64,

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -796,8 +796,11 @@ impl I420 {
 	/// Split tightly-packed NV12 (Y plane `width * height`, then interleaved UV
 	/// `width/2 * height/2` pairs) into planar I420. A chroma deinterleave, no
 	/// color-space conversion. Used by the Windows Media Foundation and Linux
-	/// PipeWire capture paths.
-	#[cfg(any(target_os = "windows", all(target_os = "linux", feature = "pipewire")))]
+	/// PipeWire capture paths, and by the VAAPI decoder.
+	#[cfg(any(
+		target_os = "windows",
+		all(target_os = "linux", any(feature = "pipewire", feature = "vaapi"))
+	))]
 	pub(crate) fn from_nv12(nv12: &[u8], width: u32, height: u32) -> Result<Self, Error> {
 		let (w, h) = (width as usize, height as usize);
 		let luma = w * h;
@@ -937,7 +940,10 @@ pub(crate) fn interleave_uv(u: &[u8], v: &[u8], uv: &mut [u8]) {
 
 /// Split a packed NV12 chroma plane into separate U and V planes, the inverse of
 /// [`interleave_uv`].
-#[cfg(any(target_os = "windows", all(target_os = "linux", feature = "pipewire")))]
+#[cfg(any(
+	target_os = "windows",
+	all(target_os = "linux", any(feature = "pipewire", feature = "vaapi"))
+))]
 pub(crate) fn deinterleave_uv(uv: &[u8], u: &mut [u8], v: &mut [u8]) {
 	for (pair, (u, v)) in uv.chunks_exact(2).zip(u.iter_mut().zip(v)) {
 		*u = pair[0];

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -130,8 +130,10 @@ pub struct DmaBufPlane {
 #[cfg(all(target_os = "linux", feature = "dmabuf"))]
 impl DmaBufPlane {
 	// The producers that build a real one, plus the importer's own tests, which
-	// build them without a producer to check how a layout is split up.
-	#[cfg(any(feature = "pipewire", feature = "vaapi", test))]
+	// build them without a producer to check how a layout is split up. The VA-API
+	// half of that is the render importer, so it needs `render` too: `vaapi`
+	// alone pulls in `dmabuf` without anything that reads a plane back.
+	#[cfg(any(feature = "pipewire", all(feature = "render", test)))]
 	pub(crate) const fn new(offset: u32, stride: u32) -> Self {
 		Self { offset, stride }
 	}
@@ -277,8 +279,9 @@ impl std::fmt::Debug for DmaBuf {
 #[cfg(all(target_os = "linux", feature = "dmabuf"))]
 impl DmaBuf {
 	// PipeWire capture builds these for real; the render importer's tests build
-	// them from a VA-API allocation, with no producer behind them.
-	#[cfg(any(feature = "pipewire", all(feature = "vaapi", test)))]
+	// them from a VA-API allocation, with no producer behind them, which is why
+	// the VA-API arm needs `render` as well.
+	#[cfg(any(feature = "pipewire", all(feature = "render", feature = "vaapi", test)))]
 	pub(crate) fn new(
 		format: DrmFormat,
 		modifier: u64,

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -129,11 +129,11 @@ pub struct DmaBufPlane {
 
 #[cfg(all(target_os = "linux", feature = "dmabuf"))]
 impl DmaBufPlane {
-	// The producers that build a real one, plus the importer's own tests, which
-	// build them without a producer to check how a layout is split up. The VA-API
-	// half of that is the render importer, so it needs `render` too: `vaapi`
-	// alone pulls in `dmabuf` without anything that reads a plane back.
-	#[cfg(any(feature = "pipewire", all(feature = "render", test)))]
+	// The producers that build a real one: PipeWire capture and, since it can
+	// hand its decode surfaces out, the VA-API decoder. Plus the importer's own
+	// tests, which build them without a producer to check how a layout is split
+	// up, and so need `render`.
+	#[cfg(any(feature = "pipewire", feature = "vaapi", all(feature = "render", test)))]
 	pub(crate) const fn new(offset: u32, stride: u32) -> Self {
 		Self { offset, stride }
 	}
@@ -278,10 +278,9 @@ impl std::fmt::Debug for DmaBuf {
 
 #[cfg(all(target_os = "linux", feature = "dmabuf"))]
 impl DmaBuf {
-	// PipeWire capture builds these for real; the render importer's tests build
-	// them from a VA-API allocation, with no producer behind them, which is why
-	// the VA-API arm needs `render` as well.
-	#[cfg(any(feature = "pipewire", all(feature = "render", feature = "vaapi", test)))]
+	// The two producers: PipeWire capture, and the VA-API decoder describing a
+	// picture it is handing out rather than downloading.
+	#[cfg(any(feature = "pipewire", feature = "vaapi"))]
 	pub(crate) fn new(
 		format: DrmFormat,
 		modifier: u64,

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -95,8 +95,10 @@ pub struct DrmFormat(u32);
 
 #[cfg(all(target_os = "linux", feature = "dmabuf"))]
 impl DrmFormat {
-	/// Semi-planar 8-bit 4:2:0 YUV.
+	/// Semi-planar 8-bit 4:2:0 YUV: one luma plane, one interleaved Cb/Cr plane.
 	pub const NV12: Self = Self::from_bytes(*b"NV12");
+	/// Fully planar 8-bit 4:2:0 YUV as named by DRM (`YU12`): luma, then Cb, then Cr.
+	pub const YUV420: Self = Self::from_bytes(*b"YU12");
 	/// Packed BGRx8888 as named by DRM (`XR24`).
 	pub const XRGB8888: Self = Self::from_bytes(*b"XR24");
 	/// Packed BGRA8888 as named by DRM (`AR24`).
@@ -127,7 +129,9 @@ pub struct DmaBufPlane {
 
 #[cfg(all(target_os = "linux", feature = "dmabuf"))]
 impl DmaBufPlane {
-	#[cfg(feature = "pipewire")]
+	// The producers that build a real one, plus the importer's own tests, which
+	// build them without a producer to check how a layout is split up.
+	#[cfg(any(feature = "pipewire", feature = "vaapi", test))]
 	pub(crate) const fn new(offset: u32, stride: u32) -> Self {
 		Self { offset, stride }
 	}
@@ -272,7 +276,7 @@ impl std::fmt::Debug for DmaBuf {
 
 #[cfg(all(target_os = "linux", feature = "dmabuf"))]
 impl DmaBuf {
-	#[cfg(feature = "pipewire")]
+	#[cfg(any(feature = "pipewire", feature = "vaapi"))]
 	pub(crate) fn new(
 		format: DrmFormat,
 		modifier: u64,
@@ -330,6 +334,15 @@ impl DmaBuf {
 	/// Plane offsets and row strides, in format order.
 	pub fn planes(&self) -> &[DmaBufPlane] {
 		&self.planes
+	}
+
+	/// The color space of these samples where the producer named one.
+	///
+	/// `None` for the usual case of a producer that says nothing, which for YUV
+	/// pixels means the consumer falls back to [`Color::infer`]. Packed RGB
+	/// needs no answer at all.
+	pub const fn color(&self) -> Option<Color> {
+		self.color
 	}
 }
 

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -325,12 +325,17 @@ impl DmaBuf {
 		self.modifier
 	}
 
-	/// Width of the coded allocation in pixels.
+	/// Visible width in pixels.
+	///
+	/// Not the extent the producer allocated, which is padded: the padding is in
+	/// each plane's [`stride`](DmaBufPlane::stride) and in where the next plane
+	/// [`starts`](DmaBufPlane::offset), and neither follows from this.
 	pub const fn width(&self) -> u32 {
 		self.width
 	}
 
-	/// Height of the coded allocation in pixels.
+	/// Visible height in pixels. As [`width`](Self::width), this is not the
+	/// allocated extent.
 	pub const fn height(&self) -> u32 {
 		self.height
 	}

--- a/rs/moq-video/src/lib.rs
+++ b/rs/moq-video/src/lib.rs
@@ -35,12 +35,13 @@
 //!     [`encode::Producer`] publishes the results.
 //! - [`decode`] subscribes to an H.264, H.265, or AV1 track and decodes it to
 //!   raw frames with a native backend (VideoToolbox on macOS, Media Foundation /
-//!   DXVA on Windows, NVDEC or an ARM SoC's V4L2 M2M decoder on Linux, openh264
+//!   DXVA on Windows, NVDEC, VAAPI, or an ARM SoC's V4L2 M2M decoder on Linux, openh264
 //!   software fallback for H.264).
 //!   [`decode::Consumer`] is the mirror of `moq_audio::decode::Consumer`. An
 //!   NVDEC frame stays in CUDA memory and feeds [`encode::Encoder::encode`]
 //!   zero-copy (the transcode path), scaled in hardware via
-//!   [`decode::Config::resize`].
+//!   [`decode::Config::resize`]. A VAAPI decoder can return importable DMA-BUFs
+//!   when [`decode::Config::gpu_frames`] is enabled.
 //! - [`convert`] downloads any [`Surface`] to owned, tightly packed RGBA pixels
 //!   for CPU image and UI toolkits, honoring native color metadata when present.
 //! - `render` draws a [`Frame`] on the GPU and hands back a `wgpu` texture to
@@ -52,7 +53,7 @@
 //! ## API stability
 //!
 //! The public API is codec-agnostic: no public type, signature, or error
-//! variant names a backend (openh264 / VideoToolbox / NVENC / NVDEC / V4L2) or a
+//! variant names a backend (openh264 / VideoToolbox / NVENC / NVDEC / VAAPI / V4L2) or a
 //! codec implementation. [`encode::Encoder`] takes a [`Frame`],
 //! [`decode::Consumer`] returns one (CPU I420 on demand, GPU-resident when
 //! hardware decoded), and [`capture::Stream`] returns a [`Surface`]. So swapping

--- a/rs/moq-video/src/render/dmabuf.rs
+++ b/rs/moq-video/src/render/dmabuf.rs
@@ -40,9 +40,11 @@ pub(super) fn import(device: &wgpu::Device, buffer: &DmaBuf) -> Result<Option<So
 		return Ok(None);
 	}
 
+	// A device carrying the feature above is Vulkan-backed, so this is not a
+	// route anything takes. It is here for what it returns rather than for what
+	// it catches: `Ok(None)` sends the frame to the CPU path without the strike
+	// an `Err` from the import itself would cost.
 	// SAFETY: the guard is only asked whether it exists, and drops here.
-	// A device carrying the feature above is Vulkan-backed, so this is a
-	// belt-and-braces check rather than a route anything takes.
 	if unsafe { device.as_hal::<wgpu::hal::api::Vulkan>() }.is_none() {
 		return Ok(None);
 	}
@@ -57,8 +59,8 @@ pub(super) fn import(device: &wgpu::Device, buffer: &DmaBuf) -> Result<Option<So
 		_ => Some(buffer.color().unwrap_or_else(|| Color::infer(size))),
 	};
 
-	// One export, and so one wait on the producer's write fence, however
-	// many import attempts follow it.
+	// One export, and so one wait on the producer's write fence, however many
+	// planes follow it.
 	let export = buffer
 		.export()
 		.map_err(|e| Error::Render(anyhow::Error::new(e).context("export DMA-BUF")))?;
@@ -68,7 +70,7 @@ pub(super) fn import(device: &wgpu::Device, buffer: &DmaBuf) -> Result<Option<So
 	// duplicates it per plane rather than consuming it. Export waited for
 	// producer writes, and the modifier, extent, stride, and offset of every
 	// plane come from the producer's own buffer metadata.
-	let direct = unsafe {
+	let source = unsafe {
 		adopt(
 			device,
 			fd.as_fd(),
@@ -76,11 +78,11 @@ pub(super) fn import(device: &wgpu::Device, buffer: &DmaBuf) -> Result<Option<So
 			shape.layout,
 			color,
 			&planes,
-			Some(Box::new(lease.clone())),
+			Some(Box::new(lease)),
 		)
-	};
+	}?;
 
-	direct.map(Some)
+	Ok(Some(source))
 }
 
 /// How a DRM format is sampled: the shader layout it feeds, and the Vulkan
@@ -321,6 +323,26 @@ pub(super) mod fixture {
 		}
 	}
 
+	/// The VA-API fourcc naming the same layout as a DRM format.
+	///
+	/// DRM spells a packed pixel from its most significant byte down and VA-API
+	/// from its first byte in memory, so one layout has two reversed names. The
+	/// planar formats' two vocabularies agree.
+	fn va_fourcc(format: DrmFormat) -> Result<u32, Error> {
+		match format {
+			DrmFormat::XRGB8888 => Ok(moq_vaapi::VA_FOURCC_BGRX),
+			DrmFormat::ARGB8888 => Ok(moq_vaapi::VA_FOURCC_BGRA),
+			DrmFormat::XBGR8888 => Ok(moq_vaapi::VA_FOURCC_RGBX),
+			DrmFormat::ABGR8888 => Ok(moq_vaapi::VA_FOURCC_RGBA),
+			DrmFormat::NV12 => Ok(moq_vaapi::VA_FOURCC_NV12),
+			DrmFormat::YUV420 => Ok(moq_vaapi::VA_FOURCC_I420),
+			format => Err(err(format!(
+				"no VA-API format for DMA-BUF format {:#x}",
+				format.as_raw()
+			))),
+		}
+	}
+
 	/// The rows and row length of each plane of `format` at `size`, tightly
 	/// packed, in the order the format lists them.
 	///
@@ -377,16 +399,27 @@ pub(super) mod fixture {
 	/// driver's padded allocation. The plane pitches and offsets are the
 	/// driver's either way, which is the whole point: they are what addresses a
 	/// row, and neither follows from the visible size.
+	///
+	/// # Panics
+	///
+	/// When the driver splits the surface across objects, which is a shape the
+	/// importer cannot read: the offsets would address memory it never sees, and
+	/// the comparison would fail somewhere far from the cause.
 	pub(in crate::render) fn adopt(
 		exported: &moq_vaapi::DrmPrimeSurfaceDescriptor,
 		format: DrmFormat,
 		size: Size,
 	) -> DmaBuf {
+		let [object] = exported.objects.as_slice() else {
+			panic!(
+				"the fixture needs one object holding every plane, got {}",
+				exported.objects.len()
+			);
+		};
 		let layer = exported.layers.first().expect("an exported layer");
 		let planes = (0..layer.num_planes as usize)
 			.map(|index| DmaBufPlane::new(layer.offset[index], layer.pitch[index]))
 			.collect();
-		let object = exported.objects.first().expect("an exported object");
 		let fd = object.fd.try_clone().expect("duplicate the exported descriptor");
 
 		DmaBuf::new(
@@ -443,27 +476,6 @@ pub(super) mod fixture {
 		drop(image);
 		surface.sync().expect("sync the uploaded surface");
 		Some(())
-	}
-}
-
-/// The VA-API fourcc naming the same layout as a DRM format.
-///
-/// DRM spells a packed pixel from its most significant byte down and VA-API from
-/// its first byte in memory, so one layout has two reversed names. The planar
-/// formats' two vocabularies agree.
-#[cfg(all(test, feature = "vaapi"))]
-fn va_fourcc(format: DrmFormat) -> Result<u32, Error> {
-	match format {
-		DrmFormat::XRGB8888 => Ok(moq_vaapi::VA_FOURCC_BGRX),
-		DrmFormat::ARGB8888 => Ok(moq_vaapi::VA_FOURCC_BGRA),
-		DrmFormat::XBGR8888 => Ok(moq_vaapi::VA_FOURCC_RGBX),
-		DrmFormat::ABGR8888 => Ok(moq_vaapi::VA_FOURCC_RGBA),
-		DrmFormat::NV12 => Ok(moq_vaapi::VA_FOURCC_NV12),
-		DrmFormat::YUV420 => Ok(moq_vaapi::VA_FOURCC_I420),
-		format => Err(err(format!(
-			"no VA-API format for DMA-BUF format {:#x}",
-			format.as_raw()
-		))),
 	}
 }
 

--- a/rs/moq-video/src/render/dmabuf.rs
+++ b/rs/moq-video/src/render/dmabuf.rs
@@ -368,28 +368,37 @@ pub(super) mod fixture {
 			.export_prime()
 			.map_err(|e| eprintln!("this driver will not export a {fourcc:#x} surface: {e}"))
 			.ok()?;
+		Some(adopt(&exported, format, size))
+	}
+
+	/// Wrap a VA-API surface export as the [`DmaBuf`] the renderer consumes.
+	///
+	/// `size` is the visible frame rather than the exported extent, which is the
+	/// driver's padded allocation. The plane pitches and offsets are the
+	/// driver's either way, which is the whole point: they are what addresses a
+	/// row, and neither follows from the visible size.
+	pub(in crate::render) fn adopt(
+		exported: &moq_vaapi::DrmPrimeSurfaceDescriptor,
+		format: DrmFormat,
+		size: Size,
+	) -> DmaBuf {
 		let layer = exported.layers.first().expect("an exported layer");
 		let planes = (0..layer.num_planes as usize)
 			.map(|index| DmaBufPlane::new(layer.offset[index], layer.pitch[index]))
 			.collect();
 		let object = exported.objects.first().expect("an exported object");
-		let modifier = object.drm_format_modifier;
 		let fd = object.fd.try_clone().expect("duplicate the exported descriptor");
 
-		// The exported extent is the driver's padded allocation; the frame is
-		// the size that was asked for, and imports at that size.
-		Some(
-			DmaBuf::new(
-				format,
-				modifier,
-				size.width,
-				size.height,
-				planes,
-				None,
-				Arc::new(Exported(fd)),
-			)
-			.expect("a well-formed DMA-BUF"),
+		DmaBuf::new(
+			format,
+			object.drm_format_modifier,
+			size.width,
+			size.height,
+			planes,
+			None,
+			Arc::new(Exported(fd)),
 		)
+		.expect("a well-formed DMA-BUF")
 	}
 
 	/// Copy tightly packed planes into a surface, honoring the image's own plane

--- a/rs/moq-video/src/render/dmabuf.rs
+++ b/rs/moq-video/src/render/dmabuf.rs
@@ -519,6 +519,46 @@ mod tests {
 		assert_eq!(planes[1].stride, 64, "chroma is half as wide but two bytes a texel");
 	}
 
+	/// Fully planar 4:2:0 splits into three single-component images, each with
+	/// its own offset and pitch.
+	///
+	/// The one arm of the split with no coverage on a builder otherwise: the
+	/// three-plane case only shows up on a driver that will allocate YU12, and
+	/// the difference from NV12 is exactly what a shared helper would get wrong
+	/// once for both.
+	#[test]
+	fn planar_420_imports_as_three_single_component_planes() {
+		let size = Size::new(64, 64);
+		let shape = Shape::of(DrmFormat::YUV420, size).expect("YU12 is importable");
+		assert_eq!(shape.layout, Layout::I420);
+
+		assert!(
+			shape
+				.planes(&[DmaBufPlane::new(0, 64), DmaBufPlane::new(64 * 64, 32)])
+				.is_err(),
+			"two planes is NV12's count, not this one's"
+		);
+
+		let planes = shape
+			.planes(&[
+				DmaBufPlane::new(0, 64),
+				DmaBufPlane::new(64 * 64, 32),
+				DmaBufPlane::new(64 * 64 + 32 * 32, 32),
+			])
+			.expect("a complete YU12 buffer");
+		assert_eq!(planes.len(), 3);
+		for plane in &planes {
+			assert_eq!(plane.format, wgpu::TextureFormat::R8Unorm);
+		}
+		assert_eq!(planes[0].size, size);
+		// Cb and Cr each cover a quarter of the pixels at one byte a texel, so
+		// unlike NV12 their rows really are half as long.
+		assert_eq!(planes[1].size, Size::new(32, 32));
+		assert_eq!(planes[2].size, Size::new(32, 32));
+		assert_eq!(planes[2].offset, 64 * 64 + 32 * 32);
+		assert_eq!(planes[2].stride, 32);
+	}
+
 	/// Packed formats stay one image, and needs no color matrix.
 	#[test]
 	fn packed_formats_import_as_a_single_plane() {

--- a/rs/moq-video/src/render/dmabuf.rs
+++ b/rs/moq-video/src/render/dmabuf.rs
@@ -321,17 +321,34 @@ pub(super) mod fixture {
 		}
 	}
 
-	/// An NV12 DMA-BUF of `size` holding `pixels`, tightly packed luma followed
-	/// by tightly packed interleaved chroma.
+	/// The rows and row length of each plane of `format` at `size`, tightly
+	/// packed, in the order the format lists them.
 	///
-	/// `None` when the host has no VA-API device, which is how this skips on a
-	/// builder rather than failing there.
-	pub(in crate::render) fn nv12(size: Size, pixels: &[u8]) -> Option<DmaBuf> {
+	/// NV12's chroma row is as long as its luma row despite covering half the
+	/// pixels, since it holds a Cb and a Cr per pair; I420's two chroma rows are
+	/// each half as long.
+	fn rows(format: DrmFormat, size: Size) -> Vec<(usize, usize)> {
+		let (width, height) = (size.width as usize, size.height as usize);
+		match format {
+			DrmFormat::NV12 => vec![(height, width), (height / 2, width)],
+			DrmFormat::YUV420 => vec![(height, width), (height / 2, width / 2), (height / 2, width / 2)],
+			format => panic!("the fixture cannot build DMA-BUF format {:#x}", format.as_raw()),
+		}
+	}
+
+	/// A DMA-BUF of `format` and `size` holding `pixels`, which are the planes
+	/// tightly packed one after another.
+	///
+	/// `None` when the host has no VA-API device or its driver will not allocate
+	/// or export such a surface, which is how this skips on a builder rather
+	/// than failing there. It says which on the way out.
+	pub(in crate::render) fn surface(format: DrmFormat, size: Size, pixels: &[u8]) -> Option<DmaBuf> {
+		let fourcc = va_fourcc(format).expect("a VA-API format");
 		let display = moq_vaapi::Display::open()?;
-		let mut surfaces = display
+		let surface = display
 			.create_surfaces::<()>(
 				moq_vaapi::VA_RT_FORMAT_YUV420,
-				Some(moq_vaapi::VA_FOURCC_NV12),
+				Some(fourcc),
 				size.width,
 				size.height,
 				// The hint a decoder uses, so the driver picks the layout it
@@ -340,12 +357,17 @@ pub(super) mod fixture {
 				Some(moq_vaapi::UsageHint::USAGE_HINT_DECODER | moq_vaapi::UsageHint::USAGE_HINT_EXPORT),
 				vec![()],
 			)
-			.expect("allocate an NV12 surface");
-		let surface = surfaces.pop().expect("one surface");
+			.map_err(|e| eprintln!("no {fourcc:#x} surface on this driver: {e}"))
+			.ok()?
+			.pop()
+			.expect("one surface");
 
-		upload(&display, &surface, size, pixels);
+		upload(&display, &surface, format, size, pixels)?;
 
-		let exported = surface.export_prime().expect("export the surface");
+		let exported = surface
+			.export_prime()
+			.map_err(|e| eprintln!("this driver will not export a {fourcc:#x} surface: {e}"))
+			.ok()?;
 		let layer = exported.layers.first().expect("an exported layer");
 		let planes = (0..layer.num_planes as usize)
 			.map(|index| DmaBufPlane::new(layer.offset[index], layer.pitch[index]))
@@ -358,7 +380,7 @@ pub(super) mod fixture {
 		// the size that was asked for, and imports at that size.
 		Some(
 			DmaBuf::new(
-				DrmFormat::NV12,
+				format,
 				modifier,
 				size.width,
 				size.height,
@@ -370,41 +392,69 @@ pub(super) mod fixture {
 		)
 	}
 
-	/// Copy tightly packed NV12 into a surface, honoring the image's own plane
+	/// Copy tightly packed planes into a surface, honoring the image's own plane
 	/// offsets and pitches. A `vaCreateImage` upload rather than a derived one,
 	/// so the driver writes the pixels into whatever layout the surface has.
-	fn upload(display: &Arc<moq_vaapi::Display>, surface: &moq_vaapi::Surface<()>, size: Size, pixels: &[u8]) {
-		let format = display
+	fn upload(
+		display: &Arc<moq_vaapi::Display>,
+		surface: &moq_vaapi::Surface<()>,
+		format: DrmFormat,
+		size: Size,
+		pixels: &[u8],
+	) -> Option<()> {
+		let fourcc = va_fourcc(format).expect("a VA-API format");
+		let image_format = display
 			.query_image_formats()
 			.expect("query image formats")
 			.into_iter()
-			.find(|format| format.fourcc == moq_vaapi::VA_FOURCC_NV12)
-			.expect("the driver has an NV12 image format");
+			.find(|image| image.fourcc == fourcc)
+			.or_else(|| {
+				eprintln!("this driver has no {fourcc:#x} image format");
+				None
+			})?;
 
-		let mut image = moq_vaapi::Image::create_from(surface, format, surface.size(), surface.size())
-			.expect("create an NV12 image");
+		let mut image = moq_vaapi::Image::create_from(surface, image_format, surface.size(), surface.size())
+			.map_err(|e| eprintln!("this driver will not create a {fourcc:#x} image: {e}"))
+			.ok()?;
 		let va_image = *image.image();
 		let destination: &mut [u8] = image.as_mut();
-		let (width, height) = (size.width as usize, size.height as usize);
 
-		// Luma: `height` rows of `width` bytes. Chroma: half as many rows, each
-		// still `width` bytes, since one row holds a Cb and a Cr per two pixels.
-		for (plane, rows) in [(0usize, height), (1, height / 2)] {
-			let source = match plane {
-				0 => &pixels[..width * height],
-				_ => &pixels[width * height..],
-			};
+		let mut source = pixels;
+		for (plane, (rows, length)) in rows(format, size).into_iter().enumerate() {
 			let (pitch, offset) = (va_image.pitches[plane] as usize, va_image.offsets[plane] as usize);
 			for row in 0..rows {
 				let start = offset + row * pitch;
-				destination[start..start + width].copy_from_slice(&source[row * width..(row + 1) * width]);
+				destination[start..start + length].copy_from_slice(&source[row * length..(row + 1) * length]);
 			}
+			source = &source[rows * length..];
 		}
 
 		// `vaPutImage` runs on drop, and the surface has to be idle before
 		// anything exports it.
 		drop(image);
 		surface.sync().expect("sync the uploaded surface");
+		Some(())
+	}
+}
+
+/// The VA-API fourcc naming the same layout as a DRM format.
+///
+/// DRM spells a packed pixel from its most significant byte down and VA-API from
+/// its first byte in memory, so one layout has two reversed names. The planar
+/// formats' two vocabularies agree.
+#[cfg(all(test, feature = "vaapi"))]
+fn va_fourcc(format: DrmFormat) -> Result<u32, Error> {
+	match format {
+		DrmFormat::XRGB8888 => Ok(moq_vaapi::VA_FOURCC_BGRX),
+		DrmFormat::ARGB8888 => Ok(moq_vaapi::VA_FOURCC_BGRA),
+		DrmFormat::XBGR8888 => Ok(moq_vaapi::VA_FOURCC_RGBX),
+		DrmFormat::ABGR8888 => Ok(moq_vaapi::VA_FOURCC_RGBA),
+		DrmFormat::NV12 => Ok(moq_vaapi::VA_FOURCC_NV12),
+		DrmFormat::YUV420 => Ok(moq_vaapi::VA_FOURCC_I420),
+		format => Err(err(format!(
+			"no VA-API format for DMA-BUF format {:#x}",
+			format.as_raw()
+		))),
 	}
 }
 

--- a/rs/moq-video/src/render/dmabuf.rs
+++ b/rs/moq-video/src/render/dmabuf.rs
@@ -15,10 +15,10 @@
 //! reformatted; only the descriptor is duplicated, once per plane.
 //!
 //! What that leaves is the modifier itself. A buffer whose modifier the driver
-//! does not list for those formats at all still has nowhere to go, and with the
-//! `vaapi` feature it gets a second chance: blitted on the GPU into an allocation
-//! the driver lays out itself. The direct import is
-//! always tried first, since it moves nothing at all.
+//! lists for neither format has nowhere to go at all, and the import fails so
+//! the renderer downloads the frame instead. Nothing here re-tiles such a
+//! buffer into a layout Vulkan would take: on the hardware this was measured on,
+//! a VA-API decode target already lands on an importable modifier.
 
 use std::os::fd::{AsFd, BorrowedFd};
 

--- a/rs/moq-video/src/render/dmabuf.rs
+++ b/rs/moq-video/src/render/dmabuf.rs
@@ -1,19 +1,37 @@
-//! Zero-copy import of packed Linux DMA-BUFs into wgpu's Vulkan backend.
+//! Zero-copy import of Linux DMA-BUFs into wgpu's Vulkan backend.
 //!
-//! wgpu owns the Vulkan image and imported fd once wrapping succeeds. The
-//! [`DmaBuf`] itself rides with the submitted render work separately, keeping
+//! wgpu owns the Vulkan images and imported descriptors once wrapping succeeds.
+//! The [`DmaBuf`] itself rides with the submitted render work separately, keeping
 //! the dequeued producer buffer out of PipeWire's pool until the GPU is done.
+//!
+//! wgpu-hal's importer describes one image made of one memory plane, which for a
+//! packed format is the whole buffer and for a planar one is not. Mesa reports
+//! two memory planes for `VK_FORMAT_G8_B8R8_2PLANE_420_UNORM` under every
+//! modifier it lists, so NV12 has no route through that importer as a single
+//! image. Taken a plane at a time it does: the same driver reports one memory
+//! plane for `R8_UNORM` and `R8G8_UNORM`, so a luma import and a chroma import of
+//! the same object, each at its own offset and row pitch, alias the buffer as the
+//! two textures the NV12 shader wants. Nothing is copied and nothing is
+//! reformatted; only the descriptor is duplicated, once per plane.
+//!
+//! What that leaves is the modifier itself. A buffer whose modifier the driver
+//! does not list for those formats at all still has nowhere to go, and with the
+//! `vaapi` feature it gets a second chance: blitted on the GPU into an allocation
+//! the driver lays out itself. The direct import is
+//! always tried first, since it moves nothing at all.
+
+use std::os::fd::{AsFd, BorrowedFd};
 
 use wgpu::hal::MemoryFlags;
 
 use super::source::{Layout, Source};
-use crate::{DmaBuf, DrmFormat, Error, Size};
+use crate::{Color, DmaBuf, DmaBufPlane, DrmFormat, Error, Size};
 
 fn err(message: impl std::fmt::Display) -> Error {
 	Error::Render(anyhow::anyhow!("{message}"))
 }
 
-/// Alias one packed DMA-BUF allocation as a sampled Vulkan texture.
+/// Alias one DMA-BUF allocation as the sampled Vulkan textures of a frame.
 pub(super) fn import(device: &wgpu::Device, buffer: &DmaBuf) -> Result<Option<Source>, Error> {
 	if !device
 		.features()
@@ -22,18 +40,206 @@ pub(super) fn import(device: &wgpu::Device, buffer: &DmaBuf) -> Result<Option<So
 		return Ok(None);
 	}
 
-	let format = match buffer.format() {
-		DrmFormat::XRGB8888 | DrmFormat::ARGB8888 => wgpu::TextureFormat::Bgra8Unorm,
-		DrmFormat::XBGR8888 | DrmFormat::ABGR8888 => wgpu::TextureFormat::Rgba8Unorm,
-		format => return Err(err(format!("cannot import DMA-BUF format {:#x}", format.as_raw()))),
-	};
-	let [plane] = buffer.planes() else {
-		return Err(err("packed DMA-BUF must have exactly one plane"));
-	};
+	// SAFETY: the guard is only asked whether it exists, and drops here.
+	// A device carrying the feature above is Vulkan-backed, so this is a
+	// belt-and-braces check rather than a route anything takes.
+	if unsafe { device.as_hal::<wgpu::hal::api::Vulkan>() }.is_none() {
+		return Ok(None);
+	}
+
 	let size = Size::new(buffer.width(), buffer.height());
+	let shape = Shape::of(buffer.format(), size)?;
+	let planes = shape.planes(buffer.planes())?;
+	// Packed RGB carries its own primaries; only YUV needs a matrix, and the
+	// producer rarely names one, so the frame size is usually all there is.
+	let color = match shape.layout {
+		Layout::Rgba => None,
+		_ => Some(buffer.color().unwrap_or_else(|| Color::infer(size))),
+	};
+
+	// One export, and so one wait on the producer's write fence, however
+	// many import attempts follow it.
+	let export = buffer
+		.export()
+		.map_err(|e| Error::Render(anyhow::Error::new(e).context("export DMA-BUF")))?;
+	let (fd, lease) = export.into_parts();
+
+	// SAFETY: `fd` is a live descriptor for this DMA-BUF, and `adopt`
+	// duplicates it per plane rather than consuming it. Export waited for
+	// producer writes, and the modifier, extent, stride, and offset of every
+	// plane come from the producer's own buffer metadata.
+	let direct = unsafe {
+		adopt(
+			device,
+			fd.as_fd(),
+			buffer.modifier(),
+			shape.layout,
+			color,
+			&planes,
+			Some(Box::new(lease.clone())),
+		)
+	};
+
+	direct.map(Some)
+}
+
+/// How a DRM format is sampled: the shader layout it feeds, and the Vulkan
+/// format and extent of each of its memory planes, in the order the buffer
+/// describes them.
+#[derive(Clone, Copy)]
+struct Shape {
+	layout: Layout,
+	/// Luma, or the whole picture for a packed format.
+	plane0: (wgpu::TextureFormat, Size),
+	/// Interleaved chroma for NV12, Cb for I420.
+	plane1: Option<(wgpu::TextureFormat, Size)>,
+	/// Cr for I420.
+	plane2: Option<(wgpu::TextureFormat, Size)>,
+}
+
+impl Shape {
+	/// The shape a `width` x `height` buffer of `format` imports as.
+	///
+	/// Every entry is a one- or two-component format, which is the point: those
+	/// are what Mesa reports a single memory plane for, so each one is a whole
+	/// image as far as wgpu-hal's importer is concerned.
+	fn of(format: DrmFormat, size: Size) -> Result<Self, Error> {
+		let packed = |format| Self {
+			layout: Layout::Rgba,
+			plane0: (format, size),
+			plane1: None,
+			plane2: None,
+		};
+
+		let subsampled = || -> Result<Size, Error> {
+			size.validate("4:2:0 DMA-BUF")?;
+			Ok(Size::new(size.width / 2, size.height / 2))
+		};
+
+		Ok(match format {
+			DrmFormat::XRGB8888 | DrmFormat::ARGB8888 => packed(wgpu::TextureFormat::Bgra8Unorm),
+			DrmFormat::XBGR8888 | DrmFormat::ABGR8888 => packed(wgpu::TextureFormat::Rgba8Unorm),
+			DrmFormat::NV12 => Self {
+				layout: Layout::Nv12,
+				plane0: (wgpu::TextureFormat::R8Unorm, size),
+				plane1: Some((wgpu::TextureFormat::Rg8Unorm, subsampled()?)),
+				plane2: None,
+			},
+			DrmFormat::YUV420 => {
+				let half = subsampled()?;
+				Self {
+					layout: Layout::I420,
+					plane0: (wgpu::TextureFormat::R8Unorm, size),
+					plane1: Some((wgpu::TextureFormat::R8Unorm, half)),
+					plane2: Some((wgpu::TextureFormat::R8Unorm, half)),
+				}
+			}
+			format => return Err(err(format!("cannot import DMA-BUF format {:#x}", format.as_raw()))),
+		})
+	}
+
+	/// Pair each plane's format and extent with the producer's offset and pitch.
+	///
+	/// Errors when the buffer does not describe the number of planes its format
+	/// calls for, rather than importing the ones it does describe and sampling
+	/// whatever the missing one's binding happens to hold. A frame short a chroma
+	/// plane renders as a uniform green picture, which looks enough like video to
+	/// be missed.
+	fn planes(&self, described: &[DmaBufPlane]) -> Result<Vec<Plane>, Error> {
+		let wanted = [Some(self.plane0), self.plane1, self.plane2];
+		let wanted = wanted.iter().flatten();
+		let count = 1 + usize::from(self.plane1.is_some()) + usize::from(self.plane2.is_some());
+		if described.len() != count {
+			return Err(err(format!(
+				"DMA-BUF describes {} planes, but its format has {count}",
+				described.len()
+			)));
+		}
+
+		Ok(wanted
+			.zip(described)
+			.map(|(&(format, size), plane)| Plane {
+				format,
+				size,
+				stride: plane.stride(),
+				offset: plane.offset(),
+			})
+			.collect())
+	}
+}
+
+/// One memory plane as it is imported: what to sample it as, how big it is, and
+/// where in the object it lives.
+struct Plane {
+	format: wgpu::TextureFormat,
+	size: Size,
+	stride: u32,
+	offset: u32,
+}
+
+/// Alias each of an object's planes as a Vulkan image and bind them as a source.
+///
+/// # Safety
+///
+/// `fd` must be a descriptor for a DMA-BUF whose pixels are written and
+/// readable, laid out exactly as `modifier` and each [`Plane`] say. The
+/// descriptor is duplicated per import, so the caller keeps its own and Vulkan
+/// keeps the copies, closing them itself if an import fails.
+unsafe fn adopt(
+	device: &wgpu::Device,
+	fd: BorrowedFd<'_>,
+	modifier: u64,
+	layout: Layout,
+	color: Option<Color>,
+	planes: &[Plane],
+	keepalive: Option<Box<dyn Send + Sync>>,
+) -> Result<Source, Error> {
+	let mut views = Vec::with_capacity(planes.len());
+	for plane in planes {
+		// A fresh descriptor per plane: Vulkan takes ownership of the one it is
+		// handed, on success by holding it and on failure by closing it, so one
+		// cannot serve two imports.
+		let dup = fd
+			.try_clone_to_owned()
+			.map_err(|e| Error::Render(anyhow::Error::new(e).context("duplicate DMA-BUF")))?;
+		// SAFETY: the caller's contract, narrowed to this plane.
+		views.push(unsafe { adopt_plane(device, dup, modifier, plane) }?);
+	}
+
+	// The NV12 shader reads plane0 and plane1 and the RGBA one reads plane0
+	// alone, but a single bind group layout serves all three, so the unread
+	// bindings get the last real view rather than a texture of their own.
+	let filler = views.last().expect("a format has at least one plane").clone();
+	let mut views = views.into_iter();
+	let plane0 = views.next().expect("a format has at least one plane");
+	let plane1 = views.next().unwrap_or_else(|| filler.clone());
+	let plane2 = views.next().unwrap_or(filler);
+
+	Ok(Source {
+		layout,
+		color,
+		plane0,
+		plane1,
+		plane2,
+		keepalive,
+	})
+}
+
+/// Hand one plane's descriptor to wgpu and wrap the result as a sampled texture.
+///
+/// # Safety
+///
+/// As [`adopt`], for this plane. Vulkan consumes `fd` on success and wgpu-hal
+/// closes it on error, so ownership passes either way.
+unsafe fn adopt_plane(
+	device: &wgpu::Device,
+	fd: std::os::fd::OwnedFd,
+	modifier: u64,
+	plane: &Plane,
+) -> Result<wgpu::TextureView, Error> {
 	let extent = wgpu::Extent3d {
-		width: size.width,
-		height: size.height,
+		width: plane.size.width,
+		height: plane.size.height,
 		depth_or_array_layers: 1,
 	};
 	let descriptor = wgpu::TextureDescriptor {
@@ -42,7 +248,7 @@ pub(super) fn import(device: &wgpu::Device, buffer: &DmaBuf) -> Result<Option<So
 		mip_level_count: 1,
 		sample_count: 1,
 		dimension: wgpu::TextureDimension::D2,
-		format,
+		format: plane.format,
 		usage: wgpu::TextureUsages::TEXTURE_BINDING,
 		view_formats: &[],
 	};
@@ -52,7 +258,7 @@ pub(super) fn import(device: &wgpu::Device, buffer: &DmaBuf) -> Result<Option<So
 		mip_level_count: 1,
 		sample_count: 1,
 		dimension: wgpu::TextureDimension::D2,
-		format,
+		format: plane.format,
 		usage: wgpu::TextureUses::RESOURCE,
 		memory_flags: MemoryFlags::empty(),
 		view_formats: Vec::new(),
@@ -60,27 +266,17 @@ pub(super) fn import(device: &wgpu::Device, buffer: &DmaBuf) -> Result<Option<So
 
 	// SAFETY: the guard is only used to import a descriptor into the same
 	// Vulkan device. It drops before the resulting HAL texture is wrapped.
-	let Some(hal) = (unsafe { device.as_hal::<wgpu::hal::api::Vulkan>() }) else {
-		return Ok(None);
-	};
-	let export = buffer
-		.export()
-		.map_err(|e| Error::Render(anyhow::Error::new(e).context("export DMA-BUF")))?;
-	let (fd, keepalive) = export.into_parts();
-	// SAFETY: `fd` is a fresh duplicate of this live DMA-BUF. Export waited for
-	// producer writes, and the format, modifier, extent, stride, and offset come
-	// from PipeWire's buffer metadata. Vulkan consumes the duplicate on success
-	// and wgpu-hal closes it on error.
-	let texture = unsafe {
-		hal.texture_from_dmabuf_fd(
-			fd,
-			&hal_descriptor,
-			buffer.modifier(),
-			plane.stride() as u64,
-			plane.offset() as u64,
-		)
-	}
-	.map_err(|e| err(format!("Vulkan DMA-BUF import: {e:?}")))?;
+	let hal = (unsafe { device.as_hal::<wgpu::hal::api::Vulkan>() })
+		.ok_or_else(|| err("wgpu device is not a Vulkan device"))?;
+	// SAFETY: the caller's contract, forwarded.
+	let texture =
+		unsafe { hal.texture_from_dmabuf_fd(fd, &hal_descriptor, modifier, plane.stride as u64, plane.offset as u64) }
+			.map_err(|e| {
+				err(format!(
+					"Vulkan DMA-BUF import of a {:?} {} plane at modifier {modifier:#x}: {e:?}",
+					plane.format, plane.size
+				))
+			})?;
 	drop(hal);
 
 	// SAFETY: wgpu-hal created `texture` on this device from `hal_descriptor`,
@@ -89,14 +285,191 @@ pub(super) fn import(device: &wgpu::Device, buffer: &DmaBuf) -> Result<Option<So
 	let texture = unsafe {
 		device.create_texture_from_hal::<wgpu::hal::api::Vulkan>(texture, &descriptor, wgpu::TextureUses::RESOURCE)
 	};
-	let view = texture.create_view(&Default::default());
+	Ok(texture.create_view(&Default::default()))
+}
 
-	Ok(Some(Source {
-		layout: Layout::Rgba,
-		color: None,
-		plane0: view.clone(),
-		plane1: view.clone(),
-		plane2: view,
-		keepalive: Some(Box::new(keepalive)),
-	}))
+/// Builds DMA-BUFs to import, for tests that would otherwise need a decoder.
+///
+/// VA-API is the allocator because it is the one already in the dependency
+/// graph that hands out the kind of buffer this module exists for: an NV12
+/// surface laid out however the driver lays out a decode target, tiling and
+/// padding included. What the caller gets is the same shape a hardware decoder
+/// would produce, with pixels it chose itself.
+#[cfg(all(test, feature = "vaapi"))]
+pub(super) mod fixture {
+	use std::os::fd::OwnedFd;
+	use std::sync::Arc;
+
+	use super::*;
+
+	/// A DMA-BUF built from an already exported descriptor.
+	///
+	/// The export holds its own reference on the underlying allocation, so the
+	/// VA-API surface it came from is long gone by the time anything imports
+	/// this. Downloading is not implemented: the point of the fixture is the
+	/// zero-copy path, and a test comparing against the CPU one builds its
+	/// reference from the bytes it uploaded rather than reading them back.
+	struct Exported(OwnedFd);
+
+	impl crate::frame::DmaBufFrame for Exported {
+		fn export(&self) -> std::io::Result<OwnedFd> {
+			self.0.try_clone()
+		}
+
+		fn download_i420(&self) -> Result<crate::frame::I420, Error> {
+			Err(err("the DMA-BUF fixture does not implement downloading"))
+		}
+	}
+
+	/// An NV12 DMA-BUF of `size` holding `pixels`, tightly packed luma followed
+	/// by tightly packed interleaved chroma.
+	///
+	/// `None` when the host has no VA-API device, which is how this skips on a
+	/// builder rather than failing there.
+	pub(in crate::render) fn nv12(size: Size, pixels: &[u8]) -> Option<DmaBuf> {
+		let display = moq_vaapi::Display::open()?;
+		let mut surfaces = display
+			.create_surfaces::<()>(
+				moq_vaapi::VA_RT_FORMAT_YUV420,
+				Some(moq_vaapi::VA_FOURCC_NV12),
+				size.width,
+				size.height,
+				// The hint a decoder uses, so the driver picks the layout it
+				// would pick for real decoded frames rather than a friendlier
+				// one it keeps for uploads.
+				Some(moq_vaapi::UsageHint::USAGE_HINT_DECODER | moq_vaapi::UsageHint::USAGE_HINT_EXPORT),
+				vec![()],
+			)
+			.expect("allocate an NV12 surface");
+		let surface = surfaces.pop().expect("one surface");
+
+		upload(&display, &surface, size, pixels);
+
+		let exported = surface.export_prime().expect("export the surface");
+		let layer = exported.layers.first().expect("an exported layer");
+		let planes = (0..layer.num_planes as usize)
+			.map(|index| DmaBufPlane::new(layer.offset[index], layer.pitch[index]))
+			.collect();
+		let object = exported.objects.first().expect("an exported object");
+		let modifier = object.drm_format_modifier;
+		let fd = object.fd.try_clone().expect("duplicate the exported descriptor");
+
+		// The exported extent is the driver's padded allocation; the frame is
+		// the size that was asked for, and imports at that size.
+		Some(
+			DmaBuf::new(
+				DrmFormat::NV12,
+				modifier,
+				size.width,
+				size.height,
+				planes,
+				None,
+				Arc::new(Exported(fd)),
+			)
+			.expect("a well-formed DMA-BUF"),
+		)
+	}
+
+	/// Copy tightly packed NV12 into a surface, honoring the image's own plane
+	/// offsets and pitches. A `vaCreateImage` upload rather than a derived one,
+	/// so the driver writes the pixels into whatever layout the surface has.
+	fn upload(display: &Arc<moq_vaapi::Display>, surface: &moq_vaapi::Surface<()>, size: Size, pixels: &[u8]) {
+		let format = display
+			.query_image_formats()
+			.expect("query image formats")
+			.into_iter()
+			.find(|format| format.fourcc == moq_vaapi::VA_FOURCC_NV12)
+			.expect("the driver has an NV12 image format");
+
+		let mut image = moq_vaapi::Image::create_from(surface, format, surface.size(), surface.size())
+			.expect("create an NV12 image");
+		let va_image = *image.image();
+		let destination: &mut [u8] = image.as_mut();
+		let (width, height) = (size.width as usize, size.height as usize);
+
+		// Luma: `height` rows of `width` bytes. Chroma: half as many rows, each
+		// still `width` bytes, since one row holds a Cb and a Cr per two pixels.
+		for (plane, rows) in [(0usize, height), (1, height / 2)] {
+			let source = match plane {
+				0 => &pixels[..width * height],
+				_ => &pixels[width * height..],
+			};
+			let (pitch, offset) = (va_image.pitches[plane] as usize, va_image.offsets[plane] as usize);
+			for row in 0..rows {
+				let start = offset + row * pitch;
+				destination[start..start + width].copy_from_slice(&source[row * width..(row + 1) * width]);
+			}
+		}
+
+		// `vaPutImage` runs on drop, and the surface has to be idle before
+		// anything exports it.
+		drop(image);
+		surface.sync().expect("sync the uploaded surface");
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	/// The plane count a format calls for has to match the buffer's, or a
+	/// missing chroma plane renders as a plausible-looking green picture instead
+	/// of an error.
+	#[test]
+	fn a_buffer_short_a_plane_is_refused() {
+		let size = Size::new(64, 64);
+		let shape = Shape::of(DrmFormat::NV12, size).expect("NV12 is importable");
+
+		let luma_only = [DmaBufPlane::new(0, 64)];
+		assert!(shape.planes(&luma_only).is_err());
+
+		let both = [DmaBufPlane::new(0, 64), DmaBufPlane::new(64 * 64, 64)];
+		let planes = shape.planes(&both).expect("a complete NV12 buffer");
+		assert_eq!(planes.len(), 2);
+		assert_eq!(planes[0].format, wgpu::TextureFormat::R8Unorm);
+		assert_eq!(planes[0].size, size);
+		assert_eq!(planes[1].format, wgpu::TextureFormat::Rg8Unorm);
+		// Half in both axes: 4:2:0 chroma is one two-channel texel per 2x2 luma.
+		assert_eq!(planes[1].size, Size::new(32, 32));
+		assert_eq!(planes[1].offset, 64 * 64);
+	}
+
+	/// The producer's pitch is what addresses a row, not the width, so it has to
+	/// survive into the import unchanged. A buffer padded to a tile boundary
+	/// shears progressively down the frame when this is dropped.
+	#[test]
+	fn the_producers_pitch_reaches_each_plane() {
+		let shape = Shape::of(DrmFormat::NV12, Size::new(60, 40)).expect("NV12 is importable");
+		let planes = shape
+			.planes(&[DmaBufPlane::new(0, 64), DmaBufPlane::new(64 * 48, 64)])
+			.expect("a complete NV12 buffer");
+
+		assert_eq!(planes[0].stride, 64, "luma keeps the padded pitch, not the width");
+		assert_eq!(planes[1].stride, 64, "chroma is half as wide but two bytes a texel");
+	}
+
+	/// Packed formats stay one image, and needs no color matrix.
+	#[test]
+	fn packed_formats_import_as_a_single_plane() {
+		let size = Size::new(64, 64);
+		for (format, expected) in [
+			(DrmFormat::XRGB8888, wgpu::TextureFormat::Bgra8Unorm),
+			(DrmFormat::ABGR8888, wgpu::TextureFormat::Rgba8Unorm),
+		] {
+			let shape = Shape::of(format, size).expect("a packed format is importable");
+			assert_eq!(shape.layout, Layout::Rgba);
+			let planes = shape.planes(&[DmaBufPlane::new(0, 64 * 4)]).expect("one plane");
+			assert_eq!(planes.len(), 1);
+			assert_eq!(planes[0].format, expected);
+		}
+	}
+
+	/// 4:2:0 chroma has no meaning at an odd width, so the format is refused
+	/// rather than imported with a plane rounded down a pixel.
+	#[test]
+	fn odd_dimensions_are_refused_for_subsampled_formats() {
+		assert!(Shape::of(DrmFormat::NV12, Size::new(65, 64)).is_err());
+		assert!(Shape::of(DrmFormat::YUV420, Size::new(64, 65)).is_err());
+		assert!(Shape::of(DrmFormat::XRGB8888, Size::new(65, 65)).is_ok());
+	}
 }

--- a/rs/moq-video/src/render/mod.rs
+++ b/rs/moq-video/src/render/mod.rs
@@ -28,7 +28,9 @@
 //! A hardware-decoded frame is imported by aliasing the decoder's surface as a
 //! texture rather than copying it: `CVMetalTextureCache` on macOS for the
 //! `PixelBuffer` variant of [`Surface`](crate::Surface), and Vulkan external
-//! memory on Linux for packed PipeWire DMA-BUFs.
+//! memory on Linux for DMA-BUFs, packed or planar. A planar one is imported a
+//! memory plane at a time, since Vulkan will not take an NV12 or YU12 buffer as
+//! a single image, and the shader was already sampling planes.
 // `PixelBuffer` is deliberately not a doc link: the variant is macOS-only, so a
 // link to it fails the `-D warnings` rustdoc build on every other platform.
 //!

--- a/rs/moq-video/src/render/renderer.rs
+++ b/rs/moq-video/src/render/renderer.rs
@@ -128,6 +128,9 @@ pub struct Renderer {
 	strikes: u32,
 	/// Set once the fast path is retired for the life of this renderer.
 	retired: bool,
+	/// Set once a frame has been imported rather than uploaded, so the line
+	/// saying so is logged once rather than per frame.
+	imported: bool,
 }
 
 /// The compiled pipeline, one variant per plane layout, and everything they share.
@@ -237,6 +240,7 @@ impl Renderer {
 			output: None,
 			strikes: 0,
 			retired: false,
+			imported: false,
 		})
 	}
 
@@ -337,6 +341,17 @@ impl Renderer {
 			match self.source.import(&self.device, &frame.surface) {
 				Ok(Some(source)) => {
 					self.strikes = 0;
+					// The one observable difference between a picture that
+					// reached the GPU untouched and one that went through system
+					// memory. Worth a line the first time it happens, because
+					// nothing else about a working renderer says which it was.
+					if !self.imported {
+						self.imported = true;
+						tracing::debug!(
+							layout = ?source.layout,
+							"drawing frames zero-copy; the picture reaches the GPU without a download"
+						);
+					}
 					return Ok(source);
 				}
 				// No import path for this surface on this platform. Not a
@@ -1105,10 +1120,15 @@ mod tests {
 	/// A real decoded picture drawn without ever reaching system memory.
 	///
 	/// The chain the whole thing is for, end to end: openh264 encodes a
-	/// gradient, VA-API decodes it, the decode surface is exported rather than
-	/// downloaded, and the renderer imports its two planes. The same stream is
-	/// decoded a second time the ordinary way and drawn through the CPU upload,
-	/// and the two pictures have to agree.
+	/// gradient, the VAAPI decode backend is asked for GPU-resident frames and
+	/// hands back the surfaces it decoded into, and the renderer imports their
+	/// two planes. The same stream is decoded a second time by the same backend
+	/// asked for CPU frames and drawn through the upload path, and the two
+	/// pictures have to agree.
+	///
+	/// Through `decode::backend` rather than `moq_vaapi` directly, so what this
+	/// covers is the path `Config::gpu_frames` actually turns on rather than an
+	/// arrangement only the test knows how to build.
 	///
 	/// A gradient rather than the block palette, because this one is checking
 	/// the plumbing rather than the color math: it varies in both axes, so a
@@ -1123,16 +1143,27 @@ mod tests {
 	#[tokio::test]
 	#[ignore = "needs a Vulkan GPU and a VA-API device"]
 	async fn decoded_frames_reach_the_gpu_without_a_download() {
+		use crate::decode::backend::{self, Codec};
+
 		let Some((device, queue)) = dmabuf_gpu().await else {
 			eprintln!("skipping: no Vulkan adapter with DMA-BUF external memory");
 			return;
 		};
-		let Ok(mut exporting) = moq_vaapi::decode::Decoder::new(moq_vaapi::decode::Config::new()) else {
+		let decode = |gpu_frames| {
+			backend::open(
+				Codec::H264,
+				&crate::decode::Config {
+					kind: crate::decode::Kind::Named("vaapi".into()),
+					gpu_frames,
+					..crate::decode::Config::new()
+				},
+			)
+		};
+		let Ok(mut exporting) = decode(true) else {
 			eprintln!("skipping: no VA-API H.264 decoder");
 			return;
 		};
-		let mut downloading =
-			moq_vaapi::decode::Decoder::new(moq_vaapi::decode::Config::new()).expect("a second decoder");
+		let mut downloading = decode(false).expect("a second decoder");
 
 		// A gradient in both axes, so the chroma planes carry structure and a
 		// plane split or stride mistake corrupts the picture rather than
@@ -1165,18 +1196,29 @@ mod tests {
 			let surface = Surface::rgba(&rgba, size).expect("a valid RGBA frame");
 			let frame = Frame::new(surface, Timestamp::from_micros(index * 33_333).unwrap());
 			for unit in encoder.encode(&frame).expect("encode a picture") {
-				let payload = unit.payload.as_ref();
-				exported.extend(exporting.decode_exported(payload, index).expect("decode to the GPU"));
-				downloaded.extend(downloading.decode(payload, index).expect("decode to the CPU"));
+				let timestamp = unit.timestamp;
+				exported.extend(
+					exporting
+						.decode(unit.payload.clone(), timestamp, index == 0)
+						.expect("decode to the GPU"),
+				);
+				downloaded.extend(
+					downloading
+						.decode(unit.payload, timestamp, index == 0)
+						.expect("decode to the CPU"),
+				);
 			}
 		}
 		assert!(!exported.is_empty(), "the decoder produced no pictures");
 		assert_eq!(exported.len(), downloaded.len(), "the two decoders disagreed");
 
+		let Surface::DmaBuf(first) = &exported[0].surface else {
+			panic!("gpu_frames did not produce a DMA-BUF surface");
+		};
 		eprintln!(
 			"decoded {} pictures, exported at modifier {:#x}",
 			exported.len(),
-			exported[0].descriptor.objects[0].drm_format_modifier
+			first.modifier()
 		);
 
 		let config = Config {
@@ -1187,30 +1229,32 @@ mod tests {
 		let mut uploading = Renderer::new(&device, &queue, config).expect("a renderer");
 
 		for (index, (gpu, cpu)) in exported.iter().zip(&downloaded).enumerate() {
-			let buffer = crate::render::dmabuf::fixture::adopt(&gpu.descriptor, crate::DrmFormat::NV12, size);
+			let Surface::DmaBuf(buffer) = &gpu.surface else {
+				panic!("picture {index} did not come back GPU-resident");
+			};
 			if index == 0 {
 				eprintln!("  planes {:?}", buffer.planes());
 			}
-			let frame = Frame::new(Surface::DmaBuf(buffer), Timestamp::ZERO);
+			assert!(
+				matches!(cpu.surface, Surface::I420(_)),
+				"picture {index} was not downloaded without gpu_frames"
+			);
 
 			// Which branch ran, per picture: the decoder's own surfaces import
 			// as NV12, and only the per-plane DMA-BUF path produces that.
 			let source = importing
 				.source
-				.import(&device, &frame.surface)
+				.import(&device, &gpu.surface)
 				.expect("import the decoded surface")
 				.expect("a DMA-BUF import path");
 			assert_eq!(source.layout, Layout::Nv12, "picture {index} did not import as NV12");
 			drop(source);
 
-			let texture = importing.render(&frame).expect("draw the imported picture");
+			let texture = importing.render(gpu).expect("draw the imported picture");
 			assert_eq!(importing.strikes, 0, "picture {index} fell back to the CPU");
 			let zero_copy = readback(&device, &queue, &texture).await;
 
-			let i420 = crate::frame::I420::from_nv12(&cpu.data, width, height).expect("deinterleave NV12");
-			let texture = uploading
-				.render(&Frame::new(Surface::I420(i420), Timestamp::ZERO))
-				.expect("draw the downloaded picture");
+			let texture = uploading.render(cpu).expect("draw the downloaded picture");
 			let cpu = readback(&device, &queue, &texture).await;
 
 			let mut worst = 0u8;

--- a/rs/moq-video/src/render/renderer.rs
+++ b/rs/moq-video/src/render/renderer.rs
@@ -872,14 +872,13 @@ mod tests {
 		[y, cb, cr].map(|c| c.round().clamp(0.0, 255.0) as u8)
 	}
 
-	/// The block pattern as tightly packed NV12: `height` rows of luma, then
-	/// `height / 2` rows of interleaved Cb, Cr at half the horizontal resolution.
+	/// The block pattern as tightly packed planes of `format`.
 	///
 	/// The blocks are 32 pixels on a side, so each 2x2 chroma group sits wholly
 	/// inside one of them and the subsampling loses nothing. Any difference the
 	/// comparison then finds is the import's, not the format's.
 	#[cfg(all(target_os = "linux", feature = "vaapi"))]
-	fn nv12_pattern(size: Size, color: Color) -> Vec<u8> {
+	fn pattern(format: crate::DrmFormat, size: Size, color: Color) -> Vec<u8> {
 		let (width, height) = (size.width, size.height);
 		let mut pixels = Vec::with_capacity((width * height * 3 / 2) as usize);
 
@@ -888,19 +887,41 @@ mod tests {
 				pixels.push(to_yuv(color, block(x, y))[0]);
 			}
 		}
-		for y in (0..height).step_by(2) {
-			for x in (0..width).step_by(2) {
-				let [_, cb, cr] = to_yuv(color, block(x, y));
-				pixels.push(cb);
-				pixels.push(cr);
+
+		// NV12 interleaves Cb then Cr in one plane; I420 keeps them as two.
+		// Getting that pair the wrong way round is the failure this test is
+		// most concerned with, so it is written out once here and read back by
+		// the shader rather than round-tripped through a helper that could
+		// share the mistake.
+		let chroma = |channel: usize, pixels: &mut Vec<u8>| {
+			for y in (0..height).step_by(2) {
+				for x in (0..width).step_by(2) {
+					pixels.push(to_yuv(color, block(x, y))[channel]);
+				}
 			}
+		};
+		match format {
+			crate::DrmFormat::NV12 => {
+				for y in (0..height).step_by(2) {
+					for x in (0..width).step_by(2) {
+						let [_, cb, cr] = to_yuv(color, block(x, y));
+						pixels.push(cb);
+						pixels.push(cr);
+					}
+				}
+			}
+			crate::DrmFormat::YUV420 => {
+				chroma(1, &mut pixels);
+				chroma(2, &mut pixels);
+			}
+			format => panic!("no pattern for DMA-BUF format {:#x}", format.as_raw()),
 		}
 
 		pixels
 	}
 
 	/// A Vulkan device that can import DMA-BUFs, or `None` where nothing can.
-	#[cfg(all(target_os = "linux", feature = "dmabuf"))]
+	#[cfg(all(target_os = "linux", feature = "vaapi"))]
 	async fn dmabuf_gpu() -> Option<(wgpu::Device, wgpu::Queue)> {
 		let instance = wgpu::Instance::default();
 		let adapter = instance
@@ -924,16 +945,15 @@ mod tests {
 		)
 	}
 
-	/// An NV12 DMA-BUF has to import as two Vulkan images and draw the same
-	/// picture the CPU path draws from the same samples.
+	/// Draw one DMA-BUF of `format` and `size` twice, imported and uploaded, and
+	/// check the two against each other and against the palette.
 	///
-	/// The test the whole per-plane import exists to pass, and it is three
-	/// assertions rather than one:
+	/// Three assertions rather than one:
 	///
-	/// - The import returns a source at all, and its layout is
-	///   [`Layout::Nv12`]. Only the DMA-BUF importer produces that, so this says
-	///   which branch ran. Without it the CPU fallback would quietly satisfy
-	///   everything below.
+	/// - The import returns a source at all, its layout is `expected`, and no
+	///   frame needed a re-tile. Only the DMA-BUF importer produces those
+	///   layouts, so this says which branch ran. Without it the CPU fallback
+	///   would quietly satisfy everything below.
 	/// - Every pixel matches the CPU upload of the same samples. That is the one
 	///   that catches a swapped chroma pair, a plane at the wrong offset, an
 	///   ignored row pitch, and a mismatched matrix, all at once.
@@ -941,31 +961,27 @@ mod tests {
 	///   here from the definition of the color space. Both paths agreeing on the
 	///   wrong answer would pass the comparison and fail this.
 	///
-	/// Ignored: needs a GPU that can import DMA-BUFs and a VA-API device to
-	/// allocate one. Run with
-	/// `cargo test -p moq-video --features render,vaapi nv12_dmabuf -- --ignored --nocapture`.
+	/// `false` when the host cannot allocate such a buffer, which is a skip
+	/// rather than a pass.
 	#[cfg(all(target_os = "linux", feature = "vaapi"))]
-	#[tokio::test]
-	#[ignore = "needs a Vulkan GPU and a VA-API device"]
-	async fn the_nv12_dmabuf_import_matches_the_cpu_path() {
-		let Some((device, queue)) = dmabuf_gpu().await else {
-			eprintln!("skipping: no Vulkan adapter with DMA-BUF external memory");
-			return;
-		};
-
-		// 192 lines is below the 576 the crate infers BT.709 above, so both
-		// paths land on BT.601 limited and the pattern is built for that.
-		let size = Size::new(256, 192);
+	async fn imported_matches_uploaded(
+		device: &wgpu::Device,
+		queue: &wgpu::Queue,
+		format: crate::DrmFormat,
+		size: Size,
+		expected: Layout,
+	) -> bool {
+		// Below the 576 lines the crate infers BT.709 above, so both paths land
+		// on BT.601 limited and the pattern is built for that.
 		let color = Color::infer(size);
 		assert_eq!(color, Color::Bt601Limited);
-		let pattern = nv12_pattern(size, color);
 
-		let Some(buffer) = crate::render::dmabuf::fixture::nv12(size, &pattern) else {
-			eprintln!("skipping: no VA-API device to allocate a DMA-BUF from");
-			return;
+		let Some(buffer) = crate::render::dmabuf::fixture::surface(format, size, &pattern(format, size, color)) else {
+			return false;
 		};
 		eprintln!(
-			"NV12 DMA-BUF: modifier {:#x}, planes {:?}",
+			"{size} {:?}: modifier {:#x}, planes {:?}",
+			expected,
 			buffer.modifier(),
 			buffer.planes()
 		);
@@ -980,52 +996,46 @@ mod tests {
 		// than read back out of it, so it shares nothing with the path it is
 		// checking.
 		let uploaded = {
-			let i420 = crate::frame::I420::from_nv12(&pattern, size.width, size.height).expect("deinterleave NV12");
+			let nv12 = pattern(crate::DrmFormat::NV12, size, color);
+			let i420 = crate::frame::I420::from_nv12(&nv12, size.width, size.height).expect("deinterleave NV12");
 			let frame = Frame::new(Surface::I420(i420), Timestamp::ZERO);
-			let mut renderer = Renderer::new(&device, &queue, config.clone()).expect("a renderer");
+			let mut renderer = Renderer::new(device, queue, config.clone()).expect("a renderer");
 			let texture = renderer.render(&frame).expect("a rendered frame");
-			readback(&device, &queue, &texture).await
+			readback(device, queue, &texture).await
 		};
 
 		let frame = Frame::new(Surface::DmaBuf(buffer), Timestamp::ZERO);
-		let mut renderer = Renderer::new(&device, &queue, config).expect("a renderer");
+		let mut renderer = Renderer::new(device, queue, config).expect("a renderer");
 
-		// Which branch ran. `Layout::Nv12` comes from the per-plane DMA-BUF
+		// Which branch ran. These layouts come from the per-plane DMA-BUF
 		// import and from nothing else on this platform.
 		let imported = renderer
 			.source
-			.import(&device, &frame.surface)
-			.expect("import the NV12 DMA-BUF")
+			.import(device, &frame.surface)
+			.expect("import the DMA-BUF")
 			.expect("a DMA-BUF import path");
-		assert_eq!(imported.layout, Layout::Nv12, "the frame did not import as NV12");
+		assert_eq!(imported.layout, expected, "the frame imported as the wrong layout");
 		assert_eq!(imported.color, Some(color));
 		drop(imported);
 
 		let texture = renderer.render(&frame).expect("a rendered frame");
 		assert_eq!(renderer.strikes, 0, "the zero-copy import should not have failed");
 		assert!(!renderer.retired);
-		let zero_copy = readback(&device, &queue, &texture).await;
+		let zero_copy = readback(device, queue, &texture).await;
 
 		// Every pixel, not a sample of them: a shear from an ignored row pitch
 		// grows down the frame and leaves the top correct.
 		assert_eq!(zero_copy.len(), uploaded.len());
-		let mut worst = (0usize, 0i32);
-		for (index, (&imported, &expected)) in zero_copy.iter().zip(&uploaded).enumerate() {
-			for channel in 0..4 {
-				let drift = imported[channel] as i32 - expected[channel] as i32;
-				if drift.abs() > worst.1 {
-					worst = (index, drift.abs());
-				}
-			}
+		let mut worst = 0u8;
+		for (index, (&imported, &reference)) in zero_copy.iter().zip(&uploaded).enumerate() {
+			let drift = (0..4).map(|c| imported[c].abs_diff(reference[c])).max().unwrap_or(0);
+			worst = worst.max(drift);
 			let (x, y) = (index % size.width as usize, index / size.width as usize);
-			assert!(
-				(0..4).all(|c| imported[c].abs_diff(expected[c]) <= 2),
-				"({x}, {y}): imported {imported:?}, uploaded {expected:?}"
-			);
+			assert!(drift <= 2, "({x}, {y}): imported {imported:?}, uploaded {reference:?}");
 		}
 		eprintln!(
-			"worst drift between the imported and uploaded frames: {} codes at pixel {}",
-			worst.1, worst.0
+			"  imported vs uploaded: worst drift {worst} of 255 over {} pixels",
+			zero_copy.len(),
 		);
 
 		// And both agree with the palette the pattern was built from, so a
@@ -1033,8 +1043,61 @@ mod tests {
 		for y in (16..size.height).step_by(32) {
 			for x in (16..size.width).step_by(32) {
 				let rgb = block(x, y);
-				let index = (y * size.width + x) as usize;
-				assert_close(zero_copy[index], [rgb[0], rgb[1], rgb[2], 255]);
+				assert_close(zero_copy[(y * size.width + x) as usize], [rgb[0], rgb[1], rgb[2], 255]);
+			}
+		}
+
+		true
+	}
+
+	/// An NV12 DMA-BUF has to import as two Vulkan images and draw the same
+	/// picture the CPU path draws from the same samples.
+	///
+	/// The test the whole per-plane import exists to pass. It runs at two sizes:
+	/// one whose width the driver leaves alone, and one it has to pad, so the
+	/// row pitch and the chroma plane's offset both stop being derivable from
+	/// the frame size. A pitch taken as the width shears the picture, and the
+	/// shear grows down the frame, which is why the comparison is over every
+	/// pixel rather than a sample of them.
+	///
+	/// Ignored: needs a GPU that can import DMA-BUFs and a VA-API device to
+	/// allocate one. Run with
+	/// `cargo test -p moq-video --features render,vaapi nv12_dmabuf -- --ignored --nocapture`.
+	#[cfg(all(target_os = "linux", feature = "vaapi"))]
+	#[tokio::test]
+	#[ignore = "needs a Vulkan GPU and a VA-API device"]
+	async fn the_nv12_dmabuf_import_matches_the_cpu_path() {
+		let Some((device, queue)) = dmabuf_gpu().await else {
+			eprintln!("skipping: no Vulkan adapter with DMA-BUF external memory");
+			return;
+		};
+
+		let mut ran = false;
+		for size in [Size::new(256, 192), Size::new(200, 120), Size::new(62, 34)] {
+			ran |= imported_matches_uploaded(&device, &queue, crate::DrmFormat::NV12, size, Layout::Nv12).await;
+		}
+		assert!(ran, "no NV12 DMA-BUF could be allocated to import");
+	}
+
+	/// The same for fully planar 4:2:0, which imports as three single-component
+	/// images rather than two.
+	///
+	/// Skips rather than fails where the driver will not allocate or export a
+	/// YU12 surface: what the layout has to get right is covered by NV12 either
+	/// way, and this is the arrangement a VA-API decode hands back.
+	#[cfg(all(target_os = "linux", feature = "vaapi"))]
+	#[tokio::test]
+	#[ignore = "needs a Vulkan GPU and a VA-API device"]
+	async fn the_i420_dmabuf_import_matches_the_cpu_path() {
+		let Some((device, queue)) = dmabuf_gpu().await else {
+			eprintln!("skipping: no Vulkan adapter with DMA-BUF external memory");
+			return;
+		};
+
+		for size in [Size::new(256, 192), Size::new(200, 120)] {
+			if !imported_matches_uploaded(&device, &queue, crate::DrmFormat::YUV420, size, Layout::I420).await {
+				eprintln!("skipping: this driver does not do YU12 DMA-BUFs");
+				return;
 			}
 		}
 	}

--- a/rs/moq-video/src/render/renderer.rs
+++ b/rs/moq-video/src/render/renderer.rs
@@ -1145,7 +1145,7 @@ mod tests {
 	#[tokio::test]
 	#[ignore = "needs a Vulkan GPU and a VA-API device"]
 	async fn decoded_frames_reach_the_gpu_without_a_download() {
-		use crate::decode::backend::{self, Codec};
+		use crate::decode::backend::{self, Codec, vaapi};
 
 		let Some((device, queue)) = dmabuf_gpu().await else {
 			eprintln!("skipping: no Vulkan adapter with DMA-BUF external memory");
@@ -1155,7 +1155,10 @@ mod tests {
 			backend::open(
 				Codec::H264,
 				&crate::decode::Config {
-					kind: crate::decode::Kind::Named("vaapi".into()),
+					// By name rather than by literal: a `Named` that matches
+					// nothing fails to open, which reads here as absent hardware
+					// and skips the test.
+					kind: crate::decode::Kind::Named(vaapi::NAME.into()),
 					gpu_frames,
 					..crate::decode::Config::new()
 				},

--- a/rs/moq-video/src/render/renderer.rs
+++ b/rs/moq-video/src/render/renderer.rs
@@ -1102,6 +1102,141 @@ mod tests {
 		}
 	}
 
+	/// A real decoded picture drawn without ever reaching system memory.
+	///
+	/// The chain the whole thing is for, end to end: openh264 encodes a
+	/// gradient, VA-API decodes it, the decode surface is exported rather than
+	/// downloaded, and the renderer imports its two planes. The same stream is
+	/// decoded a second time the ordinary way and drawn through the CPU upload,
+	/// and the two pictures have to agree.
+	///
+	/// A gradient rather than the block palette, because this one is checking
+	/// the plumbing rather than the color math: it varies in both axes, so a
+	/// plane at a wrong offset or a pitch taken as the width shows up as a
+	/// mismatch. What the samples mean is settled by the sibling tests, which
+	/// know exactly what went into the buffer; here the decoder decides, and a
+	/// lossy encoder sits in front of it.
+	///
+	/// Ignored: needs a Vulkan GPU and a VA-API device. Run with
+	/// `cargo test -p moq-video --features render,vaapi decoded_frames -- --ignored --nocapture`.
+	#[cfg(all(target_os = "linux", feature = "vaapi"))]
+	#[tokio::test]
+	#[ignore = "needs a Vulkan GPU and a VA-API device"]
+	async fn decoded_frames_reach_the_gpu_without_a_download() {
+		let Some((device, queue)) = dmabuf_gpu().await else {
+			eprintln!("skipping: no Vulkan adapter with DMA-BUF external memory");
+			return;
+		};
+		let Ok(mut exporting) = moq_vaapi::decode::Decoder::new(moq_vaapi::decode::Config::new()) else {
+			eprintln!("skipping: no VA-API H.264 decoder");
+			return;
+		};
+		let mut downloading =
+			moq_vaapi::decode::Decoder::new(moq_vaapi::decode::Config::new()).expect("a second decoder");
+
+		// A gradient in both axes, so the chroma planes carry structure and a
+		// plane split or stride mistake corrupts the picture rather than
+		// tinting it.
+		let size = Size::new(320, 240);
+		let (width, height) = (size.width, size.height);
+		let mut rgba = vec![0u8; (width * height * 4) as usize];
+		for y in 0..height {
+			for x in 0..width {
+				let index = ((y * width + x) * 4) as usize;
+				rgba[index] = (x * 255 / width) as u8;
+				rgba[index + 1] = (y * 255 / height) as u8;
+				rgba[index + 2] = ((x + y) * 255 / (width + height)) as u8;
+				rgba[index + 3] = 255;
+			}
+		}
+
+		let mut encoder = crate::encode::Encoder::new(&crate::encode::Config {
+			kind: crate::encode::Kind::Software,
+			..crate::encode::Config::new(width, height, 30)
+		})
+		.expect("a software H.264 encoder");
+
+		let mut exported = Vec::new();
+		let mut downloaded = Vec::new();
+		for index in 0..8u64 {
+			if index == 0 {
+				encoder.keyframe();
+			}
+			let surface = Surface::rgba(&rgba, size).expect("a valid RGBA frame");
+			let frame = Frame::new(surface, Timestamp::from_micros(index * 33_333).unwrap());
+			for unit in encoder.encode(&frame).expect("encode a picture") {
+				let payload = unit.payload.as_ref();
+				exported.extend(exporting.decode_exported(payload, index).expect("decode to the GPU"));
+				downloaded.extend(downloading.decode(payload, index).expect("decode to the CPU"));
+			}
+		}
+		assert!(!exported.is_empty(), "the decoder produced no pictures");
+		assert_eq!(exported.len(), downloaded.len(), "the two decoders disagreed");
+
+		eprintln!(
+			"decoded {} pictures, exported at modifier {:#x}",
+			exported.len(),
+			exported[0].descriptor.objects[0].drm_format_modifier
+		);
+
+		let config = Config {
+			usage: wgpu::TextureUsages::COPY_SRC,
+			..Config::new()
+		};
+		let mut importing = Renderer::new(&device, &queue, config.clone()).expect("a renderer");
+		let mut uploading = Renderer::new(&device, &queue, config).expect("a renderer");
+
+		for (index, (gpu, cpu)) in exported.iter().zip(&downloaded).enumerate() {
+			let buffer = crate::render::dmabuf::fixture::adopt(&gpu.descriptor, crate::DrmFormat::NV12, size);
+			if index == 0 {
+				eprintln!("  planes {:?}", buffer.planes());
+			}
+			let frame = Frame::new(Surface::DmaBuf(buffer), Timestamp::ZERO);
+
+			// Which branch ran, per picture: the decoder's own surfaces import
+			// as NV12, and only the per-plane DMA-BUF path produces that.
+			let source = importing
+				.source
+				.import(&device, &frame.surface)
+				.expect("import the decoded surface")
+				.expect("a DMA-BUF import path");
+			assert_eq!(source.layout, Layout::Nv12, "picture {index} did not import as NV12");
+			drop(source);
+
+			let texture = importing.render(&frame).expect("draw the imported picture");
+			assert_eq!(importing.strikes, 0, "picture {index} fell back to the CPU");
+			assert_eq!(
+				importing.source.dmabuf.retiled(),
+				0,
+				"picture {index} reached the GPU only by way of a re-tile"
+			);
+			let zero_copy = readback(&device, &queue, &texture).await;
+
+			let i420 = crate::frame::I420::from_nv12(&cpu.data, width, height).expect("deinterleave NV12");
+			let texture = uploading
+				.render(&Frame::new(Surface::I420(i420), Timestamp::ZERO))
+				.expect("draw the downloaded picture");
+			let cpu = readback(&device, &queue, &texture).await;
+
+			let mut worst = 0u8;
+			for (pixel, (&imported, &reference)) in zero_copy.iter().zip(&cpu).enumerate() {
+				let drift = (0..4).map(|c| imported[c].abs_diff(reference[c])).max().unwrap_or(0);
+				worst = worst.max(drift);
+				let (x, y) = (pixel % width as usize, pixel / width as usize);
+				assert!(
+					drift <= 2,
+					"picture {index} at ({x}, {y}): imported {imported:?}, downloaded {reference:?}"
+				);
+			}
+			if index == 0 {
+				eprintln!(
+					"  imported vs downloaded: worst drift {worst} of 255 over {} pixels",
+					cpu.len()
+				);
+			}
+		}
+	}
+
 	/// A pool-backed NV12 surface, shaped like a hardware decode's output.
 	#[cfg(target_os = "macos")]
 	fn pooled(size: Size, rgba: [u8; 4]) -> crate::Surface {

--- a/rs/moq-video/src/render/renderer.rs
+++ b/rs/moq-video/src/render/renderer.rs
@@ -1205,11 +1205,6 @@ mod tests {
 
 			let texture = importing.render(&frame).expect("draw the imported picture");
 			assert_eq!(importing.strikes, 0, "picture {index} fell back to the CPU");
-			assert_eq!(
-				importing.source.dmabuf.retiled(),
-				0,
-				"picture {index} reached the GPU only by way of a re-tile"
-			);
 			let zero_copy = readback(&device, &queue, &texture).await;
 
 			let i420 = crate::frame::I420::from_nv12(&cpu.data, width, height).expect("deinterleave NV12");

--- a/rs/moq-video/src/render/renderer.rs
+++ b/rs/moq-video/src/render/renderer.rs
@@ -137,7 +137,7 @@ struct Pipelines {
 	/// Paired with [`Layout::Nv12`], so it exists only where an importer can
 	/// hand back that layout. The shader still declares the entry point
 	/// everywhere, so it stays validated on every platform either way.
-	#[cfg(target_os = "macos")]
+	#[cfg(any(target_os = "macos", all(target_os = "linux", feature = "dmabuf")))]
 	nv12: wgpu::RenderPipeline,
 	#[cfg(all(target_os = "linux", feature = "dmabuf"))]
 	/// Packed RGB or BGR imported from a Linux DMA-BUF.
@@ -289,7 +289,7 @@ impl Renderer {
 		let pipeline = match source.layout {
 			#[cfg(all(target_os = "linux", feature = "dmabuf"))]
 			Layout::Rgba => &self.shader.rgba,
-			#[cfg(target_os = "macos")]
+			#[cfg(any(target_os = "macos", all(target_os = "linux", feature = "dmabuf")))]
 			Layout::Nv12 => &self.shader.nv12,
 			Layout::I420 => &self.shader.i420,
 		};
@@ -499,7 +499,7 @@ impl Pipelines {
 		Ok(Self {
 			#[cfg(all(target_os = "linux", feature = "dmabuf"))]
 			rgba: pipeline("rgba"),
-			#[cfg(target_os = "macos")]
+			#[cfg(any(target_os = "macos", all(target_os = "linux", feature = "dmabuf")))]
 			nv12: pipeline("nv12"),
 			i420: pipeline("i420"),
 			layout,
@@ -815,6 +815,228 @@ mod tests {
 
 		let pixels = readback(&device, &queue, &texture).await;
 		assert_close(pixels[8 * 32 + 16], [255, 0, 0, 255]);
+	}
+
+	/// The palette the NV12 tests draw with: saturated and mutually
+	/// distinguishable, so a wrong matrix or a swapped chroma pair changes a
+	/// block's color rather than nudging it.
+	///
+	/// Blue and orange are both here on purpose. NV12 interleaves Cb then Cr, and
+	/// reading them the other way round turns one into the other while leaving
+	/// every gray alone, so a gradient or a luma ramp would pass a swapped
+	/// import.
+	#[cfg(all(target_os = "linux", feature = "vaapi"))]
+	const PALETTE: [[u8; 3]; 8] = [
+		[255, 0, 0],
+		[0, 255, 0],
+		[0, 0, 255],
+		[255, 255, 0],
+		[0, 255, 255],
+		[255, 0, 255],
+		[255, 128, 0],
+		[255, 255, 255],
+	];
+
+	/// The block of [`PALETTE`] covering a pixel, in a grid of 32x32 blocks whose
+	/// colors shift along each row of blocks.
+	///
+	/// Shifting matters: a pattern that repeats identically down the frame still
+	/// looks right when a row pitch is ignored and the picture shears, because
+	/// every row is a copy of the one above. This one does not.
+	#[cfg(all(target_os = "linux", feature = "vaapi"))]
+	fn block(x: u32, y: u32) -> [u8; 3] {
+		PALETTE[((y / 32 * 3 + x / 32) % PALETTE.len() as u32) as usize]
+	}
+
+	/// Encode one RGB triple to 8-bit Y'CbCr with the forward matrix of `color`.
+	///
+	/// The inverse of what the shader does, written out rather than derived from
+	/// [`super::super::color`], so the expected pixels come from the definition
+	/// of the color space rather than from the code under test.
+	#[cfg(all(target_os = "linux", feature = "vaapi"))]
+	fn to_yuv(color: Color, rgb: [u8; 3]) -> [u8; 3] {
+		let (kr, kb) = match color {
+			Color::Bt601Limited | Color::Bt601Full => (0.299f32, 0.114f32),
+			Color::Bt709Limited | Color::Bt709Full => (0.2126, 0.0722),
+		};
+		let kg = 1.0 - kr - kb;
+		let [r, g, b] = rgb.map(|c| c as f32 / 255.0);
+		let luma = kr * r + kg * g + kb * b;
+
+		// Limited range: luma spans 219 codes from 16, chroma 224 around 128.
+		let (y, cb, cr) = (
+			luma * 219.0 + 16.0,
+			(b - luma) / (2.0 * (1.0 - kb)) * 224.0 + 128.0,
+			(r - luma) / (2.0 * (1.0 - kr)) * 224.0 + 128.0,
+		);
+		[y, cb, cr].map(|c| c.round().clamp(0.0, 255.0) as u8)
+	}
+
+	/// The block pattern as tightly packed NV12: `height` rows of luma, then
+	/// `height / 2` rows of interleaved Cb, Cr at half the horizontal resolution.
+	///
+	/// The blocks are 32 pixels on a side, so each 2x2 chroma group sits wholly
+	/// inside one of them and the subsampling loses nothing. Any difference the
+	/// comparison then finds is the import's, not the format's.
+	#[cfg(all(target_os = "linux", feature = "vaapi"))]
+	fn nv12_pattern(size: Size, color: Color) -> Vec<u8> {
+		let (width, height) = (size.width, size.height);
+		let mut pixels = Vec::with_capacity((width * height * 3 / 2) as usize);
+
+		for y in 0..height {
+			for x in 0..width {
+				pixels.push(to_yuv(color, block(x, y))[0]);
+			}
+		}
+		for y in (0..height).step_by(2) {
+			for x in (0..width).step_by(2) {
+				let [_, cb, cr] = to_yuv(color, block(x, y));
+				pixels.push(cb);
+				pixels.push(cr);
+			}
+		}
+
+		pixels
+	}
+
+	/// A Vulkan device that can import DMA-BUFs, or `None` where nothing can.
+	#[cfg(all(target_os = "linux", feature = "dmabuf"))]
+	async fn dmabuf_gpu() -> Option<(wgpu::Device, wgpu::Queue)> {
+		let instance = wgpu::Instance::default();
+		let adapter = instance
+			.request_adapter(&wgpu::RequestAdapterOptions::default())
+			.await
+			.expect("a GPU adapter");
+
+		let external_memory = wgpu::Features::VULKAN_EXTERNAL_MEMORY_DMA_BUF;
+		if adapter.get_info().backend != wgpu::Backend::Vulkan || !adapter.features().contains(external_memory) {
+			return None;
+		}
+
+		Some(
+			adapter
+				.request_device(&wgpu::DeviceDescriptor {
+					required_features: external_memory,
+					..Default::default()
+				})
+				.await
+				.expect("a DMA-BUF-capable GPU device"),
+		)
+	}
+
+	/// An NV12 DMA-BUF has to import as two Vulkan images and draw the same
+	/// picture the CPU path draws from the same samples.
+	///
+	/// The test the whole per-plane import exists to pass, and it is three
+	/// assertions rather than one:
+	///
+	/// - The import returns a source at all, and its layout is
+	///   [`Layout::Nv12`]. Only the DMA-BUF importer produces that, so this says
+	///   which branch ran. Without it the CPU fallback would quietly satisfy
+	///   everything below.
+	/// - Every pixel matches the CPU upload of the same samples. That is the one
+	///   that catches a swapped chroma pair, a plane at the wrong offset, an
+	///   ignored row pitch, and a mismatched matrix, all at once.
+	/// - The block centers match the colors the pattern was built from, computed
+	///   here from the definition of the color space. Both paths agreeing on the
+	///   wrong answer would pass the comparison and fail this.
+	///
+	/// Ignored: needs a GPU that can import DMA-BUFs and a VA-API device to
+	/// allocate one. Run with
+	/// `cargo test -p moq-video --features render,vaapi nv12_dmabuf -- --ignored --nocapture`.
+	#[cfg(all(target_os = "linux", feature = "vaapi"))]
+	#[tokio::test]
+	#[ignore = "needs a Vulkan GPU and a VA-API device"]
+	async fn the_nv12_dmabuf_import_matches_the_cpu_path() {
+		let Some((device, queue)) = dmabuf_gpu().await else {
+			eprintln!("skipping: no Vulkan adapter with DMA-BUF external memory");
+			return;
+		};
+
+		// 192 lines is below the 576 the crate infers BT.709 above, so both
+		// paths land on BT.601 limited and the pattern is built for that.
+		let size = Size::new(256, 192);
+		let color = Color::infer(size);
+		assert_eq!(color, Color::Bt601Limited);
+		let pattern = nv12_pattern(size, color);
+
+		let Some(buffer) = crate::render::dmabuf::fixture::nv12(size, &pattern) else {
+			eprintln!("skipping: no VA-API device to allocate a DMA-BUF from");
+			return;
+		};
+		eprintln!(
+			"NV12 DMA-BUF: modifier {:#x}, planes {:?}",
+			buffer.modifier(),
+			buffer.planes()
+		);
+
+		let config = Config {
+			usage: wgpu::TextureUsages::COPY_SRC,
+			..Config::new()
+		};
+
+		// The reference: the same samples, deinterleaved and uploaded as three
+		// CPU planes. Built from the bytes that went into the DMA-BUF rather
+		// than read back out of it, so it shares nothing with the path it is
+		// checking.
+		let uploaded = {
+			let i420 = crate::frame::I420::from_nv12(&pattern, size.width, size.height).expect("deinterleave NV12");
+			let frame = Frame::new(Surface::I420(i420), Timestamp::ZERO);
+			let mut renderer = Renderer::new(&device, &queue, config.clone()).expect("a renderer");
+			let texture = renderer.render(&frame).expect("a rendered frame");
+			readback(&device, &queue, &texture).await
+		};
+
+		let frame = Frame::new(Surface::DmaBuf(buffer), Timestamp::ZERO);
+		let mut renderer = Renderer::new(&device, &queue, config).expect("a renderer");
+
+		// Which branch ran. `Layout::Nv12` comes from the per-plane DMA-BUF
+		// import and from nothing else on this platform.
+		let imported = renderer
+			.source
+			.import(&device, &frame.surface)
+			.expect("import the NV12 DMA-BUF")
+			.expect("a DMA-BUF import path");
+		assert_eq!(imported.layout, Layout::Nv12, "the frame did not import as NV12");
+		assert_eq!(imported.color, Some(color));
+		drop(imported);
+
+		let texture = renderer.render(&frame).expect("a rendered frame");
+		assert_eq!(renderer.strikes, 0, "the zero-copy import should not have failed");
+		assert!(!renderer.retired);
+		let zero_copy = readback(&device, &queue, &texture).await;
+
+		// Every pixel, not a sample of them: a shear from an ignored row pitch
+		// grows down the frame and leaves the top correct.
+		assert_eq!(zero_copy.len(), uploaded.len());
+		let mut worst = (0usize, 0i32);
+		for (index, (&imported, &expected)) in zero_copy.iter().zip(&uploaded).enumerate() {
+			for channel in 0..4 {
+				let drift = imported[channel] as i32 - expected[channel] as i32;
+				if drift.abs() > worst.1 {
+					worst = (index, drift.abs());
+				}
+			}
+			let (x, y) = (index % size.width as usize, index / size.width as usize);
+			assert!(
+				(0..4).all(|c| imported[c].abs_diff(expected[c]) <= 2),
+				"({x}, {y}): imported {imported:?}, uploaded {expected:?}"
+			);
+		}
+		eprintln!(
+			"worst drift between the imported and uploaded frames: {} codes at pixel {}",
+			worst.1, worst.0
+		);
+
+		// And both agree with the palette the pattern was built from, so a
+		// shared misreading of the samples cannot pass.
+		for y in (16..size.height).step_by(32) {
+			for x in (16..size.width).step_by(32) {
+				let rgb = block(x, y);
+				let index = (y * size.width + x) as usize;
+				assert_close(zero_copy[index], [rgb[0], rgb[1], rgb[2], 255]);
+			}
+		}
 	}
 
 	/// A pool-backed NV12 surface, shaped like a hardware decode's output.

--- a/rs/moq-video/src/render/renderer.rs
+++ b/rs/moq-video/src/render/renderer.rs
@@ -863,11 +863,14 @@ mod tests {
 		PALETTE[((y / 32 * 3 + x / 32) % PALETTE.len() as u32) as usize]
 	}
 
-	/// Encode one RGB triple to 8-bit Y'CbCr with the forward matrix of `color`.
+	/// Encode one RGB triple to limited-range 8-bit Y'CbCr with the forward
+	/// matrix of `color`.
 	///
 	/// The inverse of what the shader does, written out rather than derived from
 	/// [`super::super::color`], so the expected pixels come from the definition
-	/// of the color space rather than from the code under test.
+	/// of the color space rather than from the code under test. Only the matrix
+	/// follows `color`; the range does not, which is all the callers need since
+	/// they assert the space is limited before building a pattern.
 	#[cfg(all(target_os = "linux", feature = "vaapi"))]
 	fn to_yuv(color: Color, rgb: [u8; 3]) -> [u8; 3] {
 		let (kr, kb) = match color {
@@ -965,10 +968,9 @@ mod tests {
 	///
 	/// Three assertions rather than one:
 	///
-	/// - The import returns a source at all, its layout is `expected`, and no
-	///   frame needed a re-tile. Only the DMA-BUF importer produces those
-	///   layouts, so this says which branch ran. Without it the CPU fallback
-	///   would quietly satisfy everything below.
+	/// - The import returns a source at all and its layout is `expected`. Only
+	///   the DMA-BUF importer produces those layouts, so this says which branch
+	///   ran. Without it the CPU fallback would quietly satisfy everything below.
 	/// - Every pixel matches the CPU upload of the same samples. That is the one
 	///   that catches a swapped chroma pair, a plane at the wrong offset, an
 	///   ignored row pitch, and a mismatched matrix, all at once.

--- a/rs/moq-video/src/render/renderer.rs
+++ b/rs/moq-video/src/render/renderer.rs
@@ -1262,6 +1262,11 @@ mod tests {
 			let texture = uploading.render(cpu).expect("draw the downloaded picture");
 			let cpu = readback(&device, &queue, &texture).await;
 
+			assert_eq!(
+				zero_copy.len(),
+				cpu.len(),
+				"picture {index} read back at a different size"
+			);
 			let mut worst = 0u8;
 			for (pixel, (&imported, &reference)) in zero_copy.iter().zip(&cpu).enumerate() {
 				let drift = (0..4).map(|c| imported[c].abs_diff(reference[c])).max().unwrap_or(0);

--- a/rs/moq-video/src/render/source.rs
+++ b/rs/moq-video/src/render/source.rs
@@ -13,8 +13,9 @@ pub(super) enum Layout {
 	/// Luma plane plus one interleaved chroma plane. What every hardware
 	/// decoder hands back, so only a zero-copy import produces it: the CPU
 	/// upload path is always I420. Gated to the platforms that have such an
-	/// importer, which today means macOS alone.
-	#[cfg(target_os = "macos")]
+	/// importer: macOS via CoreVideo, and Linux by importing an NV12 DMA-BUF's
+	/// two memory planes as two Vulkan images.
+	#[cfg(any(target_os = "macos", all(target_os = "linux", feature = "dmabuf")))]
 	Nv12,
 	/// Three separate planes.
 	I420,


### PR DESCRIPTION
Adds a VA-API H.264 decode backend and, with it, the missing half of Linux zero-copy rendering: moq-video imported no YUV, so every hardware-decoded frame went through system memory while the `nv12` shader entry point sat compiled and unreachable.

*This PR is part of a series to update iroh-live to latest moq, see n0-computer/iroh-live#45. The code and below description was written by Claude Code*

## What is here

`decode/backend/vaapi.rs` adapts `moq_vaapi::decode` to the `Backend` trait, mirroring the encode backend and registered next to NVDEC, gated on Linux and `vaapi`. `render/dmabuf.rs` gains an NV12 import path. `decode::Config::gpu_frames` is the switch that connects the two, so a subscriber that only draws its frames never pays for a download.

Depends on moq-dev/vaapi#2, which adds the decoder this calls. That is not in moq-vaapi 0.0.3, so this points `moq-vaapi` at the branch to give CI something to build. **That dependency line has to go back to a released version before merge.**

## Why NV12 import looked impossible

wgpu-hal's importer builds a single `vk::SubresourceLayout`, so an import describes one image made of one memory plane. Mesa reports two memory planes for `VK_FORMAT_G8_B8R8_2PLANE_420_UNORM` under every modifier it lists, which reads as "NV12 cannot go through this importer" and stops the investigation there.

That is the wrong question. Vulkan validates the plane count per format, and the same driver reports **one** memory plane for `R8_UNORM` and `R8G8_UNORM` under `0x0`, `0x100000000000001` and `0x100000000000009` alike. So a luma import and a chroma import of the same object, each at its own offset and row pitch, alias the buffer as the two textures the NV12 shader already wants. Nothing is copied and nothing is reformatted; only the descriptor is duplicated, once per plane.

`texture_from_dmabuf_fd` already takes an offset and a stride, so this needs no new API, no new dependency, and no change in wgpu. Vulkan takes ownership of the fd on success and closes it on failure, so each plane import gets its own duplicate.

## Why GPU-resident output is opt-in

`Surface::into_i420` is a guarantee of the type, and an exported VA-API surface used to arrive with nothing that could map it: the frame outlives the decoder whose display could reach it, and a decode target is tiled, so reading the descriptor as rows would be wrong. Handing out GPU frames unconditionally would have quietly broken every consumer that reads a pixel.

moq-dev/vaapi#2 fixes that by keeping the retired surface alongside the descriptor, so the read-back goes through `vaDeriveImage` on the same path an ordinary download takes. With the guarantee intact, the remaining question is cost: exporting retires a surface from the decoder's recycling pool, because a later picture decoded over it would corrupt one the consumer still holds. That is an allocation per picture, which buys nothing for a consumer that was going to download anyway. Hence a flag, off by default, that other backends ignore as they do `resize`. A driver that decodes but will not export drops the flag after one warning rather than failing the stream.

## Decoder delay, and the drain

Output trails input by `num_ref_frames`, not by the reorder depth the VUI declares, because the DPB bumps only when a new picture needs the slot. With x264's default `ref=3`, a short stream yields nothing until the fourth access unit. NVDEC gets zero delay from an explicit cuvid knob and VA-API has no equivalent.

The consequence is that a stream simply stopping leaves its tail in the DPB, so `Backend` grows a `flush` that defaults to returning nothing, which is correct for every backend configured for zero delay, and the layers above call it when a track ends. The VAAPI backend overrides it on both forks: `flush` for downloaded pictures and `flush_exported` for shared ones.

## Verified

On Intel Meteor Lake with iHD 26.1.5 and Mesa. The same frame is rendered twice, once through the zero-copy path and once through the existing CPU upload, then both are read back and compared per pixel across all four channels:

```
256x192  worst drift 0 of 255 over 49152 pixels
200x120  worst drift 0 of 255 over 24000 pixels
62x34    worst drift 0 of 255 over  2108 pixels
```

The padded sizes are the ones with teeth. At 200x120 the driver returns a 256-byte pitch for a 200-pixel row and puts chroma at 256*128, not 256*120, so neither the pitch nor the offset follows from the frame size.

Block centres are separately asserted against RGB computed in the test from the definition of BT.601 limited range, so a shared misreading of the samples cannot pass. The palette carries saturated blue and orange, which is what makes a Cb/Cr swap fail rather than quietly pass.

End to end on real decoded frames, `decoded_frames_reach_the_gpu_without_a_download` runs this backend with `gpu_frames` on and a second one with it off, over the same stream: drift 0 of 255 over 76800 pixels, at modifier `0x100000000000009`, with the renderer's strike count confirming the CPU path was not taken. `gpu_frames_still_answer_into_i420` pins the read-back byte for byte, `flushing_returns_the_tail_the_dpb_holds` and `flushing_returns_the_tail_of_a_gpu_stream` pin both drains, and `vaapi_h264_round_trip` compares planes by mean absolute error with exact timestamps.

Those tests self-skip rather than being `#[ignore]`d, so they run wherever the hardware exists and stay silent elsewhere. `Kind::Auto` selects `vaapi` on this machine with NVDEC compiled in and refusing. The underlying decoder is verified byte-for-byte against ffmpeg in moq-dev/vaapi#2.

## No re-tile

An earlier version carried a VA-API post-processing fallback for buffers whose modifier Vulkan refuses. It is not here, and the tests are why: the re-tile counter read zero on every run, because this driver already allocates NV12 on an importable modifier. The fallback is a separate concern and can come later on its own merits.

## Conflicts with #3332

Both register a Linux hardware decode candidate in the same list in `decode/backend/mod.rs` and both extend the same sentence of its module doc, so whichever merges second needs a three-line resolution: keep both candidates, VAAPI before V4L2. Nothing else in the two overlaps.


## Review round

A later pass over this branch found two things worth calling out, both fixed here.

`adopt` trusted the shape of the VA-API export: it read the modifier off object 0 and every plane offset off layer 0, while handing the importer only object 0's file descriptor. `VA_EXPORT_SURFACE_COMPOSED_LAYERS` asks for one object in one layer; it does not promise one. A driver that split the allocation would have addressed chroma in memory the importer never saw and rendered a plausible picture from the wrong bytes, with no error anywhere. Both counts were in the descriptor and unread. It also indexed a fixed four-element array with a driver-reported plane count.

A bitstream error inside `decode_exported` was reported as "this driver cannot export", which cleared `gpu_frames` for the rest of the session and returned success. One corrupt access unit therefore cost the stream its zero-copy path silently. Only a failure before the first descriptor comes back is now read as the driver's verdict; after that it is a decode error.
