### PR TITLE
fix(moq-mux): drive the fMP4 export poll with a loop, not tail recursion

### DIFF
--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -169,160 +169,167 @@ impl<S: Stream> Export<S> {
 
 	/// Poll-based variant of [`Self::next_fragment`].
 	pub fn poll_next_fragment(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<Fragment>>> {
-		// 1. Drain catalog updates and (un)subscribe tracks accordingly.
-		while let Some(catalog) = self.catalog.as_mut() {
-			match catalog.poll_next(waiter)? {
-				Poll::Ready(Some(snapshot)) => self.update_catalog(&snapshot.media())?,
-				Poll::Ready(None) => {
-					self.catalog = None;
-					break;
-				}
-				Poll::Pending => break,
-			}
-		}
-
-		// 2. Fill any empty pending slots by polling each source. ExportSource
-		// has already applied any codec-shape transform (Avc3 → avc1) and
-		// absorbed parameter-only frames.
-		//
-		// Pre-init: drop slices that arrived before this track's codec config
-		// is ready, so the source keeps polling for SPS/PPS-bearing frames
-		// instead of parking.
-		let waiting_for_init = !self.init_emitted;
-		for (name, track) in &mut self.tracks {
-			if track.pending.is_some() || track.finished {
-				continue;
-			}
-			loop {
-				match track.source.poll_read(waiter)? {
-					Poll::Ready(Some(frame)) => {
-						let geometry_ready = !track.is_video
-							|| self
-								.catalog_snapshot
-								.as_ref()
-								.and_then(|catalog| catalog.video.renditions.get(name))
-								.is_some_and(|config| {
-									matches!(config.container, Container::Cmaf { .. })
-										|| track.source.video_geometry_ready(config)
-								});
-						if waiting_for_init && (!track.source.header_ready() || !geometry_ready) {
-							continue;
-						}
-						track.pending = Some(frame);
-						break;
-					}
+		// One pass per iteration rather than per stack frame. Appending a frame
+		// to a track's buffer restarts the search for work, and doing that by
+		// calling back into this function left one frame behind per buffered
+		// sample: a track buffers a whole GOP, so ten seconds of 60 fps video
+		// overflowed the stack instead of emitting a fragment.
+		loop {
+			// 1. Drain catalog updates and (un)subscribe tracks accordingly.
+			while let Some(catalog) = self.catalog.as_mut() {
+				match catalog.poll_next(waiter)? {
+					Poll::Ready(Some(snapshot)) => self.update_catalog(&snapshot.media())?,
 					Poll::Ready(None) => {
-						track.finished = true;
+						self.catalog = None;
 						break;
 					}
 					Poll::Pending => break,
 				}
 			}
-		}
 
-		// 3. Build and emit the init segment once every source has resolved
-		// its codec config (immediately for CMAF-passthrough sources;
-		// after the first keyframe for Avc3/Hev1 sources).
-		if !self.init_emitted {
-			if self.init_ready() {
-				let init = self.build_init()?;
-				self.init_emitted = true;
-				return Poll::Ready(Ok(Some(Fragment {
-					data: init,
-					init: true,
-					independent: false,
-					duration: 0.0,
-				})));
+			// 2. Fill any empty pending slots by polling each source. ExportSource
+			// has already applied any codec-shape transform (Avc3 → avc1) and
+			// absorbed parameter-only frames.
+			//
+			// Pre-init: drop slices that arrived before this track's codec config
+			// is ready, so the source keeps polling for SPS/PPS-bearing frames
+			// instead of parking.
+			let waiting_for_init = !self.init_emitted;
+			for (name, track) in &mut self.tracks {
+				if track.pending.is_some() || track.finished {
+					continue;
+				}
+				loop {
+					match track.source.poll_read(waiter)? {
+						Poll::Ready(Some(frame)) => {
+							let geometry_ready = !track.is_video
+								|| self
+									.catalog_snapshot
+									.as_ref()
+									.and_then(|catalog| catalog.video.renditions.get(name))
+									.is_some_and(|config| {
+										matches!(config.container, Container::Cmaf { .. })
+											|| track.source.video_geometry_ready(config)
+									});
+							if waiting_for_init && (!track.source.header_ready() || !geometry_ready) {
+								continue;
+							}
+							track.pending = Some(frame);
+							break;
+						}
+						Poll::Ready(None) => {
+							track.finished = true;
+							break;
+						}
+						Poll::Pending => break,
+					}
+				}
 			}
-			// Still waiting for codec configs. If every track is finished and
-			// the init still isn't buildable, the source ended before producing
-			// enough info.
-			if self.catalog.is_none() && self.tracks.values().all(|t| t.finished) {
-				return Poll::Ready(Ok(None));
+
+			// 3. Build and emit the init segment once every source has resolved
+			// its codec config (immediately for CMAF-passthrough sources;
+			// after the first keyframe for Avc3/Hev1 sources).
+			if !self.init_emitted {
+				if self.init_ready() {
+					let init = self.build_init()?;
+					self.init_emitted = true;
+					return Poll::Ready(Ok(Some(Fragment {
+						data: init,
+						init: true,
+						independent: false,
+						duration: 0.0,
+					})));
+				}
+				// Still waiting for codec configs. If every track is finished and
+				// the init still isn't buildable, the source ended before producing
+				// enough info.
+				if self.catalog.is_none() && self.tracks.values().all(|t| t.finished) {
+					return Poll::Ready(Ok(None));
+				}
+				return Poll::Pending;
 			}
-			return Poll::Pending;
-		}
 
-		// 4. Pick the track whose pending frame has the smallest timestamp and
-		// decide whether to flush its buffer before appending the new frame.
-		let chosen = self
-			.tracks
-			.iter()
-			.filter_map(|(name, t)| t.pending.as_ref().map(|f| (name.clone(), f.timestamp)))
-			.min_by_key(|(_, ts)| *ts)
-			.map(|(name, _)| name);
+			// 4. Pick the track whose pending frame has the smallest timestamp and
+			// decide whether to flush its buffer before appending the new frame.
+			let chosen = self
+				.tracks
+				.iter()
+				.filter_map(|(name, t)| t.pending.as_ref().map(|f| (name.clone(), f.timestamp)))
+				.min_by_key(|(_, ts)| *ts)
+				.map(|(name, _)| name);
 
-		if let Some(name) = chosen {
-			let frag = self.fragment_duration;
-			// One fragment per frame: a zero cap, or the audio-only default where
-			// no keyframe will ever roll the fragment. These never depend on the
-			// successor, so emit immediately instead of buffering the frame until
-			// the next one flushes it.
-			let has_video = self.tracks.values().any(|t| t.is_video);
-			let per_frame = frag == Some(Duration::ZERO) || (frag.is_none() && !has_video);
-			let track = self.tracks.get_mut(&name).unwrap();
-			let frame = track.pending.take().unwrap();
-			if per_frame {
-				// A catalog change can leave buffered frames behind. Drain them
-				// first and retry this frame on the next poll.
-				if !track.buffer.is_empty() {
-					let frames = std::mem::take(&mut track.buffer);
-					let fragment = emit_fragment(track, frames, Some(&frame))?;
-					track.pending = Some(frame);
+			if let Some(name) = chosen {
+				let frag = self.fragment_duration;
+				// One fragment per frame: a zero cap, or the audio-only default where
+				// no keyframe will ever roll the fragment. These never depend on the
+				// successor, so emit immediately instead of buffering the frame until
+				// the next one flushes it.
+				let has_video = self.tracks.values().any(|t| t.is_video);
+				let per_frame = frag == Some(Duration::ZERO) || (frag.is_none() && !has_video);
+				let track = self.tracks.get_mut(&name).unwrap();
+				let frame = track.pending.take().unwrap();
+				if per_frame {
+					// A catalog change can leave buffered frames behind. Drain them
+					// first and retry this frame on the next poll.
+					if !track.buffer.is_empty() {
+						let frames = std::mem::take(&mut track.buffer);
+						let fragment = emit_fragment(track, frames, Some(&frame))?;
+						track.pending = Some(frame);
+						return Poll::Ready(Ok(Some(fragment)));
+					}
+					track.buffer_independent = frame.keyframe;
+					let fragment = emit_fragment(track, vec![frame], None)?;
 					return Poll::Ready(Ok(Some(fragment)));
 				}
-				track.buffer_independent = frame.keyframe;
-				let fragment = emit_fragment(track, vec![frame], None)?;
-				return Poll::Ready(Ok(Some(fragment)));
-			}
-			if should_flush(track, &frame, frag) {
-				let frames = std::mem::take(&mut track.buffer);
-				let fragment = emit_fragment(track, frames, Some(&frame))?;
-				// The flushed run is done; the incoming frame opens the next buffer.
-				track.buffer_independent = frame.keyframe;
-				track.buffer.push(frame);
-				return Poll::Ready(Ok(Some(fragment)));
-			}
-			if track.buffer.is_empty() {
-				track.buffer_independent = frame.keyframe;
-			}
-			track.buffer.push(frame);
-			// Frame appended to buffer; loop again to look for more work or a flush.
-			return self.poll_next_fragment(waiter);
-		}
-
-		// 5. No pending frames. Flush any finished tracks' remaining buffers,
-		// in ascending first-frame-timestamp order.
-		let flushable = self
-			.tracks
-			.iter()
-			.filter_map(|(name, t)| {
-				if t.finished && !t.buffer.is_empty() {
-					Some((name.clone(), t.buffer.first().unwrap().timestamp))
-				} else {
-					None
+				if should_flush(track, &frame, frag) {
+					let frames = std::mem::take(&mut track.buffer);
+					let fragment = emit_fragment(track, frames, Some(&frame))?;
+					// The flushed run is done; the incoming frame opens the next buffer.
+					track.buffer_independent = frame.keyframe;
+					track.buffer.push(frame);
+					return Poll::Ready(Ok(Some(fragment)));
 				}
-			})
-			.min_by_key(|(_, ts)| *ts)
-			.map(|(name, _)| name);
+				if track.buffer.is_empty() {
+					track.buffer_independent = frame.keyframe;
+				}
+				track.buffer.push(frame);
+				// Frame appended to buffer; go round again to look for more work or a flush.
+				continue;
+			}
 
-		if let Some(name) = flushable {
-			let track = self.tracks.get_mut(&name).unwrap();
-			let frames = std::mem::take(&mut track.buffer);
-			let fragment = emit_fragment(track, frames, None)?;
-			return Poll::Ready(Ok(Some(fragment)));
+			// 5. No pending frames. Flush any finished tracks' remaining buffers,
+			// in ascending first-frame-timestamp order.
+			let flushable = self
+				.tracks
+				.iter()
+				.filter_map(|(name, t)| {
+					if t.finished && !t.buffer.is_empty() {
+						Some((name.clone(), t.buffer.first().unwrap().timestamp))
+					} else {
+						None
+					}
+				})
+				.min_by_key(|(_, ts)| *ts)
+				.map(|(name, _)| name);
+
+			if let Some(name) = flushable {
+				let track = self.tracks.get_mut(&name).unwrap();
+				let frames = std::mem::take(&mut track.buffer);
+				let fragment = emit_fragment(track, frames, None)?;
+				return Poll::Ready(Ok(Some(fragment)));
+			}
+
+			// 6. If catalog is closed and every track is finished and drained, we're done.
+			if self.catalog.is_none() && self.tracks.values().all(|t| t.finished && t.buffer.is_empty()) {
+				return Poll::Ready(Ok(None));
+			}
+
+			// 7. Drop finished tracks with empty buffers so the next catalog update can re-add a track of the same name.
+			self.tracks
+				.retain(|_, t| !(t.finished && t.pending.is_none() && t.buffer.is_empty()));
+
+			return Poll::Pending;
 		}
-
-		// 6. If catalog is closed and every track is finished and drained, we're done.
-		if self.catalog.is_none() && self.tracks.values().all(|t| t.finished && t.buffer.is_empty()) {
-			return Poll::Ready(Ok(None));
-		}
-
-		// 7. Drop finished tracks with empty buffers so the next catalog update can re-add a track of the same name.
-		self.tracks
-			.retain(|_, t| !(t.finished && t.pending.is_none() && t.buffer.is_empty()));
-
-		Poll::Pending
 	}
 
 	fn update_catalog(&mut self, catalog: &Catalog) -> Result<()> {

--- a/rs/moq-mux/src/container/fmp4/export.rs
+++ b/rs/moq-mux/src/container/fmp4/export.rs
@@ -169,11 +169,10 @@ impl<S: Stream> Export<S> {
 
 	/// Poll-based variant of [`Self::next_fragment`].
 	pub fn poll_next_fragment(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<Fragment>>> {
-		// One pass per iteration rather than per stack frame. Appending a frame
-		// to a track's buffer restarts the search for work, and doing that by
-		// calling back into this function left one frame behind per buffered
-		// sample: a track buffers a whole GOP, so ten seconds of 60 fps video
-		// overflowed the stack instead of emitting a fragment.
+		// Appending a frame to a track's buffer restarts the search for work by
+		// going around this loop again, never by re-entering the function: a
+		// track buffers a whole GOP, and stack use must stay flat however many
+		// samples that is.
 		loop {
 			// 1. Drain catalog updates and (un)subscribe tracks accordingly.
 			while let Some(catalog) = self.catalog.as_mut() {

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -713,6 +713,47 @@ fn synthesize_flac_trak() {
 }
 
 /// The next fragment, required to be ready without another frame arriving.
+/// A long GOP must not cost a stack frame per sample.
+///
+/// Appending a frame to a track's buffer restarts the search for work, and
+/// doing that by calling back into the poll leaves one stack frame behind per
+/// buffered sample. A track buffers a whole GOP, so ten seconds of 60 fps video
+/// overflows the stack rather than emitting a fragment.
+///
+/// The thread is given a small stack on purpose. The default is large enough to
+/// need thousands of frames before it fails, which is more video than a test
+/// should have to build; 1 MiB fails on the recursive version at this GOP
+/// length and is ample for the iterative one.
+#[test]
+fn a_long_gop_does_not_cost_a_stack_frame_per_sample() {
+	let run = std::thread::Builder::new()
+		.stack_size(1024 * 1024)
+		.spawn(|| {
+			let rt = tokio::runtime::Builder::new_current_thread()
+				.enable_time()
+				.start_paused(true)
+				.build()
+				.expect("runtime");
+
+			rt.block_on(async {
+				let mut live = Live::avc3();
+				// Ten seconds of 60 fps in one GOP, closed by the next keyframe.
+				for i in 0..600u64 {
+					live.track.write(video_frame(i * 16_666, i == 0)).unwrap();
+				}
+				live.track.write(video_frame(600 * 16_666, true)).unwrap();
+
+				let mut exporter = crate::container::fmp4::Export::new(live.source(), live.catalog_stream().await);
+				let _init = fragment_now(&mut exporter).await;
+				let fragment = fragment_now(&mut exporter).await;
+				assert!(!fragment.data.is_empty(), "the GOP must reach the file");
+			});
+		})
+		.expect("spawn");
+
+	run.join().expect("a long GOP overflowed the stack");
+}
+
 async fn fragment_now(
 	exporter: &mut crate::container::fmp4::Export<crate::catalog::Consumer>,
 ) -> crate::container::fmp4::Fragment {

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -753,7 +753,17 @@ fn a_long_gop_does_not_cost_a_stack_frame_per_sample() {
 				let fragment = fragment_now(&mut exporter).await;
 				assert!(!fragment.init);
 				assert!(fragment.independent, "a GOP opens on a keyframe");
-				assert!(fragment.duration > 0.0);
+				// All 600 frames, so an exporter that emitted a partial fragment
+				// early would fail here rather than pass on any positive duration.
+				// A lower bound rather than an exact figure: the trailing sample's
+				// duration is the exporter's to infer, and one frame either way is
+				// not what this test is about.
+				let gop = 600.0 * 16_666.0 / 1_000_000.0;
+				assert!(
+					fragment.duration >= gop && fragment.duration < gop + 0.05,
+					"the fragment holds {}s of a {gop}s GOP",
+					fragment.duration
+				);
 			});
 		})
 		.expect("spawn");

--- a/rs/moq-mux/src/container/fmp4/export_test.rs
+++ b/rs/moq-mux/src/container/fmp4/export_test.rs
@@ -712,7 +712,6 @@ fn synthesize_flac_trak() {
 	assert_eq!(stream_info, (96_000, 1));
 }
 
-/// The next fragment, required to be ready without another frame arriving.
 /// A long GOP must not cost a stack frame per sample.
 ///
 /// Appending a frame to a track's buffer restarts the search for work, and
@@ -744,9 +743,17 @@ fn a_long_gop_does_not_cost_a_stack_frame_per_sample() {
 				live.track.write(video_frame(600 * 16_666, true)).unwrap();
 
 				let mut exporter = crate::container::fmp4::Export::new(live.source(), live.catalog_stream().await);
-				let _init = fragment_now(&mut exporter).await;
+				assert!(
+					fragment_now(&mut exporter).await.init,
+					"first fragment must be the init segment"
+				);
+
+				// The whole GOP in one fragment, which is also what says the
+				// loop kept appending rather than emitting early.
 				let fragment = fragment_now(&mut exporter).await;
-				assert!(!fragment.data.is_empty(), "the GOP must reach the file");
+				assert!(!fragment.init);
+				assert!(fragment.independent, "a GOP opens on a keyframe");
+				assert!(fragment.duration > 0.0);
 			});
 		})
 		.expect("spawn");
@@ -754,6 +761,7 @@ fn a_long_gop_does_not_cost_a_stack_frame_per_sample() {
 	run.join().expect("a long GOP overflowed the stack");
 }
 
+/// The next fragment, required to be ready without another frame arriving.
 async fn fragment_now(
 	exporter: &mut crate::container::fmp4::Export<crate::catalog::Consumer>,
 ) -> crate::container::fmp4::Fragment {


### PR DESCRIPTION
`poll_next_fragment` restarts itself by calling back into itself once per buffered sample, so a long GOP overflows the stack instead of emitting a fragment.

*This PR is part of a series to update iroh-live to latest moq, see n0-computer/iroh-live#45. The code and below description was written by Claude Code*

Appending a frame to a track's buffer restarts the search for work. Doing that by recursion leaves one stack frame behind per buffered sample, and a track buffers a whole GOP by default. Ten seconds of 60 fps video is enough, as is the audio of a broadcast whose video has stalled.

Going round a loop instead runs the same steps in the same order on the same state, so it is the same traversal without the frames.

## Verified

`a_long_gop_does_not_cost_a_stack_frame_per_sample` builds that GOP on a thread with a 1 MiB stack. The recursive version overflows it and aborts the process; the iterative one clears it comfortably. Sizing the stack down rather than the GOP up keeps the test to about a second, where reaching the default stack would need thousands of frames.

I watched it fail before the fix and pass after. The rest of the suite is unchanged at 552 tests.

## Where this was found

Writing an mp4 recorder for iroh-live on top of `fmp4::Export`. A test that should have failed aborted the process instead, which is what led here. The defect is older than that work and independent of it.

`dev` does not have this fix either. It looks at a glance as though it might, because `poll_next_fragment` moved during the `Fragment` to `Chunk` rename, but `origin/dev:rs/moq-mux/src/container/fmp4/export.rs:334` still tail-recurses.

## Review round

The regression test had landed between `fragment_now`'s doc comment and the function, so the helper lost its doc and the test's own began with a sentence about something else. Its assertion was also weaker than the bug deserves: a non-empty fragment says nothing about whether the loop kept appending. It now checks the init segment arrives first and the GOP comes back as one independent media fragment, and still overflows the stack without the fix.
