### PR TITLE
test(ts): add pcr-timing.py, grading PCR release timing and byte position

### DIFF
--- a/test/ts/README.md
+++ b/test/ts/README.md
@@ -116,8 +116,21 @@ internally consistent, so absolute rate is not what this grades.
 | `continuity` | hard | no discontinuities, and a payload-less packet must not advance the counter (ISO 13818-1 2.4.3.3) |
 | `pcr-single-pid` | hard | every PCR rides one PID |
 | `pcr-value-interval` | hard | no interval above `--repetition-ms` (default 40, TR 101 290) |
-| `pcr-release-timing` | hard | each interval's arrival is within `--release-ms` of the interval its own values assert, and accumulated drift over the whole sample stays within `--drift-ms` (`--live` only) |
+| `pcr-release-timing` | hard | no more than `--release-pct-max` of intervals arrive further than `--release-ms` from the interval their own values assert, and accumulated drift stays within `--drift-ms`, being the standing lag the sender is allowed to hold (`--live` only) |
 | `pcr-position` | shape | share of PCR packets within `--adjacent-packets` of the previous one |
+
+Accumulated drift has two shapes and only one is a defect, so the check bounds
+the total and reports the rate over the tail of the sample beside it. A sender
+that buffers builds a standing lag once and then runs at the media rate: the lag
+is a constant offset no receiver can see, and it cannot grow past the latency
+budget the sender is allowed to hold, so set `--drift-ms` to that budget
+(`export ts --latency-max`, 500 ms by default). A pipe that is not running at the
+media rate never stops accumulating and so breaches any fixed bound given a long
+enough sample. The tail rate is what tells the two apart, and it needs a sample
+longer than the lag takes to build: measured against the grid-sliced exporter,
+the lag reaches ~480 ms over the first ~48 s and then holds to within 0.02 ms/s
+over the following 40 s, whereas a 20 s window catches it still filling at
+\~8.7 ms/s and cannot distinguish that from a slow pipe.
 
 `pcr-position` is a shape check because `export ts` is VBR by design. It is worth
 reporting even so: a consumer holding only the byte stream, which is every

--- a/test/ts/README.md
+++ b/test/ts/README.md
@@ -11,6 +11,10 @@ is VBR, inserts no null packets, and paces PCR once per media frame, so several
 broadcast-shape checks are expected to flag. The report quantifies exactly where
 and by how much.
 
+Two instruments live here. `compliance.py` (via `run.sh`) grades a captured file
+against the IRD model. [`pcr-timing.py`](#pcr-timing-pcr-timingpy) grades a live
+pipe, which is the only way to see *when* the exporter released each PCR.
+
 ## Running
 
 ```bash
@@ -73,6 +77,71 @@ Thresholds are CLI flags forwarded through `run.sh` (e.g.
 `--tb-size-bytes`, `--video-leak-bps`, `--audio-leak-bps`). `--report-json <path>`
 writes the full machine-readable report.
 
+## PCR timing (`pcr-timing.py`)
+
+A PCR makes three claims at once, and an instrument pointed at one of them
+cannot see the other two:
+
+| Domain | What it claims | Graded from |
+|---|---|---|
+| value | consecutive PCR values are spaced within the repetition limit | the values |
+| release | the bytes carrying a PCR were handed over when that PCR asserts | arrival stamps |
+| position | a PCR packet sits among the media bytes it describes | packet offsets |
+
+`compliance.py` grades `value` from a file, deterministically and with no
+wall-clock capture, which is the right basis for the model math it does. That
+also means it cannot grade `release`: a change to *when* the exporter hands bytes
+over is invisible to any harness that does not stamp arrivals.
+`pcr-timing.py` reads a pipe and grades all three in one pass.
+
+```bash
+# live: all three domains, reading the exporter directly
+moq --client-connect http://localhost:4443 --broadcast live.hang export ts \
+  | ./pcr-timing.py --live --seconds 45
+
+# offline: value and position only (a file has no release timing left in it)
+./pcr-timing.py capture.ts
+```
+
+It needs only `python3` — no TSDuck, no source file and no declared mux rate,
+because every check is graded against the stream's **own** PCR values. If two
+consecutive PCRs are 25 ms apart in value then they must be ~25 ms apart in
+arrival, whatever clock rate the stream is running at. The price of that basis is
+the same one `compliance.py` pays: a PCR emitted at the wrong rate stays
+internally consistent, so absolute rate is not what this grades.
+
+| Check | Severity | What it verifies |
+|---|---|---|
+| `sync` | hard | no invalid sync bytes / transport-error packets |
+| `continuity` | hard | no discontinuities, and a payload-less packet must not advance the counter (ISO 13818-1 2.4.3.3) |
+| `pcr-single-pid` | hard | every PCR rides one PID |
+| `pcr-value-interval` | hard | no interval above `--repetition-ms` (default 40, TR 101 290) |
+| `pcr-release-timing` | hard | each interval's arrival is within `--release-ms` of the interval its own values assert, with bounded accumulated drift (`--live` only) |
+| `pcr-position` | shape | share of PCR packets within `--adjacent-packets` of the previous one |
+
+`pcr-position` is a shape check because `export ts` is VBR by design. It is worth
+reporting even so: a consumer holding only the byte stream — which is every
+MPEG-TS tool — recovers the clock from where the PCR packets sit, so a layout
+that clusters them and heaps the media bytes between the clusters is one such a
+consumer cannot follow, however exact the values are.
+
+When both `release` and `position` flag, the report cross-tabulates them:
+
+```text
+  release timing by byte position (report only)
+    adjacent + early       615  ( 34.0%)
+    adjacent + on time     408  ( 22.5%)
+    spaced   + on time     641  ( 35.4%)
+    spaced   + late        136  (  7.5%)
+```
+
+Two invariants failing on the *same* PCRs is one cause rather than two, which two
+aggregate percentages cannot show. It is report-only: it explains a failure, it
+does not define one.
+
+`--report-json <path>` writes the full report, and `--strict` promotes the shape
+check to hard.
+
 ## EIT fixture
 
 `make-eit-fixture.sh` adds a synthetic DVB EPG to any transport stream, so the
@@ -126,8 +195,9 @@ local developer would.
 
 - Physical-layer TR 101 290 items (RF, real sync-byte loss) cannot be measured
   from a file; TSDuck notes the same limitation.
-- Wall-clock delivery jitter/burstiness is intentionally out of scope: all timing
-  is derived from the stream's PCR, not from socket arrival times.
+- Wall-clock delivery jitter/burstiness is out of scope *for `compliance.py`*:
+  all of its timing is derived from the stream's PCR, not from arrival times.
+  `pcr-timing.py --live` covers that axis separately, by stamping a pipe.
 - `tstd` models only the transport-buffer (TB) smoothing stage of the ISO 13818-1
   T-STD, not the full multiplex/elementary decode buffers. Its leak rates are
   defaults, not level-derived, so treat overflow as a smell rather than proof.

--- a/test/ts/README.md
+++ b/test/ts/README.md
@@ -115,8 +115,8 @@ internally consistent, so absolute rate is not what this grades.
 | `sync` | hard | no invalid sync bytes / transport-error packets |
 | `continuity` | hard | no discontinuities, and a payload-less packet must not advance the counter (ISO 13818-1 2.4.3.3) |
 | `pcr-single-pid` | hard | every PCR rides one PID |
-| `pcr-value-interval` | hard | no interval above `--repetition-ms` (default 40, TR 101 290) |
-| `pcr-release-timing` | hard | no more than `--release-pct-max` of intervals arrive further than `--release-ms` from the interval their own values assert, and accumulated drift stays within `--drift-ms`, being the standing lag the sender is allowed to hold (`--live` only) |
+| `pcr-value-interval` | hard | no interval above `--repetition-ms` (default 40, TR 101 290), within one time base |
+| `pcr-release-timing` | hard | no more than `--release-pct-max` of intervals arrive further than `--release-ms` from the interval their own values assert, and accumulated drift stays within `--drift-ms`, being the standing lag the sender is allowed to hold; a sample below `--live-min-pcr` PCRs or `--live-cover-pct` of the window is a failure, not a pass (`--live` only) |
 | `pcr-position` | shape | share of PCR packets within `--adjacent-packets` of the previous one |
 
 Accumulated drift has two shapes and only one is a defect, so the check bounds
@@ -131,6 +131,22 @@ longer than the lag takes to build: measured against the grid-sliced exporter,
 the lag reaches ~480 ms over the first ~48 s and then holds to within 0.02 ms/s
 over the following 40 s, whereas a 20 s window catches it still filling at
 \~8.7 ms/s and cannot distinguish that from a slow pipe.
+
+Two conditions are legal and must not be reported as defects. ISO 13818-1 2.4.3.4
+lets a source declare a new time base by setting `discontinuity_indicator`, after
+which the next PCR is a fresh value rather than the next point on the old ramp, so
+the difference across that boundary measures nothing: the value and release checks
+drop that one interval and count it separately, drift is summed over the intervals
+actually graded, and the jump is not mistaken for a 33-bit wrap. Counting it read a
+signalled splice as an 820 ms repetition breach and a continuity error at once.
+
+Separately, "not measured" and "passed" are different answers and only one of them
+belongs to a file. A file carries no arrival stamps, so release timing genuinely
+cannot be graded and the check says so. Under `--live` the stamps were expected, and
+a sample too small to mean anything is a truncated capture rather than a clean
+stream, so it fails: without that, a producer which emitted two packets and exited
+turned the gate green, and an exporter exiting early is common enough that the route
+is a real one rather than a hypothetical.
 
 `pcr-position` is a shape check because `export ts` is VBR by design. It is worth
 reporting even so: a consumer holding only the byte stream, which is every

--- a/test/ts/README.md
+++ b/test/ts/README.md
@@ -103,7 +103,7 @@ moq --client-connect http://localhost:4443 --broadcast live.hang export ts \
 ./pcr-timing.py capture.ts
 ```
 
-It needs only `python3` — no TSDuck, no source file and no declared mux rate,
+It needs only `python3`, with no TSDuck, no source file and no declared mux rate,
 because every check is graded against the stream's **own** PCR values. If two
 consecutive PCRs are 25 ms apart in value then they must be ~25 ms apart in
 arrival, whatever clock rate the stream is running at. The price of that basis is
@@ -116,12 +116,12 @@ internally consistent, so absolute rate is not what this grades.
 | `continuity` | hard | no discontinuities, and a payload-less packet must not advance the counter (ISO 13818-1 2.4.3.3) |
 | `pcr-single-pid` | hard | every PCR rides one PID |
 | `pcr-value-interval` | hard | no interval above `--repetition-ms` (default 40, TR 101 290) |
-| `pcr-release-timing` | hard | each interval's arrival is within `--release-ms` of the interval its own values assert, with bounded accumulated drift (`--live` only) |
+| `pcr-release-timing` | hard | each interval's arrival is within `--release-ms` of the interval its own values assert, and accumulated drift over the whole sample stays within `--drift-ms` (`--live` only) |
 | `pcr-position` | shape | share of PCR packets within `--adjacent-packets` of the previous one |
 
 `pcr-position` is a shape check because `export ts` is VBR by design. It is worth
-reporting even so: a consumer holding only the byte stream — which is every
-MPEG-TS tool — recovers the clock from where the PCR packets sit, so a layout
+reporting even so: a consumer holding only the byte stream, which is every
+MPEG-TS tool, recovers the clock from where the PCR packets sit, so a layout
 that clusters them and heaps the media bytes between the clusters is one such a
 consumer cannot follow, however exact the values are.
 

--- a/test/ts/pcr-timing.py
+++ b/test/ts/pcr-timing.py
@@ -73,8 +73,10 @@ class Scan:
         self.cc_errors = []
         self.cc_on_empty = []
         self.wraps = 0
+        self.new_base = set()  # positions in self.pcr that state a new time base
         self._cc = {}
         self._dup = {}
+        self._new_base = set()  # PIDs whose next PCR states a new time base
         self._pcr_raw = {}
         self._pcr_offset = {}
 
@@ -88,6 +90,17 @@ class Scan:
             self.transport_error += 1
         pid = ((p[1] & 0x1F) << 8) | p[2]
 
+        # ISO 13818-1 2.4.3.3 allows the counter to jump when the adaptation field sets
+        # discontinuity_indicator, and allows one packet to be sent twice, repeating its
+        # counter. Both are legal, and treating either as an error fails a conforming
+        # stream on a hard check. Read the flag before the PCR, because 2.4.3.4 makes the
+        # same flag mean the clock may jump too, and the value and release checks both need
+        # to know which of their intervals spans that.
+        cc = p[3] & 0x0F
+        payload = bool((p[3] >> 4) & 0x1)
+        adaptation = bool((p[3] >> 4) & 0x2)
+        discontinuity = adaptation and p[4] > 0 and bool(p[5] & 0x80)
+
         ticks = parse_pcr(p)
         if ticks is not None:
             # Unwrap, so the checks see a monotone timeline. A capture crossing the
@@ -96,24 +109,27 @@ class Scan:
             # release check reads it as a day of lateness. A rollover drops the value by
             # nearly the whole modulus, so only a drop past halfway is treated as one and
             # a merely backwards PCR stays visible as the defect it is.
-            prev_raw = self._pcr_raw.get(pid)
-            if prev_raw is not None and ticks < prev_raw - PCR_MODULUS // 2:
-                self._pcr_offset[pid] = self._pcr_offset.get(pid, 0) + PCR_MODULUS
-                self.wraps += 1
+            #
+            # A signalled discontinuity is the exception in both directions: the next PCR
+            # states a new time base, so a drop across it is neither a wrap to unwrap nor a
+            # backwards clock to report, and the interval spanning it is not a measurement
+            # of anything. Mark it instead, and let the checks drop that one interval.
+            if discontinuity or pid in self._new_base:
+                self._new_base.discard(pid)
+                self.new_base.add(len(self.pcr))
+                self._pcr_raw.pop(pid, None)
+            else:
+                prev_raw = self._pcr_raw.get(pid)
+                if prev_raw is not None and ticks < prev_raw - PCR_MODULUS // 2:
+                    self._pcr_offset[pid] = self._pcr_offset.get(pid, 0) + PCR_MODULUS
+                    self.wraps += 1
             self._pcr_raw[pid] = ticks
             self.pcr.append((index, ticks + self._pcr_offset.get(pid, 0), arrival, pid))
+        elif discontinuity:
+            # The flag rode a packet with no PCR in it, so the new base arrives with the
+            # next PCR on this PID rather than with this packet.
+            self._new_base.add(pid)
 
-        # ISO 13818-1 2.4.3.3: the continuity counter advances only on a packet
-        # carrying a payload, so an adaptation-only PCR packet must repeat the
-        # previous value rather than increment it.
-        cc = p[3] & 0x0F
-        payload = bool((p[3] >> 4) & 0x1)
-        # The same clause allows the counter to jump when the adaptation field sets
-        # discontinuity_indicator, and allows one packet to be sent twice, repeating its
-        # counter. Both are legal, and treating either as an error fails a conforming
-        # stream on a hard check.
-        adaptation = bool((p[3] >> 4) & 0x2)
-        discontinuity = adaptation and p[4] > 0 and bool(p[5] & 0x80)
         prev = self._cc.get(pid)
         self._cc[pid] = cc
         if prev is None or pid == 0x1FFF:
@@ -246,8 +262,20 @@ def check_pcr_single_pid(scan, args):
 
 
 def check_value_interval(scan, args):
-    """PCR values must be spaced within the repetition limit."""
-    iv = [(b[1] - a[1]) / TICKS_PER_MS for a, b in zip(scan.pcr, scan.pcr[1:])]
+    """PCR values must be spaced within the repetition limit.
+
+    Within one time base. ISO 13818-1 2.4.3.4 lets a source declare a new one by setting
+    discontinuity_indicator, after which the next PCR is a fresh value rather than the next
+    point on the old ramp, so the difference across that boundary measures nothing. Counting
+    it fails a conforming stream: a signalled splice reads as one enormous interval, which is
+    the same class of false positive review found in the continuity check.
+    """
+    iv = [
+        (b[1] - a[1]) / TICKS_PER_MS
+        for i, (a, b) in enumerate(zip(scan.pcr, scan.pcr[1:]))
+        if (i + 1) not in scan.new_base
+    ]
+    spliced = sum(1 for i in range(1, len(scan.pcr)) if i in scan.new_base)
     if not iv:
         return ("pcr-value-interval", HARD, False, "no PCR intervals in the stream", {})
     over = [m for m in iv if m > args.repetition_ms]
@@ -268,8 +296,11 @@ def check_value_interval(scan, args):
         "sub_ms": sum(1 for m in iv if m < 1.0),
         "non_positive": len(backwards),
         "wraps_unwrapped": scan.wraps,
+        "signalled_discontinuities": spliced,
     }
     backwards_note = f", {len(backwards)} non-positive" if backwards else ""
+    if spliced:
+        backwards_note += f", {spliced} signalled discontinuity not counted"
     return (
         "pcr-value-interval",
         HARD,
@@ -299,13 +330,55 @@ def check_release(scan, args):
     lag's rate over the tail of the sample is reported beside it, which is what
     distinguishes a lag that has settled from one still growing.
     """
-    pts = [(ticks, arrival) for _, ticks, arrival, _ in scan.pcr if arrival is not None]
-    if len(pts) < 3:
-        return ("pcr-release-timing", HARD, True, "not measured (no arrival stamps)", {})
+    stamped = [i for i, (_, _, arrival, _) in enumerate(scan.pcr) if arrival is not None]
+    pts = [(scan.pcr[i][1], scan.pcr[i][2]) for i in stamped]
+    # scan.new_base indexes scan.pcr; pts drops the unstamped entries, so remap.
+    live_new_base = {j for j, i in enumerate(stamped) if i in scan.new_base}
+    # A file has no arrival stamps in it, so there is nothing to grade and saying so is
+    # the honest verdict. Live is the opposite case: arrivals were expected, and too few
+    # of them is a truncated capture rather than a clean stream. Passing that is how a
+    # gate reports success on a producer that died, which is the state this tool exists
+    # to catch, so the two have to be told apart rather than sharing one branch.
+    if not args.live:
+        if len(pts) < 3:
+            return ("pcr-release-timing", HARD, True, "not measured (no arrival stamps)", {})
+    else:
+        covered_ms = (pts[-1][0] - pts[0][0]) / TICKS_PER_MS if len(pts) >= 2 else 0.0
+        want_ms = 1000.0 * args.seconds * args.live_cover_pct / 100.0
+        short = len(pts) < args.live_min_pcr or covered_ms < want_ms
+        if short:
+            return (
+                "pcr-release-timing",
+                HARD,
+                False,
+                f"insufficient live sample: {len(pts)} PCR with arrival stamps spanning "
+                f"{covered_ms / 1000.0:.3f} s, against a floor of {args.live_min_pcr} PCR and "
+                f"{want_ms / 1000.0:g} s ({args.live_cover_pct:g} % of the {args.seconds:g} s "
+                f"window). A truncated capture cannot be graded and must not pass",
+                {
+                    "count": len(pts),
+                    "covered_s": round(covered_ms / 1000.0, 3),
+                    "required_pcr": args.live_min_pcr,
+                    "required_s": round(want_ms / 1000.0, 3),
+                },
+            )
 
-    err = [((b[1] - a[1]) * 1000.0) - ((b[0] - a[0]) / TICKS_PER_MS) for a, b in zip(pts, pts[1:])]
+    # Same exclusion as the value check: an interval spanning a signalled new time base is
+    # not a release measurement, and counting it reports a splice as seconds of lateness.
+    graded = [
+        (((b[1] - a[1]) * 1000.0) - ((b[0] - a[0]) / TICKS_PER_MS), (b[0] - a[0]) / TICKS_PER_MS)
+        for i, (a, b) in enumerate(zip(pts, pts[1:]))
+        if (i + 1) not in live_new_base
+    ]
+    err = [e for e, _ in graded]
+    span = [s for _, s in graded]
+    if not err:
+        return ("pcr-release-timing", HARD, False, "no gradable release intervals", {})
     magnitude = [abs(e) for e in err]
-    drift = ((pts[-1][1] - pts[0][1]) * 1000.0) - ((pts[-1][0] - pts[0][0]) / TICKS_PER_MS)
+    # Accumulated drift is the sum of the intervals actually graded. That telescopes to the
+    # endpoint difference on an unspliced sample, and stays correct on a spliced one, where
+    # the endpoints straddle a time base the stream never claimed to be running on.
+    drift = sum(err)
     late = [e for e in err if e > args.release_ms]
     early = [e for e in err if e < -args.release_ms]
     detail = {
@@ -324,11 +397,10 @@ def check_release(scan, args):
     # Whether the lag has settled is the difference between a buffer that filled and a
     # pipe running slow, and the two are only separable over a sample longer than the
     # fill. Grade the last third: a settled lag adds nothing to it.
-    tail = pts[max(1, (2 * len(pts)) // 3) :]
-    tail_span_ms = (tail[-1][0] - tail[0][0]) / TICKS_PER_MS if len(tail) >= 2 else 0.0
+    cut = (2 * len(err)) // 3
+    tail_span_ms = sum(span[cut:])
     if tail_span_ms > 0:
-        tail_drift = ((tail[-1][1] - tail[0][1]) * 1000.0) - tail_span_ms
-        detail["tail_drift_rate_ms_per_s"] = round(1000.0 * tail_drift / tail_span_ms, 3)
+        detail["tail_drift_rate_ms_per_s"] = round(1000.0 * sum(err[cut:]) / tail_span_ms, 3)
         detail["tail_span_s"] = round(tail_span_ms / 1000.0, 1)
     # Per-interval error and accumulated drift fail independently, and bounding only the
     # first leaves the second unbounded: a consistent 1 ms error on a 25 ms grid sits well
@@ -441,6 +513,20 @@ def main():
         type=float,
         default=0.0,
         help="share of intervals allowed outside the release tolerance (default 0)",
+    )
+    ap.add_argument(
+        "--live-min-pcr",
+        type=int,
+        default=20,
+        help="fewest PCR samples a --live run may grade before it is a truncated capture "
+        "rather than a result (default 20)",
+    )
+    ap.add_argument(
+        "--live-cover-pct",
+        type=float,
+        default=50.0,
+        help="share of the --seconds window a --live sample must span, or it is treated as "
+        "truncated (default 50)",
     )
     ap.add_argument(
         "--drift-ms",

--- a/test/ts/pcr-timing.py
+++ b/test/ts/pcr-timing.py
@@ -289,6 +289,15 @@ def check_release(scan, args):
     which is what a receiver PLL and any downstream re-timing stage sees, and
     accumulated drift, which must stay bounded or the pipe is not running at the
     media rate at all.
+
+    Bounded is the whole of the drift requirement, and the bound is the sender's
+    latency budget. An exporter that buffers builds a standing lag once, at
+    startup, and then runs at the media rate; the lag is a constant offset, which
+    no receiver can see and which cannot grow past the budget the sender is
+    allowed to hold. A pipe running slow never stops accumulating and so breaches
+    any fixed bound given a long enough sample. So the total is the gate and the
+    lag's rate over the tail of the sample is reported beside it, which is what
+    distinguishes a lag that has settled from one still growing.
     """
     pts = [(ticks, arrival) for _, ticks, arrival, _ in scan.pcr if arrival is not None]
     if len(pts) < 3:
@@ -312,20 +321,32 @@ def check_release(scan, args):
         "total_drift_ms": round(drift, 1),
         "drift_limit_ms": args.drift_ms,
     }
+    # Whether the lag has settled is the difference between a buffer that filled and a
+    # pipe running slow, and the two are only separable over a sample longer than the
+    # fill. Grade the last third: a settled lag adds nothing to it.
+    tail = pts[max(1, (2 * len(pts)) // 3) :]
+    tail_span_ms = (tail[-1][0] - tail[0][0]) / TICKS_PER_MS if len(tail) >= 2 else 0.0
+    if tail_span_ms > 0:
+        tail_drift = ((tail[-1][1] - tail[0][1]) * 1000.0) - tail_span_ms
+        detail["tail_drift_rate_ms_per_s"] = round(1000.0 * tail_drift / tail_span_ms, 3)
+        detail["tail_span_s"] = round(tail_span_ms / 1000.0, 1)
     # Per-interval error and accumulated drift fail independently, and bounding only the
     # first leaves the second unbounded: a consistent 1 ms error on a 25 ms grid sits well
     # inside a 10 ms tolerance while reaching nearly two seconds over a 45 s sample. The
     # docstring claimed drift was bounded; until now only the per-interval error was.
     drifted = abs(drift) > args.drift_ms
     drift_note = f" > ±{args.drift_ms:g} ms" if drifted else ""
+    rate = detail.get("tail_drift_rate_ms_per_s")
+    tail_note = "" if rate is None else f", {rate:+g} ms/s over the last {detail['tail_span_s']:g} s"
+    over = detail["outside_tolerance_pct"] > args.release_pct_max
     return (
         "pcr-release-timing",
         HARD,
-        not (late or early or drifted),
+        not (over or drifted),
         f"{detail['outside_tolerance']}/{len(err)} releases outside ±{args.release_ms:g} ms of the "
         f"interval the PCR asserts ({detail['released_early']} early, {detail['released_late']} late; "
         f"p95 {detail['p95_abs_ms']:g} ms, worst {detail['max_abs_ms']:g} ms; "
-        f"drift {detail['total_drift_ms']:g} ms{drift_note})",
+        f"drift {detail['total_drift_ms']:g} ms{drift_note}{tail_note})",
         detail,
     )
 
@@ -416,10 +437,18 @@ def main():
         help="tolerance on release timing against the asserted interval (default 10)",
     )
     ap.add_argument(
+        "--release-pct-max",
+        type=float,
+        default=0.0,
+        help="share of intervals allowed outside the release tolerance (default 0)",
+    )
+    ap.add_argument(
         "--drift-ms",
         type=float,
-        default=250.0,
-        help="bound on accumulated release drift over the whole sample (default 250)",
+        default=500.0,
+        help="bound on accumulated release drift, being the standing lag the sender may "
+        "hold; set it to the sender's latency budget (moq export ts --latency-max, "
+        "itself 500ms by default)",
     )
     ap.add_argument(
         "--adjacent-packets", type=int, default=1, help="packet gap at or below which two PCRs count as clustered"

--- a/test/ts/pcr-timing.py
+++ b/test/ts/pcr-timing.py
@@ -11,12 +11,6 @@ instrument pointed at another:
     release     when the bytes carrying them were handed over  (--live only)
     position    where the PCR packets sit among the media bytes
 
-`compliance.py` grades the first from a file, which is the right basis for what
-it checks and is why it states that wall-clock delivery timing is out of its
-scope. This grades all three from one pass, and reads a pipe so that `release`
-exists at all: a change to *when* bytes are handed over cannot be seen by any
-harness that needs no wall-clock capture.
-
 Every check is an invariant on the stream, not an assertion about how the stream
 was produced. `release` grades arrival against the PCR's *own* values rather than
 against a wall clock, so it needs no reference clock, no source file and no
@@ -30,6 +24,7 @@ the report-only (shape) checks to hard.
 import argparse
 import collections
 import json
+import select
 import statistics
 import sys
 import time
@@ -37,6 +32,11 @@ import time
 PKT = 188
 SYNC = 0x47
 HARD, SHAPE = "hard", "shape"
+TICKS_PER_MS = 27_000.0
+# The 33-bit PCR base counts 90 kHz ticks and the 9-bit extension counts 27 MHz ticks
+# within one of them, so the whole field restarts after this many 27 MHz ticks, roughly
+# every 26.5 hours.
+PCR_MODULUS = (1 << 33) * 300
 
 
 def percentile(xs, p):
@@ -51,7 +51,11 @@ def parse_pcr(p):
     """The 33+9-bit PCR of an adaptation field, in 27 MHz ticks, or None."""
     if (p[3] >> 4) & 0x3 not in (2, 3):  # adaptation_field_control
         return None
-    if p[4] == 0 or not (p[5] & 0x10):  # adaptation_field_length, PCR_flag
+    # A PCR occupies six bytes after the flags byte, so an adaptation field shorter than
+    # seven cannot hold one however the flag is set. Without this a stream that sets
+    # PCR_flag on a short field yields a value read out of stuffing or payload, and that
+    # sample then feeds all three timing checks.
+    if p[4] < 7 or not (p[5] & 0x10):  # adaptation_field_length, PCR_flag
         return None
     base = (p[6] << 25) | (p[7] << 17) | (p[8] << 9) | (p[9] << 1) | (p[10] >> 7)
     ext = ((p[10] & 0x01) << 8) | p[11]
@@ -68,7 +72,11 @@ class Scan:
         self.transport_error = 0
         self.cc_errors = []
         self.cc_on_empty = []
+        self.wraps = 0
         self._cc = {}
+        self._dup = {}
+        self._pcr_raw = {}
+        self._pcr_offset = {}
 
     def feed(self, p, arrival=None):
         index = self.packets
@@ -82,20 +90,48 @@ class Scan:
 
         ticks = parse_pcr(p)
         if ticks is not None:
-            self.pcr.append((index, ticks, arrival, pid))
+            # Unwrap, so the checks see a monotone timeline. A capture crossing the
+            # rollover would otherwise show one huge negative interval, which the value
+            # check accepts (it only rejects intervals that are too long) while the
+            # release check reads it as a day of lateness. A rollover drops the value by
+            # nearly the whole modulus, so only a drop past halfway is treated as one and
+            # a merely backwards PCR stays visible as the defect it is.
+            prev_raw = self._pcr_raw.get(pid)
+            if prev_raw is not None and ticks < prev_raw - PCR_MODULUS // 2:
+                self._pcr_offset[pid] = self._pcr_offset.get(pid, 0) + PCR_MODULUS
+                self.wraps += 1
+            self._pcr_raw[pid] = ticks
+            self.pcr.append((index, ticks + self._pcr_offset.get(pid, 0), arrival, pid))
 
         # ISO 13818-1 2.4.3.3: the continuity counter advances only on a packet
         # carrying a payload, so an adaptation-only PCR packet must repeat the
         # previous value rather than increment it.
         cc = p[3] & 0x0F
         payload = bool((p[3] >> 4) & 0x1)
+        # The same clause allows the counter to jump when the adaptation field sets
+        # discontinuity_indicator, and allows one packet to be sent twice, repeating its
+        # counter. Both are legal, and treating either as an error fails a conforming
+        # stream on a hard check.
+        adaptation = bool((p[3] >> 4) & 0x2)
+        discontinuity = adaptation and p[4] > 0 and bool(p[5] & 0x80)
         prev = self._cc.get(pid)
         self._cc[pid] = cc
         if prev is None or pid == 0x1FFF:
             return
+        if discontinuity:
+            self._dup[pid] = False
+            return
         if payload:
-            if cc != (prev + 1) & 0x0F:
+            if cc == prev:
+                # Legal only once: a second repeat is a stuck counter, not a duplicate.
+                if self._dup.get(pid):
+                    self.cc_errors.append((index, pid, (prev + 1) & 0x0F, cc))
+                self._dup[pid] = not self._dup.get(pid)
+            elif cc == (prev + 1) & 0x0F:
+                self._dup[pid] = False
+            else:
                 self.cc_errors.append((index, pid, (prev + 1) & 0x0F, cc))
+                self._dup[pid] = False
         elif cc != prev:
             self.cc_on_empty.append((index, pid, prev, cc))
 
@@ -120,23 +156,43 @@ def scan_live(seconds):
     """
     scan = Scan()
     fd = sys.stdin.buffer
+    deadline = time.monotonic() + seconds
+
+    def read_exactly(n):
+        """Read n bytes, or return None once the capture window has expired.
+
+        A plain read blocks until the producer sends something, so a producer that
+        holds the pipe open and stops writing suspends the loop indefinitely and
+        --seconds never takes effect. That is the likeliest state to be in while
+        diagnosing an exporter or a network stall, which is when the tool has to
+        return a report rather than hang.
+        """
+        buf = b""
+        while len(buf) < n:
+            left = deadline - time.monotonic()
+            if left <= 0 or not select.select([fd], [], [], left)[0]:
+                return None
+            chunk = fd.read1(n - len(buf))
+            if not chunk:
+                return None
+            buf += chunk
+        return buf
 
     # Find the first sync byte, then stay aligned on it.
     while True:
-        b = fd.read(1)
+        b = read_exactly(1)
         if not b:
             return scan
         if b[0] == SYNC:
-            rest = fd.read(PKT - 1)
-            if len(rest) < PKT - 1:
+            rest = read_exactly(PKT - 1)
+            if not rest:
                 return scan
-            start = time.monotonic()
-            scan.feed(b + rest, start)
+            scan.feed(b + rest, time.monotonic())
             break
 
-    while time.monotonic() - start < seconds:
-        p = fd.read(PKT)
-        if len(p) < PKT:
+    while time.monotonic() < deadline:
+        p = read_exactly(PKT)
+        if not p:
             return scan
         scan.feed(p, time.monotonic())
     return scan
@@ -191,10 +247,17 @@ def check_pcr_single_pid(scan, args):
 
 def check_value_interval(scan, args):
     """PCR values must be spaced within the repetition limit."""
-    iv = [(b[1] - a[1]) / 27_000.0 for a, b in zip(scan.pcr, scan.pcr[1:])]
+    iv = [(b[1] - a[1]) / TICKS_PER_MS for a, b in zip(scan.pcr, scan.pcr[1:])]
     if not iv:
         return ("pcr-value-interval", HARD, False, "no PCR intervals in the stream", {})
     over = [m for m in iv if m > args.repetition_ms]
+    # A PCR that goes backwards is as much a clock defect as one that arrives too late,
+    # and testing only the upper bound makes it invisible: the negative interval passes,
+    # and it drags the median and the over-limit share down with it. Rollover is already
+    # unwrapped in the scan, so a negative interval here is the stream's own doing. Zero
+    # is not: ISO 13818-1 2.4.3.3 allows a packet to be sent twice, and the duplicate
+    # repeats its PCR exactly, so testing `<= 0` would fail a conforming stream.
+    backwards = [m for m in iv if m < 0]
     detail = {
         "count": len(iv),
         "median_ms": round(statistics.median(iv), 3),
@@ -203,13 +266,16 @@ def check_value_interval(scan, args):
         "over_limit": len(over),
         "over_limit_pct": round(100.0 * len(over) / len(iv), 2),
         "sub_ms": sum(1 for m in iv if m < 1.0),
+        "non_positive": len(backwards),
+        "wraps_unwrapped": scan.wraps,
     }
+    backwards_note = f", {len(backwards)} non-positive" if backwards else ""
     return (
         "pcr-value-interval",
         HARD,
-        not over,
+        not over and not backwards,
         f"{len(over)}/{len(iv)} intervals over {args.repetition_ms:g} ms "
-        f"(median {detail['median_ms']:g} ms, worst {detail['max_ms']:g} ms)",
+        f"(median {detail['median_ms']:g} ms, worst {detail['max_ms']:g} ms{backwards_note})",
         detail,
     )
 
@@ -219,7 +285,7 @@ def check_release(scan, args):
 
     Graded against the stream's own values, so it holds at any clock rate: if two
     consecutive PCRs are 25 ms apart in value they must be ~25 ms apart in
-    arrival. Two statistics, because they fail independently — per-interval error,
+    arrival. Two statistics, because they fail independently: per-interval error,
     which is what a receiver PLL and any downstream re-timing stage sees, and
     accumulated drift, which must stay bounded or the pipe is not running at the
     media rate at all.
@@ -228,9 +294,9 @@ def check_release(scan, args):
     if len(pts) < 3:
         return ("pcr-release-timing", HARD, True, "not measured (no arrival stamps)", {})
 
-    err = [((b[1] - a[1]) * 1000.0) - ((b[0] - a[0]) / 27_000.0) for a, b in zip(pts, pts[1:])]
+    err = [((b[1] - a[1]) * 1000.0) - ((b[0] - a[0]) / TICKS_PER_MS) for a, b in zip(pts, pts[1:])]
     magnitude = [abs(e) for e in err]
-    drift = ((pts[-1][1] - pts[0][1]) * 1000.0) - ((pts[-1][0] - pts[0][0]) / 27_000.0)
+    drift = ((pts[-1][1] - pts[0][1]) * 1000.0) - ((pts[-1][0] - pts[0][0]) / TICKS_PER_MS)
     late = [e for e in err if e > args.release_ms]
     early = [e for e in err if e < -args.release_ms]
     detail = {
@@ -244,15 +310,22 @@ def check_release(scan, args):
         "released_early": len(early),
         "released_late": len(late),
         "total_drift_ms": round(drift, 1),
+        "drift_limit_ms": args.drift_ms,
     }
+    # Per-interval error and accumulated drift fail independently, and bounding only the
+    # first leaves the second unbounded: a consistent 1 ms error on a 25 ms grid sits well
+    # inside a 10 ms tolerance while reaching nearly two seconds over a 45 s sample. The
+    # docstring claimed drift was bounded; until now only the per-interval error was.
+    drifted = abs(drift) > args.drift_ms
+    drift_note = f" > ±{args.drift_ms:g} ms" if drifted else ""
     return (
         "pcr-release-timing",
         HARD,
-        not (late or early),
+        not (late or early or drifted),
         f"{detail['outside_tolerance']}/{len(err)} releases outside ±{args.release_ms:g} ms of the "
         f"interval the PCR asserts ({detail['released_early']} early, {detail['released_late']} late; "
         f"p95 {detail['p95_abs_ms']:g} ms, worst {detail['max_abs_ms']:g} ms; "
-        f"drift {detail['total_drift_ms']:g} ms)",
+        f"drift {detail['total_drift_ms']:g} ms{drift_note})",
         detail,
     )
 
@@ -263,7 +336,7 @@ def check_position(scan, args):
     The grid is uniform in media time, so if position tracks time then the packet
     gap between consecutive PCRs is roughly uniform too. That needs no assumption
     that the stream is CBR, only that comparable spans of media time carry
-    comparable numbers of bytes. What it catches is a bimodal layout — PCR packets
+    comparable numbers of bytes. What it catches is a bimodal layout, PCR packets
     laid back-to-back with the media bytes they label heaped between the clusters.
     A consumer holding only the byte stream cannot recover the clock from such a
     layout, and one that re-stamps PCR from byte position regenerates exactly the
@@ -319,7 +392,7 @@ def coincidence(scan, args):
         return None
     rows = collections.Counter()
     for a, b in zip(pts, pts[1:]):
-        err = ((b[2] - a[2]) * 1000.0) - ((b[1] - a[1]) / 27_000.0)
+        err = ((b[2] - a[2]) * 1000.0) - ((b[1] - a[1]) / TICKS_PER_MS)
         when = "early" if err < -args.release_ms else "late" if err > args.release_ms else "on time"
         where = "adjacent" if (b[0] - a[0]) <= args.adjacent_packets else "spaced"
         rows[(where, when)] += 1
@@ -341,6 +414,12 @@ def main():
         type=float,
         default=10.0,
         help="tolerance on release timing against the asserted interval (default 10)",
+    )
+    ap.add_argument(
+        "--drift-ms",
+        type=float,
+        default=250.0,
+        help="bound on accumulated release drift over the whole sample (default 250)",
     )
     ap.add_argument(
         "--adjacent-packets", type=int, default=1, help="packet gap at or below which two PCRs count as clustered"

--- a/test/ts/pcr-timing.py
+++ b/test/ts/pcr-timing.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+"""Grade an MPEG-TS stream's PCR against its own asserted clock.
+
+    moq ... export ts | ./pcr-timing.py --live --seconds 45
+    ./pcr-timing.py capture.ts
+
+A PCR is three claims at once, and a fix in one of them is invisible to an
+instrument pointed at another:
+
+    value       the intervals between PCR values         (ISO 13818-1 / TR 101 290)
+    release     when the bytes carrying them were handed over  (--live only)
+    position    where the PCR packets sit among the media bytes
+
+`compliance.py` grades the first from a file, which is the right basis for what
+it checks and is why it states that wall-clock delivery timing is out of its
+scope. This grades all three from one pass, and reads a pipe so that `release`
+exists at all: a change to *when* bytes are handed over cannot be seen by any
+harness that needs no wall-clock capture.
+
+Every check is an invariant on the stream, not an assertion about how the stream
+was produced. `release` grades arrival against the PCR's *own* values rather than
+against a wall clock, so it needs no reference clock, no source file and no
+declared mux rate; the price is that a clock running at the wrong rate stays
+internally consistent under it and has to be caught by `value` and `position`.
+
+Exit status is 0 when every hard check passes, 1 otherwise. `--strict` promotes
+the report-only (shape) checks to hard.
+"""
+
+import argparse
+import collections
+import json
+import statistics
+import sys
+import time
+
+PKT = 188
+SYNC = 0x47
+HARD, SHAPE = "hard", "shape"
+
+
+def percentile(xs, p):
+    s = sorted(xs)
+    if not s:
+        return float("nan")
+    k = min(len(s) - 1, max(0, int(round(p / 100.0 * (len(s) - 1)))))
+    return s[k]
+
+
+def parse_pcr(p):
+    """The 33+9-bit PCR of an adaptation field, in 27 MHz ticks, or None."""
+    if (p[3] >> 4) & 0x3 not in (2, 3):  # adaptation_field_control
+        return None
+    if p[4] == 0 or not (p[5] & 0x10):  # adaptation_field_length, PCR_flag
+        return None
+    base = (p[6] << 25) | (p[7] << 17) | (p[8] << 9) | (p[9] << 1) | (p[10] >> 7)
+    ext = ((p[10] & 0x01) << 8) | p[11]
+    return base * 300 + ext
+
+
+class Scan:
+    """One pass over the packets, collecting only what the checks need."""
+
+    def __init__(self):
+        self.pcr = []  # (packet_index, ticks, arrival_or_None, pid)
+        self.packets = 0
+        self.bad_sync = 0
+        self.transport_error = 0
+        self.cc_errors = []
+        self.cc_on_empty = []
+        self._cc = {}
+
+    def feed(self, p, arrival=None):
+        index = self.packets
+        self.packets += 1
+        if p[0] != SYNC:
+            self.bad_sync += 1
+            return
+        if p[1] & 0x80:
+            self.transport_error += 1
+        pid = ((p[1] & 0x1F) << 8) | p[2]
+
+        ticks = parse_pcr(p)
+        if ticks is not None:
+            self.pcr.append((index, ticks, arrival, pid))
+
+        # ISO 13818-1 2.4.3.3: the continuity counter advances only on a packet
+        # carrying a payload, so an adaptation-only PCR packet must repeat the
+        # previous value rather than increment it.
+        cc = p[3] & 0x0F
+        payload = bool((p[3] >> 4) & 0x1)
+        prev = self._cc.get(pid)
+        self._cc[pid] = cc
+        if prev is None or pid == 0x1FFF:
+            return
+        if payload:
+            if cc != (prev + 1) & 0x0F:
+                self.cc_errors.append((index, pid, (prev + 1) & 0x0F, cc))
+        elif cc != prev:
+            self.cc_on_empty.append((index, pid, prev, cc))
+
+
+def scan_file(path):
+    scan = Scan()
+    with open(path, "rb") as f:
+        while True:
+            p = f.read(PKT)
+            if len(p) < PKT:
+                return scan
+            scan.feed(p)
+
+
+def scan_live(seconds):
+    """Read stdin one packet at a time, stamping each read.
+
+    The granularity is deliberate: a coarser read cannot distinguish a run of
+    packets released together from a run released on a cadence, which is the
+    distinction `release` exists to measure. Each stamp is taken after its read
+    returns, so it is an upper bound on when the writer released those bytes.
+    """
+    scan = Scan()
+    fd = sys.stdin.buffer
+
+    # Find the first sync byte, then stay aligned on it.
+    while True:
+        b = fd.read(1)
+        if not b:
+            return scan
+        if b[0] == SYNC:
+            rest = fd.read(PKT - 1)
+            if len(rest) < PKT - 1:
+                return scan
+            start = time.monotonic()
+            scan.feed(b + rest, start)
+            break
+
+    while time.monotonic() - start < seconds:
+        p = fd.read(PKT)
+        if len(p) < PKT:
+            return scan
+        scan.feed(p, time.monotonic())
+    return scan
+
+
+# --- checks: each returns (name, severity, ok, headline, detail) -------------
+
+
+def check_sync(scan, args):
+    detail = {
+        "packets": scan.packets,
+        "bad_sync": scan.bad_sync,
+        "transport_error": scan.transport_error,
+    }
+    return (
+        "sync",
+        HARD,
+        not (scan.bad_sync or scan.transport_error),
+        f"{scan.packets} packets, {scan.bad_sync} bad sync bytes, "
+        f"{scan.transport_error} with transport_error_indicator",
+        detail,
+    )
+
+
+def check_continuity(scan, args):
+    detail = {
+        "discontinuities": len(scan.cc_errors),
+        "empty_packets_advancing_cc": len(scan.cc_on_empty),
+        "first_few": scan.cc_errors[:5],
+    }
+    return (
+        "continuity",
+        HARD,
+        not (scan.cc_errors or scan.cc_on_empty),
+        f"{len(scan.cc_errors)} continuity discontinuities, {len(scan.cc_on_empty)} payload-less "
+        f"packets advanced the counter (ISO 13818-1 2.4.3.3)",
+        detail,
+    )
+
+
+def check_pcr_single_pid(scan, args):
+    """Every PCR must ride the one PID the PMT declares."""
+    pids = collections.Counter(pid for _, _, _, pid in scan.pcr)
+    return (
+        "pcr-single-pid",
+        HARD,
+        len(pids) <= 1,
+        f"PCR carried on {len(pids)} PID(s): " + ", ".join(f"{k} ({v})" for k, v in pids.most_common()),
+        {"pids": {str(k): v for k, v in pids.items()}},
+    )
+
+
+def check_value_interval(scan, args):
+    """PCR values must be spaced within the repetition limit."""
+    iv = [(b[1] - a[1]) / 27_000.0 for a, b in zip(scan.pcr, scan.pcr[1:])]
+    if not iv:
+        return ("pcr-value-interval", HARD, False, "no PCR intervals in the stream", {})
+    over = [m for m in iv if m > args.repetition_ms]
+    detail = {
+        "count": len(iv),
+        "median_ms": round(statistics.median(iv), 3),
+        "p95_ms": round(percentile(iv, 95), 3),
+        "max_ms": round(max(iv), 3),
+        "over_limit": len(over),
+        "over_limit_pct": round(100.0 * len(over) / len(iv), 2),
+        "sub_ms": sum(1 for m in iv if m < 1.0),
+    }
+    return (
+        "pcr-value-interval",
+        HARD,
+        not over,
+        f"{len(over)}/{len(iv)} intervals over {args.repetition_ms:g} ms "
+        f"(median {detail['median_ms']:g} ms, worst {detail['max_ms']:g} ms)",
+        detail,
+    )
+
+
+def check_release(scan, args):
+    """The bytes carrying a PCR must be released at the time that PCR asserts.
+
+    Graded against the stream's own values, so it holds at any clock rate: if two
+    consecutive PCRs are 25 ms apart in value they must be ~25 ms apart in
+    arrival. Two statistics, because they fail independently — per-interval error,
+    which is what a receiver PLL and any downstream re-timing stage sees, and
+    accumulated drift, which must stay bounded or the pipe is not running at the
+    media rate at all.
+    """
+    pts = [(ticks, arrival) for _, ticks, arrival, _ in scan.pcr if arrival is not None]
+    if len(pts) < 3:
+        return ("pcr-release-timing", HARD, True, "not measured (no arrival stamps)", {})
+
+    err = [((b[1] - a[1]) * 1000.0) - ((b[0] - a[0]) / 27_000.0) for a, b in zip(pts, pts[1:])]
+    magnitude = [abs(e) for e in err]
+    drift = ((pts[-1][1] - pts[0][1]) * 1000.0) - ((pts[-1][0] - pts[0][0]) / 27_000.0)
+    late = [e for e in err if e > args.release_ms]
+    early = [e for e in err if e < -args.release_ms]
+    detail = {
+        "count": len(err),
+        "median_abs_ms": round(statistics.median(magnitude), 3),
+        "p95_abs_ms": round(percentile(magnitude, 95), 3),
+        "p99_abs_ms": round(percentile(magnitude, 99), 3),
+        "max_abs_ms": round(max(magnitude), 3),
+        "outside_tolerance": len(late) + len(early),
+        "outside_tolerance_pct": round(100.0 * (len(late) + len(early)) / len(err), 2),
+        "released_early": len(early),
+        "released_late": len(late),
+        "total_drift_ms": round(drift, 1),
+    }
+    return (
+        "pcr-release-timing",
+        HARD,
+        not (late or early),
+        f"{detail['outside_tolerance']}/{len(err)} releases outside ±{args.release_ms:g} ms of the "
+        f"interval the PCR asserts ({detail['released_early']} early, {detail['released_late']} late; "
+        f"p95 {detail['p95_abs_ms']:g} ms, worst {detail['max_abs_ms']:g} ms; "
+        f"drift {detail['total_drift_ms']:g} ms)",
+        detail,
+    )
+
+
+def check_position(scan, args):
+    """A PCR packet must sit among the media bytes whose arrival it describes.
+
+    The grid is uniform in media time, so if position tracks time then the packet
+    gap between consecutive PCRs is roughly uniform too. That needs no assumption
+    that the stream is CBR, only that comparable spans of media time carry
+    comparable numbers of bytes. What it catches is a bimodal layout — PCR packets
+    laid back-to-back with the media bytes they label heaped between the clusters.
+    A consumer holding only the byte stream cannot recover the clock from such a
+    layout, and one that re-stamps PCR from byte position regenerates exactly the
+    clustering the value domain was fixed to remove.
+    """
+    if len(scan.pcr) < 3:
+        return ("pcr-position", SHAPE, True, "not measured (too few PCRs)", {})
+    gap = [b[0] - a[0] for a, b in zip(scan.pcr, scan.pcr[1:])]
+    adjacent = sum(1 for g in gap if g <= args.adjacent_packets)
+    median = statistics.median(gap)
+    detail = {
+        "count": len(gap),
+        "median_packets": median,
+        "p95_packets": percentile(gap, 95),
+        "max_packets": max(gap),
+        "adjacent": adjacent,
+        "adjacent_pct": round(100.0 * adjacent / len(gap), 2),
+        # Dispersion about the middle of the distribution: near 1 for a uniform
+        # layout, large for cluster-and-hole. Guard a zero median.
+        "p95_over_median": round(percentile(gap, 95) / median, 1) if median else None,
+    }
+    return (
+        "pcr-position",
+        SHAPE,
+        detail["adjacent_pct"] <= args.adjacent_pct_max,
+        f"{detail['adjacent_pct']:g}% of PCR packets sit within {args.adjacent_packets} packet(s) of "
+        f"the previous one (median gap {median} packets, p95 {detail['p95_packets']}, worst {max(gap)})",
+        detail,
+    )
+
+
+CHECKS = [
+    check_sync,
+    check_continuity,
+    check_pcr_single_pid,
+    check_value_interval,
+    check_release,
+    check_position,
+]
+
+
+def coincidence(scan, args):
+    """Cross-tabulate release error against byte position, for one pass's PCRs.
+
+    `release` and `position` are separate invariants and a stream can fail either
+    alone, but when they fail *on the same PCRs* they have one cause rather than
+    two, and that is worth reporting rather than leaving to be inferred from two
+    aggregate percentages. Report-only: it explains a failure, it does not define
+    one.
+    """
+    pts = [(i, ticks, arrival) for i, ticks, arrival, _ in scan.pcr if arrival is not None]
+    if len(pts) < 3:
+        return None
+    rows = collections.Counter()
+    for a, b in zip(pts, pts[1:]):
+        err = ((b[2] - a[2]) * 1000.0) - ((b[1] - a[1]) / 27_000.0)
+        when = "early" if err < -args.release_ms else "late" if err > args.release_ms else "on time"
+        where = "adjacent" if (b[0] - a[0]) <= args.adjacent_packets else "spaced"
+        rows[(where, when)] += 1
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("path", nargs="?", help="TS file; omit with --live to read stdin")
+    ap.add_argument("--live", action="store_true", help="read stdin and stamp arrivals, grading release timing")
+    ap.add_argument("--seconds", type=float, default=45.0, help="live capture window (default 45)")
+    ap.add_argument(
+        "--repetition-ms", type=float, default=40.0, help="max PCR value interval, TR 101 290 (default 40)"
+    )
+    ap.add_argument(
+        "--release-ms",
+        type=float,
+        default=10.0,
+        help="tolerance on release timing against the asserted interval (default 10)",
+    )
+    ap.add_argument(
+        "--adjacent-packets", type=int, default=1, help="packet gap at or below which two PCRs count as clustered"
+    )
+    ap.add_argument(
+        "--adjacent-pct-max", type=float, default=1.0, help="share of clustered PCRs before pcr-position flags"
+    )
+    ap.add_argument("--strict", action="store_true", help="fail on shape checks too")
+    ap.add_argument("--report-json", help="write the full report here")
+    args = ap.parse_args()
+
+    if args.live:
+        scan = scan_live(args.seconds)
+    elif args.path:
+        scan = scan_file(args.path)
+    else:
+        ap.error("give a path or --live")
+
+    results = [check(scan, args) for check in CHECKS]
+    width = max(len(r[0]) for r in results)
+
+    print(f"### PCR timing report - {scan.packets} packets, {len(scan.pcr)} PCR")
+    print()
+    failed = 0
+    for name, severity, ok, headline, _ in results:
+        if ok:
+            verdict = "PASS"
+        elif severity == HARD or args.strict:
+            verdict = "FAIL"
+            failed += 1
+        else:
+            verdict = "WARN"
+        print(f"  {verdict:4}  {name:<{width}}  {headline}")
+    rows = coincidence(scan, args)
+    if rows:
+        total = sum(rows.values())
+        print()
+        print("  release timing by byte position (report only)")
+        for where in ("adjacent", "spaced"):
+            for when in ("early", "on time", "late"):
+                n = rows[(where, when)]
+                if n:
+                    print(f"    {where:<8} + {when:<7}  {n:6}  ({100.0 * n / total:5.1f}%)")
+
+    print()
+    print(f"{failed} check(s) failed" if failed else "all checks passed")
+
+    if args.report_json:
+        with open(args.report_json, "w") as f:
+            json.dump(
+                {
+                    "packets": scan.packets,
+                    "pcr_count": len(scan.pcr),
+                    "live": args.live,
+                    "checks": [
+                        {"name": n, "severity": s, "ok": ok, "headline": h, "detail": d}
+                        for n, s, ok, h, d in results
+                    ],
+                },
+                f,
+                indent=2,
+            )
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Test tooling only. No behaviour changes.

`compliance.py` grades a captured file on the stream's own PCR clock. That is the right basis for the IRD model math it does, and this directory's README records the consequence in its own caveats:

> Wall-clock delivery jitter/burstiness is intentionally out of scope: all timing is derived from the stream's PCR, not from socket arrival times.

Which means nothing here can observe a change to *when* `export ts` hands bytes over — a file has no release timing left in it. [#3006](https://github.com/moq-dev/moq/pull/3006) landed without a test for exactly that reason, and I could not report [#3334](https://github.com/moq-dev/moq/issues/3334) without first building an instrument that could see it.

### What it adds

`test/ts/pcr-timing.py` grades the three claims a PCR makes, in one pass:

| Domain | What it claims | Graded from |
|---|---|---|
| value | consecutive PCR values are spaced within the repetition limit | the values |
| release | the bytes carrying a PCR were handed over when that PCR asserts | arrival stamps |
| position | a PCR packet sits among the media bytes it describes | packet offsets |

```bash
# live: all three domains, reading the exporter directly
moq --client-connect http://localhost:4443 --broadcast live.hang export ts \
  | ./pcr-timing.py --live --seconds 45

# offline: value and position only
./pcr-timing.py capture.ts
```

It needs only `python3` — no TSDuck, no source file, no declared mux rate — because every check is graded against the stream's **own** PCR values rather than a nominal you supply. If two consecutive PCRs are 25 ms apart in value then they must be ~25 ms apart in arrival, whatever rate the stream runs at. It pays the same price as `compliance.py` for that basis, and for the same reason: a PCR emitted at the wrong rate stays internally consistent, so absolute rate is not what either grades.

Reads stdin one packet at a time. The granularity is deliberate — a coarser read cannot distinguish a run of packets released together from a run released on a cadence, which is the distinction `release` exists to measure.

### Why the checks are severities rather than all-hard

`pcr-position` is a **shape** check (WARN unless `--strict`), because `export ts` is VBR by design. It is reported anyway because a consumer holding only the byte stream — every MPEG-TS tool, and the thing stdout is — recovers the clock from where the PCR packets sit, so it distinguishes a stream whose values are exact from one whose values are also *recoverable*. `pcr-value-interval`, `pcr-release-timing`, `continuity`, `sync` and `pcr-single-pid` are hard.

When `release` and `position` both flag, the report cross-tabulates them, because two invariants failing on the *same* PCRs is one cause rather than two and two aggregate percentages cannot show that. Report-only: it explains a failure, it does not define one.

### Calibration

The property that matters for a gate, and the one that is easy to lose: it **passes a real broadcast source unmodified**. Offline over a 1080i25 contribution capture that never went through moq, every check passes — 1,318 PCRs, median interval 24.648 ms, worst 24.951 ms, 0% adjacent at a median gap of 163 packets. Over a pre-#2967 export capture the same command fails `pcr-value-interval` alone, at the characteristic 0.011 ms median, and *passes* `pcr-position` — pre-#2967 the PCR rode payload packets and so was naturally spread. So neither the value nor the position check is calibrated to moq's output, in either direction.

Against the three builds I have to hand:

| | value | release | position |
|---|---|---|---|
| pre-#2967 | FAIL | FAIL | PASS |
| #2967+#3006 | PASS | FAIL | FAIL |

`just fix` and `just check` are clean on this branch. Happy to wire it in under `just test ts --live` rather than as a sibling script if you would prefer one entry point — I left it standalone because the live mode needs a pipe rather than a capture, which does not fit `run.sh`'s round-trip-then-analyze shape.
