### PR TITLE
fix(net): do not count delivered continuations as stale

### DIFF
--- a/rs/moq-net/src/model/resume.rs
+++ b/rs/moq-net/src/model/resume.rs
@@ -463,6 +463,8 @@ impl Consumer {
 			end_sequence: None,
 			stale_cap: None,
 			drift_cap: kio::Producer::new(None),
+			arrival_stale: ArrivalStale::default(),
+			open_delivery: None,
 		}
 	}
 
@@ -1158,6 +1160,51 @@ struct SegmentSub {
 	/// the lowest is re-offered first; holding them here (rather than blocking on
 	/// the first) keeps in-range groups that arrive behind a capped one flowing.
 	parked: BTreeMap<u64, group::Consumer>,
+	/// Arrival-stale decisions inherited from a wrapping splice.
+	arrival_stale: ArrivalStale,
+	/// The accounting state for this segment's mid-group start, if it has one.
+	continuation: Option<ArrivalStaleState>,
+}
+
+#[derive(Clone, Default)]
+struct ArrivalStale(Vec<(u64, ArrivalStaleState)>);
+
+impl ArrivalStale {
+	fn get(&self, sequence: u64) -> Option<ArrivalStaleState> {
+		self.0
+			.iter()
+			.find_map(|(key, state)| (*key == sequence).then_some(*state))
+	}
+
+	fn insert(&mut self, sequence: u64, state: ArrivalStaleState) {
+		if let Some((_, current)) = self.0.iter_mut().find(|(key, _)| *key == sequence) {
+			*current = state;
+		} else {
+			self.0.push((sequence, state));
+		}
+	}
+
+	fn insert_pending(&mut self, sequence: u64) {
+		if self.get(sequence).is_none() {
+			self.0.push((sequence, ArrivalStaleState::Pending));
+		}
+	}
+
+	fn remove(&mut self, sequence: u64) {
+		if let Some(index) = self.0.iter().position(|(key, _)| *key == sequence) {
+			self.0.swap_remove(index);
+		}
+	}
+
+	fn iter(&self) -> impl Iterator<Item = (u64, ArrivalStaleState)> + '_ {
+		self.0.iter().copied()
+	}
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum ArrivalStaleState {
+	Pending,
+	Forgiven,
 }
 
 impl SegmentSub {
@@ -1167,6 +1214,21 @@ impl SegmentSub {
 		match &mut self.sub {
 			SubState::Active(sub) => Some(sub.as_mut()),
 			_ => self.terminal.as_mut(),
+		}
+	}
+
+	fn configure_arrival_stale(&self, sub: &mut track::Subscriber) {
+		for (sequence, state) in self.arrival_stale.iter() {
+			match state {
+				ArrivalStaleState::Pending => sub.defer_arrival_stale(sequence),
+				ArrivalStaleState::Forgiven => sub.forgive_arrival_stale(sequence),
+			}
+		}
+		if let (Some(start), Some(state)) = (self.start, self.continuation) {
+			match state {
+				ArrivalStaleState::Pending => sub.defer_arrival_stale(start.group),
+				ArrivalStaleState::Forgiven => sub.forgive_arrival_stale(start.group),
+			}
 		}
 	}
 
@@ -1265,6 +1327,11 @@ pub struct Subscriber {
 	/// Shared copy of the effective cap ([`Self::end_sequence`] and [`Self::stale_cap`]
 	/// combined) for groups that outlive this cursor poll.
 	drift_cap: kio::Producer<Option<u64>>,
+	/// Arrival-stale decisions imposed by a wrapping splice and inherited by new segments.
+	arrival_stale: ArrivalStale,
+	/// The handed-out group that is still the producer's open edge and can become
+	/// a continuation boundary on the next takeover.
+	open_delivery: Option<u64>,
 }
 
 impl Subscriber {
@@ -1272,7 +1339,31 @@ impl Subscriber {
 	/// boundaries, re-slice demand, and register the waiter for the next change.
 	fn poll_sync(&mut self, waiter: &kio::Waiter) {
 		self.sync(waiter);
+		self.settle_arrival_continuations();
 		self.reap();
+	}
+
+	fn settle_arrival_continuations(&mut self) {
+		for index in 0..self.segments.len() {
+			if self.segments[index].continuation != Some(ArrivalStaleState::Pending) {
+				continue;
+			}
+			let sequence = self.segments[index].start.expect("continuation has a start").group;
+			let head_possible = self.segments[..index].iter().any(|seg| {
+				frames(seg.start, seg.end, sequence).is_some_and(|(start, _)| start == 0)
+					&& (!matches!(seg.sub, SubState::Done(_)) || seg.parked.contains_key(&sequence))
+			});
+			if head_possible {
+				continue;
+			}
+
+			self.segments[index].continuation = None;
+			if self.segments[index].arrival_stale.get(sequence).is_none()
+				&& let Some(sub) = self.segments[index].stale_sub_mut()
+			{
+				sub.commit_arrival_stale(sequence);
+			}
+		}
 	}
 
 	/// Reap retired cursors, then bound the live stragglers: a pruned segment's
@@ -1414,6 +1505,13 @@ impl Subscriber {
 					}
 				}
 				None => {
+					let continuation = segment.start.filter(|start| start.frame > 0).map(|start| {
+						if self.open_delivery == Some(start.group) {
+							ArrivalStaleState::Forgiven
+						} else {
+							ArrivalStaleState::Pending
+						}
+					});
 					let sub = segment
 						.track
 						.subscribe(slice(&self.last_prefs, segment.start, segment.end));
@@ -1425,6 +1523,8 @@ impl Subscriber {
 						terminal: None,
 						pruned: false,
 						parked: BTreeMap::new(),
+						arrival_stale: self.arrival_stale.clone(),
+						continuation,
 					});
 				}
 			}
@@ -1438,13 +1538,36 @@ impl Subscriber {
 	/// starts partway into the group, which only happens after an earlier segment served
 	/// the head. Those frames reach the reader through the group it already holds, so
 	/// surfacing the copy again would duplicate them.
-	fn hand_out(&self, segment: usize, group: group::Consumer) -> Option<group::Consumer> {
-		let seg = &self.segments[segment];
+	fn hand_out(&mut self, segment: usize, group: group::Consumer) -> Option<group::Consumer> {
 		let sequence = group.sequence;
-		let (start, end) = frames(seg.start, seg.end, sequence)?;
+		let (id, last_group, start, end) = {
+			let seg = &self.segments[segment];
+			let (start, end) = frames(seg.start, seg.end, sequence)?;
+			(seg.id, seg.last_group(), start, end)
+		};
 		if start != 0 {
 			return None;
 		}
+
+		for seg in &mut self.segments {
+			if seg
+				.start
+				.is_some_and(|start| start.group == sequence && start.frame > 0)
+			{
+				seg.continuation = Some(ArrivalStaleState::Forgiven);
+				if let Some(sub) = seg.stale_sub_mut() {
+					sub.forgive_arrival_stale(sequence);
+				}
+			}
+		}
+		self.open_delivery = self
+			.state
+			.read()
+			.resume_position()
+			.filter(|position| position.group == sequence && position.frame > 0)
+			.map(|position| position.group);
+		self.settle_arrival_continuations();
+
 		// Latch the delivering copy: the spliced reader otherwise re-resolves it
 		// through the segment list, which forgets this route the moment its
 		// segment is pruned, turning a group the cursor already delivered into an
@@ -1456,7 +1579,7 @@ impl Subscriber {
 			sequence,
 			0,
 		)
-		.latched(seg.id, end, seg.last_group(), group.clone());
+		.latched(id, end, last_group, group.clone());
 		Some(group.into_spliced(spliced))
 	}
 
@@ -1515,6 +1638,36 @@ impl Subscriber {
 		}
 	}
 
+	pub(crate) fn defer_arrival_stale(&mut self, sequence: u64) {
+		self.arrival_stale.insert_pending(sequence);
+		for seg in &mut self.segments {
+			seg.arrival_stale.insert_pending(sequence);
+			if let Some(sub) = seg.stale_sub_mut() {
+				sub.defer_arrival_stale(sequence);
+			}
+		}
+	}
+
+	pub(crate) fn forgive_arrival_stale(&mut self, sequence: u64) {
+		self.arrival_stale.insert(sequence, ArrivalStaleState::Forgiven);
+		for seg in &mut self.segments {
+			seg.arrival_stale.insert(sequence, ArrivalStaleState::Forgiven);
+			if let Some(sub) = seg.stale_sub_mut() {
+				sub.forgive_arrival_stale(sequence);
+			}
+		}
+	}
+
+	pub(crate) fn commit_arrival_stale(&mut self, sequence: u64) {
+		self.arrival_stale.remove(sequence);
+		for seg in &mut self.segments {
+			seg.arrival_stale.remove(sequence);
+			if let Some(sub) = seg.stale_sub_mut() {
+				sub.commit_arrival_stale(sequence);
+			}
+		}
+	}
+
 	/// Whether the drift budget says to skip `group`, asked of the segment whose
 	/// window covers it; the spliced arm of [`track::Subscriber::poll_stale`], for a
 	/// nested splice's parked group being re-offered after a cap rise.
@@ -1563,6 +1716,7 @@ impl Subscriber {
 					sub.raise_start_to(seg.first_group().max(min_sequence));
 					sub.set_stale_cap(Self::stale_cap(seg, anchor_end));
 					let _ = sub.update(slice(prefs, seg.start, seg.end));
+					seg.configure_arrival_stale(&mut sub);
 					seg.sub = SubState::Active(Box::new(sub));
 				}
 				// The underlying track was rejected or closed: stall, not error.
@@ -1587,7 +1741,7 @@ impl Subscriber {
 				SubState::Pending(_) => {
 					ready!(Self::poll_activate(seg, prefs, min_sequence, anchor_end, waiter));
 				}
-				SubState::Active(sub) => match sub.poll_recv_group(waiter) {
+				SubState::Active(sub) => match sub.poll_recv_group_nested(waiter) {
 					Poll::Ready(Ok(Some(group))) => {
 						// `start_at` already floors the cursor; enforce the cap here since
 						// arrival-order reads don't honor `end_at`.
@@ -3082,6 +3236,42 @@ mod test {
 		// discard B's copy, not count it.
 		assert_eq!(next(&mut sub), 1);
 		assert_eq!(next(&mut sub), 3);
+		assert_eq!(
+			sub.take_stale().groups,
+			2,
+			"groups 0 and 2 are stale; the delivered continuation of 1 is not"
+		);
+	}
+
+	/// The arrival cursor has the same continuation accounting contract as the
+	/// ordered cursor: content reached through a handed-out group is not stale.
+	#[tokio::test]
+	async fn an_arrival_delivered_continuation_is_not_counted_stale() {
+		let stamp = |sequence: u64| Duration::from_secs(10 * sequence);
+
+		let (mut track_a, consumer_a) = track_pair("a");
+		let (mut track_b, consumer_b) = track_pair("b");
+		let mut producer = Producer::new();
+		producer.switch(&consumer_a, None).unwrap();
+		producer.switch(&consumer_b, Position { group: 1, frame: 1 }).unwrap();
+		write_group_at(&mut track_a, 0, "a0", stamp(0));
+		write_group_at(&mut track_a, 1, "a1", stamp(1));
+		write_group_at(&mut track_b, 1, "b1", stamp(1));
+		write_group_at(&mut track_b, 2, "b2", stamp(2));
+		write_group_at(&mut track_b, 3, "b3", stamp(3));
+
+		let mut sub = producer.consume().subscribe(None);
+		let recv = |sub: &mut Subscriber| {
+			kio::wait(|waiter| sub.poll_recv_group(waiter))
+				.now_or_never()
+				.expect("should not block")
+				.expect("should not error")
+				.expect("should not be finished")
+				.sequence
+		};
+
+		assert_eq!(recv(&mut sub), 1);
+		assert_eq!(recv(&mut sub), 3);
 		assert_eq!(
 			sub.take_stale().groups,
 			2,

--- a/rs/moq-net/src/model/track.rs
+++ b/rs/moq-net/src/model/track.rs
@@ -1407,6 +1407,7 @@ impl Producer {
 				stale_cap: None,
 				drift_cap,
 				stale: stats::Content::default(),
+				arrival_stale: None,
 				seek_pending: BTreeMap::new(),
 			}),
 			// A producer-side (in-process) subscribe is not egress: stay untagged.
@@ -2397,6 +2398,7 @@ impl Subscribing {
 						stale_cap: None,
 						drift_cap,
 						stale: stats::Content::default(),
+						arrival_stale: None,
 						seek_pending: BTreeMap::new(),
 					}),
 					stats: self.stats.clone(),
@@ -2858,9 +2860,22 @@ struct PlainSubscriber {
 	/// [`super::resume::Subscriber`] segment (untagged, so the outer wrapper is the
 	/// only place attribution happens once).
 	stale: stats::Content,
+	/// Arrival skips awaiting a wrapping splice's decision. Empty for plain reads.
+	arrival_stale: Option<Box<ArrivalStale>>,
 	/// Groups the seek path has convicted but whose sequences no caller has committed
 	/// past yet, keyed by sequence; see [`Self::commit_seek_stale`].
 	seek_pending: BTreeMap<u64, stats::Content>,
+}
+
+struct ArrivalStale {
+	sequence: u64,
+	state: ArrivalStaleState,
+	next: Option<Box<ArrivalStale>>,
+}
+
+enum ArrivalStaleState {
+	Pending(stats::Content),
+	Forgiven,
 }
 
 impl PlainSubscriber {
@@ -2891,6 +2906,62 @@ impl PlainSubscriber {
 	/// same counter as the ones skipped here.
 	fn note_stale(&mut self, group: &group::Consumer) {
 		self.stale.add(group.content());
+	}
+
+	fn note_arrival_stale(&mut self, group: &group::Consumer) {
+		match self.arrival_stale_mut(group.sequence) {
+			Some(ArrivalStaleState::Pending(content)) => content.add(group.content()),
+			Some(ArrivalStaleState::Forgiven) => {}
+			None => self.stale.add(group.content()),
+		}
+	}
+
+	fn defer_arrival_stale(&mut self, sequence: u64) {
+		if self.arrival_stale_mut(sequence).is_none() {
+			self.arrival_stale = Some(Box::new(ArrivalStale {
+				sequence,
+				state: ArrivalStaleState::Pending(stats::Content::default()),
+				next: self.arrival_stale.take(),
+			}));
+		}
+	}
+
+	fn forgive_arrival_stale(&mut self, sequence: u64) {
+		if let Some(state) = self.arrival_stale_mut(sequence) {
+			*state = ArrivalStaleState::Forgiven;
+		} else {
+			self.arrival_stale = Some(Box::new(ArrivalStale {
+				sequence,
+				state: ArrivalStaleState::Forgiven,
+				next: self.arrival_stale.take(),
+			}));
+		}
+	}
+
+	fn commit_arrival_stale(&mut self, sequence: u64) {
+		fn remove(entry: &mut Option<Box<ArrivalStale>>, sequence: u64) -> Option<ArrivalStaleState> {
+			if entry.as_ref()?.sequence == sequence {
+				let mut removed = entry.take().expect("entry just observed");
+				*entry = removed.next.take();
+				return Some(removed.state);
+			}
+			remove(&mut entry.as_mut()?.next, sequence)
+		}
+
+		if let Some(ArrivalStaleState::Pending(content)) = remove(&mut self.arrival_stale, sequence) {
+			self.stale.add(content);
+		}
+	}
+
+	fn arrival_stale_mut(&mut self, sequence: u64) -> Option<&mut ArrivalStaleState> {
+		let mut entry = self.arrival_stale.as_deref_mut();
+		while let Some(current) = entry {
+			if current.sequence == sequence {
+				return Some(&mut current.state);
+			}
+			entry = current.next.as_deref_mut();
+		}
+		None
 	}
 
 	/// This subscriber's clamped drift budget and the live edge to measure against,
@@ -2936,7 +3007,7 @@ impl PlainSubscriber {
 		}))
 	}
 
-	fn poll_recv_group(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<group::Consumer>>> {
+	fn poll_recv_group<const NESTED: bool>(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<group::Consumer>>> {
 		// An eviction aborts a parked group without touching any cursor this
 		// subscriber polls, so each entry needs a waiter or this poll would never
 		// rerun. `poll_closed` observes-or-registers under one lock: `Pending`
@@ -3001,7 +3072,11 @@ impl PlainSubscriber {
 			// Drop a group the drift budget has given up on and keep scanning, so one
 			// poll walks a whole backlog off rather than handing it out group by group.
 			if ready!(self.poll_stale(&consumer, &drift, waiter))? {
-				self.stale.add(consumer.content());
+				if NESTED {
+					self.note_arrival_stale(&consumer);
+				} else {
+					self.stale.add(consumer.content());
+				}
 				continue;
 			}
 			return Poll::Ready(Ok(Some(self.with_expiry(consumer))));
@@ -3225,6 +3300,31 @@ impl Subscriber {
 		}
 	}
 
+	/// Hold an arrival-path skip until a wrapping splice resolves whether another
+	/// segment delivered the same logical group.
+	pub(crate) fn defer_arrival_stale(&mut self, sequence: u64) {
+		match &mut self.inner {
+			SubscriberKind::Plain(plain) => plain.defer_arrival_stale(sequence),
+			SubscriberKind::Spliced(spliced) => spliced.defer_arrival_stale(sequence),
+		}
+	}
+
+	/// Drop an arrival-path skip because another segment delivered the group.
+	pub(crate) fn forgive_arrival_stale(&mut self, sequence: u64) {
+		match &mut self.inner {
+			SubscriberKind::Plain(plain) => plain.forgive_arrival_stale(sequence),
+			SubscriberKind::Spliced(spliced) => spliced.forgive_arrival_stale(sequence),
+		}
+	}
+
+	/// Commit a deferred arrival-path skip once no segment can deliver the group.
+	pub(crate) fn commit_arrival_stale(&mut self, sequence: u64) {
+		match &mut self.inner {
+			SubscriberKind::Plain(plain) => plain.commit_arrival_stale(sequence),
+			SubscriberKind::Spliced(spliced) => spliced.commit_arrival_stale(sequence),
+		}
+	}
+
 	/// Whether the drift budget says to skip `group`, for a reader holding a group this
 	/// subscriber handed it earlier (a parked one, re-offered once a cap rose). Counts
 	/// the skip here so it reaches the stats with the rest. A spliced subscriber asks
@@ -3282,13 +3382,25 @@ impl Subscriber {
 	/// `Poll::Ready(Err(e))` when the track has been aborted, or
 	/// `Poll::Pending` when no group is available yet.
 	pub fn poll_recv_group(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<group::Consumer>>> {
+		self.poll_recv_group_inner::<false>(waiter)
+	}
+
+	fn poll_recv_group_inner<const NESTED: bool>(
+		&mut self,
+		waiter: &kio::Waiter,
+	) -> Poll<Result<Option<group::Consumer>>> {
 		let meter = self.stats.meter();
 		let res = match &mut self.inner {
-			SubscriberKind::Plain(plain) => plain.poll_recv_group(waiter),
+			SubscriberKind::Plain(plain) => plain.poll_recv_group::<NESTED>(waiter),
 			SubscriberKind::Spliced(spliced) => spliced.poll_recv_group(waiter),
 		};
 		self.count_stale(&meter);
 		res.map(|res| res.map(|group| group.map(|group| group.with_meter(meter))))
+	}
+
+	/// Poll through a splice segment, enabling its continuation accounting.
+	pub(crate) fn poll_recv_group_nested(&mut self, waiter: &kio::Waiter) -> Poll<Result<Option<group::Consumer>>> {
+		self.poll_recv_group_inner::<true>(waiter)
 	}
 
 	/// Receive the next group in arrival order.


### PR DESCRIPTION
## Summary

- Defer arrival-path stale accounting for a mid-group continuation until the splice knows whether the preceding segment handed out the group.
- Forgive continuation copies reached through an already-delivered group, while committing copies once no earlier segment can deliver the head.
- Keep `PlainSubscriber` inline and leave its existing seek-accounting map unchanged.
- Compile direct plain reads through the original accounting path. The new 8-byte optional sidecar allocates only when a splice has a mid-group continuation decision to track.
- Keep inherited splice decisions in a small vector, where the bound is nesting depth.
- Add an arrival-order regression test mirroring the ordered-path coverage.

The root cause was that `PlainSubscriber::poll_recv_group` collapsed skipped content directly into the stale aggregate before the spliced reader could resolve the boundary. A continuation could therefore be counted stale on the later segment even though the group already handed out by the earlier segment delivered that content.

Fixes #3269

## Public API changes

None.

## Wire behavior changes

None. This changes local stats accounting only.

## Test plan

- `nix develop --command just check`
- `nix develop --command just test` (3,557 passed, 2 skipped)
- `cargo test --locked -p moq-net model::resume::test` (84 passed)
- `cargo clippy --locked -p moq-net --all-targets -- -D warnings`

(Written by GPT-5)