### PR TITLE
fix(moq-audio): let a capture publication outlive a missing input

### DIFF
--- a/doc/lib/rs/crate/moq-audio.md
+++ b/doc/lib/rs/crate/moq-audio.md
@@ -62,9 +62,9 @@ mix as its reference.
 
 ## Publishing
 
-`encode::Publication` advertises the track and catalog up front and opens the
-microphone only while somebody is listening. Its separate driver owns capture
-and encoding, while clones of the retained handle control that same track:
+`encode::Publication` advertises the track up front and opens the microphone
+only while somebody is listening. Its separate driver owns capture and encoding,
+while clones of the retained handle control that same track:
 
 ```rust
 use moq_audio::{capture, encode};
@@ -76,8 +76,7 @@ local.run_until(async move {
     options.capture = capture::Config::default();
     options.clock = clock;
 
-    let (mut microphone, driver) =
-        encode::Publication::new(broadcast, catalog, options).await?;
+    let (mut microphone, driver) = encode::Publication::new(broadcast, catalog, options)?;
     let publish = tokio::task::spawn_local(driver.run());
 
     microphone.stop(); // releases the device, but keeps the track
@@ -103,10 +102,16 @@ local.run_until(async move {
 
 The native capture driver is not `Send`, so await it directly or use a
 `LocalSet` when it needs a separate task. `encode::publish_capture` remains the
-shorthand when no controls are needed. Transient input failures retry with
-capped backoff. Terminal failures leave the track registered in
-`Status::Failed`; `start` retries, while `replace` selects another device without
-changing the identity subscribers already know. `Publication::level` is measured
+shorthand when no controls are needed.
+
+Constructing a publication never touches the device, so the controls exist even
+on a machine with no microphone. The driver probes the input for the PCM layout
+the catalog rendition describes and registers that rendition on the first
+success, so the catalog advertises no audio until then and `Status::Starting` is
+how an observer sees it. Transient input failures retry with capped backoff.
+Terminal failures leave the track registered in `Status::Failed`; `start`
+retries, while `replace` selects another device without changing the identity
+subscribers already know. `Publication::level` is measured
 after AEC and other capture processing, so it is suitable for a local meter or
 active-speaker input. It rides its own channel rather than `State`, because it
 changes every buffer and `changed` reports lifecycle transitions only.

--- a/rs/moq-audio/src/encode/capture.rs
+++ b/rs/moq-audio/src/encode/capture.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 
 use rand::RngExt;
 
+use super::producer::Reserved;
 use super::{Input, Options, Producer};
 use crate::capture;
 use crate::resample::{Resampler, remix, validate_channels};
@@ -25,7 +26,7 @@ pub enum Status {
 	Stopped,
 	/// Capture is enabled and waiting for a subscriber.
 	Waiting,
-	/// The selected input is being opened.
+	/// The selected input is being probed or opened.
 	Starting,
 	/// Post-processing samples are being encoded and published.
 	Live,
@@ -185,35 +186,27 @@ impl Publication {
 	/// streams are not `Send`; [`Publication`] itself is `Send + Sync`, so the
 	/// controls can live anywhere.
 	///
-	/// Reads the source's PCM layout first, since the catalog rendition is
-	/// registered from it, retrying a transient discovery failure with capped
-	/// backoff. A source that never appears keeps this pending, so the caller
-	/// owns the timeout by dropping the future.
-	pub async fn new(
+	/// The track is registered here, but its catalog rendition describes the
+	/// source's PCM layout, so the driver probes for that first and registers the
+	/// rendition on the first success. Until then the broadcast advertises no
+	/// audio, which [`Status::Starting`] reports. A source that never appears is
+	/// retried with capped backoff rather than blocking the controls.
+	pub fn new(
 		broadcast: moq_net::broadcast::Producer,
 		catalog: moq_mux::catalog::Producer,
 		options: PublicationOptions,
 	) -> Result<(Self, Driver), Error> {
-		let mut supervisor = Supervisor::default();
-		let mut source = DeviceSource;
-		let layout = supervisor.discover(&mut source, &options.capture).await?;
-		Self::build(broadcast, catalog, options, layout, supervisor)
+		Self::build(broadcast, catalog, options, Supervisor::default())
 	}
 
 	fn build(
 		mut broadcast: moq_net::broadcast::Producer,
 		catalog: moq_mux::catalog::Producer,
 		options: PublicationOptions,
-		layout: capture::Layout,
 		supervisor: Supervisor,
 	) -> Result<(Self, Driver), Error> {
-		let input = Input {
-			format: Format::F32,
-			sample_rate: layout.sample_rate,
-			channels: layout.channels,
-		};
-		let producer = Producer::new(&mut broadcast, catalog, input, &options.encode)?;
-		let track_name: Arc<str> = producer.track_name().into();
+		let reserved = Reserved::new(&mut broadcast, catalog, &options.encode)?;
+		let track_name: Arc<str> = reserved.name().into();
 		let desired = Desired {
 			config: options.capture,
 			enabled: true,
@@ -221,7 +214,7 @@ impl Publication {
 		};
 		let initial = PublishedState {
 			state: State {
-				status: Status::Waiting,
+				status: Status::Starting,
 				source: desired.config.source.clone(),
 				device: None,
 				failure: None,
@@ -240,7 +233,8 @@ impl Publication {
 		};
 		let driver = Driver {
 			_broadcast: broadcast,
-			producer: Some(producer),
+			track: Some(Track::Reserved(reserved)),
+			encode: options.encode,
 			clock: options.clock,
 			supervisor,
 			desired: desired_tx.consume(),
@@ -338,7 +332,9 @@ impl Publication {
 /// ends the driver and releases that identity.
 pub struct Driver {
 	_broadcast: moq_net::broadcast::Producer,
-	producer: Option<Producer>,
+	track: Option<Track>,
+	/// The codec settings the rendition is built from once the layout is known.
+	encode: Options,
 	clock: moq_mux::Clock,
 	supervisor: Supervisor,
 	desired: kio::Consumer<Desired>,
@@ -364,18 +360,22 @@ impl Driver {
 
 	async fn run_with<S: CaptureSource>(mut self, mut source: S) -> Result<(), Error> {
 		let result = self.drive(&mut source).await;
-		let producer = self.producer.take().expect("driver always owns its producer");
+		// An encoder that rejects the discovered layout consumes the reservation,
+		// leaving nothing to finalize.
+		let track = self.track.take();
 
 		match &result {
 			Ok(()) => {
 				self.update(Status::Ended, None, None);
-				if let Err(err) = producer.finish() {
+				if let Some(Err(err)) = track.map(Track::finish) {
 					tracing::debug!(error = %err, "audio track finish after capture ended");
 				}
 			}
 			Err(err) => {
 				self.fail(err);
-				producer.abort(moq_net::Error::Transport(err.to_string()));
+				if let Some(track) = track {
+					track.abort(moq_net::Error::Transport(err.to_string()));
+				}
 			}
 		}
 		self.silence();
@@ -385,33 +385,105 @@ impl Driver {
 
 	async fn drive<S: CaptureSource>(&mut self, source: &mut S) -> Result<(), Error> {
 		let track = self
-			.producer
+			.track
 			.as_ref()
-			.expect("driver always owns its producer")
+			.expect("driver always owns its track")
 			.track()
 			.clone();
 
+		if let Some(result) = self.discover(source, &track).await {
+			return result;
+		}
+		self.capture(source, &track).await
+	}
+
+	/// Probe the selected input for the PCM layout the catalog rendition
+	/// describes, registering the rendition on the first success.
+	///
+	/// Returns `Some` when the driver should exit before that happens: the
+	/// controls were dropped, the track ended, or a probe failed terminally with
+	/// nobody left to retry it.
+	async fn discover<S: CaptureSource>(
+		&mut self,
+		source: &mut S,
+		track: &moq_net::track::Producer,
+	) -> Option<Result<(), Error>> {
 		loop {
 			let desired = self.desired.read().clone();
 			if !desired.enabled {
-				self.silence();
-				self.update(Status::Stopped, None, None);
-				tokio::select! {
-					biased;
-					changed = desired_changed(&self.desired, desired.revision) => {
-						if changed.is_none() { return Ok(()) }
-						continue;
-					}
-					err = track.closed() => {
-						log_track_ended(err);
-						return Ok(());
-					}
+				if !self.idle(track, desired.revision).await {
+					return Some(Ok(()));
 				}
+				continue;
+			}
+
+			self.update(Status::Starting, None, None);
+			let discovered = tokio::select! {
+				biased;
+				changed = desired_changed(&self.desired, desired.revision) => {
+					if changed.is_none() {
+						return Some(Ok(()));
+					}
+					// A replaced source deserves an immediate probe, not the backoff
+					// the one it replaced had climbed to.
+					self.supervisor.reset();
+					continue;
+				}
+				closed = track.closed() => {
+					log_track_ended(closed);
+					return Some(Ok(()));
+				}
+				layout = self.supervisor.discover(source, &desired.config) => layout,
+			};
+
+			let layout = match discovered {
+				Ok(layout) => layout,
+				Err(err) => match self.failed(err, track, desired.revision).await {
+					Some(result) => return Some(result),
+					None => continue,
+				},
+			};
+
+			let Some(Track::Reserved(reserved)) = self.track.take() else {
+				unreachable!("the track stays reserved until discovery succeeds")
+			};
+			let input = Input {
+				format: Format::F32,
+				sample_rate: layout.sample_rate,
+				channels: layout.channels,
+			};
+			return match reserved.encode(input, &self.encode) {
+				Ok(producer) => {
+					self.track = Some(Track::Encoding(producer));
+					None
+				}
+				Err(err) => Some(Err(err)),
+			};
+		}
+	}
+
+	async fn capture<S: CaptureSource>(
+		&mut self,
+		source: &mut S,
+		track: &moq_net::track::Producer,
+	) -> Result<(), Error> {
+		loop {
+			let desired = self.desired.read().clone();
+			if !desired.enabled {
+				if !self.idle(track, desired.revision).await {
+					return Ok(());
+				}
+				continue;
 			}
 
 			let event = {
-				let producer = self.producer.as_mut().expect("driver always owns its producer");
-				let mut demand = TrackDemand { track: &track };
+				// Borrow the field, not all of `self`: the select below needs the rest.
+				let producer = self
+					.track
+					.as_mut()
+					.and_then(Track::producer)
+					.expect("the layout is discovered before capture runs");
+				let mut demand = TrackDemand { track };
 				let mut output = EncoderOutput {
 					producer,
 					clock: &self.clock,
@@ -439,27 +511,58 @@ impl Driver {
 				}
 				DriveEvent::Capture(Ok(())) => return Ok(()),
 				DriveEvent::Capture(Err(err)) => {
-					self.fail(&err);
-					if !self.park_on_failure || track.is_closed() {
-						return Err(err);
-					}
-					tokio::select! {
-						biased;
-						changed = desired_changed(&self.desired, desired.revision) => {
-							if changed.is_none() { return Ok(()) }
-						}
-						closed = track.closed() => {
-							log_track_ended(closed);
-							return Err(err);
-						}
+					if let Some(result) = self.failed(err, track, desired.revision).await {
+						return result;
 					}
 				}
 			}
 		}
 	}
 
+	/// Release the input and wait for a control action, returning false when the
+	/// driver should exit.
+	async fn idle(&mut self, track: &moq_net::track::Producer, revision: u64) -> bool {
+		self.silence();
+		self.update(Status::Stopped, None, None);
+		tokio::select! {
+			biased;
+			changed = desired_changed(&self.desired, revision) => changed.is_some(),
+			err = track.closed() => {
+				log_track_ended(err);
+				false
+			}
+		}
+	}
+
+	/// Publish a terminal input failure and park until a control action retries
+	/// it, returning `Some` with the result when the driver should exit instead.
+	async fn failed(
+		&mut self,
+		err: Error,
+		track: &moq_net::track::Producer,
+		revision: u64,
+	) -> Option<Result<(), Error>> {
+		self.fail(&err);
+		if !self.park_on_failure || track.is_closed() {
+			return Some(Err(err));
+		}
+		tokio::select! {
+			biased;
+			changed = desired_changed(&self.desired, revision) => {
+				changed.is_none().then_some(Ok(()))
+			}
+			closed = track.closed() => {
+				log_track_ended(closed);
+				Some(Err(err))
+			}
+		}
+	}
+
 	fn producer_mut(&mut self) -> &mut Producer {
-		self.producer.as_mut().expect("driver always owns its producer")
+		self.track
+			.as_mut()
+			.and_then(Track::producer)
+			.expect("the layout is discovered before capture runs")
 	}
 
 	fn update(&self, status: Status, device: Option<capture::Device>, failure: Option<Error>) {
@@ -488,6 +591,45 @@ impl Driver {
 enum DriveEvent {
 	Control(Option<Desired>),
 	Capture(Result<(), Error>),
+}
+
+/// The publication's track, before and after the input's layout is known.
+enum Track {
+	/// Registered in the broadcast but not the catalog, because the rendition
+	/// describes a PCM layout no probe has returned yet.
+	Reserved(Reserved),
+	/// Probed, so the rendition is registered and samples can be encoded.
+	Encoding(Producer),
+}
+
+impl Track {
+	fn track(&self) -> &moq_net::track::Producer {
+		match self {
+			Self::Reserved(reserved) => reserved.track(),
+			Self::Encoding(producer) => producer.track(),
+		}
+	}
+
+	fn producer(&mut self) -> Option<&mut Producer> {
+		match self {
+			Self::Reserved(_) => None,
+			Self::Encoding(producer) => Some(producer),
+		}
+	}
+
+	fn finish(self) -> Result<(), Error> {
+		match self {
+			Self::Reserved(reserved) => reserved.finish(),
+			Self::Encoding(producer) => producer.finish(),
+		}
+	}
+
+	fn abort(self, err: moq_net::Error) {
+		match self {
+			Self::Reserved(reserved) => reserved.abort(err),
+			Self::Encoding(producer) => producer.abort(err),
+		}
+	}
 }
 
 async fn desired_changed(desired: &kio::Consumer<Desired>, revision: u64) -> Option<Desired> {
@@ -551,7 +693,7 @@ pub async fn publish_capture(
 ) -> Result<(), Error> {
 	let options = PublicationOptions { capture, encode, clock };
 	// Held, not dropped: the driver ends as soon as the last control handle goes.
-	let (_publication, driver) = Publication::new(broadcast, catalog, options).await?;
+	let (_publication, driver) = Publication::new(broadcast, catalog, options)?;
 	Driver {
 		park_on_failure: false,
 		..driver
@@ -1252,26 +1394,23 @@ mod tests {
 
 	async fn setup_publication(
 		opens: impl IntoIterator<Item = Open>,
-	) -> (Publication, Driver, MockSource, moq_net::track::Subscriber) {
+	) -> (
+		Publication,
+		Driver,
+		MockSource,
+		moq_net::track::Subscriber,
+		moq_mux::catalog::Producer,
+	) {
 		let mut broadcast = moq_net::broadcast::Info::new().produce();
 		let consumer = broadcast.consume();
 		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
 		let mut options = PublicationOptions::default();
 		options.capture.source = capture::Source::Microphone(Some("first".into()));
 		options.encode.track = Some("audio".into());
-		let (publication, driver) = Publication::build(
-			broadcast,
-			catalog,
-			options,
-			capture::Layout {
-				sample_rate: 48_000,
-				channels: 2,
-			},
-			Supervisor::exact(),
-		)
-		.unwrap();
+		let (publication, driver) =
+			Publication::build(broadcast, catalog.clone(), options, Supervisor::exact()).unwrap();
 		let subscription = consumer.track("audio").unwrap().subscribe(None).await.unwrap();
-		(publication, driver, source(opens, false), subscription)
+		(publication, driver, source(opens, false), subscription, catalog)
 	}
 
 	async fn wait_for(publication: &mut Publication, status: Status) -> State {
@@ -1292,7 +1431,7 @@ mod tests {
 	async fn failed_publication_retries_but_duplicate_start_is_idempotent() {
 		let (_events, recovered) = stream(None);
 		let recovered = with_device(recovered, "allowed");
-		let (mut publication, driver, source, _subscription) =
+		let (mut publication, driver, source, _subscription, _catalog) =
 			setup_publication([Open::Fatal("permission denied"), Open::Stream(recovered)]).await;
 		let attempts = source.attempts.clone();
 		let task = tokio::spawn(driver.run_with(source));
@@ -1321,7 +1460,7 @@ mod tests {
 		let first = with_device(first, "first");
 		let (_second_events, second) = stream(None);
 		let second = with_device(second, "second");
-		let (mut publication, driver, source, _subscription) =
+		let (mut publication, driver, source, _subscription, _catalog) =
 			setup_publication([Open::Stream(first), Open::Stream(second)]).await;
 		let task = tokio::spawn(driver.run_with(source));
 
@@ -1344,7 +1483,7 @@ mod tests {
 	#[tokio::test]
 	async fn reports_post_processing_level() {
 		let (events, input) = stream(None);
-		let (mut publication, driver, source, _subscription) = setup_publication([Open::Stream(input)]).await;
+		let (mut publication, driver, source, _subscription, _catalog) = setup_publication([Open::Stream(input)]).await;
 		let task = tokio::spawn(driver.run_with(source));
 		wait_for(&mut publication, Status::Live).await;
 		assert_eq!(publication.level(), Level::default());
@@ -1374,7 +1513,7 @@ mod tests {
 	#[tokio::test]
 	async fn level_updates_do_not_wake_state_waiters() {
 		let (events, input) = stream(None);
-		let (mut publication, driver, source, _subscription) = setup_publication([Open::Stream(input)]).await;
+		let (mut publication, driver, source, _subscription, _catalog) = setup_publication([Open::Stream(input)]).await;
 		let task = tokio::spawn(driver.run_with(source));
 		wait_for(&mut publication, Status::Live).await;
 
@@ -1395,7 +1534,8 @@ mod tests {
 	/// failure would hang `moq import capture` instead of reporting the denial.
 	#[tokio::test]
 	async fn a_publication_without_controls_returns_its_terminal_failure() {
-		let (publication, driver, source, _subscription) = setup_publication([Open::Fatal("permission denied")]).await;
+		let (publication, driver, source, _subscription, _catalog) =
+			setup_publication([Open::Fatal("permission denied")]).await;
 		let driver = Driver {
 			park_on_failure: false,
 			..driver
@@ -1413,7 +1553,7 @@ mod tests {
 	/// A retained publication keeps the track and waits to be told what to do.
 	#[tokio::test]
 	async fn a_terminal_failure_parks_a_retained_publication() {
-		let (mut publication, driver, source, _subscription) =
+		let (mut publication, driver, source, _subscription, _catalog) =
 			setup_publication([Open::Fatal("permission denied")]).await;
 		let task = tokio::spawn(driver.run_with(source));
 
@@ -1428,7 +1568,7 @@ mod tests {
 	#[tokio::test]
 	async fn stopping_zeroes_the_level() {
 		let (events, input) = stream(None);
-		let (mut publication, driver, source, _subscription) = setup_publication([Open::Stream(input)]).await;
+		let (mut publication, driver, source, _subscription, _catalog) = setup_publication([Open::Stream(input)]).await;
 		let task = tokio::spawn(driver.run_with(source));
 		wait_for(&mut publication, Status::Live).await;
 
@@ -1457,7 +1597,7 @@ mod tests {
 	async fn a_terminal_live_failure_keeps_the_device_that_failed() {
 		let (events, input) = stream(None);
 		let input = with_device(input, "wired");
-		let (mut publication, driver, source, _subscription) = setup_publication([Open::Stream(input)]).await;
+		let (mut publication, driver, source, _subscription, _catalog) = setup_publication([Open::Stream(input)]).await;
 		let task = tokio::spawn(driver.run_with(source));
 		wait_for(&mut publication, Status::Live).await;
 
@@ -1470,6 +1610,67 @@ mod tests {
 		assert!(matches!(failed.failure(), Some(Error::Capture(message)) if message == "device vanished"));
 
 		// Retained controls park rather than end, so dropping them is the clean exit.
+		drop(publication);
+		task.await.unwrap().unwrap();
+	}
+
+	/// The whole point of a retained handle is to outlive a missing device, so
+	/// construction must not wait on one and the controls must work meanwhile.
+	#[tokio::test]
+	async fn controls_are_live_before_the_input_is_discovered() {
+		let (mut publication, driver, mut source, _subscription, catalog) = setup_publication([]).await;
+		// Nothing ever answers a probe, which is a machine with no input device.
+		source.formats.clear();
+		let attempts = source.format_attempts.clone();
+		let task = tokio::spawn(driver.run_with(source));
+
+		assert_eq!(publication.track_name(), "audio");
+		tokio::time::timeout(Duration::from_secs(1), async {
+			while attempts.load(Ordering::SeqCst) == 0 {
+				tokio::task::yield_now().await;
+			}
+		})
+		.await
+		.expect("the driver never probed the input");
+
+		assert_eq!(publication.state().status(), Status::Starting);
+		// The layout is unknown, so there is no rendition to advertise yet.
+		assert!(catalog.snapshot().audio.renditions.is_empty());
+
+		// A probe nothing answers is still cancellable by the controls.
+		publication.stop();
+		wait_for(&mut publication, Status::Stopped).await;
+		assert_eq!(attempts.load(Ordering::SeqCst), 1);
+
+		drop(publication);
+		task.await.unwrap().unwrap();
+	}
+
+	/// The rendition the catalog advertises describes the discovered layout, so
+	/// it appears only once a probe succeeds.
+	#[tokio::test]
+	async fn discovery_registers_the_rendition() {
+		let (_events, input) = stream(None);
+		let (mut publication, driver, mut source, _subscription, catalog) =
+			setup_publication([Open::Stream(input)]).await;
+		source.formats = [Discovery::Fatal("permission denied"), Discovery::Format(48_000, 2)]
+			.into_iter()
+			.collect();
+		let task = tokio::spawn(driver.run_with(source));
+
+		let failed = wait_for(&mut publication, Status::Failed).await;
+		assert!(matches!(failed.failure(), Some(Error::Capture(message)) if message == "permission denied"));
+		assert!(catalog.snapshot().audio.renditions.is_empty());
+
+		// A terminal probe failure parks like a terminal open failure, so `start`
+		// retries it rather than the driver ending with no track.
+		publication.start();
+		wait_for(&mut publication, Status::Live).await;
+		let renditions = catalog.snapshot().audio.renditions;
+		let config = renditions.get("audio").expect("the rendition was never registered");
+		assert_eq!(config.sample_rate, 48_000);
+		assert_eq!(config.channel_count, 2);
+
 		drop(publication);
 		task.await.unwrap().unwrap();
 	}

--- a/rs/moq-audio/src/encode/capture.rs
+++ b/rs/moq-audio/src/encode/capture.rs
@@ -360,22 +360,18 @@ impl Driver {
 
 	async fn run_with<S: CaptureSource>(mut self, mut source: S) -> Result<(), Error> {
 		let result = self.drive(&mut source).await;
-		// An encoder that rejects the discovered layout consumes the reservation,
-		// leaving nothing to finalize.
-		let track = self.track.take();
+		let track = self.track.take().expect("driver always owns its track");
 
 		match &result {
 			Ok(()) => {
 				self.update(Status::Ended, None, None);
-				if let Some(Err(err)) = track.map(Track::finish) {
+				if let Err(err) = track.finish() {
 					tracing::debug!(error = %err, "audio track finish after capture ended");
 				}
 			}
 			Err(err) => {
 				self.fail(err);
-				if let Some(track) = track {
-					track.abort(moq_net::Error::Transport(err.to_string()));
-				}
+				track.abort(moq_net::Error::Transport(err.to_string()));
 			}
 		}
 		self.silence();
@@ -444,7 +440,7 @@ impl Driver {
 				},
 			};
 
-			let Some(Track::Reserved(reserved)) = self.track.take() else {
+			let Some(Track::Reserved(mut reserved)) = self.track.take() else {
 				unreachable!("the track stays reserved until discovery succeeds")
 			};
 			let input = Input {
@@ -452,13 +448,21 @@ impl Driver {
 				sample_rate: layout.sample_rate,
 				channels: layout.channels,
 			};
-			return match reserved.encode(input, &self.encode) {
-				Ok(producer) => {
-					self.track = Some(Track::Encoding(producer));
-					None
+			let registered = match reserved.register(input, &self.encode) {
+				Ok(registered) => registered,
+				// A layout the codec rejects parks like any other terminal failure,
+				// so `replace` can still hand the same track a compatible input.
+				Err(err) => {
+					self.track = Some(Track::Reserved(reserved));
+					match self.failed(err, track, desired.revision).await {
+						Some(result) => return Some(result),
+						None => continue,
+					}
 				}
-				Err(err) => Some(Err(err)),
 			};
+
+			self.track = Some(Track::Encoding(reserved.encode(registered)));
+			return None;
 		}
 	}
 
@@ -594,6 +598,10 @@ enum DriveEvent {
 }
 
 /// The publication's track, before and after the input's layout is known.
+///
+/// One per publication, moved twice in its life, so the size difference between
+/// the variants never costs a copy worth an allocation to avoid.
+#[allow(clippy::large_enum_variant)]
 enum Track {
 	/// Registered in the broadcast but not the catalog, because the rendition
 	/// describes a PCM layout no probe has returned yet.
@@ -1413,6 +1421,30 @@ mod tests {
 		(publication, driver, source(opens, false), subscription, catalog)
 	}
 
+	/// Same, with the caller's encode options, which `setup_publication` fixes.
+	async fn setup_encoding(
+		channels: u32,
+		opens: impl IntoIterator<Item = Open>,
+	) -> (
+		Publication,
+		Driver,
+		MockSource,
+		moq_net::track::Subscriber,
+		moq_mux::catalog::Producer,
+	) {
+		let mut broadcast = moq_net::broadcast::Info::new().produce();
+		let consumer = broadcast.consume();
+		let catalog = moq_mux::catalog::Producer::new(&mut broadcast).unwrap();
+		let mut options = PublicationOptions::default();
+		options.capture.source = capture::Source::Microphone(Some("first".into()));
+		options.encode.track = Some("audio".into());
+		options.encode.channels = Some(channels);
+		let (publication, driver) =
+			Publication::build(broadcast, catalog.clone(), options, Supervisor::exact()).unwrap();
+		let subscription = consumer.track("audio").unwrap().subscribe(None).await.unwrap();
+		(publication, driver, source(opens, false), subscription, catalog)
+	}
+
 	async fn wait_for(publication: &mut Publication, status: Status) -> State {
 		tokio::time::timeout(Duration::from_secs(1), async {
 			loop {
@@ -1670,6 +1702,33 @@ mod tests {
 		let config = renditions.get("audio").expect("the rendition was never registered");
 		assert_eq!(config.sample_rate, 48_000);
 		assert_eq!(config.channel_count, 2);
+
+		drop(publication);
+		task.await.unwrap().unwrap();
+	}
+
+	/// A discovered layout the codec rejects must not take the track down with
+	/// it: the whole promise of the retained handle is that `replace` can still
+	/// point the same track at an input that works.
+	#[tokio::test]
+	async fn a_rejected_layout_parks_the_publication() {
+		let (_events, input) = stream(None);
+		// Opus does not remap channels, so a stereo codec rejects a mono input.
+		let (mut publication, driver, mut source, _subscription, catalog) =
+			setup_encoding(2, [Open::Stream(input)]).await;
+		source.formats = [Discovery::Format(48_000, 1), Discovery::Format(48_000, 2)]
+			.into_iter()
+			.collect();
+		let task = tokio::spawn(driver.run_with(source));
+
+		let failed = wait_for(&mut publication, Status::Failed).await;
+		assert!(failed.failure().is_some());
+		assert!(!publication.is_finished());
+		assert!(catalog.snapshot().audio.renditions.is_empty());
+
+		publication.replace(capture::Source::Microphone(Some("second".into())));
+		wait_for(&mut publication, Status::Live).await;
+		assert_eq!(catalog.snapshot().audio.renditions.len(), 1);
 
 		drop(publication);
 		task.await.unwrap().unwrap();

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -151,8 +151,12 @@ impl<E: CatalogExt> Reserved<E> {
 		Ok(Self { catalog, track, name })
 	}
 
-	/// Register the rendition for `input` and start encoding into the track.
-	pub(crate) fn encode(mut self, input: Input, options: &Options) -> Result<Producer<E>, Error> {
+	/// Build the encoder for `input` and register the rendition describing it.
+	///
+	/// Separate from [`encode`](Self::encode), which cannot fail, so a layout the
+	/// codec rejects (more channels than Opus takes, a mismatch with
+	/// [`Options::channels`]) leaves the reservation intact for another input.
+	pub(crate) fn register(&mut self, input: Input, options: &Options) -> Result<Registered, Error> {
 		let encoder = Encoder::new(&options.config(input))?;
 		let input = &encoder.config().input;
 
@@ -175,9 +179,14 @@ impl<E: CatalogExt> Reserved<E> {
 		config.timeline = Some(self.catalog.timeline(&self.name)?.section());
 		self.catalog.lock().audio.insert(&self.name, config)?;
 
-		Ok(Producer {
-			encoder,
-			resampler,
+		Ok(Registered { encoder, resampler })
+	}
+
+	/// Spend the reservation on a registered encoder, publishing through the track.
+	pub(crate) fn encode(self, registered: Registered) -> Producer<E> {
+		Producer {
+			encoder: registered.encoder,
+			resampler: registered.resampler,
 			track: self.track,
 			rendition: Rendition {
 				catalog: self.catalog,
@@ -189,8 +198,17 @@ impl<E: CatalogExt> Reserved<E> {
 			pending_discontinuity: false,
 			decoder_boundary: true,
 			activity: Activity::Active,
-		})
+		}
 	}
+}
+
+/// A registered rendition, waiting for its [`Reserved`] to be spent on it.
+///
+/// Proof that [`Reserved::register`] succeeded, so [`Reserved::encode`] takes no
+/// fallible step and cannot strand the track it consumes.
+pub(crate) struct Registered {
+	encoder: Encoder,
+	resampler: Option<Resampler>,
 }
 
 /// What a capture publication needs while its layout is still undiscovered.
@@ -227,7 +245,9 @@ impl<E: CatalogExt> Producer<E> {
 		input: Input,
 		options: &Options,
 	) -> Result<Self, Error> {
-		Reserved::new(broadcast, catalog, options)?.encode(input, options)
+		let mut reserved = Reserved::new(broadcast, catalog, options)?;
+		let registered = reserved.register(input, options)?;
+		Ok(reserved.encode(registered))
 	}
 
 	/// The name of the published track, which is [`Options::track`] resolved.

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -117,15 +117,42 @@ struct Terminal {
 	codec_rate: u32,
 }
 
-impl<E: CatalogExt> Producer<E> {
-	/// Publish a track encoding `input` into `broadcast`, registering its
-	/// rendition in `catalog` immediately.
-	pub fn new(
+/// A published track whose PCM layout is not known yet.
+///
+/// The track exists in the broadcast immediately, so its name and subscriber
+/// state are available, while the catalog rendition waits for
+/// [`encode`](Self::encode) to supply the layout it describes. Unlike a catalog
+/// [`Reserved`](moq_mux::catalog::Reserved) this does not withhold the catalog:
+/// subscribers see the broadcast without this rendition until it resolves.
+pub(crate) struct Reserved<E: CatalogExt = ()> {
+	catalog: moq_mux::catalog::Producer<E>,
+	track: moq_mux::container::Producer<moq_mux::container::legacy::Wire>,
+	name: String,
+}
+
+impl<E: CatalogExt> Reserved<E> {
+	pub(crate) fn new(
 		broadcast: &mut moq_net::broadcast::Producer,
 		catalog: moq_mux::catalog::Producer<E>,
-		input: Input,
 		options: &Options,
 	) -> Result<Self, Error> {
+		let track = match &options.track {
+			// The catalog's info carries the microsecond timescale audio hang frames stamp, so
+			// Lite05 subscribers know what scale to expect and the model layer accepts
+			// Frame::timestamp on append, plus whatever retention the broadcast declared.
+			Some(name) => broadcast.create_track(name.clone(), catalog.track_info())?,
+			// Mirrors the video side, which derives a unique name from the codec
+			// rather than making every caller invent one.
+			None => broadcast.unique_track(&format!(".{}", options.codec), catalog.track_info())?,
+		};
+		let name = track.name().to_string();
+		let track = catalog.media_producer(track, moq_mux::container::legacy::Wire)?;
+
+		Ok(Self { catalog, track, name })
+	}
+
+	/// Register the rendition for `input` and start encoding into the track.
+	pub(crate) fn encode(mut self, input: Input, options: &Options) -> Result<Producer<E>, Error> {
 		let encoder = Encoder::new(&options.config(input))?;
 		let input = &encoder.config().input;
 
@@ -144,28 +171,18 @@ impl<E: CatalogExt> Producer<E> {
 			)?)
 		};
 
-		let track = match &options.track {
-			// The catalog's info carries the microsecond timescale audio hang frames stamp, so
-			// Lite05 subscribers know what scale to expect and the model layer accepts
-			// Frame::timestamp on append, plus whatever retention the broadcast declared.
-			Some(name) => broadcast.create_track(name.clone(), catalog.track_info())?,
-			// Mirrors the video side, which derives a unique name from the codec
-			// rather than making every caller invent one.
-			None => broadcast.unique_track(&format!(".{}", options.codec), catalog.track_info())?,
-		};
-		let name = track.name().to_string();
-		let track = catalog.media_producer(track, moq_mux::container::legacy::Wire)?;
-
-		let mut catalog_mut = catalog.clone();
 		let mut config = encoder.catalog();
-		config.timeline = Some(catalog.timeline(&name)?.section());
-		catalog_mut.lock().audio.insert(&name, config)?;
+		config.timeline = Some(self.catalog.timeline(&self.name)?.section());
+		self.catalog.lock().audio.insert(&self.name, config)?;
 
-		Ok(Self {
+		Ok(Producer {
 			encoder,
 			resampler,
-			track,
-			rendition: Rendition { catalog, name },
+			track: self.track,
+			rendition: Rendition {
+				catalog: self.catalog,
+				name: self.name,
+			},
 			pending: Vec::new(),
 			frames_produced: 0,
 			epoch_us: None,
@@ -173,6 +190,44 @@ impl<E: CatalogExt> Producer<E> {
 			decoder_boundary: true,
 			activity: Activity::Active,
 		})
+	}
+}
+
+/// What a capture publication needs while its layout is still undiscovered.
+#[cfg(feature = "capture")]
+impl<E: CatalogExt> Reserved<E> {
+	/// The resolved track name, available before the layout is.
+	pub(crate) fn name(&self) -> &str {
+		&self.name
+	}
+
+	/// The underlying track producer, e.g. to watch subscriber state.
+	pub(crate) fn track(&self) -> &moq_net::track::Producer {
+		self.track.track()
+	}
+
+	/// Finalize a track that never got a rendition.
+	pub(crate) fn finish(mut self) -> Result<(), Error> {
+		self.track.finish()?;
+		Ok(())
+	}
+
+	/// Abort a track that never got a rendition, so subscribers see `err`.
+	pub(crate) fn abort(self, err: moq_net::Error) {
+		self.track.abort(err);
+	}
+}
+
+impl<E: CatalogExt> Producer<E> {
+	/// Publish a track encoding `input` into `broadcast`, registering its
+	/// rendition in `catalog` immediately.
+	pub fn new(
+		broadcast: &mut moq_net::broadcast::Producer,
+		catalog: moq_mux::catalog::Producer<E>,
+		input: Input,
+		options: &Options,
+	) -> Result<Self, Error> {
+		Reserved::new(broadcast, catalog, options)?.encode(input, options)
 	}
 
 	/// The name of the published track, which is [`Options::track`] resolved.


### PR DESCRIPTION
Fixes #3324.

## Summary

- **Root cause**: `encode::Publication::new` awaited `Supervisor::discover`, which retries a retryable `capture::Failure` with capped backoff and no attempt budget. `capture::format` -> `resolve` classifies "no default input device" as retryable, so on a machine with no input the constructor never returned. The caller got no `Publication`, so there was nothing to `stop()`, `replace()`, or observe, which is the opposite of what a retained control handle is for.
- Discovery moves into `Driver::run`. `Publication::new` registers the track (so the name and broadcast identity are available immediately) and the driver probes for the PCM layout, registering the catalog rendition on the first success.
- Until that probe succeeds the broadcast advertises no audio rendition, and the publication reports `Status::Starting`. This is the deliberate behavior change the issue flagged: a subscriber can briefly see a broadcast whose catalog has no audio.
- A probe is now cancellable by the controls: `stop()` ends it and `replace()` retargets it, resetting the backoff the replaced source had climbed to. Previously the source was fixed at construction, before any control existed.
- `encode::Producer::new` is split internally into a `pub(crate) Reserved` (track created, rendition deferred) plus `Reserved::register` / `Reserved::encode`. This does *not* use the catalog's `Reserved` gate, which would withhold the whole catalog until the microphone appeared, i.e. the same hang moved one layer down.
- A discovered layout the codec rejects (more channels than Opus takes, or a mismatch with `Options::channels`) parks in `Status::Failed` with the track intact, so `replace()` can still point it at a working input. `register` is the fallible half behind `&mut self` and returns a `Registered` token that the infallible `encode` spends, so the failure path cannot strand the track. (Found by Codex in review.)

## Public API changes

- **Breaking** (`moq-audio` is `0.0.x`, so per Branch Targeting this lands on `main`): `encode::Publication::new` is no longer `async`. Callers drop the `.await`; it still returns `Result<(Publication, Driver), Error>`.
- No other public item changes. `Reserved` / `Registered` are `pub(crate)`; `encode::Producer::new` keeps its signature and behavior.

## Test plan

- `just fix`, `just check`, `just test` (all green), plus `cargo clippy -p moq-audio --features capture --all-targets -- -D warnings`, since `just check` builds moq-audio without the optional `capture` feature and so never lints this module.
- New `controls_are_live_before_the_input_is_discovered`: with a source that never answers a probe, the publication still exists, `track_name()` resolves, the catalog carries no audio rendition, and `stop()` cancels the in-flight probe. This fails without the change, because construction never returns.
- New `discovery_registers_the_rendition`: a terminal probe failure parks the retained publication with no rendition; `start()` retries, and the rendition then appears with the discovered sample rate and channel count.
- New `a_rejected_layout_parks_the_publication`: a mono input against `channels: Some(2)` parks instead of ending the driver, and `replace()` onto a stereo input registers the rendition and goes live.
- Existing capture tests moved to the deferred setup (`Publication::build` no longer takes a layout) and still pass, including the terminal-failure, replace, and level cases.

## Cross-package sync

`doc/lib/rs/crate/moq-audio.md` updated (the example loses its `.await`, plus the new rendition timing). No other row applies: no wire, catalog format, FFI, or CLI surface changed, and nothing outside `moq-audio` and that doc references `Publication`.

(Written by Claude Opus 5)
