### PR TITLE
fix(packaging): render nfpm environment variables

### DIFF
--- a/.github/workflows/moq-cli.yml
+++ b/.github/workflows/moq-cli.yml
@@ -75,13 +75,7 @@ jobs:
           VERSION: ${{ steps.parse.outputs.version }}
           ARCH: ${{ matrix.deb-arch }}
           BINARY_PATH: target/${{ matrix.target }}/release/moq
-        run: |
-          # nfpm doesn't expand ${VAR} in contents[].src or templating
-          # there either, so render the env vars in ourselves.
-          # shellcheck disable=SC2016  # envsubst varlist must be single-quoted
-          envsubst '$VERSION $ARCH $BINARY_PATH' \
-            < packaging/moq-cli/nfpm.yaml > /tmp/nfpm.yaml
-          nfpm pkg --packager deb --config /tmp/nfpm.yaml --target dist/
+        run: rs/scripts/package-nfpm.sh packaging/moq-cli/nfpm.yaml deb dist/
 
       - name: Package .rpm
         shell: bash
@@ -89,11 +83,7 @@ jobs:
           VERSION: ${{ steps.parse.outputs.version }}
           ARCH: ${{ matrix.rpm-arch }}
           BINARY_PATH: target/${{ matrix.target }}/release/moq
-        run: |
-          # shellcheck disable=SC2016  # envsubst varlist must be single-quoted
-          envsubst '$VERSION $ARCH $BINARY_PATH' \
-            < packaging/moq-cli/nfpm.yaml > /tmp/nfpm.yaml
-          nfpm pkg --packager rpm --config /tmp/nfpm.yaml --target dist/
+        run: rs/scripts/package-nfpm.sh packaging/moq-cli/nfpm.yaml rpm dist/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/moq-gst.yml
+++ b/.github/workflows/moq-gst.yml
@@ -156,10 +156,7 @@ jobs:
           PLUGIN_DIR: /usr/lib/${{ matrix.deb-multiarch }}/gstreamer-1.0
         run: |
           mkdir -p dist
-          # shellcheck disable=SC2016  # envsubst varlist must be single-quoted
-          envsubst '$VERSION $ARCH $PKG_NAME $PLUGIN_PATH $PLUGIN_DIR' \
-            < packaging/moq-gst/nfpm.yaml > /tmp/nfpm.yaml
-          nfpm pkg --packager deb --config /tmp/nfpm.yaml --target dist/
+          rs/scripts/package-nfpm.sh packaging/moq-gst/nfpm.yaml deb dist/
 
       - name: Package .rpm
         shell: bash
@@ -171,10 +168,7 @@ jobs:
           PLUGIN_DIR: /usr/lib64/gstreamer-1.0
         run: |
           mkdir -p dist
-          # shellcheck disable=SC2016  # envsubst varlist must be single-quoted
-          envsubst '$VERSION $ARCH $PKG_NAME $PLUGIN_PATH $PLUGIN_DIR' \
-            < packaging/moq-gst/nfpm.yaml > /tmp/nfpm.yaml
-          nfpm pkg --packager rpm --config /tmp/nfpm.yaml --target dist/
+          rs/scripts/package-nfpm.sh packaging/moq-gst/nfpm.yaml rpm dist/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/moq-relay.yml
+++ b/.github/workflows/moq-relay.yml
@@ -78,11 +78,7 @@ jobs:
           VERSION: ${{ steps.parse.outputs.version }}
           ARCH: ${{ matrix.deb-arch }}
           BINARY_PATH: target/${{ matrix.target }}/release/moq-relay
-        run: |
-          # shellcheck disable=SC2016  # envsubst varlist must be single-quoted
-          envsubst '$VERSION $ARCH $BINARY_PATH' \
-            < packaging/moq-relay/nfpm.yaml > /tmp/nfpm.yaml
-          nfpm pkg --packager deb --config /tmp/nfpm.yaml --target dist/
+        run: rs/scripts/package-nfpm.sh packaging/moq-relay/nfpm.yaml deb dist/
 
       - name: Package .rpm
         shell: bash
@@ -90,11 +86,7 @@ jobs:
           VERSION: ${{ steps.parse.outputs.version }}
           ARCH: ${{ matrix.rpm-arch }}
           BINARY_PATH: target/${{ matrix.target }}/release/moq-relay
-        run: |
-          # shellcheck disable=SC2016  # envsubst varlist must be single-quoted
-          envsubst '$VERSION $ARCH $BINARY_PATH' \
-            < packaging/moq-relay/nfpm.yaml > /tmp/nfpm.yaml
-          nfpm pkg --packager rpm --config /tmp/nfpm.yaml --target dist/
+        run: rs/scripts/package-nfpm.sh packaging/moq-relay/nfpm.yaml rpm dist/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/.github/workflows/moq-token-cli.yml
+++ b/.github/workflows/moq-token-cli.yml
@@ -75,11 +75,7 @@ jobs:
           VERSION: ${{ steps.parse.outputs.version }}
           ARCH: ${{ matrix.deb-arch }}
           BINARY_PATH: target/${{ matrix.target }}/release/moq-token
-        run: |
-          # shellcheck disable=SC2016  # envsubst varlist must be single-quoted
-          envsubst '$VERSION $ARCH $BINARY_PATH' \
-            < packaging/moq-token-cli/nfpm.yaml > /tmp/nfpm.yaml
-          nfpm pkg --packager deb --config /tmp/nfpm.yaml --target dist/
+        run: rs/scripts/package-nfpm.sh packaging/moq-token-cli/nfpm.yaml deb dist/
 
       - name: Package .rpm
         shell: bash
@@ -87,11 +83,7 @@ jobs:
           VERSION: ${{ steps.parse.outputs.version }}
           ARCH: ${{ matrix.rpm-arch }}
           BINARY_PATH: target/${{ matrix.target }}/release/moq-token
-        run: |
-          # shellcheck disable=SC2016  # envsubst varlist must be single-quoted
-          envsubst '$VERSION $ARCH $BINARY_PATH' \
-            < packaging/moq-token-cli/nfpm.yaml > /tmp/nfpm.yaml
-          nfpm pkg --packager rpm --config /tmp/nfpm.yaml --target dist/
+        run: rs/scripts/package-nfpm.sh packaging/moq-token-cli/nfpm.yaml rpm dist/
 
       - name: Upload artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/justfile
+++ b/justfile
@@ -237,7 +237,7 @@ _tools $FILES="":
 
     # `_check-common` runs on every invocation, so its tools are unconditional.
     tools=(actionlint bun jq nix nixfmt shellcheck shfmt taplo)
-    scoped '^(quest/|rs/|Cargo\.(toml|lock)$|rust-toolchain\.toml$)' && tools+=(cargo)
+    scoped '^(quest/|rs/|Cargo\.(toml|lock)$|rust-toolchain\.toml$)' && tools+=(cargo envsubst)
     scoped '^(py/|pyproject\.toml$|uv\.lock$|rs/moq-ffi/)'     && tools+=(uv)
     scoped '^(kt/|rs/moq-ffi/)'                                && tools+=(gradle java)
     # cargo because `go check` builds moq-ffi for the host, and skips on a

--- a/rs/justfile
+++ b/rs/justfile
@@ -46,6 +46,7 @@ check *args:
     just rs _select-test
     just rs _publish-test
     just rs _doc-names-test
+    rs/scripts/package-nfpm.test.sh
     {{ cargo_compile }} clippy --locked --all-targets {{ args }} -- -D warnings
     cargo fmt --all --check
     just rs _doc-names
@@ -656,7 +657,5 @@ package crate packager:
     cargo build --locked --release -p {{ crate }}
     mkdir -p dist
     VERSION="$version" ARCH="$arch" BINARY_PATH="target/release/$bin" \
-    	nfpm pkg --packager {{ packager }} \
-    		--config packaging/{{ crate }}/nfpm.yaml \
-    		--target dist/
+        rs/scripts/package-nfpm.sh packaging/{{ crate }}/nfpm.yaml {{ packager }} dist/
     ls -1 dist/

--- a/rs/moq-gst/package.sh
+++ b/rs/moq-gst/package.sh
@@ -145,10 +145,8 @@ mkdir -p "$OUTPUT_DIR"
 
 echo ">> Running nfpm ($PACKAGER)..."
 export VERSION ARCH="$PKG_ARCH" PKG_NAME PLUGIN_PATH="$BUILT_SO" PLUGIN_DIR
-nfpm pkg \
-    --packager "$PACKAGER" \
-    --config "$WORKSPACE_DIR/packaging/moq-gst/nfpm.yaml" \
-    --target "$OUTPUT_DIR/"
+"$WORKSPACE_DIR/rs/scripts/package-nfpm.sh" \
+    "$WORKSPACE_DIR/packaging/moq-gst/nfpm.yaml" "$PACKAGER" "$OUTPUT_DIR/"
 
 echo ">> Done. Artifacts in: $OUTPUT_DIR"
 ls -1 "$OUTPUT_DIR"

--- a/rs/scripts/package-nfpm.sh
+++ b/rs/scripts/package-nfpm.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if (($# != 3)); then
+    echo "Usage: $0 <config> <packager> <target>" >&2
+    exit 2
+fi
+
+config=$1
+packager=$2
+target=$3
+
+mapfile -t variables < <(envsubst --variables "$(<"$config")")
+format=
+for variable in "${variables[@]}"; do
+    if [[ ! -v "$variable" ]]; then
+        echo "Missing environment variable in $config: $variable" >&2
+        exit 1
+    fi
+    printf -v format '%s$%s ' "$format" "$variable"
+done
+
+rendered=$(mktemp)
+trap 'rm -f "$rendered"' EXIT
+envsubst "$format" <"$config" >"$rendered"
+
+nfpm pkg \
+    --packager "$packager" \
+    --config "$rendered" \
+    --target "$target"

--- a/rs/scripts/package-nfpm.test.sh
+++ b/rs/scripts/package-nfpm.test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v envsubst >/dev/null 2>&1; then
+    exit 0
+fi
+
+scratch=$(mktemp -d)
+trap 'rm -rf "$scratch"' EXIT
+mkdir -p "$scratch/bin" "$scratch/capture"
+
+cat >"$scratch/bin/nfpm" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+while (($#)); do
+	case "$1" in
+		--config)
+			config=$2
+			shift 2
+			;;
+		--packager)
+			printf '%s\n' "$2" >"$NFPM_CAPTURE/packager"
+			shift 2
+			;;
+		--target)
+			printf '%s\n' "$2" >"$NFPM_CAPTURE/target"
+			shift 2
+			;;
+		*) shift ;;
+	esac
+done
+
+cp "$config" "$NFPM_CAPTURE/config.yaml"
+SH
+chmod +x "$scratch/bin/nfpm"
+
+cat >"$scratch/nfpm.yaml" <<'YAML'
+name: test
+version: ${VERSION}
+arch: ${ARCH}
+contents:
+  - src: ${BINARY_PATH}
+    dst: /usr/bin/test
+YAML
+
+PATH="$scratch/bin:$PATH" \
+    NFPM_CAPTURE="$scratch/capture" \
+    VERSION=1.2.3 \
+    ARCH=amd64 \
+    BINARY_PATH=target/release/test \
+    rs/scripts/package-nfpm.sh "$scratch/nfpm.yaml" deb "$scratch/dist"
+
+grep -qx 'version: 1.2.3' "$scratch/capture/config.yaml"
+grep -qx 'arch: amd64' "$scratch/capture/config.yaml"
+grep -qx '  - src: target/release/test' "$scratch/capture/config.yaml"
+grep -qx 'deb' "$scratch/capture/packager"
+grep -qx "$scratch/dist" "$scratch/capture/target"
+
+if PATH="$scratch/bin:$PATH" \
+    NFPM_CAPTURE="$scratch/capture" \
+    VERSION=1.2.3 \
+    ARCH=amd64 \
+    rs/scripts/package-nfpm.sh "$scratch/nfpm.yaml" deb "$scratch/dist" 2>"$scratch/missing.log"; then
+    echo "package-nfpm accepted a missing BINARY_PATH" >&2
+    exit 1
+fi
+grep -qx "Missing environment variable in $scratch/nfpm.yaml: BINARY_PATH" "$scratch/missing.log"


### PR DESCRIPTION
## Summary

- Render nfpm config placeholders before packaging because nfpm treats `${BINARY_PATH}` in `contents[].src` as a literal path.
- Share the renderer across local binary and GStreamer packaging plus release workflows, rejecting missing variables early.
- Add regression coverage for rendered config values and missing variables.

## Public API changes

None.

## Test plan

- `nix develop --command just fix`
- `nix develop --command just check`
- `nix develop --command just test`
- `nix develop --command just rs package moq-token-cli deb`

Cross-package sync is not applicable because this only changes packaging automation.

(Written by GPT-5)
