### PR TITLE
fix(video): compile the PipeWire render test

### DIFF
--- a/rs/moq-video/src/render/renderer.rs
+++ b/rs/moq-video/src/render/renderer.rs
@@ -571,6 +571,7 @@ mod tests {
 			let surface = tokio::time::timeout(std::time::Duration::from_secs(5), stream.read())
 				.await
 				.unwrap_or_else(|_| panic!("timed out waiting for frame {index}"))
+				.unwrap_or_else(|error| panic!("capture failed before frame {index}: {error}"))
 				.unwrap_or_else(|| panic!("capture ended before frame {index}"));
 			let Surface::DmaBuf(buffer) = &surface else {
 				panic!("frame {index} used shared memory instead of DMA-BUF");


### PR DESCRIPTION
## Summary

- Fix the nightly all-features compile failure in the ignored PipeWire DMA-BUF rendering test.
- Root cause: the test treated capture::Stream::read() as Option<Surface>, but it returns Result<Option<Surface>, Error>. Unwrap the capture error before handling end-of-stream.

## Public API changes

- None.

## Test plan

- nix develop --command cargo clippy --locked -p moq-video --all-targets --all-features -- -D warnings
- nix develop --command just fix
- nix develop --command just check
- nix develop --command just test (279 tests passed)

(Written by GPT-5)