### PR TITLE
chore(quest): plan the MPEG-TS and open-GOP quests

### DIFF
--- a/quest/m0/2067-test-open-gop-h-264-tune-in-end-to-end-leading-picture.md
+++ b/quest/m0/2067-test-open-gop-h-264-tune-in-end-to-end-leading-picture.md
@@ -1,46 +1,42 @@
-# [M] Test open-GOP H.264 tune-in end to end (leading-picture handling)
+# [M] Open-GOP H.264: fixture and cold tune-in characterization
 
 ## Goal
 
-Implement and verify the behavior tracked in [#2067](https://github.com/moq-dev/moq/issues/2067)
-within the issue's stated scope and boundaries.
+An open-GOP H.264 broadcast (non-IDR recovery-point keyframes with leading
+pictures) round-trips in the `test/ts` harness as a regression fixture, and
+the cold tune-in behaviour in a WebCodecs viewer is measured and written down:
+glitch duration, dropped versus corrupt frames, and whether any decoder errors.
 
 ## Plan
 
-Use the public issue's scope, implementation notes, and acceptance criteria
-below as the starting plan. Reconcile paths and assumptions with the current
-tree before implementation.
+#2066 taught the H.264 splitter to treat a recovery-point SEI as a keyframe,
+so groups start at the recovery point and the rendition resolves. The
+reference capture from #2050 is the hard case: every recovery point is
+followed in decode order by about seven pictures presented *before* it, which
+reference the previous GOP. At a cold tune-in those leading pictures decode
+against missing references, and nothing in the Rust splitter or the JS
+consumer identifies them. Continuous playback across a recovery point has all
+the references and should be clean.
 
-### Issue context
-
-#### Context
-
-[#2066](https://github.com/moq-dev/moq/pull/2066) fixes [#2050](https://github.com/moq-dev/moq/issues/2050): the H.264 splitter now recognizes recovery-point SEI random access, so open-GOP broadcast H.264 (non-IDR I-slice keyframes) resolves a video rendition and round-trips. That fix is about **catalog/rendition resolution and group boundaries**  -  it makes the group start at the recovery point.
-
-What it does **not** do is validate or smooth out playback behavior at a cold tune-in into an open GOP. This issue tracks that testing (and any follow-up work it surfaces).
-
-#### What needs testing
-
-Two distinct playback situations:
-
-1. **Continuous playback across a recovery point.** All reference frames are already decoded, so this should be clean. Confirm.
-2. **Cold tune-in at a recovery point** (fresh subscriber, first group received). This splits further:
-   - **Clean recovery point** (I-frame, `recovery_frame_cnt = 0`, no leading pictures  -  common for broadcast contribution). Expected to decode cleanly through WebCodecs.
-   - **True open GOP with leading pictures** (B-frames after the I in decode order that reference the *previous* GOP). The I-frame decodes, but those leading B-frames have missing references at tune-in. WebCodecs marks them `"delta"` and behavior is decoder-dependent (Chrome software path typically drops/garbles for a fraction of a GOP; a stricter hardware decoder could error). Neither the Rust splitter nor the JS consumer (`js/hang/src/container/consumer.ts`) identifies/drops leading pictures, so any glitch is exposed to the renderer.
-
-#### Concrete tasks
-
-- \[ ] Determine whether the reference open-GOP capture (`~/CNNiEMEA2.ts` from #2050) actually uses leading pictures  -  inspect POC / `frame_num` ordering around the recovery points  -  so we know which case is real in practice.
-- \[ ] Add an open-GOP source to the `test/ts` harness as a regression fixture (real capture or a synthetic clip with recovery-point SEI and no IDR). #2050 notes `test/ts` now has a `--via-srt` mode to build on.
-- \[ ] End-to-end browser playback of an open-GOP broadcast via `<moq-watch>` (Chrome + WebCodecs): verify continuous playback is clean, and characterize cold tune-in (clean recovery point vs leading-picture case)  -  glitch duration, dropped vs corrupt frames, any decoder error.
-- \[ ] If the leading-picture case causes a real problem, decide whether to drop leading pictures at tune-in (skip B-frames whose references precede the group start until the recovery point is reached), and where that logic should live (Rust ingest vs JS consumer).
-
-#### References
-
-- Splitter fix: `rs/moq-mux/src/codec/h264/split.rs` (recovery-point SEI keyframe detection).
-- JS keyframe/group invariant: `js/hang/src/container/consumer.ts` (forces group index 0 to `keyframe`), `js/watch/src/video/decoder.ts` (`type: frame.keyframe ? "key" : "delta"`).
-- Related: #2050, #2066, #1979.
+- Fixture: `rs/moq-mux/src/container/ts/test_data/scte35/kyrion_dirtystart.ts`
+  is already open GOP with B-frames; confirm it carries leading pictures
+  (POC below the keyframe after a recovery point) and use it, else generate a
+  clip with x264 `open-gop=1` and a recovery-point SEI. The generated clip in
+  `test/ts/run.sh` is closed-GOP IDR today, so add the open-GOP source as a
+  second round-trip rather than replacing it.
+- Characterization: there is no browser playback harness (`test/wasm` is
+  transport-only), so measure by hand through `<moq-watch>` in Chrome:
+  continuous playback across recovery points, cold tune-in at one, and a
+  hardware decoder if available. Record the numbers in the PR and in the
+  leading-picture quest.
+- The consumer-side fix is
+  [Open-GOP leading pictures](/quest/m0/open-gop-leading-pictures.md), which
+  waits on these numbers.
 
 ## Closes
 
 - [#2067](https://github.com/moq-dev/moq/issues/2067) - close this issue when the quest finishes
+
+## Related
+
+- [Open-GOP leading pictures](/quest/m0/open-gop-leading-pictures.md) - the tune-in drop this characterizes

--- a/quest/m0/2798-moq-import-ts-an-audio-resync-is-silent-no-log-no-counter.md
+++ b/quest/m0/2798-moq-import-ts-an-audio-resync-is-silent-no-log-no-counter.md
@@ -1,56 +1,39 @@
-# [L] moq import ts: an audio resync is silent - no log, no counter, no downstream signal
+# [M] moq import ts: an audio resync leaves no trace
 
 ## Goal
 
-Implement and verify the behavior tracked in [#2798](https://github.com/moq-dev/moq/issues/2798)
-within the issue's stated scope and boundaries.
+A feed that is losing or substituting audio is distinguishable from a healthy
+one: every completed resync logs a warning naming the PID and the bytes
+discarded, and the importer exposes counters an operator can alarm on as a
+rate.
 
 ## Plan
 
-Use the public issue's scope, implementation notes, and acceptance criteria
-below as the starting plan. Reconcile paths and assumptions with the current
-tree before implementation.
+Since #2751 the MPEG-TS importer recovers from a damaged MP2, AC-3, or AAC
+frame by scanning to the next confirmed sync instead of ending the session.
+That was the right trade, but it took the diagnostic signal with it:
+`Resync::recovered` in `rs/moq-mux/src/container/ts/import.rs` only zeroes its
+counters, neither call site (`AacStream`, `LegacyStream`) logs, the importer
+has no stats surface at all (its public API is `new`, `decode`, `seek`,
+`finish`, `abort`), and the emitted timeline just steps 24 ms to 48 ms. Only
+the budget-exhausted failure surfaces, as an error string. Testing against a
+looped real broadcast also showed a frame published *unconfirmed* at a wrap
+that lands inside a PES, which is a silent substitution rather than a gap, so
+the counters have to cover any frame the demuxer published that it could not
+confirm, not only the resync path.
 
-### Issue context
-
-##### First, the fix works
-
-Replicated #2751 against real content, building the merge commit (`36c3bbd73`, `moq-mux` 0.9.5) and its parent (`2b62488e5`, 0.9.4) so each arm has a before and an after. Source is a 20 s cut of a 9.95 Mbps DVB capture  -  H.264 1080i + MP2 + AC-3 + teletext + 3× SCTE-35  -  through a real relay to a real subscriber.
-
-| Arm | one-byte change | 0.9.4 | 0.9.5 |
-|---|---|---|---|
-| MP2 header | sync `0xFF` → `0xFE` (`cmp -l` = 1) | **died at 12 s**, `missing MP2 frame sync` | ran to end, rc=0 |
-| H.264 start code (control) | `0x01` → `0x00` | survived | survived |
-| Full A/V, `--infinite` | none | **died at the first wrap** | survived 2+ wraps |
-
-The looped arm is the production shape from the original report  -  the one that accumulated 216 publisher restarts  -  and it now runs through its wraps.
-
-The cost is as small as it could reasonably be. Comparing the damaged run against a clean control by PTS set on every elementary stream: **exactly one 24 ms MP2 frame dropped**, at the damage point; **nothing published that the clean run did not publish**, on any PID, so the damaged frame is discarded rather than emitted as mixed bytes; video, AC-3, teletext and all three SCTE-35 PIDs untouched; all eight tracks delivered. Thank you  -  that is exactly the right shape, and confirm-before-trust is a better answer than the naive scan suggested in #2729.
-
-##### The ask
-
-A resync currently leaves no trace anywhere. On the recovered stream:
-
-- **no log line**  -  the resync path has no `tracing` call at any level (the only new ones are `debug!` in `finish()` for a partial frame at end of stream);
-- **no counter or metric** exposed by the importer;
-- **no `container::Producer::discontinuity`**  -  that counter exists and is bumped on a timeline rewind, but a resync does not touch it;
-- **nothing in the emitted TS**  -  0 continuity errors, 0 `discontinuity_indicator`s, identical to the clean control. The audio timeline simply steps 24 ms → 48 ms.
-
-So a feed that is losing audio has no signal distinguishing it from a healthy one, at any layer.
-
-This is a trade worth naming: before the fix, sync loss was *maximally* visible  -  the process died. I only discovered my own source was wrapping mid-frame because of the 216 restarts it caused. After the fix the identical condition produces a stream that looks perfectly well-formed. The robustness is plainly the right call, but the diagnostic signal went with it, and for a 24/7 contribution feed "quietly dropping frames" is the failure mode you most want to be able to see.
-
-To be clear about what this is *not*. I checked whether two independent importers on the same damaged source resync differently, and they do not  -  both dropped precisely the same frame  -  so this is not a correctness or redundancy problem. And a PTS gap is arguably the right way for MPEG-TS to represent a lost access unit; `discontinuity_indicator` is about the timebase, not a missing frame. This is an observability request, not a claim that the output is wrong.
-
-The minimum that would help is a `tracing::warn!` on a completed resync carrying the PID and the bytes discarded  -  enough to correlate against a source. A counter surfaced with the other importer statistics would be better, because the thing worth alarming on is a *rate* of resyncs rather than any single one. Whether it should also reach consumers through `container::Producer::discontinuity` is a larger question and I have no strong view; the counter alone would cover the operational case.
-
-I appreciate the doc comment on `Resync` states the policy deliberately ("a few lost milliseconds of audio stay a gap in one track rather than an error that takes the whole session down")  -  this is not arguing with that policy, only asking that the gap be countable.
-
-##### Environment
-
-`moq-mux` 0.9.5 (`36c3bbd73`) against 0.9.4 (`2b62488e5`), macOS, `moq-relay` and `moq` built from the same tree, all on loopback. Source: real DVB capture, H.264 1080i25 + MP2 + AC-3 + teletext + 3× SCTE-35, 9.95 Mbps.
-
-Follow-up to #2729 / #2751.
+- `tracing::warn!` on a completed resync that discarded bytes, carrying the PID,
+  the track suffix, and the count.
+- A `#[non_exhaustive]` `Stats` snapshot on `ts::Import` (resyncs, bytes
+  discarded, frames published unconfirmed, per PID) and `moq import` logging it
+  when it changes. A rate of resyncs is what is worth alarming on, so the counter
+  matters more than any single line.
+- Not in scope: bumping `container::Producer::discontinuity()` per resync. The
+  TS importer never calls it today, and a marker group per lost 24 ms frame
+  changes downstream behaviour; that is a separate decision.
+- Tests: the one-byte-damage fixture from #2751 asserts one resync and its byte
+  count in the snapshot; the looped-fixture wrap asserts the unconfirmed frame is
+  counted.
 
 ## Closes
 

--- a/quest/m0/2833-moq-export-ts-a-rewound-timeline-stalls-the-si-table.md
+++ b/quest/m0/2833-moq-export-ts-a-rewound-timeline-stalls-the-si-table.md
@@ -1,39 +1,45 @@
-# [M] moq export ts: a rewound timeline stalls the SI table cadence until the media clock catches up
+# [M] moq export ts: a rewound timeline stalls SI tables, PCR, and pacing
 
 ## Goal
 
-Implement and verify the behavior tracked in [#2833](https://github.com/moq-dev/moq/issues/2833)
-within the issue's stated scope and boundaries.
+When the publisher rewinds its timeline, `moq export ts` keeps emitting SI
+tables and PCR on cadence from the first frame of the new epoch, marks the
+break with `discontinuity_indicator`, and re-anchors its pacer, instead of
+going quiet until the media clock climbs back past where it had been.
 
 ## Plan
 
-Use the public issue's scope, implementation notes, and acceptance criteria
-below as the starting plan. Reconcile paths and assumptions with the current
-tree before implementation.
+Three consumers in the exporter anchor on a media timestamp that only ever
+moves forward, so a backwards jump freezes each of them for the rewound span:
 
-### Issue context
+- `due` in `rs/moq-mux/src/container/ts/export.rs` fires when a timestamp
+  reaches a later repetition slot than the last emission's. PAT/PMT recover at
+  the next video keyframe, but the SI PIDs (SDT, NIT) have no such escape and
+  an audio-only program has none for PAT/PMT either.
+- `write_pcr` treats a backwards slot as already served since #2967, so the
+  PCR grid freezes rather than jumping.
+- The stdout path in `rs/moq-cli/src/subscribe.rs` paces on `moq_mux::Pacer`,
+  whose anchor also only moves forward, so a new epoch's frames are written on
+  arrival with no smoothing until they recross the old base.
 
-#### Summary
+Firing whenever the slot changes is not the fix: video is in decode order, so
+a reordered B-frame PTS steps backwards constantly, and that was measured at
+25x the intended PSI rate. A rewind and a reorder are separable without a
+threshold, because `container::Consumer::discontinuity()` already counts
+exactly the rewinds that matter, with group-level context. `ExportSource`
+holds that consumer and never reads the counter, and `discontinuity_indicator`
+is hardcoded false at the exporter's one adaptation-field site.
 
-`moq export ts` re-emits the standalone SI tables (SDT on 0x0011, NIT on 0x0010) on a repetition cadence driven by the media timestamp. When the publisher rewinds its timeline, the cadence stops firing until the media clock climbs back past the point it had already reached, which for a large rewind means the SI tables are absent for that entire span.
-
-PAT/PMT do not have this problem, because they are also re-emitted at every video keyframe and a rewind resumes at a keyframe. There is no equivalent trigger for the SI PIDs, and an audio-only program has no keyframe trigger for PAT/PMT either.
-
-#### Mechanism
-
-`due` in `rs/moq-mux/src/container/ts/export.rs` fires when a timestamp reaches a repetition slot later than the last emission's. The stored "last emission" only ever moves forward, so after a backwards jump every subsequent frame compares against a slot the stream has already left behind, and nothing is due until the timeline catches up.
-
-This is not a regression. Before #2825 the same comparison was `elapsed = timestamp - last`, which underflowed on a backwards timestamp and reported not-due, so a rewind stalled the cadence exactly the same way. #2825 changed how the cadence is anchored, not how it behaves across a rewind, and deliberately kept the existing behavior rather than widening scope.
-
-The reason the obvious fix is not simply "fire whenever the slot changes" is that video is emitted in decode order, so a reordered (B-frame) PTS steps backwards constantly. Treating that as a new slot re-emits the tables on every oscillation across a boundary, which was measured on real contribution content at roughly 25x the intended PSI rate (0.071% to 1.747% of the stream). See the discussion on #2825.
-
-#### Direction
-
-A rewind and a reorder are separable by magnitude: reorder depth is bounded by the codec's reorder buffer (the catalog records it as `jitter`, measured at 180 ms on the content above), where a rewind is a discontinuity of arbitrary size. Either a threshold comfortably above the reorder depth, or the existing rewind signal, would do:
-
-`container::Consumer` already detects the rewind that matters here (a newer group whose timestamps jump backwards past the live edge) and exposes it as `discontinuity()`. Reacting to that counter changing, rather than inferring a rewind from timestamp arithmetic, would need no threshold and would reuse a mechanism that already has the group-level context to tell a rewind from a reordered frame.
-
-Worth handling together with whatever the exporter should be doing about PCR and the `discontinuity_indicator` across a rewind, which is a related gap: the emitted PCR jumps backwards with no adaptation-field flag to say so.
+- Forward the counter from `ExportSource` to `ts::Export`. When it changes:
+  clear `last_psi`, `last_si`, and `last_pcr` so the next frame is due; set
+  `discontinuity_indicator` on the first packet of the PCR PID in the new
+  epoch, which is what the flag is for.
+- `Delivery` in the cli export path calls `Pacer::hurry` on the same signal;
+  that function exists for this and is only reached from an overshoot today.
+- Tests: a rewound-timeline fixture asserts SI re-emitted within one interval,
+  PCR resuming on the first new frame, the indicator set exactly once, and the
+  reordered-B-frame case still emitting tables at the intended rate; the
+  `test/ts` TSDuck analysis stays clean.
 
 ## Closes
 

--- a/quest/m0/2833-moq-export-ts-a-rewound-timeline-stalls-the-si-table.md
+++ b/quest/m0/2833-moq-export-ts-a-rewound-timeline-stalls-the-si-table.md
@@ -31,9 +31,11 @@ holds that consumer and never reads the counter, and `discontinuity_indicator`
 is hardcoded false at the exporter's one adaptation-field site.
 
 - Forward the counter from `ExportSource` to `ts::Export`. When it changes:
-  clear `last_psi`, `last_si`, and `last_pcr` so the next frame is due; set
-  `discontinuity_indicator` on the first packet of the PCR PID in the new
-  epoch, which is what the flag is for.
+  clear `last_psi`, `last_si`, and `last_pcr` so the next frame is due, and
+  carry a pending `discontinuity_indicator` that the next packet on the PCR
+  PID sets exactly once. That packet is the standalone PCR-only one from
+  `pcr_packet`, whose flags byte is hardcoded today, not the PES adaptation
+  field in `write_pes`; an audio-only program never reaches the latter.
 - `Delivery` in the cli export path calls `Pacer::hurry` on the same signal;
   that function exists for this and is only reached from an overshoot today.
 - Tests: a rewound-timeline fixture asserts SI re-emitted within one interval,

--- a/quest/m0/2849-moq-import-ts-a-truncated-or-spliced-opus-pes-ends-the.md
+++ b/quest/m0/2849-moq-import-ts-a-truncated-or-spliced-opus-pes-ends-the.md
@@ -2,61 +2,32 @@
 
 ## Goal
 
-Implement and verify the behavior tracked in [#2849](https://github.com/moq-dev/moq/issues/2849)
-within the issue's stated scope and boundaries.
+A damaged, truncated, or spliced Opus PES costs the frames it covers and
+nothing else. A PID that never parses as Opus still fails loudly once the
+resync budget is spent.
 
 ## Plan
 
-Use the public issue's scope, implementation notes, and acceptance criteria
-below as the starting plan. Reconcile paths and assumptions with the current
-tree before implementation.
+`OpusStream::write` in `rs/moq-mux/src/container/ts/import.rs` treats any
+malformed control header as fatal: `Opus access unit exceeds PES payload` when
+a PES is cut short of the length its header promises, and
+`invalid Opus control header sync` when the bytes after a splice are not a
+header. Both propagate out of `Import::decode`, which callers treat as
+terminal. A PES need not be damaged in transit to reach this: `handle_pes_start`
+flushes whatever is pending when the next PES begins, so a wrap, a dropped
+packet, or a capture that starts mid-stream hands a short PES to `write` as if
+complete. Opus is excluded from `Resync` and from the carry-across-PES class
+that the legacy codecs got in #2751 and #2823.
 
-### Issue context
-
-##### Summary
-
-A truncated or spliced Opus PES ends the whole session, the same way a damaged AC-3 header used to before #2751. Found while reviewing #2823; it predates that PR and is not introduced by it.
-
-##### Mechanism
-
-`OpusStream::write` treats any malformed packet as fatal, and the error travels up out of `Import::decode`, which the callers treat as terminal:
-
-```rust
-let (header_len, size) = parse_opus_control_header(&data[offset..])?;
-let start = offset + header_len;
-let end = start + size;
-anyhow::ensure!(end <= data.len(), "Opus access unit exceeds PES payload");
-```
-
-A PES does not have to be damaged in transit to reach this. `handle_pes_start` flushes whatever is pending whenever the next PES begins, so a PES left short by a wrap, a dropped packet, or a capture that starts mid-stream is handed to `write` as though it were complete.
-
-##### Reproduction
-
-Loop the in-tree fixture at each packet boundary and import each result:
-
-```rust
-let data = include_bytes!("test_data/opus.ts");
-for cut in (188..data.len()).step_by(188) {
-    let mut looped = data[..cut].to_vec();
-    looped.extend_from_slice(data);
-    // ... Import::new(...).decode(&looped) must not error
-}
-```
-
-Two distinct failures, both on `main`:
-
-- wrap at packet 21: `Opus access unit exceeds PES payload` (the `ensure!` above, a PES cut short of the length its control header promises)
-- wrap at packet 22: `invalid Opus control header sync (0x7d6a)` (the post-splice bytes are not a control header)
-
-##### Why it is not fixed in #2823
-
-That PR stops a continuity break from handing a spliced buffer to any codec, and excludes Opus from the salvage path so it adds no new abort. Neither addresses this, because the truncated PES arrives through the ordinary `handle_pes_start` flush with continuity intact.
-
-Making the first case graceful is a few lines (drop the truncated tail rather than erroring). The second is the harder half: it needs what #2751 built for the legacy codecs, a scan to the next plausible boundary with confirmation before publishing, and Opus has none of that machinery. Doing only the first leaves a half-fix that the reproduction above still fails, which is why #2823 ships neither.
-
-##### Worth deciding alongside
-
-The legacy path deliberately keeps a byte budget so that a PID whose payload never parses still fails loudly rather than publishing nothing forever. Opus should not simply swallow every parse error, or a PMT that mislabels a PID as Opus becomes a silent dead track. The budget in `Resync` is the precedent to follow.
+- Route Opus through `Resync`: scan for the control-header sync (`0x7f` then
+  `0xe0` under mask), confirm by parsing the header and finding the next
+  header at the promised end before publishing, and keep the 64 KiB budget so a
+  PMT that mislabels a PID as Opus does not become a silent dead track.
+- Include Opus in the carry class, so a control header split across a PES
+  boundary is reassembled and a truncated tail is carried rather than errored.
+- Tests: loop `test_data/opus.ts` at every packet boundary (the reproduction in
+  the issue) and import each without error; a PID of non-Opus bytes labelled
+  Opus exhausts the budget and fails.
 
 ## Closes
 

--- a/quest/m0/README.md
+++ b/quest/m0/README.md
@@ -28,7 +28,7 @@ regression test per Root Cause First.
 - [#2812](/quest/m0/2812-watch-has-audio-stutter-on-ios-on-https-moq-dev-watch.md) - Watch has Audio stutter on iOS on https://moq.dev/watch/
 - [#2981](/quest/m0/2981-moq-audio-nothing-in-the-decode-or-playback-path-models-a.md) - moq-audio: nothing in the decode or playback path models a media gap
 - [#3080](/quest/m0/3080-fix-watch-audio-ring-truncate-can-race-the-worklet-reader.md) - fix(watch): audio ring truncate can race the worklet reader for one quantum
-- [#2833](/quest/m0/2833-moq-export-ts-a-rewound-timeline-stalls-the-si-table.md) - moq export ts: a rewound timeline stalls the SI table cadence until the media clock catches up
+- [#2833](/quest/m0/2833-moq-export-ts-a-rewound-timeline-stalls-the-si-table.md) - moq export ts: a rewound timeline stalls SI tables, PCR, and pacing until the media clock catches up
 - [#2806](/quest/m0/2806-js-net-the-draft-14-15-adapter-keeps-one-request-per.md) - js/net: the draft-14/15 adapter keeps one request per namespace, so a duplicate strands the first
 - [Windows window capture](/quest/m0/windows-window-capture-blank.md) - Windows window capture returns black pixels for GPU-composited windows
 - [Capture device loss](/quest/m0/capture-device-loss.md) - an AVFoundation camera that disappears parks the reader forever
@@ -44,7 +44,8 @@ regression test per Root Cause First.
 - [#3123](/quest/m0/3123-moq-bench-a-lagged-group-permanently-ends-the.md) - moq-bench: a lagged group permanently ends the subscription, so offered load silently decays mid-run
 - [#2838](/quest/m0/2838-js-flate-codec-rejects-frames-that-inflate-past-the.md) - js/flate: "codec rejects frames that inflate past the default cap" times out under parallel test load
 - [#3115](/quest/m0/3115-moqsink-the-publication-has-no-generation-so-a-flush.md) - moqsink: the publication has no generation, so a flush after EOS cannot restart it
-- [#2798](/quest/m0/2798-moq-import-ts-an-audio-resync-is-silent-no-log-no-counter.md) - moq import ts: an audio resync is silent - no log, no counter, no downstream signal
+- [#2798](/quest/m0/2798-moq-import-ts-an-audio-resync-is-silent-no-log-no-counter.md) - moq import ts: an audio resync leaves no trace, no log, no counter
 - [#2860](/quest/m0/2860-cpp-obs-moq-source-cpp-has-no-test-coverage.md) - cpp/obs: moq-source.cpp has no test coverage
 - [#2868](/quest/m0/2868-obs-the-plugin-targets-obs-31-1-1-while-linux-ci-links.md) - obs: the plugin targets OBS 31.1.1 while Linux CI links against nixpkgs' 32.1.2
-- [#2067](/quest/m0/2067-test-open-gop-h-264-tune-in-end-to-end-leading-picture.md) - Test open-GOP H.264 tune-in end to end (leading-picture handling)
+- [#2067](/quest/m0/2067-test-open-gop-h-264-tune-in-end-to-end-leading-picture.md) - Open-GOP H.264: a regression fixture and a measured cold tune-in
+- [Open-GOP leading pictures](/quest/m0/open-gop-leading-pictures.md) - a viewer joining at a recovery point drops the leading pictures it cannot decode; continuous viewers keep them

--- a/quest/m0/open-gop-leading-pictures.md
+++ b/quest/m0/open-gop-leading-pictures.md
@@ -1,0 +1,33 @@
+# [M] Open-GOP leading pictures are dropped at tune-in only
+
+## Goal
+
+A viewer joining an open-GOP broadcast at a recovery point never hands the
+decoder a leading picture whose references it does not have, while a viewer
+already playing keeps every frame. The rule is the same for H.264
+recovery-point keyframes and H.265 CRA pictures.
+
+## Plan
+
+Leading pictures are decoded after the keyframe and presented before it, so
+they are exactly the frames of a group whose timestamp is below the group's
+keyframe timestamp. That makes them identifiable from the container timestamps
+alone, with no POC parsing and no change to the splitter, which is why the
+drop belongs on the consumer: ingest cannot know whether a given viewer has the
+previous GOP, and dropping at ingest would degrade continuous playback for
+everyone.
+
+- In the JS consumer (`js/hang/src/container/consumer.ts` forces the first
+  sample of a group to `keyframe`, and `js/watch/src/video/decoder.ts` submits
+  it as `"key"`): for the first group decoded after a subscribe or a
+  discontinuity, skip delta frames stamped before that group's keyframe. Every
+  later group is passed through untouched.
+- The same rule in the Rust decode path (`moq-video` decode consumers), so
+  native playback and the transcoder tune in the same way.
+- Tests: a synthetic group with a keyframe followed by two earlier-stamped
+  deltas is trimmed on the first group and kept on the second, in both
+  languages.
+
+## Required
+
+- [#2067](/quest/m0/2067-test-open-gop-h-264-tune-in-end-to-end-leading-picture.md) - decides whether the glitch is dropped frames, corrupt frames, or a decoder error, which sets what this has to prove

--- a/quest/m0/open-gop-leading-pictures.md
+++ b/quest/m0/open-gop-leading-pictures.md
@@ -5,7 +5,11 @@
 A viewer joining an open-GOP broadcast at a recovery point never hands the
 decoder a leading picture whose references it does not have, while a viewer
 already playing keeps every frame. The rule is the same for H.264
-recovery-point keyframes and H.265 CRA pictures.
+recovery-point keyframes with `recovery_frame_cnt = 0` (the broadcast
+contribution case, and what the reference capture carries) and H.265 CRA
+pictures. Gradual recovery (`recovery_frame_cnt > 0`) is out of scope: the
+splitter does not retain the count, and unsafe pictures there can sit at or
+after the keyframe timestamp, so it needs its own plan.
 
 ## Plan
 
@@ -19,11 +23,16 @@ everyone.
 
 - In the JS consumer (`js/hang/src/container/consumer.ts` forces the first
   sample of a group to `keyframe`, and `js/watch/src/video/decoder.ts` submits
-  it as `"key"`): for the first group decoded after a subscribe or a
-  discontinuity, skip delta frames stamped before that group's keyframe. Every
-  later group is passed through untouched.
-- The same rule in the Rust decode path (`moq-video` decode consumers), so
-  native playback and the transcoder tune in the same way.
+  it as `"key"`): for the first group after any non-continuous transition,
+  skip delta frames stamped before that group's keyframe. That covers a
+  subscribe, a declared discontinuity, and a latency skip: `#checkLatency`
+  records the skip through `#gap` and `next()` reports the next frame with
+  `continuous: false` without touching the discontinuity counter, and a viewer
+  that skipped into a later GOP lacks its references just like a cold join.
+  Every continuous group is passed through untouched.
+- The same rule in the Rust decode path (`moq-video` decode consumers), with
+  an equivalent non-continuous signal from `container::Consumer`, so native
+  playback and the transcoder tune in the same way.
 - Tests: a synthetic group with a keyframe followed by two earlier-stamped
   deltas is trimmed on the first group and kept on the second, in both
   languages.


### PR DESCRIPTION
Replans the MPEG-TS and open-GOP quests in m0.

- **#2798** `warn!` per completed resync plus a `#[non_exhaustive]` `Import::stats()` snapshot that `moq import` logs, counting resyncs, bytes discarded, and frames published unconfirmed (the silent-substitution case from the issue thread). A discontinuity marker group per resync is explicitly out of scope.
- **#2849** Opus goes through the existing `Resync` (confirm-before-trust, 64 KiB budget) and joins the carry-across-PES class, instead of a bespoke tolerant parse.
- **#2833** one signal, three consumers: `ExportSource` forwards `Consumer::discontinuity()`, the exporter resets SI/PSI/PCR anchors and sets `discontinuity_indicator` once, and the cli path calls `Pacer::hurry`.
- **#2067** split: the existing quest becomes fixture + measured cold tune-in (`kyrion_dirtystart.ts` is already open GOP), and a new [Open-GOP leading pictures](quest/m0/open-gop-leading-pictures.md) quest drops leading pictures on the consumer at tune-in only, keyed on timestamp below the group keyframe rather than POC parsing, so continuous viewers keep every frame. The drop requires the characterization.

Part of a per-cluster replan of `quest/m0`: every issue-imported quest had the boilerplate "implement what the issue says" goal with the issue body pasted as the plan. Each quest now states its observable outcome and the decisions taken, and drops the pasted body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Claude Fable 5.1)
