### PR TITLE
chore(quest): fold in the review findings the m0 replans merged past

### DIFF
--- a/quest/m0/2676-libmoq-process-exit-can-abort-in-glibcs-pthread-tpp.md
+++ b/quest/m0/2676-libmoq-process-exit-can-abort-in-glibcs-pthread-tpp.md
@@ -36,8 +36,14 @@ running thread touches state whose destructor already ran.
 - Fix the mechanism where it lives. If it is teardown ordering, an atexit
   handler that quiesces the runtime thread before static destructors run is
   the likely shape; do not add a `moq_shutdown` the contract does not ask for.
-- Remove `_exit` from the smoke client's success path. The failure paths keep
-  it for the separate `user_data` lifetime reason from #2675.
+- Remove `_exit` from the smoke client's success path. Returning is only safe
+  once every registration that holds the stack `ctx_t` has fired its terminal
+  callback: closing the session ends its status registration alone, while
+  `moq_origin_consume_announced`, `moq_consume_catalog`, and
+  `moq_consume_video` each keep the pointer until their own terminal, so close
+  and drain all of them before `return`, or a late frame callback reproduces
+  a second lifetime bug instead of isolating atexit teardown. The failure
+  paths keep `_exit` for the `user_data` lifetime reason from #2675.
 
 ## Closes
 

--- a/quest/m0/2799-moq-video-capture-negotiates-twice-so-a-window-resize.md
+++ b/quest/m0/2799-moq-video-capture-negotiates-twice-so-a-window-resize.md
@@ -34,7 +34,9 @@ the fix, and the two opens stay.
   native playback reselects too; that is part of this quest, not a follow-up.
 - Test: a source that republishes its rendition at a new size; assert the
   ladder changes, passthrough follows, and a subscriber on a retired rung is
-  ended cleanly.
+  ended cleanly. For `moq play`, complete the active video task and assert a
+  later catalog snapshot starts the replacement track, so an implementation
+  that leaves `video_started` set fails.
 
 ## Closes
 

--- a/quest/m0/2981-moq-audio-nothing-in-the-decode-or-playback-path-models-a.md
+++ b/quest/m0/2981-moq-audio-nothing-in-the-decode-or-playback-path-models-a.md
@@ -21,32 +21,33 @@ treated as contiguous audio.
 - `play_audio` in `rs/moq-cli/src/play.rs` writes PCM back to back into a
   clockless `playback::Sink`, so a gap shortens the audio; the A/V clock
   re-anchors within one buffer, with video running ahead until then.
-- `encode::Producer` uses the same resampler but never reads `skipped()`, so
-  every resampled publisher's PTS carries the filter delay as a fixed offset
-  (about 1.4 ms at 44.1 to 48 kHz). `decode::Consumer` compensates; the
-  encoder should too, in the same change, since both are about the resampler
-  telling its caller where its samples belong in time.
+- `encode::Producer` needs no such correction: it anchors its epoch to the
+  first input timestamp and advances by emitted samples, and
+  `Resampler::process` already drops the startup delay from its output, so the
+  first emitted sample lines up with the first input. `skipped()` exists for
+  `decode::Consumer`, which reconstructs each batch's time from a later packet
+  timestamp. Pin that with a test rather than changing it.
 
 Exact contiguity cannot be the test. RTMP stamps in milliseconds and an AAC
 frame at 44.1 kHz is 23.22 ms, so every packet on the most common ingest path
 reads as discontinuous under a strict rule.
 
 - One stated policy in `decode::Consumer`: a packet counts as discontinuous
-  when its timestamp differs from the tracked tail by more than half a codec
-  frame at the track timescale, derived from the frame size and timescale
-  rather than a constant. One lost frame lands exactly one frame off, so the
-  tolerance has to sit well below a frame; millisecond rounding is under
-  1 ms against a 23 ms frame, so it stays well inside.
+  when its timestamp differs from the tracked tail by more than the source's
+  timestamp quantization, one unit of the coarsest timescale on the path (one
+  millisecond for RTMP), plus rounding. The tolerance cannot derive from a
+  frame duration: one lost frame lands exactly one frame off, and Opus packets
+  vary between 2.5 ms and 60 ms with no fixed duration in the catalog, so a
+  half-frame rule from a 20 ms neighbour would splice across a lost 2.5 ms
+  packet. Quantization is the only slack the stamps actually carry.
 - On a gap: flush the resampler's pending samples as their own frame (they
   belong before the hole) or drop them, reset it, and stamp the next output
   from the new packet rather than by rewinding.
 - `play_audio` writes silence for the missing duration, which also covers
   `latency_max` skips.
-- `encode::Producer` subtracts the resampler's skipped frames from its epoch
-  so the first published frame is stamped where its input was.
-- Tests: frames at 0 and 2048 samples across a gap produce a hole; millisecond
-  stamped 1024-sample AAC packets detect no gap; the encoder's first PTS
-  matches its first input.
+- Tests: frames at 0 and 2048 samples across a gap produce a hole; a 2.5 ms
+  Opus packet lost after a 20 ms one is a gap; millisecond-stamped 1024-sample
+  AAC packets detect no gap; the encoder's first PTS matches its first input.
 
 ## Closes
 

--- a/quest/m0/3115-moqsink-the-publication-has-no-generation-so-a-flush.md
+++ b/quest/m0/3115-moqsink-the-publication-has-no-generation-so-a-flush.md
@@ -29,12 +29,17 @@ opening its own, so aggregate EOS membership is one set per generation.
   the element-level latch (`eos_delivered`) needs the same split so a
   generation can post EOS again.
 - Pad lifecycles reset into the new generation on join, reusing
-  `lifecycle.reset()` from `start_session`.
+  `lifecycle.reset()` from `start_session`. That reset replaces the pad state
+  with `Pad::new()`, which has no caps and no track, and a normal
+  `FLUSH_STOP` resends the segment but not the sticky CAPS, so the joining
+  pad must replay its sticky caps and rebuild its producer before accepting
+  the first buffer of the new generation, or `push_buffer` drops it silently.
 - The stale-error window in `post_session_error` (identity check, then a bus
   post outside the lock, which a sync handler may re-enter) is a separate
   delivery problem that generations do not close; leave it as documented.
 - Tests: EOS on every pad, then `FLUSH_STOP` and buffers, asserts a second
-  broadcast with a second catalog and a second EOS; a pad that flushes late
+  broadcast with a second catalog, media in it from the first post-flush
+  buffer, and a second EOS; a pad that flushes late
   joins the current generation, not a third; the post-EOS buffer without a
   flush still answers `Eos`.
 

--- a/quest/m0/3139-moqsrc-a-rendition-nobody-answers-keeps-the-session-alive.md
+++ b/quest/m0/3139-moqsrc-a-rendition-nobody-answers-keeps-the-session-alive.md
@@ -26,12 +26,16 @@ A timeout would stand in for information the publisher has, so the fix is a
 promise on the publisher side: closing the catalog means the announced set is
 final.
 
-- moq-net: dropping or refusing an unaccepted `track::Request`, and closing a
-  producer that never published info, resolves every pending subscribe with
-  `NotFound`; verify and pin that.
+- moq-net keeps its generic semantics: a dropped `track::Request` or a
+  producer closed without a reason resolves pending subscribes with
+  `Error::Dropped`, as `rs/moq-net/src/model/track.rs` documents, and a
+  `request.reject(reason)` carries that reason. Verify and pin both; do not
+  fold `NotFound` into the drop path, since a handler lost to a publisher or
+  transport failure is not an absent track.
 - hang publishers (`moqsink` reserves per pad, `moq-cli` and the FFI create
-  tracks by name): when the catalog finishes, refuse every reserved or
-  info-less track the catalog named, so their subscribers resolve.
+  tracks by name): when the catalog finishes, `reject(Error::NotFound)` every
+  reserved or info-less track the catalog named, so their subscribers resolve
+  and the catalog meaning stays out of moq-net.
 - moqsrc: a pump whose subscribe resolves with an error ends that pump alone,
   and the loop exits once the catalog is closed and the served pumps drain.
 - Tests: the existing test keeps its media; a new one names a reserved track,

--- a/quest/m0/README.md
+++ b/quest/m0/README.md
@@ -47,3 +47,4 @@ regression test per Root Cause First.
 - [#2868](/quest/m0/2868-obs-the-plugin-targets-obs-31-1-1-while-linux-ci-links.md) - obs: the plugin targets OBS 31.1.1 while Linux CI links against 32
 - [#2067](/quest/m0/2067-test-open-gop-h-264-tune-in-end-to-end-leading-picture.md) - Open-GOP H.264: a regression fixture and a measured cold tune-in
 - [Open-GOP leading pictures](/quest/m0/open-gop-leading-pictures.md) - a viewer joining at a recovery point drops the leading pictures it cannot decode; continuous viewers keep them
+- [Gradual recovery](/quest/m0/open-gop-gradual-recovery.md) - tune-in at a recovery point with `recovery_frame_cnt > 0` trims through the recovery picture

--- a/quest/m0/open-gop-gradual-recovery.md
+++ b/quest/m0/open-gop-gradual-recovery.md
@@ -1,0 +1,32 @@
+# [M] Open-GOP gradual recovery trims through the recovery picture
+
+## Goal
+
+A viewer tuning in at an H.264 recovery point with `recovery_frame_cnt > 0`
+never hands the decoder a picture before recovery completes, and a viewer
+already playing keeps every frame. Today such a stream tunes in with the same
+glitches as any open GOP, and the leading-picture rule cannot help because the
+unsafe pictures sit at or after the keyframe timestamp.
+
+## Plan
+
+`rs/moq-mux/src/codec/h264/split.rs` treats every recovery-point SEI as a
+keyframe and drops the count (`sei_has_recovery_point` returns a bool), so
+nothing downstream can tell an immediately usable recovery point from a
+gradual one, where recovery lands `recovery_frame_cnt` frames later in output
+order.
+
+- Retain the count from the SEI in the splitter and carry it on the group in
+  the container framing, so a consumer knows how far past the keyframe the
+  first safe picture is. That is a framing change, so it lands with a
+  `draft-lcurley-moq-hang` update.
+- On the first group after a non-continuous transition, the consumer skips
+  every picture until the recovery picture, in JS and in the Rust decode path,
+  using the same non-continuous signal the leading-picture rule keys on.
+- Tests: a fixture with `recovery_frame_cnt = 2`, trimmed through the
+  recovery picture on tune-in and untouched when continuous, in both
+  languages; a zero-count stream stays on the leading-picture rule alone.
+
+## Required
+
+- [Open-GOP leading pictures](/quest/m0/open-gop-leading-pictures.md) - the non-continuous signal and first-group trimming this extends

--- a/quest/m0/open-gop-gradual-recovery.md
+++ b/quest/m0/open-gop-gradual-recovery.md
@@ -3,8 +3,8 @@
 ## Goal
 
 A viewer tuning in at an H.264 recovery point with `recovery_frame_cnt > 0`
-never hands the decoder a picture before recovery completes, and a viewer
-already playing keeps every frame. Today such a stream tunes in with the same
+never displays a picture before recovery completes, and a viewer already
+playing shows every frame. Today such a stream tunes in with the same
 glitches as any open GOP, and the leading-picture rule cannot help because the
 unsafe pictures sit at or after the keyframe timestamp.
 
@@ -17,15 +17,24 @@ gradual one, where recovery lands `recovery_frame_cnt` frames later in output
 order.
 
 - Retain the count from the SEI in the splitter and carry it on the group in
-  the container framing, so a consumer knows how far past the keyframe the
-  first safe picture is. That is a framing change, so it lands with a
+  the container framing, so a consumer knows recovery is gradual and how far
+  it runs. That is a framing change, so it lands with a
   `draft-lcurley-moq-hang` update.
-- On the first group after a non-continuous transition, the consumer skips
-  every picture until the recovery picture, in JS and in the Rust decode path,
-  using the same non-continuous signal the leading-picture rule keys on.
-- Tests: a fixture with `recovery_frame_cnt = 2`, trimmed through the
-  recovery picture on tune-in and untouched when continuous, in both
-  languages; a zero-count stream stays on the leading-picture rule alone.
+- Gradual refresh is different from leading pictures: the decoder must
+  consume every picture from the recovery-point access unit onward, because
+  those pictures build the reference state the recovery picture needs
+  (H.264 D.2.8, RFC 6184 section 8.5.2). So on the first group after a
+  non-continuous transition the consumer decodes everything and withholds
+  *display* until the recovery picture, in JS and in the Rust decode path,
+  keyed on the same non-continuous signal the leading-picture rule uses.
+- Identify the recovery picture the way the spec does: `recovery_frame_cnt`
+  counts in `frame_num` units from the recovery point, in output order, not
+  in container frames, so the consumer tracks `frame_num` progression (or the
+  decoder's output order) rather than counting samples.
+- Tests: a fixture with `recovery_frame_cnt = 2` whose pictures before the
+  recovery picture are decoded but not presented on tune-in and all presented
+  when continuous, in both languages; a zero-count stream stays on the
+  leading-picture rule alone.
 
 ## Required
 

--- a/quest/m0/open-gop-gradual-recovery.md
+++ b/quest/m0/open-gop-gradual-recovery.md
@@ -1,4 +1,4 @@
-# [M] Open-GOP gradual recovery trims through the recovery picture
+# [M] Open-GOP gradual recovery withholds display until the recovery picture
 
 ## Goal
 
@@ -6,7 +6,9 @@ A viewer tuning in at an H.264 recovery point with `recovery_frame_cnt > 0`
 never displays a picture before recovery completes, and a viewer already
 playing shows every frame. Today such a stream tunes in with the same
 glitches as any open GOP, and the leading-picture rule cannot help because the
-unsafe pictures sit at or after the keyframe timestamp.
+unsafe pictures sit at or after the keyframe timestamp. Recovery points with
+`broken_link_flag` set are out of scope: there even a continuous viewer must
+withhold display (H.264 D.2.8), which is a different rule with its own plan.
 
 ## Plan
 

--- a/quest/m0/open-gop-leading-pictures.md
+++ b/quest/m0/open-gop-leading-pictures.md
@@ -9,7 +9,8 @@ recovery-point keyframes with `recovery_frame_cnt = 0` (the broadcast
 contribution case, and what the reference capture carries) and H.265 CRA
 pictures. Gradual recovery (`recovery_frame_cnt > 0`) is out of scope: the
 splitter does not retain the count, and unsafe pictures there can sit at or
-after the keyframe timestamp, so it needs its own plan.
+after the keyframe timestamp, so it has its own quest,
+[gradual recovery](/quest/m0/open-gop-gradual-recovery.md).
 
 ## Plan
 
@@ -34,9 +35,15 @@ everyone.
   an equivalent non-continuous signal from `container::Consumer`, so native
   playback and the transcoder tune in the same way.
 - Tests: a synthetic group with a keyframe followed by two earlier-stamped
-  deltas is trimmed on the first group and kept on the second, in both
-  languages.
+  deltas is trimmed on the first group and kept on the second; and a viewer
+  that plays continuously, then latency-skips into a later open GOP, has that
+  group's leading pictures trimmed too, so an implementation that only trims
+  the initial group fails. Both cases in both languages.
 
 ## Required
 
 - [#2067](/quest/m0/2067-test-open-gop-h-264-tune-in-end-to-end-leading-picture.md) - decides whether the glitch is dropped frames, corrupt frames, or a decoder error, which sets what this has to prove
+
+## Related
+
+- [Gradual recovery](/quest/m0/open-gop-gradual-recovery.md) - the `recovery_frame_cnt > 0` case this rule does not cover


### PR DESCRIPTION
#3346, #3347, and #3349 merged while their last review findings were still being addressed. These are the fixes for the findings that stand; each was verified against the code before editing.

- **Open GOP** (#3346): the tests now include a latency skip into a later GOP, since an implementation that only trims the initial group would pass otherwise; and `recovery_frame_cnt > 0` gets its own quest, `quest/m0/open-gop-gradual-recovery.md`, instead of a sentence that vanishes when the parent is deleted.
- **Audio gap and ladder** (#3347): the gap tolerance keys on timestamp quantization rather than half a codec frame, because Opus packets vary from 2.5 ms to 60 ms and a half-frame rule from a 20 ms neighbour splices across a lost 2.5 ms packet. The `encode::Producer` `skipped()` correction is replaced by a pin: the producer already anchors to its first input and `Resampler::process` drops the startup delay, so subtracting it would shift PTS early. The ladder test now proves `moq play` reselects a rung.
- **GStreamer, libmoq, OBS** (#3349): catalog finality is expressed by the hang publisher rejecting with `NotFound`, keeping moq-net's documented `Dropped` semantics for requests lost to failures; the C smoke client drains every callback registration before returning, since the consume registrations retain the stack context past session close; and a pad joining a new moqsink generation replays its sticky caps and rebuilds its producer before the first buffer, or `push_buffer` drops it.

`quest check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Claude Fable 5.1)
