### PR TITLE
fix(moq-mux): slice the TS export on the PCR grid

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -83,9 +83,15 @@ jobs:
       # cannot: the grader has to sit on the exporter's stdout for the length of
       # the run, stamping each packet. That is a real-time window no per-PR gate
       # should pay for, so it lives here (see test/ts/README.md).
+      #
+      # 120 s rather than the 20 s default, because the drift term needs it. The
+      # exporter builds its mux buffer once and holds it, and a window that ends
+      # while it is still filling cannot tell that from a pipe running slow: the
+      # lag reaches ~480 ms over the first ~48 s and is flat after. Nightly is the
+      # one arm with the wall-clock time to see the flat part.
       - name: TS timing
         if: ${{ !cancelled() }}
-        run: nix develop --command just test ts --live
+        run: nix develop --command just test ts --live --duration 120
 
   # `just rs windows` is the only thing that compiles moq-video's Media
   # Foundation capture/encode/decode, its D3D11 frames, and every

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -78,6 +78,15 @@ jobs:
         if: ${{ !cancelled() }}
         run: nix develop --command just obs ci
 
+      # The TS exporter's PCR release timing. Everything else about the stream
+      # can be graded from a capture, but *when* the bytes were handed over
+      # cannot: the grader has to sit on the exporter's stdout for the length of
+      # the run, stamping each packet. That is a real-time window no per-PR gate
+      # should pay for, so it lives here (see test/ts/README.md).
+      - name: TS timing
+        if: ${{ !cancelled() }}
+        run: nix develop --command just test ts --live
+
   # `just rs windows` is the only thing that compiles moq-video's Media
   # Foundation capture/encode/decode, its D3D11 frames, and every
   # `#[cfg(target_os = "windows")]` test module. The Linux gate skips all of it,

--- a/rs/moq-cli/src/subscribe.rs
+++ b/rs/moq-cli/src/subscribe.rs
@@ -364,8 +364,16 @@ impl Subscribe {
 /// schedule overshoots that epoch by more than the lead, it is delivered
 /// immediately and becomes the live edge
 /// ([`Pacer::hurry`](moq_mux::Pacer::hurry)). The anchor then rides the newest
-/// frame through a backlog, so pacing resumes from the live edge once the
-/// export makes us wait again.
+/// frame through a backlog, so pacing resumes from the live edge.
+///
+/// A hurry moves the epoch with it, because the frame it delivers *is* the live
+/// edge and the distance it is measured from has to be too. `hurry` returns `now`,
+/// so the credit below can never fire on the frame that hurried; leaving the epoch
+/// behind would put every later frame the same overshoot past it and shed the whole
+/// stream at the arrival cadence, which the buffered export would never correct
+/// since it never makes us wait. A sink that is genuinely slow still sheds on every
+/// stall: each one leaves the next frame far enough past the epoch to overshoot
+/// again.
 ///
 /// Reaching a scheduled instant also advances the epoch, and has to. The TS export
 /// holds a mux buffer: it always has the next grid slot ready, so it stops making
@@ -423,6 +431,11 @@ impl Delivery {
 		let mut send_at = self.pacer.pace(frame.timestamp, now.into_std());
 		if send_at.saturating_duration_since(self.arrived.into_std()) > budget {
 			send_at = self.pacer.hurry(frame.timestamp, now.into_std());
+			// A hurry makes this frame the live edge, so the epoch it is measured
+			// against becomes now as well. `hurry` returns `now`, so the credit below
+			// can't do it, and a stale epoch would overshoot the budget on every
+			// later frame, latching the shed on for good.
+			self.arrived = now;
 		}
 
 		let send_at = tokio::time::Instant::from_std(send_at);
@@ -494,10 +507,10 @@ mod tests {
 	/// A sink that cannot reach its schedule still sheds the lag, which is the case
 	/// the budget is left guarding.
 	///
-	/// The epoch advances on a wait or on reaching a scheduled instant, and a sink
-	/// falling behind does neither: every frame is already overdue, so nothing
-	/// sleeps and nothing credits. The schedule then runs away from the frozen
-	/// epoch and the overshoot hurries.
+	/// The epoch advances on a wait, on reaching a scheduled instant, or on a hurry.
+	/// A sink falling behind reaches none of its instants and is never made to wait,
+	/// so only the hurry moves it, and each fresh stall puts the next frame far
+	/// enough past that epoch to overshoot the budget and hurry again.
 	///
 	/// What this no longer covers, deliberately, is a one-off pre-queued backlog
 	/// (a tune-in group replaying from its keyframe). That now paces out at the
@@ -527,23 +540,74 @@ mod tests {
 		assert_eq!(
 			start.elapsed(),
 			Duration::from_secs(2),
-			"an overdue frame writes at once, and the pacer takes its 500ms of lead as slack"
+			"an overdue frame writes at once: the overshoot hurries and makes it the live edge"
 		);
 
-		// 1100ms of schedule against a budget of lead + slack: the overshoot hurries
-		// and makes this the live edge.
+		// Shedding happens at the re-anchor, once, not on every frame after it. This
+		// one is 200ms of media past the new edge and 200ms past the epoch the hurry
+		// set with it, so it is inside the budget and paces.
 		delivery
 			.deliver(&frame(600_000, Timescale::MICRO), false, &mut out)
 			.await
 			.unwrap();
-		assert_eq!(start.elapsed(), Duration::from_secs(2));
+		assert_eq!(start.elapsed(), Duration::from_secs(2) + Duration::from_millis(200));
 
-		// Pacing resumes relative to that edge.
+		// A sink that goes on stalling goes on shedding, which is the property this
+		// test is here for: each stall leaves the next frame far enough past the
+		// epoch to overshoot the budget again, however recently the last hurry moved
+		// it. Media steps 25ms per iteration while the wall clock steps 2s.
+		for slot in 1..=3u64 {
+			tokio::time::advance(Duration::from_secs(2)).await;
+			let before = start.elapsed();
+			delivery
+				.deliver(&frame(600_000 + slot * 25_000, Timescale::MICRO), false, &mut out)
+				.await
+				.unwrap();
+			assert_eq!(start.elapsed(), before, "stall {slot} must shed, not pace");
+		}
+	}
+
+	/// A hurry has to move the arrival epoch with it, or it latches.
+	///
+	/// `hurry` returns `now`, so the credit for reaching a scheduled instant can
+	/// never fire on the frame that hurried. Left there, the epoch stays wherever it
+	/// was before the shed while the schedule walks forward from the new edge, so the
+	/// next frame overshoots the budget too, and so does every one after it. The
+	/// buffered export never waits, so nothing else would move the epoch back.
+	#[tokio::test(start_paused = true)]
+	async fn pacing_resumes_after_a_hurry_without_a_wait() {
+		let mut delivery = Delivery::new(Duration::from_millis(500));
+		let mut out = Vec::new();
+
+		let start = tokio::time::Instant::now();
 		delivery
-			.deliver(&frame(640_000, Timescale::MICRO), true, &mut out)
+			.deliver(&frame(0, Timescale::MICRO), true, &mut out)
 			.await
 			.unwrap();
-		assert_eq!(start.elapsed(), Duration::from_secs(2) + Duration::from_millis(40));
+
+		// Stall long enough that the schedule outruns the budget and sheds.
+		tokio::time::advance(Duration::from_secs(2)).await;
+		delivery
+			.deliver(&frame(400_000, Timescale::MICRO), false, &mut out)
+			.await
+			.unwrap();
+		let hurried = start.elapsed();
+		assert_eq!(hurried, Duration::from_secs(2), "the overshoot sheds");
+
+		// Grid slots from the new edge, every one already queued and none waited on.
+		// Against a stale epoch each is a whole stall past it, so each would hurry and
+		// write at once, pinning `start.elapsed()` at `hurried` for the whole loop.
+		for slot in 1..=8u64 {
+			delivery
+				.deliver(&frame(400_000 + slot * 25_000, Timescale::MICRO), false, &mut out)
+				.await
+				.unwrap();
+			assert_eq!(
+				start.elapsed(),
+				hurried + Duration::from_millis(slot * 25),
+				"slot {slot} must be paced, not shed"
+			);
+		}
 	}
 
 	/// The TS export holds a mux buffer, so it always has the next grid slot ready

--- a/rs/moq-cli/src/subscribe.rs
+++ b/rs/moq-cli/src/subscribe.rs
@@ -302,11 +302,11 @@ impl Subscribe {
 			.with_latency(self.args.max_latency);
 
 		// A TS byte stream carries no per-frame timing, so delivery time is the only
-		// carrier of each frame's spacing: the exporter emits its PCR grid as
-		// standalone frames stamped at their slot boundaries, on the contract that
-		// the caller writes the bytes at the time the stamp asserts. Draining on
-		// arrival instead collapses the clock into position clusters no downstream
-		// stage can repair (#2984). See [`Delivery`] for how the pacing stays
+		// carrier of each frame's spacing: the exporter slices its output on the PCR
+		// grid and stamps each slice at its slot boundary, on the contract that the
+		// caller writes the bytes at the time the stamp asserts. Draining on arrival
+		// instead collapses the clock into position clusters no downstream stage can
+		// repair (#2984). See [`Delivery`] for how the pacing stays
 		// bounded; it needs to know whether each frame was waited for, hence the
 		// hand-rolled poll instead of `ts.next()`.
 		let mut delivery = Delivery::new(self.args.max_latency);
@@ -367,12 +367,20 @@ impl Subscribe {
 /// frame through a backlog, so pacing resumes from the live edge once the
 /// export makes us wait again.
 ///
-/// The epoch is deliberately conservative: a ready frame may in truth have
-/// arrived later, during a pacing sleep, but one-frame polling can't observe
-/// that, and crediting sleep intervals would let a pre-queued backlog restart
-/// the budget on every sleep. The cost is bounded: a hurry can collapse at
-/// most the lead-sized interval ahead of the epoch, and smoothing resumes at
-/// the next actual wait.
+/// Reaching a scheduled instant also advances the epoch, and has to. The TS export
+/// holds a mux buffer: it always has the next grid slot ready, so it stops making
+/// us wait, and an epoch that only moved on a wait would freeze for good and take
+/// the budget with it (measured: a hurry roughly every second, each shedding the
+/// pacing it was there to protect). Sleeping to the schedule is the proof that
+/// replaces the wait, since nothing the export queued while we slept could have
+/// gone out any earlier. What that gives up is a producer running faster than real
+/// time indefinitely: the sink keeps pace with it and falls further behind live
+/// without the budget noticing. Bounding *that* is the export's own
+/// `--latency-max`, which sheds media rather than compressing the clock.
+///
+/// The budget is the lead plus whatever standing lag the pacer has absorbed
+/// ([`Pacer::slack`](moq_mux::Pacer::slack)), which is a distance it is holding on
+/// purpose rather than lag to shed.
 struct Delivery {
 	pacer: moq_mux::Pacer,
 	/// The delivery-lag bound, and the pacer's lead: both are the export's
@@ -407,12 +415,26 @@ impl Delivery {
 			self.arrived = now;
 		}
 
+		// The pacer's own slack is not lag: it is the producer's standing delivery
+		// distance, which the pacer discovered and is holding on purpose. Counting
+		// it here would shed the margin on a fixed cadence and put the writes back
+		// on the arrival clock, which is the whole thing this is here to avoid.
+		let budget = self.lead + self.pacer.slack();
 		let mut send_at = self.pacer.pace(frame.timestamp, now.into_std());
-		if send_at.saturating_duration_since(self.arrived.into_std()) > self.lead {
+		if send_at.saturating_duration_since(self.arrived.into_std()) > budget {
 			send_at = self.pacer.hurry(frame.timestamp, now.into_std());
 		}
 
-		tokio::time::sleep_until(tokio::time::Instant::from_std(send_at)).await;
+		let send_at = tokio::time::Instant::from_std(send_at);
+		tokio::time::sleep_until(send_at).await;
+		// Reaching a scheduled instant is proof we are not behind, and it is the only
+		// such proof once the export holds a buffer: it always has the next slot
+		// ready, so it stops making us wait and the arrival epoch would freeze for
+		// good, taking the budget with it. Credit the scheduled instant rather than
+		// `now`, so an overshoot isn't credited as headroom.
+		if send_at > now {
+			self.arrived = send_at;
+		}
 		out.write_all(&frame.payload).await?;
 		out.flush().await?;
 		Ok(())
@@ -469,52 +491,88 @@ mod tests {
 		assert_eq!(out.len(), 3 * 188, "every payload was written");
 	}
 
-	/// A backlog delivered faster than real time (a tune-in group replaying from
-	/// its keyframe) must not be slept through step by step: each frame is within
-	/// the lead of the previous sleep's end, but total delivery lag versus the
-	/// frames' arrival would grow with the backlog's length and then stand for
-	/// the pipe's lifetime. Lag is measured against the last wait instead, so the
-	/// drain hurries once it overshoots the latency budget.
+	/// A sink that cannot reach its schedule still sheds the lag, which is the case
+	/// the budget is left guarding.
+	///
+	/// The epoch advances on a wait or on reaching a scheduled instant, and a sink
+	/// falling behind does neither: every frame is already overdue, so nothing
+	/// sleeps and nothing credits. The schedule then runs away from the frozen
+	/// epoch and the overshoot hurries.
+	///
+	/// What this no longer covers, deliberately, is a one-off pre-queued backlog
+	/// (a tune-in group replaying from its keyframe). That now paces out at the
+	/// media rate instead of being shed, because it is indistinguishable from the
+	/// TS export's own mux buffer from here: both hand over a frame that is ready
+	/// and ahead of the schedule. The size of such a backlog is bounded by the
+	/// export's `--latency-max`, which is where it belongs.
 	#[tokio::test(start_paused = true)]
-	async fn backlog_lag_is_bounded_by_the_latency_budget() {
+	async fn a_sink_that_cannot_keep_up_sheds_the_lag() {
 		let mut delivery = Delivery::new(Duration::from_millis(500));
 		let mut out = Vec::new();
 
 		let start = tokio::time::Instant::now();
-
-		// Frames spanning 1200ms of media, all available at once (waited = false
-		// after the first): pacing may hold each for at most the 500ms budget
-		// past the last wait, not restart the budget after every sleep.
 		delivery
 			.deliver(&frame(0, Timescale::MICRO), true, &mut out)
 			.await
 			.unwrap();
+
+		// The writer stalls for 2s (a blocked pipe): wall clock runs on, the media
+		// clock does not, and every frame after this is overdue on arrival.
+		tokio::time::advance(Duration::from_secs(2)).await;
+
 		delivery
 			.deliver(&frame(400_000, Timescale::MICRO), false, &mut out)
 			.await
 			.unwrap();
-		assert_eq!(start.elapsed(), Duration::from_millis(400), "within the budget: paced");
-
-		delivery
-			.deliver(&frame(800_000, Timescale::MICRO), false, &mut out)
-			.await
-			.unwrap();
-		delivery
-			.deliver(&frame(1_200_000, Timescale::MICRO), false, &mut out)
-			.await
-			.unwrap();
 		assert_eq!(
 			start.elapsed(),
-			Duration::from_millis(400),
-			"past the budget: the drain hurries instead of sleeping"
+			Duration::from_secs(2),
+			"an overdue frame writes at once, and the pacer takes its 500ms of lead as slack"
 		);
 
-		// The hurry made the newest frame the live edge, so pacing resumes
-		// relative to it once the export makes us wait again.
+		// 1100ms of schedule against a budget of lead + slack: the overshoot hurries
+		// and makes this the live edge.
 		delivery
-			.deliver(&frame(1_240_000, Timescale::MICRO), true, &mut out)
+			.deliver(&frame(600_000, Timescale::MICRO), false, &mut out)
 			.await
 			.unwrap();
-		assert_eq!(start.elapsed(), Duration::from_millis(440));
+		assert_eq!(start.elapsed(), Duration::from_secs(2));
+
+		// Pacing resumes relative to that edge.
+		delivery
+			.deliver(&frame(640_000, Timescale::MICRO), true, &mut out)
+			.await
+			.unwrap();
+		assert_eq!(start.elapsed(), Duration::from_secs(2) + Duration::from_millis(40));
+	}
+
+	/// The TS export holds a mux buffer, so it always has the next grid slot ready
+	/// and stops making the sink wait. Reaching a scheduled instant has to advance
+	/// the epoch too, or the budget freezes and hurries on a fixed cadence, shedding
+	/// the pacing it exists to protect.
+	#[tokio::test(start_paused = true)]
+	async fn a_buffered_producer_keeps_pacing() {
+		let mut delivery = Delivery::new(Duration::from_millis(500));
+		let mut out = Vec::new();
+
+		let start = tokio::time::Instant::now();
+		delivery
+			.deliver(&frame(0, Timescale::MICRO), true, &mut out)
+			.await
+			.unwrap();
+
+		// A grid slot every 25ms, each already queued: an epoch that only moved on a
+		// wait would freeze here and hurry once the schedule passed 500ms.
+		for slot in 1..=40u64 {
+			delivery
+				.deliver(&frame(slot * 25_000, Timescale::MICRO), false, &mut out)
+				.await
+				.unwrap();
+			assert_eq!(
+				start.elapsed(),
+				Duration::from_millis(slot * 25),
+				"slot {slot} must be paced, not shed"
+			);
+		}
 	}
 }

--- a/rs/moq-mux/src/container/ts/export.rs
+++ b/rs/moq-mux/src/container/ts/export.rs
@@ -1,11 +1,13 @@
 //! MPEG-TS muxer.
 //!
-//! [`Export`] subscribes to a MoQ broadcast and produces MPEG-TS, yielding one
-//! [`Frame`] per media frame: PAT/PMT program tables followed by one PES packet,
-//! packetized into 188-byte TS packets. Each frame keeps its media timestamp so
-//! the caller can pace delivery on the media clock. The PCR rides its own
-//! adaptation-field-only packets on a fixed media-time grid ([`Export::write_pcr`]).
-//! Video is carried as Annex-B, audio as ADTS AAC.
+//! [`Export`] subscribes to a MoQ broadcast and produces MPEG-TS: PAT/PMT program
+//! tables and PES packets, packetized into 188-byte TS packets, with the PCR
+//! riding its own adaptation-field-only packets on a fixed media-time grid.
+//! Output is sliced on that grid rather than per media frame ([`Export::emit`]):
+//! each [`Frame`] is one slot's clock packet plus the bytes belonging to it,
+//! stamped at the slot boundary, so the clock a receiver recovers from byte
+//! position agrees with the values, and a pacing caller releases each slot at
+//! the instant it asserts. Video is carried as Annex-B, audio as ADTS AAC.
 //!
 //! Video flows through [`ExportSource`], which normalizes every H.264/H.265
 //! source to length-prefixed NALU plus a resolved avcC/hvcC (parsing in-band
@@ -14,7 +16,7 @@
 //! length-prefixed -> Annex-B conversion, re-injecting the parameter sets as
 //! inline NALs on every keyframe. CMAF tracks are rejected with a clear error.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::task::Poll;
 use std::time::Duration;
 
@@ -46,9 +48,9 @@ const PMT_PID: u16 = 0x1000;
 const FIRST_ES_PID: u16 = 0x1001;
 /// Re-emit PAT/PMT at least this often (wall-clock of the media) for tune-in.
 const PSI_INTERVAL: Duration = Duration::from_millis(500);
-/// Emit a PCR on every crossing of this media-time grid ([`Export::write_pcr`]).
+/// Emit a PCR on every crossing of this media-time grid ([`Export::emit`]).
 /// TR 101 290 flags a gap over 40 ms; broadcast muxes emit every 25-40 ms.
-const PCR_INTERVAL: Duration = Duration::from_millis(25);
+pub(super) const PCR_INTERVAL: Duration = Duration::from_millis(25);
 /// How many missed PCR slots to backfill at most: one second's worth. Frames
 /// coarser than the grid cross several slots at a time and every one is filled so
 /// the ramp stays uniform, down to a 1 fps cadence. Past this cap the media
@@ -59,11 +61,11 @@ const PCR_BACKFILL: u128 = 40;
 
 /// Subscribe to a broadcast and produce an MPEG-TS byte stream.
 ///
-/// Use [`next`](Self::next) to pull one [`Frame`] per media frame: its `payload`
-/// is the TS packets, stamped with the source `timestamp` and `keyframe` flag.
-/// The leading PAT/PMT rides on the first frame (so it inherits a real
-/// timestamp), and is re-emitted at video keyframes and periodically for
-/// mid-stream tune-in. Returns `None` when the broadcast ends.
+/// Use [`next`](Self::next) to pull one [`Frame`] per PCR grid slot: its `payload`
+/// is the TS packets belonging to that slot, stamped at the slot's boundary. The
+/// leading PAT/PMT rides on the first frame (so it inherits a real timestamp), and
+/// is re-emitted at video keyframes and periodically for mid-stream tune-in.
+/// Returns `None` when the broadcast ends.
 pub struct Export<E: catalog::Catalog = ()> {
 	source: crate::Source,
 	catalog: Option<crate::catalog::Consumer<E>>,
@@ -87,8 +89,28 @@ pub struct Export<E: catalog::Catalog = ()> {
 	psi: Option<Psi>,
 	/// Media timestamp of the last PAT/PMT emission ([`due`]).
 	last_psi: Option<Timestamp>,
-	/// Grid slot of the last PCR emission ([`Self::write_pcr`]).
+	/// Grid slot of the last PCR emission ([`Self::emit`]).
 	last_pcr: Option<u128>,
+	/// TS packets muxed into the span that is still open.
+	pending: Vec<u8>,
+	/// Offsets into [`pending`](Self::pending) where a keyframe's packets begin, so
+	/// the output frame carrying one keeps the flag.
+	keyframes: Vec<usize>,
+	/// Output frames ready to hand out, one per grid slot the last span covered.
+	queue: VecDeque<Frame>,
+	/// Continuity counter of the last packet emitted on the PCR PID. A clock packet
+	/// carries no payload, so it repeats whatever preceded it on the wire rather
+	/// than advancing the counter ([`Export::pcr_at`]).
+	pcr_cc: Option<u8>,
+	/// Media time the next span's bytes are transmitted from ([`Export::emit`]).
+	clock: Option<Timestamp>,
+	/// Earliest media timestamp muxed into the open span: the decode time its bytes
+	/// have to arrive before, so it bounds how far the clock may run.
+	low: Option<Timestamp>,
+	/// Media timestamp that opened the current span. Reordered (B-frame) timestamps
+	/// step backwards all the time, so a span closes on a timestamp passing this
+	/// high-water mark rather than on every frame.
+	watermark: Option<Timestamp>,
 	/// Tune-in point: the first video keyframe's timestamp, captured when the program
 	/// tables are built. Non-video frames before it are dropped so the keyframe leads
 	/// the stream.
@@ -221,6 +243,13 @@ impl<E: catalog::Catalog> Export<E> {
 			psi: None,
 			last_psi: None,
 			last_pcr: None,
+			pending: Vec::new(),
+			keyframes: Vec::new(),
+			queue: VecDeque::new(),
+			pcr_cc: None,
+			clock: None,
+			low: None,
+			watermark: None,
 			video_start: None,
 		})
 	}
@@ -233,12 +262,14 @@ impl<E: catalog::Catalog> Export<E> {
 
 	/// Get the next muxed frame.
 	///
-	/// Each [`Frame`] carries the TS packets for one media frame in `payload`,
-	/// stamped with that frame's media `timestamp` and `keyframe` flag so a
-	/// transport can pace delivery on the media clock. The leading PAT/PMT rides
-	/// on the first frame (inheriting its timestamp), and is re-emitted at video
-	/// keyframes and periodically for mid-stream tune-in. Returns `None` when the
-	/// broadcast ends. `duration` is always `None`: the muxer has no use for it.
+	/// Each [`Frame`] carries one slice of the PCR grid in `payload`: the clock
+	/// packets that slice opens with, followed by the muxed bytes belonging to it.
+	/// It is stamped with the media time that slice starts at, so a transport can
+	/// pace delivery on the media clock, and `keyframe` marks the slice a video
+	/// keyframe begins in. The leading PAT/PMT rides on the first slice, and is
+	/// re-emitted at video keyframes and periodically for mid-stream tune-in.
+	/// Returns `None` when the broadcast ends. `duration` is always `None`: the
+	/// muxer has no use for it.
 	pub async fn next(&mut self) -> crate::Result<Option<Frame>> {
 		kio::wait(|waiter| self.poll_next(waiter)).await
 	}
@@ -256,48 +287,13 @@ impl<E: catalog::Catalog> Export<E> {
 			}
 		}
 
-		// 2. Pull a frame into every idle track. ExportSource has already
-		// transformed Annex-B avc3/hev1 into length-prefixed form and resolved
-		// the avcC/hvcC. Before the program tables are written, drop slices that
-		// arrive before their codec config resolves: a receiver joining mid-GOP
-		// can't use them, and parking them would stop us polling for the keyframe
-		// that carries the parameter sets.
-		let waiting_for_header = self.psi.is_none();
-		let video_start = self.video_start;
-		for track in self.tracks.values_mut() {
-			if track.pending.is_some() || track.finished {
-				continue;
-			}
-			let is_video = matches!(track.kind, Kind::Video(_));
-			loop {
-				match track.source.poll_read(waiter)? {
-					Poll::Ready(Some(frame)) => {
-						if waiting_for_header && !track.source.header_ready() {
-							continue;
-						}
-						// Tune-in alignment: drop non-video frames before the first video
-						// keyframe (see `video_start`) so the in-band SPS/PPS leads the stream.
-						if let Some(start) = video_start
-							&& !is_video && frame.timestamp < start
-						{
-							continue;
-						}
-						track.pending = Some(frame);
-						break;
-					}
-					Poll::Ready(None) => {
-						track.finished = true;
-						break;
-					}
-					Poll::Pending => break,
-				}
-			}
-		}
+		// 2. Pull a frame into every idle track.
+		self.fill(waiter)?;
 
 		// 3. Build the program tables once the layout is resolved and every
 		// track's codec config is ready. The tables aren't emitted here: PSI has
-		// no media time of its own, so `write_frame` prepends them to the first
-		// frame instead, letting the leading PAT/PMT inherit a real timestamp.
+		// no media time of its own, so `mux` prepends them to the first frame's
+		// packets instead, letting the leading PAT/PMT inherit a real timestamp.
 		if self.psi.is_none() {
 			if self.tracks.is_empty() {
 				// No tracks yet. If the catalog is also done, the broadcast is empty.
@@ -332,30 +328,85 @@ impl<E: catalog::Catalog> Export<E> {
 			}
 		}
 
-		// 4. Emit the smallest-timestamp pending frame as a PES packet (the first
-		// one carries the buffered PAT/PMT). The program clock leads it: each grid
-		// slot the frame's timestamp has crossed goes out first as its own frame,
-		// stamped at the slot boundary, so the caller's pacer places the PCR at the
-		// time it asserts instead of bunching it with the frame that revealed it.
-		if let Some(name) = self.pick_next_track() {
-			let timestamp = self.tracks[&name].pending.as_ref().unwrap().timestamp;
-			if let Some(out) = self.write_pcr(timestamp)? {
+		// 4. Mux the smallest-timestamp pending frame into the open span (the first
+		// one carries the buffered PAT/PMT). Nothing goes out until a later
+		// timestamp measures that span: only then is it known how many bytes it
+		// carried, which is what puts the clock packets at the byte position their
+		// own values imply and lets the caller's pacer release each at the instant
+		// it asserts. See [`Self::advance`].
+		loop {
+			if let Some(out) = self.queue.pop_front() {
 				return Poll::Ready(Ok(Some(out)));
 			}
+			let Some(name) = self.pick_next_track() else { break };
 			let frame = self.tracks.get_mut(&name).unwrap().pending.take().unwrap();
-			let out = self.write_frame(&name, frame)?;
-			return Poll::Ready(Ok(Some(out)));
+			self.advance(frame.timestamp)?;
+			self.mux(&name, frame)?;
+			// Refill the track we just drained: the next span is measured by its
+			// successor, and without the refill nothing would be polling for it.
+			self.fill(waiter)?;
 		}
 
-		// 5. End of stream once every track has drained and the catalog is closed.
-		if self.catalog.is_none() && !self.tracks.is_empty() && self.tracks.values().all(|t| t.finished) {
-			return Poll::Ready(Ok(None));
+		// 5. Once every track has drained, no later timestamp is coming to measure
+		// the open span, so its bytes go out whole. That's independent of the
+		// catalog: a retained track finishes while the broadcast stays live, and
+		// holding its tail until the catalog closed would strand it indefinitely.
+		let drained = !self.tracks.is_empty() && self.tracks.values().all(|t| t.finished);
+		if drained {
+			self.emit(None)?;
+			if let Some(out) = self.queue.pop_front() {
+				return Poll::Ready(Ok(Some(out)));
+			}
 		}
-		if self.catalog.is_none() && self.tracks.is_empty() {
+
+		// End of stream once the catalog is closed too: nothing more can appear.
+		if self.catalog.is_none() && (drained || self.tracks.is_empty()) {
 			return Poll::Ready(Ok(None));
 		}
 
 		Poll::Pending
+	}
+
+	/// Pull a frame into every idle track.
+	///
+	/// [`ExportSource`] has already transformed Annex-B avc3/hev1 into
+	/// length-prefixed form and resolved the avcC/hvcC. Before the program tables
+	/// are written, drop slices that arrive before their codec config resolves: a
+	/// receiver joining mid-GOP can't use them, and parking them would stop us
+	/// polling for the keyframe that carries the parameter sets.
+	fn fill(&mut self, waiter: &kio::Waiter) -> crate::Result<()> {
+		let waiting_for_header = self.psi.is_none();
+		let video_start = self.video_start;
+		for track in self.tracks.values_mut() {
+			if track.pending.is_some() || track.finished {
+				continue;
+			}
+			let is_video = matches!(track.kind, Kind::Video(_));
+			loop {
+				match track.source.poll_read(waiter)? {
+					Poll::Ready(Some(frame)) => {
+						if waiting_for_header && !track.source.header_ready() {
+							continue;
+						}
+						// Tune-in alignment: drop non-video frames before the first video
+						// keyframe (see `video_start`) so the in-band SPS/PPS leads the stream.
+						if let Some(start) = video_start
+							&& !is_video && frame.timestamp < start
+						{
+							continue;
+						}
+						track.pending = Some(frame);
+						break;
+					}
+					Poll::Ready(None) => {
+						track.finished = true;
+						break;
+					}
+					Poll::Pending => break,
+				}
+			}
+		}
+		Ok(())
 	}
 
 	fn update_catalog(&mut self, mut catalog: Catalog<E>) -> anyhow::Result<()> {
@@ -712,11 +763,13 @@ impl<E: catalog::Catalog> Export<E> {
 			.map(|(_, _, name)| name.clone())
 	}
 
-	/// Packetize one media frame into an output [`Frame`], re-emitting PAT/PMT
-	/// before video keyframes (and periodically) so receivers can tune in
-	/// mid-stream. The returned frame keeps the source `timestamp` and `keyframe`
-	/// flag so the caller can pace it.
-	fn write_frame(&mut self, name: &str, frame: Frame) -> anyhow::Result<Frame> {
+	/// Packetize one media frame into the open span, re-emitting PAT/PMT before
+	/// video keyframes (and periodically) so receivers can tune in mid-stream.
+	///
+	/// The bytes are buffered rather than returned: which grid slots they belong
+	/// to isn't known until a later timestamp measures the span (see
+	/// [`Self::advance`]).
+	fn mux(&mut self, name: &str, frame: Frame) -> anyhow::Result<()> {
 		let track = self.tracks.get(name).context("missing track")?;
 		let pid = track.pid;
 		let kind = track.kind.clone();
@@ -824,111 +877,184 @@ impl<E: catalog::Catalog> Export<E> {
 				self.write_pes(&mut out, &unit, &es_payload)?;
 			}
 		}
-		Ok(Frame {
-			timestamp,
-			duration: None,
-			payload: Bytes::from(out),
-			keyframe,
-		})
+		if keyframe {
+			self.keyframes.push(self.pending.len());
+		}
+		self.pending.extend_from_slice(&out);
+		self.low = Some(self.low.map_or(timestamp, |low| low.min(timestamp)));
+		Ok(())
 	}
 
-	/// Emit the program clock: one adaptation-field-only packet on the PCR PID per
-	/// [`PCR_INTERVAL`] slot of the media timeline, each returned as its own
-	/// [`Frame`] stamped at its slot boundary so the caller's pacer delivers the
-	/// packet at the time it asserts.
+	/// Close the open span if `ts` passes the watermark, laying its bytes out.
 	///
-	/// The PES units cannot carry the clock. Frames arrive in decode order, so the
-	/// authored DTS is a saw: a reference frame leaps a whole reorder span ahead and
-	/// each B-frame nudges one tick past it. A PCR sampled from it freezes and jumps
-	/// (measured as 85% of intervals within 11 us of each other, the rest collected
-	/// into gaps of hundreds of ms), and no downstream CBR stage can repair that,
-	/// because a groomer can only place the clock samples it receives. So the PCR
-	/// asserts its own uniform ramp instead: absolute grid slots on the media
-	/// timeline (shared by every exporter of the broadcast, like [`due`]), each
-	/// backed off by the largest decode-clock reserve of any track so every PES
-	/// unit, whichever rendition it belongs to, decodes at or after the clock that
-	/// precedes it.
+	/// `ts` belongs to the frame about to be muxed. Passing the watermark means the
+	/// span that timestamp opened is done: everything buffered since is exactly the
+	/// bytes it carried, and the distance from it measures how long it ran. A
+	/// reordered (B-frame) timestamp that trails the watermark closes nothing, and
+	/// its bytes join the open span, which is where they are transmitted anyway.
 	///
-	/// `timestamp` is the next media frame's; `None` when its slot has already been
-	/// served (the caller then emits the media frame itself). One slot per call:
-	/// missed slots drain over successive polls, each at its own boundary, capped at
-	/// [`PCR_BACKFILL`]. The clock always leads, including ahead of the very first
-	/// frame's PAT/PMT: a receiver joins a TS mid-stream at an arbitrary packet, so
-	/// there is no "first" on the wire, and holding the clock back would leave the
-	/// leading PES without one.
-	fn write_pcr(&mut self, timestamp: Timestamp) -> anyhow::Result<Option<Frame>> {
-		let pcr_pid = self.psi.as_ref().context("PSI not built")?.pcr_pid;
-		let current = slot(timestamp, PCR_INTERVAL);
-		let index = match self.last_pcr {
-			None => current,
-			Some(last) => {
-				// A reordered (B-frame) timestamp steps backwards into a slot already
-				// served; the clock only ever moves forward.
-				if current <= last {
-					return Ok(None);
-				}
-				// Backfill every missed slot so the ramp stays uniform when frames are
-				// coarser than the grid, but cap it: past the cap the media itself
-				// gapped, and a dense clock history for a span that carried no bytes
-				// helps nobody.
-				(last + 1).max(current.saturating_sub(PCR_BACKFILL - 1))
-			}
+	/// This is why nothing goes out on arrival, and why it can't. A span's bytes
+	/// have to reach a receiver before the units in it decode, so they ride the
+	/// grid slots *preceding* the span, which are only known once the span has
+	/// closed. That is the mux buffer: the exporter runs two spans behind the media
+	/// clock, by a constant amount, so a caller pacing on the stamps still releases
+	/// every slot at the interval its own PCR value asserts.
+	fn advance(&mut self, ts: Timestamp) -> anyhow::Result<()> {
+		let Some(watermark) = self.watermark else {
+			self.watermark = Some(ts);
+			return Ok(());
 		};
-		// The largest reserve of any track, not just the PCR track's: every
-		// rendition's PES must decode at or after the clock, and each video track
-		// backs its DTS off by its own catalog jitter.
+		if ts <= watermark {
+			return Ok(());
+		}
+		self.watermark = Some(ts);
+		let span = ts.as_nanos().saturating_sub(watermark.as_nanos());
+		self.emit(Some(span))
+	}
+
+	/// Lay the open span's bytes across the grid slots that run up to its decode
+	/// time, one [`Frame`] per slot. `span` is how long the span ran, or `None` at
+	/// end of stream, where nothing measured it.
+	///
+	/// Each frame opens with the clock packets whose slot boundary it starts at,
+	/// then carries the share of the bytes its slice of the interval earns. Three
+	/// things follow, and they are the whole point of muxing this way. The packet
+	/// count between consecutive PCRs is proportional to the difference between
+	/// their values, so a consumer holding only the byte stream (which is every
+	/// MPEG-TS tool) recovers the same clock from byte position that the values
+	/// assert. Each frame is stamped at its own slot boundary, so a pacing caller
+	/// releases the clock at the instant it asserts rather than when the media that
+	/// revealed it arrived. And the interval ends at the span's earliest media
+	/// timestamp, so every byte precedes the decode time of the unit it belongs to.
+	///
+	/// The PES units cannot carry the clock themselves. Frames arrive in decode
+	/// order, so the authored DTS is a saw: a reference frame leaps a whole reorder
+	/// span ahead and each B-frame nudges one tick past it. A PCR sampled from it
+	/// freezes and jumps, and no downstream CBR stage can repair that, because a
+	/// groomer can only place the clock samples it receives. So the PCR asserts its
+	/// own uniform ramp instead: absolute grid slots on the media timeline (shared by
+	/// every exporter of the broadcast, like [`due`]), each backed off by the largest
+	/// decode-clock reserve of any track so every PES unit, whichever rendition it
+	/// belongs to, decodes at or after the clock that precedes it.
+	fn emit(&mut self, span: Option<u128>) -> anyhow::Result<()> {
+		let bytes = std::mem::take(&mut self.pending);
+		let keyframes = std::mem::take(&mut self.keyframes);
+		let Some(to) = self.low.take() else { return Ok(()) };
+		let packets = bytes.len() / TsPacket::SIZE;
+
+		// Transmit from where the last span stopped up to this one's decode time, so
+		// the intervals abut and the clock neither repeats nor reverses. The first
+		// has nothing to abut, so it takes the span's own measured length.
+		//
+		// The clock only ever moves forward. A track skewed far enough behind that it
+		// decodes before the clock already reached it can't be placed ahead of its own
+		// decode time, and `with_latency` owns that skew, so its bytes go out at the
+		// clock rather than dragging it backwards.
+		let start = match self.clock {
+			Some(clock) => clock.as_nanos(),
+			None => to.as_nanos().saturating_sub(span.unwrap_or(0)),
+		};
+		let end = to.as_nanos().max(start);
+		let from = stamp(start)?;
+		self.clock = Some(stamp(end)?);
+
+		// The slot `start` sits in; its boundary is at or before every byte here.
+		let open = start / PCR_INTERVAL.as_nanos();
+		// The last boundary strictly inside the interval: `end` opens the next one's.
+		let last = slot_before(end, PCR_INTERVAL).max(open);
+		// Slots still owed a clock packet. Backfill every missed one so the ramp
+		// stays uniform when frames are coarser than the grid, but cap it: past the
+		// cap the media itself gapped, and a dense clock history for a span that
+		// carried no bytes helps nobody.
+		let first = self
+			.last_pcr
+			.map_or(open, |l| l + 1)
+			.max((last + 1).saturating_sub(PCR_BACKFILL));
+		// Spread the bytes only across an interval the grid can describe. Past the
+		// cap they were muxed before a media gap, so they belong at its start rather
+		// than smeared across silence.
+		let spread = last - open < PCR_BACKFILL;
+		let width = end - start;
+
+		// The first frame opens at `from` rather than a boundary, and carries every
+		// clock packet whose slot has already begun.
+		let pcr_pid = self.psi.as_ref().context("PSI not built")?.pcr_pid;
+		let mut payload = Vec::new();
+		for index in first..=open {
+			let before = counter_before(&bytes, 0, pcr_pid, self.pcr_cc);
+			payload.extend_from_slice(&self.pcr_at(index, before)?);
+		}
+		let mut cut = 0;
+		let mut at = from;
+
+		// One frame per boundary inside the interval. `first` can only exceed
+		// `open + 1` when the backfill cap skipped the slots below it, and that cap
+		// bounds this range to [`PCR_BACKFILL`] iterations however long the gap was.
+		for index in (open + 1).max(first)..=last {
+			let boundary = slot_stamp(index)?;
+			let next = if spread && width > 0 {
+				(packets as u128 * (boundary.as_nanos() - start) / width) as usize
+			} else {
+				packets
+			};
+			payload.extend_from_slice(&bytes[cut * TsPacket::SIZE..next * TsPacket::SIZE]);
+			self.push(at, payload, &keyframes, cut, next);
+			cut = next;
+			at = boundary;
+			let before = counter_before(&bytes, cut * TsPacket::SIZE, pcr_pid, self.pcr_cc);
+			payload = self.pcr_at(index, before)?;
+		}
+
+		payload.extend_from_slice(&bytes[cut * TsPacket::SIZE..]);
+		self.push(at, payload, &keyframes, cut, packets);
+		if let Some(cc) = counter_before(&bytes, bytes.len(), pcr_pid, None) {
+			self.pcr_cc = Some(cc);
+		}
+		Ok(())
+	}
+
+	/// Queue one output frame, unless it would be empty. `from`..`to` are the packet
+	/// indices it carries, which decide whether a keyframe begins in it.
+	fn push(&mut self, timestamp: Timestamp, payload: Vec<u8>, keyframes: &[usize], from: usize, to: usize) {
+		if payload.is_empty() {
+			return;
+		}
+		let (from, to) = (from * TsPacket::SIZE, to * TsPacket::SIZE);
+		let keyframe = keyframes.iter().any(|&at| at >= from && at < to);
+		self.queue.push_back(Frame {
+			timestamp,
+			duration: None,
+			payload: Bytes::from(payload),
+			keyframe,
+		});
+	}
+
+	/// The clock packet for grid slot `index`, and record that the slot is served.
+	///
+	/// The value backs off by the largest reserve of any track, not just the PCR
+	/// track's: every rendition's PES must decode at or after the clock, and each
+	/// video track backs its DTS off by its own catalog jitter. Back off through the
+	/// 33-bit wrap rather than saturating: a timeline that starts inside the reserve
+	/// would otherwise clamp its first slots to zero and break the uniform step. The
+	/// wire field is a circular clock, so the masked wrapped value is the correct
+	/// mod-2^33 back-off.
+	fn pcr_at(&mut self, index: u128, before: Option<u8>) -> anyhow::Result<Vec<u8>> {
+		let pcr_pid = self.psi.as_ref().context("PSI not built")?.pcr_pid;
 		let reserve = self
 			.tracks
 			.values()
 			.map(|t| t.dts_reserve)
 			.max()
 			.unwrap_or(DEFAULT_DTS_RESERVE);
-		// Back off through the 33-bit wrap rather than saturating: a timeline that
-		// starts inside the reserve would otherwise clamp its first slots to zero
-		// and break the uniform step. The wire field is a circular clock, so the
-		// masked wrapped value is the correct mod-2^33 back-off.
 		let ticks = slot_ticks(index, PCR_INTERVAL).wrapping_sub(reserve);
-		let payload = self.pcr_packet(pcr_pid, ticks)?;
+		// Nothing has gone out on this PID yet, so there is no counter to repeat and
+		// any value starts a valid run; take the one before the next to be used.
+		let cc = match before {
+			Some(cc) => cc,
+			None => self.counters.entry(pcr_pid).or_default().as_u8().wrapping_sub(1),
+		};
 		self.last_pcr = Some(index);
-		Ok(Some(Frame {
-			timestamp: Timestamp::from_micros((index * PCR_INTERVAL.as_micros()) as u64)?,
-			duration: None,
-			payload: Bytes::from(payload),
-			keyframe: false,
-		}))
-	}
-
-	/// One adaptation-field-only TS packet carrying `ticks` (continuous 90 kHz) as
-	/// its PCR, laid out by hand: the `mpeg2ts` serializer writes the six reserved
-	/// bits between PCR base and extension as zeros where ISO 13818-1 requires
-	/// ones, and strict analyzers flag that. There is no payload, so the field's
-	/// stuffing fills the packet and the continuity counter is not incremented
-	/// (ISO 13818-1 2.4.3.3): it repeats the previous packet's value, one behind
-	/// the stored next-to-use value.
-	fn pcr_packet(&mut self, pid: u16, ticks: u64) -> anyhow::Result<Vec<u8>> {
-		anyhow::ensure!(pid <= 0x1FFF, "PID out of range: {pid}");
-		let cc = self.counters.entry(pid).or_default().as_u8().wrapping_sub(1) & ContinuityCounter::MAX;
-		let base = ticks & TS_TIMESTAMP_MASK;
-		let mut p = Vec::with_capacity(TsPacket::SIZE);
-		p.push(0x47);
-		p.push((pid >> 8) as u8);
-		p.push(pid as u8);
-		// adaptation_field_control = adaptation field only, no scrambling.
-		p.push(0x20 | cc);
-		// adaptation_field_length covers the rest of the packet.
-		p.push(183);
-		// PCR_flag alone.
-		p.push(0x10);
-		// program_clock_reference_base (33 bits), 6 reserved '1' bits, and a zero
-		// 9-bit extension (the grid is 90 kHz-exact, so there is nothing sub-tick).
-		p.push((base >> 25) as u8);
-		p.push((base >> 17) as u8);
-		p.push((base >> 9) as u8);
-		p.push((base >> 1) as u8);
-		p.push(((base as u8) << 7) | 0x7e);
-		p.push(0x00);
-		p.resize(TsPacket::SIZE, 0xff);
-		Ok(p)
+		pcr_packet(pcr_pid, ticks, cc)
 	}
 
 	/// Packetize a PES payload into 188-byte TS packets.
@@ -1085,6 +1211,63 @@ impl<E: catalog::Catalog> Export<E> {
 	}
 }
 
+/// One adaptation-field-only TS packet carrying `ticks` (continuous 90 kHz) as its
+/// PCR, laid out by hand: the `mpeg2ts` serializer writes the six reserved bits
+/// between PCR base and extension as zeros where ISO 13818-1 requires ones, and
+/// strict analyzers flag that.
+///
+/// There is no payload, so the field's stuffing fills the packet and the continuity
+/// counter is not incremented (ISO 13818-1 2.4.3.3): `cc` is the counter of
+/// whatever preceded this packet on the same PID, which it repeats. The clock rides
+/// a PID that also carries media, and the packets around it were numbered when they
+/// were muxed rather than when they go out, so this has to come from the wire order
+/// rather than from the counter's current value.
+fn pcr_packet(pid: u16, ticks: u64, cc: u8) -> anyhow::Result<Vec<u8>> {
+	anyhow::ensure!(pid <= 0x1FFF, "PID out of range: {pid}");
+	let cc = cc & ContinuityCounter::MAX;
+	let base = ticks & TS_TIMESTAMP_MASK;
+	let mut p = Vec::with_capacity(TsPacket::SIZE);
+	p.push(0x47);
+	p.push((pid >> 8) as u8);
+	p.push(pid as u8);
+	// adaptation_field_control = adaptation field only, no scrambling.
+	p.push(0x20 | cc);
+	// adaptation_field_length covers the rest of the packet.
+	p.push(183);
+	// PCR_flag alone.
+	p.push(0x10);
+	// program_clock_reference_base (33 bits), 6 reserved '1' bits, and a zero
+	// 9-bit extension (the grid is 90 kHz-exact, so there is nothing sub-tick).
+	p.push((base >> 25) as u8);
+	p.push((base >> 17) as u8);
+	p.push((base >> 9) as u8);
+	p.push((base >> 1) as u8);
+	p.push(((base as u8) << 7) | 0x7e);
+	p.push(0x00);
+	p.resize(TsPacket::SIZE, 0xff);
+	Ok(p)
+}
+
+/// The continuity counter a payload-less packet inserted at byte offset `cut` has to
+/// repeat: the last one before it on `pid`, else the one carried in from the last
+/// span, else one behind the first packet that follows it, which is what keeps the
+/// run continuous where the clock leads the stream and nothing precedes it.
+fn counter_before(bytes: &[u8], cut: usize, pid: u16, carried: Option<u8>) -> Option<u8> {
+	let on_pid = |p: &&[u8]| (u16::from(p[1] & 0x1f) << 8 | u16::from(p[2])) == pid;
+	let counter = |p: &[u8]| p[3] & ContinuityCounter::MAX;
+	bytes[..cut]
+		.rchunks_exact(TsPacket::SIZE)
+		.find(on_pid)
+		.map(counter)
+		.or(carried)
+		.or_else(|| {
+			bytes[cut..]
+				.chunks_exact(TsPacket::SIZE)
+				.find(on_pid)
+				.map(|p| counter(p).wrapping_sub(1) & ContinuityCounter::MAX)
+		})
+}
+
 /// Optional PES header region carrying PTS only: 2 flag bytes + 1 length byte + 5 PTS bytes.
 const PES_OPTIONAL_LEN: usize = 3 + 5;
 /// Extra bytes when the optional region also carries a DTS (5 DTS bytes).
@@ -1127,6 +1310,30 @@ fn due(timestamp: Timestamp, last: Option<Timestamp>, interval: Duration) -> boo
 /// divide by it.
 fn slot(timestamp: Timestamp, interval: Duration) -> u128 {
 	Duration::from(timestamp).as_nanos() / interval.as_nanos()
+}
+
+/// Index of the last repetition slot to *begin* strictly before `nanos`.
+///
+/// [`slot`] rounds down, so a position sitting exactly on a boundary belongs to the slot that
+/// boundary opens. When the position is the exclusive end of an interval, that slot is the
+/// next interval's, not this one's, hence the offset.
+fn slot_before(nanos: u128, interval: Duration) -> u128 {
+	if nanos == 0 {
+		return 0;
+	}
+	(nanos - 1) / interval.as_nanos()
+}
+
+/// A repetition slot's boundary as a media timestamp.
+fn slot_stamp(index: u128) -> anyhow::Result<Timestamp> {
+	stamp(index * PCR_INTERVAL.as_micros() * 1_000)
+}
+
+/// A nanosecond position on the media timeline as a microsecond [`Timestamp`], the
+/// scale the exporter stamps its own output in.
+fn stamp(nanos: u128) -> anyhow::Result<Timestamp> {
+	let micros = (nanos / 1_000).try_into().context("media timeline out of range")?;
+	Ok(Timestamp::from_micros(micros)?)
 }
 
 /// A repetition slot's boundary (`index * interval`) in 90 kHz ticks.

--- a/rs/moq-mux/src/container/ts/export_test.rs
+++ b/rs/moq-mux/src/container/ts/export_test.rs
@@ -16,6 +16,7 @@ use mpeg2ts::pes::{PesPacketReader, ReadPesPacket};
 use mpeg2ts::ts::{ReadTsPacket, TsPacketReader, TsPayload};
 
 use crate::catalog::hang::Container as HangContainer;
+use crate::container::ts::export::PCR_INTERVAL;
 use crate::container::ts::{Export, catalog as tscat};
 use crate::container::{Frame, Producer};
 use moq_net::Timestamp;
@@ -728,35 +729,40 @@ async fn export_pcr_wraps_below_the_reserve_at_start() {
 	let mut exporter = Export::new(crate::source::announced(&consumer)).await.unwrap();
 	let frames = drain_frames(&mut exporter).await;
 
-	// Each PCR is its own single-packet frame, stamped at its slot boundary so the
-	// caller's pacer delivers the clock at the time it asserts.
+	// A slot's clock packets lead the frame carrying that slot's bytes, and the
+	// frame is stamped at the slot boundary so the caller's pacer delivers the
+	// clock at the time it asserts.
 	let mut pcrs: Vec<u64> = Vec::new();
 	for (i, frame) in frames.iter().enumerate() {
 		assert_packet_aligned(&frame.payload);
-		let packet = &frame.payload[..188];
-		// adaptation-field-only packets (adaptation_field_control == 0b10) are the clock.
-		if packet[3] & 0x30 != 0x20 {
-			continue;
+		let mut head = None;
+		for packet in frame.payload.chunks(188) {
+			// adaptation-field-only packets (adaptation_field_control == 0b10) are the clock.
+			if packet[3] & 0x30 != 0x20 {
+				break;
+			}
+			assert_eq!(packet[5], 0x10, "PCR_flag alone, at {i}");
+			// The six reserved bits between base and extension are ones (ISO 13818-1);
+			// the crate's serializer writes zeros here, which is why the packet is
+			// laid out by hand.
+			assert_eq!(packet[10] & 0x7e, 0x7e, "reserved bits must be ones, at {i}");
+			let base = (u64::from(packet[6]) << 25)
+				| (u64::from(packet[7]) << 17)
+				| (u64::from(packet[8]) << 9)
+				| (u64::from(packet[9]) << 1)
+				| u64::from(packet[10] >> 7);
+			pcrs.push(base);
+			head = Some(base);
 		}
-		assert_eq!(frame.payload.len(), 188, "a PCR frame is one packet, at {i}");
-		assert_eq!(packet[5], 0x10, "PCR_flag alone, at {i}");
-		// The six reserved bits between base and extension are ones (ISO 13818-1);
-		// the crate's serializer writes zeros here, which is why the packet is
-		// laid out by hand.
-		assert_eq!(packet[10] & 0x7e, 0x7e, "reserved bits must be ones, at {i}");
-		let base = (u64::from(packet[6]) << 25)
-			| (u64::from(packet[7]) << 17)
-			| (u64::from(packet[8]) << 9)
-			| (u64::from(packet[9]) << 1)
-			| u64::from(packet[10] >> 7);
-		// The frame is paced at the slot the value asserts (plus the reserve).
-		let slot_ticks = frame.timestamp.as_micros() * 90_000 / 1_000_000;
+		// The frame is paced at the slot its last leading clock asserts (plus the
+		// reserve), which is the newest slot that has begun by then.
+		let Some(base) = head else { continue };
+		let slot_ticks = frame.timestamp.as_micros() / 25_000 * 25_000 * 90 / 1_000;
 		assert_eq!(
 			base,
 			(slot_ticks as u64).wrapping_sub(16) & WIRE,
 			"pacing off value, at {i}"
 		);
-		pcrs.push(base);
 	}
 
 	const WIRE: u64 = (1 << 33) - 1;
@@ -2276,4 +2282,206 @@ async fn late_join_matches_a_running_exporter_without_video() {
 	let tune_in = b.iter().find(|f| !is_pcr_frame(f)).expect("a tune-in frame").timestamp;
 	let from = b.iter().map(|f| f.timestamp).filter(|&t| t > tune_in).min().unwrap();
 	assert_only_continuity_differs(&a, &b, from);
+}
+
+/// Every PCR packet in transport order: its packet index in the stream, its value
+/// (90 kHz), and the media timestamp of the frame carrying it.
+fn collect_pcrs(frames: &[Frame]) -> Vec<(usize, u64, u128)> {
+	let mut at = 0;
+	let mut pcrs = Vec::new();
+	for frame in frames {
+		for packet in frame.payload.chunks(188) {
+			// adaptation-field-only packets (adaptation_field_control == 0b10) are the clock.
+			if packet[3] & 0x30 == 0x20 && packet[5] & 0x10 != 0 {
+				let base = (u64::from(packet[6]) << 25)
+					| (u64::from(packet[7]) << 17)
+					| (u64::from(packet[8]) << 9)
+					| (u64::from(packet[9]) << 1)
+					| u64::from(packet[10] >> 7);
+				pcrs.push((at, base, frame.timestamp.as_micros()));
+			}
+			at += 1;
+		}
+	}
+	pcrs
+}
+
+/// A 4 s CBR-ish single-rendition H.264 feed at 25 fps, one second per group: the
+/// shape of a broadcast contribution capture, and the one #3334 measured.
+async fn export_cbr_video() -> Vec<Frame> {
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let consumer = broadcast.consume();
+	let mut catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+
+	let track = broadcast
+		.create_track(broadcast.unique_name(".h264"), hang::container::track_info())
+		.unwrap();
+	{
+		let mut cfg = VideoConfig::new(H264 {
+			profile: 0x42,
+			constraints: 0xc0,
+			level: 0x1f,
+			inline: true,
+		});
+		cfg.container = Container::Legacy;
+		catalog.lock().video.renditions.insert(track.name().to_string(), cfg);
+	}
+	let mut video = Producer::new(track, HangContainer::Legacy);
+	for i in 0..100u64 {
+		let keyframe = i % 25 == 0;
+		let mut nal = vec![if keyframe { 0x65u8 } else { 0x41 }];
+		nal.extend(std::iter::repeat_n(0xAB, 7_000));
+		if keyframe && i > 0 {
+			video.cut(None).unwrap();
+		}
+		video
+			.write(Frame {
+				timestamp: Timestamp::from_micros(i * 40_000).unwrap(),
+				duration: None,
+				payload: if keyframe {
+					annexb(&[SPS, PPS, &nal])
+				} else {
+					annexb(&[&nal])
+				},
+				keyframe,
+			})
+			.unwrap();
+	}
+	video.finish().unwrap();
+
+	let mut exporter = Export::new(crate::source::announced(&consumer)).await.unwrap();
+	drain_frames(&mut exporter).await
+}
+
+/// #3334: the clock a receiver recovers from *byte position* has to agree with the
+/// values, because a byte stream carries no other timing. Emitting each media frame
+/// whole put every PCR between two frames instead of among the bytes it labels, so
+/// the grid #2967 made exact could not be read off the wire: consecutive clock
+/// packets sat one packet apart with the media they described heaped between the
+/// clusters, and a downstream stage re-deriving PCR from position regenerated the
+/// original clustered distribution.
+#[tokio::test(start_paused = true)]
+async fn pcr_rides_the_bytes_it_labels() {
+	let frames = export_cbr_video().await;
+	let pcrs = collect_pcrs(&frames);
+	assert!(pcrs.len() > 100, "expected the full feed, got {} PCRs", pcrs.len());
+
+	// Every step is one grid slot, so every gap should carry the same span of media
+	// and therefore a comparable number of packets.
+	let step = PCR_INTERVAL.as_micros() as u64 * 90 / 1_000;
+	for (i, w) in pcrs.windows(2).enumerate() {
+		assert_eq!(w[1].1.wrapping_sub(w[0].1) & ((1 << 33) - 1), step, "value step at {i}");
+	}
+
+	let gaps: Vec<usize> = pcrs.windows(2).map(|w| w[1].0 - w[0].0).collect();
+	assert_eq!(
+		gaps.iter().filter(|&&gap| gap == 1).count(),
+		0,
+		"no clock packet may sit adjacent to the previous one: {gaps:?}"
+	);
+	let mut sorted = gaps.clone();
+	sorted.sort_unstable();
+	let median = sorted[sorted.len() / 2];
+	// The leading group carries the parameter sets and program tables on top of its
+	// media, so allow generous headroom; what this rules out is the bimodal
+	// distribution (one packet, then hundreds) that made the clock unrecoverable.
+	assert!(
+		sorted[0] * 3 >= median && sorted[sorted.len() - 1] <= median * 3,
+		"packet gaps must track the interval the values assert, got {sorted:?}"
+	);
+}
+
+/// The other half of #3334: a PCR's *release* has to track the interval its own
+/// value asserts. The exporter only stamps; the caller paces on the stamps (see
+/// [`moq_mux::Pacer`]), so the property here is that consecutive clock packets are
+/// stamped exactly one grid interval apart. Frames are emitted whole and a slot's
+/// bytes are only all in hand once media past it has arrived, so a stamp that
+/// tracked frame arrival was already in the past and its sleep was a no-op.
+#[tokio::test(start_paused = true)]
+async fn pcr_stamps_step_by_the_grid() {
+	let frames = export_cbr_video().await;
+	let pcrs = collect_pcrs(&frames);
+
+	let steps: Vec<i128> = pcrs.windows(2).map(|w| w[1].2 as i128 - w[0].2 as i128).collect();
+	let interval = PCR_INTERVAL.as_micros() as i128;
+	assert!(
+		steps.iter().all(|&step| step == interval),
+		"every clock packet must be stamped one grid interval past the last: {steps:?}"
+	);
+}
+
+/// The same positional property on a real reordered (B-frame) capture with a second
+/// rendition, where the exporter has no uniform cadence to lean on: frames arrive in
+/// decode order, and the two tracks advance the media clock at different rates. The
+/// clock still lands among the bytes it labels rather than clustering, though the
+/// gaps are no longer uniform: a span is however long it took the next timestamp to
+/// arrive, which for interleaved tracks is nothing like the media a frame's bytes
+/// represent. Evening that out needs the muxer to hold a byte buffer and drain it at
+/// a measured rate, which this does not do.
+#[tokio::test(start_paused = true)]
+async fn pcr_stays_among_the_bytes_across_reordered_tracks() {
+	let data = include_bytes!("test_data/scte35/kyrion_dirtystart.ts");
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let consumer = broadcast.consume();
+	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+	let mut import = crate::container::ts::Import::new(broadcast, catalog.reserve());
+	import.decode(&BytesMut::from(&data[..])).unwrap();
+	import.finish().unwrap();
+
+	let mut exporter = Export::new(crate::source::announced(&consumer)).await.unwrap();
+	let frames = drain_frames(&mut exporter).await;
+	let pcrs = collect_pcrs(&frames);
+	assert!(pcrs.len() > 50, "expected the full feed, got {} PCRs", pcrs.len());
+
+	let gaps: Vec<usize> = pcrs.windows(2).map(|w| w[1].0 - w[0].0).collect();
+	assert_eq!(
+		gaps.iter().filter(|&&gap| gap == 1).count(),
+		0,
+		"no clock packet may sit adjacent to the previous one: {gaps:?}"
+	);
+
+	// Stamps still step by exactly one slot, apart from the first interval, which
+	// covers the leading span rather than a whole slot.
+	let interval = PCR_INTERVAL.as_micros() as i128;
+	let off = pcrs
+		.windows(2)
+		.filter(|w| w[1].2 as i128 - w[0].2 as i128 != interval)
+		.count();
+	assert!(off <= 1, "{off} clock packets are stamped off the grid");
+}
+
+/// A clock packet carries no payload, so ISO 13818-1 2.4.3.3 says it must repeat
+/// the continuity counter of whatever preceded it on its PID rather than advance
+/// it. The clock rides a PID that also carries media, and slicing on the grid puts
+/// clock packets *inside* a frame's packet run, whose counters were assigned when
+/// the frame was muxed rather than when the bytes go out. Numbering the clock
+/// packet from the counter's current value there lands it a whole frame ahead, and
+/// an analyzer reports a discontinuity on it and another on the payload packet
+/// after it.
+#[tokio::test(start_paused = true)]
+async fn payload_less_clock_packets_repeat_the_counter() {
+	let frames = export_cbr_video().await;
+	let ts: Vec<u8> = frames.iter().flat_map(|f| f.payload.iter().copied()).collect();
+	assert_packet_aligned(&ts);
+
+	let mut last: std::collections::HashMap<u16, u8> = std::collections::HashMap::new();
+	let mut advanced = 0;
+	let mut discontinuities = 0;
+	for (i, packet) in ts.chunks(188).enumerate() {
+		let pid = u16::from(packet[1] & 0x1f) << 8 | u16::from(packet[2]);
+		let cc = packet[3] & 0x0f;
+		let payload = packet[3] & 0x10 != 0;
+		if let Some(&prev) = last.get(&pid) {
+			if payload && cc != (prev + 1) & 0x0f {
+				discontinuities += 1;
+				eprintln!("discontinuity at packet {i} on pid {pid}: {prev} -> {cc}");
+			} else if !payload && cc != prev {
+				advanced += 1;
+				eprintln!("payload-less packet {i} on pid {pid} advanced: {prev} -> {cc}");
+			}
+		}
+		last.insert(pid, cc);
+	}
+	assert_eq!(advanced, 0, "payload-less packets must repeat the counter");
+	assert_eq!(discontinuities, 0, "the counter must be continuous on every PID");
 }

--- a/rs/moq-mux/src/pace.rs
+++ b/rs/moq-mux/src/pace.rs
@@ -11,8 +11,8 @@ use moq_net::Timestamp;
 /// timestamp on the contract that the caller delivers the bytes at the time the
 /// stamp asserts. That matters most for MPEG-TS, where the byte stream itself
 /// carries no per-frame timing: [`ts::Export`](crate::container::ts::Export)
-/// emits its PCR grid as standalone frames stamped at their slot boundaries, and
-/// a caller that drains them on arrival collapses the clock into position
+/// slices its output on the PCR grid and stamps each slice at its slot boundary,
+/// and a caller that drains them on arrival collapses the clock into position
 /// clusters no downstream stage can repair. "Deliver" is up to the transport:
 /// a paced sink sleeps until the returned instant before writing, while a
 /// transport with receiver-side buffering (e.g. SRT's TSBPD) stamps the payload
@@ -21,9 +21,9 @@ use moq_net::Timestamp;
 /// `send_at = anchor + (ts - base)` maps the frame's media time onto the wall
 /// clock, where `base`'s media time and `anchor`'s wall instant were pinned to
 /// each other at the last re-anchor. Offsets are computed in nanoseconds, so the
-/// frames may change [`Timescale`](moq_net::Timescale) mid-stream (the TS
-/// exporter stamps PCR frames in microseconds and media frames at the source's
-/// own scale).
+/// frames may change [`Timescale`](moq_net::Timescale) mid-stream: each exporter
+/// picks its own, and the TS one stamps grid boundaries in microseconds whatever
+/// scale the source's frames carry.
 ///
 /// When `send_at` would lead `now` by more than the configured
 /// [`lead`](Self::with_lead), the media clock has outrun wall-clock by more than
@@ -33,6 +33,15 @@ use moq_net::Timestamp;
 /// ever moves the anchor *forward*: a frame that merely arrives late (network
 /// or CPU jitter, or a reordered B-frame whose timestamp trails the edge) keeps
 /// its earlier media instant instead of collapsing to its arrival instant.
+///
+/// The other direction is the standing lag. Every producer delivers some fixed
+/// distance behind the media clock (a muxer's buffer, a hop of network), and the
+/// first frame pins an offset that has no room for it, so every later frame is
+/// due the instant it arrives, the sleep is a no-op, and the sink ends up writing
+/// at whatever cadence frames turned up in. So the anchor slides back by however
+/// much a frame fell behind, up to `lead` in total: it discovers that distance
+/// rather than assuming one, and the bound is the buffer the caller already said
+/// it would hold.
 #[derive(Default)]
 pub struct Pacer {
 	/// How far ahead of `now` a frame may be scheduled before re-anchoring.
@@ -40,6 +49,8 @@ pub struct Pacer {
 	/// The wall instant and media time (in nanoseconds) pinned to each other at
 	/// the last re-anchor; every frame paces relative to this pair.
 	anchor: Option<(Instant, u128)>,
+	/// How far the anchor has slid back to absorb late arrivals, capped at `lead`.
+	slack: Duration,
 }
 
 impl Pacer {
@@ -79,10 +90,39 @@ impl Pacer {
 		match send_at {
 			// `saturating_duration_since` is zero for an `at` in the past, which any
 			// lead admits; the subtraction form can't overflow on a huge lead.
-			Some(at) if at.saturating_duration_since(now) <= self.lead => at,
+			Some(at) if at.saturating_duration_since(now) <= self.lead => self.absorb(at, now),
 			// Media outran wall-clock (or overflowed the platform clock).
 			_ => self.hurry(ts, now),
 		}
+	}
+
+	/// Slide the anchor back by however much `at` fell behind `now`, and return the
+	/// instant that leaves.
+	///
+	/// This is how the pacer finds the producer's standing delivery lag (see the
+	/// type docs). The shift is capped so the total never exceeds the lead, and it
+	/// can only ever raise a past instant toward `now`, never past it, so absorbing
+	/// never schedules a frame later than it would have gone out anyway.
+	fn absorb(&mut self, at: Instant, now: Instant) -> Instant {
+		let behind = now.saturating_duration_since(at);
+		let shift = behind.min(self.lead.saturating_sub(self.slack));
+		if shift.is_zero() {
+			return at;
+		}
+		self.slack += shift;
+		if let Some((anchor, _)) = self.anchor.as_mut() {
+			*anchor += shift;
+		}
+		at + shift
+	}
+
+	/// How much of the producer's standing delivery lag the anchor has absorbed.
+	///
+	/// A caller running its own lag budget has to know this: the pacer is holding
+	/// it deliberately (see the type docs), so counting it as lag would have the
+	/// caller shedding the very margin that makes its sleeps do anything.
+	pub fn slack(&self) -> Duration {
+		self.slack
 	}
 
 	/// Deliver `ts` at `now` and make it the live edge: later frames pace
@@ -96,6 +136,8 @@ impl Pacer {
 	/// have arrived and hurries when that overshoots.
 	pub fn hurry(&mut self, ts: Timestamp, now: Instant) -> Instant {
 		self.anchor = Some((now, ts.as_nanos()));
+		// A fresh pin has no lag absorbed into it yet, so the budget starts over.
+		self.slack = Duration::ZERO;
 		now
 	}
 }
@@ -176,6 +218,59 @@ mod tests {
 		let mut pacer = Pacer::default().with_lead(Duration::MAX);
 		assert_eq!(pacer.pace(ms(0), start), start);
 		assert_eq!(pacer.pace(ms(40), start), start + Duration::from_millis(40));
+	}
+
+	/// A producer that delivers a constant distance behind the media clock (the TS
+	/// exporter's mux buffer, or a hop of network) would otherwise pin that distance
+	/// into the first frame's anchor and never get it back: every later frame is due
+	/// exactly when it arrives, so the sleep is a no-op and the sink writes at the
+	/// arrival cadence rather than the media one.
+	#[test]
+	fn absorbs_a_standing_delivery_lag() {
+		let start = Instant::now();
+		let mut pacer = Pacer::default().with_lead(Duration::from_millis(500));
+		assert_eq!(pacer.pace(ms(0), start), start, "the first frame anchors at now");
+
+		// Steady state: the producer is 40ms behind, so this frame is already due.
+		let now = start + Duration::from_millis(80);
+		assert_eq!(pacer.pace(ms(40), now), now, "a late frame still goes out at once");
+
+		// The anchor absorbed those 40ms, so the next frame has room to be paced.
+		assert_eq!(
+			pacer.pace(ms(80), now),
+			now + Duration::from_millis(40),
+			"the discovered lag becomes the sink's margin"
+		);
+	}
+
+	/// The absorbed lag is a buffer the caller holds, so it is capped by the lead
+	/// rather than growing with every outlier.
+	#[test]
+	fn absorbed_lag_is_capped_by_the_lead() {
+		let start = Instant::now();
+		let mut pacer = Pacer::default().with_lead(Duration::from_millis(50));
+		assert_eq!(pacer.pace(ms(0), start), start);
+
+		// 200ms behind, but only 50ms of that may be taken.
+		let now = start + Duration::from_millis(240);
+		assert_eq!(pacer.pace(ms(40), now), start + Duration::from_millis(90));
+		assert_eq!(
+			pacer.pace(ms(80), now),
+			start + Duration::from_millis(130),
+			"the anchor moved by the cap, not by the shortfall"
+		);
+	}
+
+	/// Zero lead (SRT, whose receiver owns the jitter buffer) absorbs nothing.
+	#[test]
+	fn zero_lead_absorbs_nothing() {
+		let start = Instant::now();
+		let mut pacer = Pacer::default();
+		assert_eq!(pacer.pace(ms(0), start), start);
+
+		let now = start + Duration::from_millis(80);
+		assert_eq!(pacer.pace(ms(40), now), start + Duration::from_millis(40));
+		assert_eq!(pacer.pace(ms(80), now), start + Duration::from_millis(80));
 	}
 
 	#[test]

--- a/test/justfile
+++ b/test/justfile
@@ -90,7 +90,9 @@ smoke-negative *args:
 # ts` output with TSDuck plus a custom analyzer (PCR jitter/repetition,
 # burstiness, instantaneous bitrate, T-STD). Flags: `--analyze-only file.ts`
 # (skip the round-trip), `--strict` (fail on shape warnings), `--source file.ts`
-# (use a real capture). See ts/README.md.
+# (use a real capture), `--live` (grade PCR release timing and byte position off
+# the pipe instead, which a capture cannot carry; nightly runs this arm). See
+# ts/README.md.
 
 # Check the subscriber's MPEG-TS output for IRD compliance.
 ts *args:

--- a/test/ts/README.md
+++ b/test/ts/README.md
@@ -11,6 +11,10 @@ is VBR, inserts no null packets, and paces PCR once per media frame, so several
 broadcast-shape checks are expected to flag. The report quantifies exactly where
 and by how much.
 
+Two instruments live here. `compliance.py` (via `run.sh`) grades a captured file
+against the IRD model. [`pcr-timing.py`](#pcr-timing-pcr-timingpy) grades a live
+pipe, which is the only way to see *when* the exporter released each PCR.
+
 ## Running
 
 ```bash
@@ -19,7 +23,13 @@ just test ts --source cap.ts    # round-trip a real capture instead
 just test ts --analyze-only x.ts # skip the round-trip, analyze a file
 just test ts --strict           # also fail on broadcast-shape warnings
 just test ts --with-eit         # add a synthetic EPG first, report which SI survived
+just test ts --live             # grade PCR release timing off the live pipe
 ```
+
+`--live` swaps the analyzer, not the rig: the same round-trip runs, but the
+subscriber's stdout goes straight into `pcr-timing.py` instead of a capture file.
+That is the only arm that can see release timing at all, and it is what nightly
+runs (see [CI](#ci)).
 
 `--analyze-only` needs only TSDuck + Python, so you can point it at any captured
 subscriber output:
@@ -73,6 +83,71 @@ Thresholds are CLI flags forwarded through `run.sh` (e.g.
 `--tb-size-bytes`, `--video-leak-bps`, `--audio-leak-bps`). `--report-json <path>`
 writes the full machine-readable report.
 
+## PCR timing (`pcr-timing.py`)
+
+A PCR makes three claims at once, and an instrument pointed at one of them
+cannot see the other two:
+
+| Domain | What it claims | Graded from |
+|---|---|---|
+| value | consecutive PCR values are spaced within the repetition limit | the values |
+| release | the bytes carrying a PCR were handed over when that PCR asserts | arrival stamps |
+| position | a PCR packet sits among the media bytes it describes | packet offsets |
+
+`compliance.py` grades `value` from a file, deterministically and with no
+wall-clock capture, which is the right basis for the model math it does. That
+also means it cannot grade `release`: a change to *when* the exporter hands bytes
+over is invisible to any harness that does not stamp arrivals.
+`pcr-timing.py` reads a pipe and grades all three in one pass.
+
+```bash
+# live: all three domains, reading the exporter directly
+moq --client-connect http://localhost:4443 --broadcast live.hang export ts \
+  | ./pcr-timing.py --live --seconds 45
+
+# offline: value and position only (a file has no release timing left in it)
+./pcr-timing.py capture.ts
+```
+
+It needs only `python3` — no TSDuck, no source file and no declared mux rate,
+because every check is graded against the stream's **own** PCR values. If two
+consecutive PCRs are 25 ms apart in value then they must be ~25 ms apart in
+arrival, whatever clock rate the stream is running at. The price of that basis is
+the same one `compliance.py` pays: a PCR emitted at the wrong rate stays
+internally consistent, so absolute rate is not what this grades.
+
+| Check | Severity | What it verifies |
+|---|---|---|
+| `sync` | hard | no invalid sync bytes / transport-error packets |
+| `continuity` | hard | no discontinuities, and a payload-less packet must not advance the counter (ISO 13818-1 2.4.3.3) |
+| `pcr-single-pid` | hard | every PCR rides one PID |
+| `pcr-value-interval` | hard | no interval above `--repetition-ms` (default 40, TR 101 290) |
+| `pcr-release-timing` | hard | each interval's arrival is within `--release-ms` of the interval its own values assert, with bounded accumulated drift (`--live` only) |
+| `pcr-position` | shape | share of PCR packets within `--adjacent-packets` of the previous one |
+
+`pcr-position` is a shape check because `export ts` is VBR by design. It is worth
+reporting even so: a consumer holding only the byte stream — which is every
+MPEG-TS tool — recovers the clock from where the PCR packets sit, so a layout
+that clusters them and heaps the media bytes between the clusters is one such a
+consumer cannot follow, however exact the values are.
+
+When both `release` and `position` flag, the report cross-tabulates them:
+
+```text
+  release timing by byte position (report only)
+    adjacent + early       615  ( 34.0%)
+    adjacent + on time     408  ( 22.5%)
+    spaced   + on time     641  ( 35.4%)
+    spaced   + late        136  (  7.5%)
+```
+
+Two invariants failing on the *same* PCRs is one cause rather than two, which two
+aggregate percentages cannot show. It is report-only: it explains a failure, it
+does not define one.
+
+`--report-json <path>` writes the full report, and `--strict` promotes the shape
+check to hard.
+
 ## EIT fixture
 
 `make-eit-fixture.sh` adds a synthetic DVB EPG to any transport stream, so the
@@ -122,12 +197,19 @@ matrix (nightly, on demand, and on PRs touching `test/ts/`). TSDuck
 comes from the `nix develop` shell, so the run uses the same `tsp`/`tsanalyze` a
 local developer would.
 
+`.github/workflows/nightly.yml` runs `just test ts --live` as well. It stays off
+the PR path because release timing needs a real-time window to measure: the
+grader has to sit on the pipe for the length of the capture, which no per-PR gate
+should be paying for, and a scheduled arm on a quiet runner is a better place to
+notice the exporter drifting off its own clock anyway.
+
 ## Caveats
 
 - Physical-layer TR 101 290 items (RF, real sync-byte loss) cannot be measured
   from a file; TSDuck notes the same limitation.
-- Wall-clock delivery jitter/burstiness is intentionally out of scope: all timing
-  is derived from the stream's PCR, not from socket arrival times.
+- Wall-clock delivery jitter/burstiness is out of scope *for `compliance.py`*:
+  all of its timing is derived from the stream's PCR, not from arrival times.
+  `pcr-timing.py --live` covers that axis separately, by stamping a pipe.
 - `tstd` models only the transport-buffer (TB) smoothing stage of the ISO 13818-1
   T-STD, not the full multiplex/elementary decode buffers. Its leak rates are
   defaults, not level-derived, so treat overflow as a smell rather than proof.

--- a/test/ts/README.md
+++ b/test/ts/README.md
@@ -109,7 +109,7 @@ moq --client-connect http://localhost:4443 --broadcast live.hang export ts \
 ./pcr-timing.py capture.ts
 ```
 
-It needs only `python3` — no TSDuck, no source file and no declared mux rate,
+It needs only `python3`, with no TSDuck, no source file and no declared mux rate,
 because every check is graded against the stream's **own** PCR values. If two
 consecutive PCRs are 25 ms apart in value then they must be ~25 ms apart in
 arrival, whatever clock rate the stream is running at. The price of that basis is
@@ -121,13 +121,42 @@ internally consistent, so absolute rate is not what this grades.
 | `sync` | hard | no invalid sync bytes / transport-error packets |
 | `continuity` | hard | no discontinuities, and a payload-less packet must not advance the counter (ISO 13818-1 2.4.3.3) |
 | `pcr-single-pid` | hard | every PCR rides one PID |
-| `pcr-value-interval` | hard | no interval above `--repetition-ms` (default 40, TR 101 290) |
-| `pcr-release-timing` | hard | each interval's arrival is within `--release-ms` of the interval its own values assert, with bounded accumulated drift (`--live` only) |
+| `pcr-value-interval` | hard | no interval above `--repetition-ms` (default 40, TR 101 290), within one time base |
+| `pcr-release-timing` | hard | no more than `--release-pct-max` of intervals arrive further than `--release-ms` from the interval their own values assert, and accumulated drift stays within `--drift-ms`, being the standing lag the sender is allowed to hold; a sample below `--live-min-pcr` PCRs or `--live-cover-pct` of the window is a failure, not a pass (`--live` only) |
 | `pcr-position` | shape | share of PCR packets within `--adjacent-packets` of the previous one |
 
+Accumulated drift has two shapes and only one is a defect, so the check bounds
+the total and reports the rate over the tail of the sample beside it. A sender
+that buffers builds a standing lag once and then runs at the media rate: the lag
+is a constant offset no receiver can see, and it cannot grow past the latency
+budget the sender is allowed to hold, so set `--drift-ms` to that budget
+(`export ts --latency-max`, 500 ms by default). A pipe that is not running at the
+media rate never stops accumulating and so breaches any fixed bound given a long
+enough sample. The tail rate is what tells the two apart, and it needs a sample
+longer than the lag takes to build: measured against the grid-sliced exporter,
+the lag reaches ~480 ms over the first ~48 s and then holds to within 0.02 ms/s
+over the following 40 s, whereas a 20 s window catches it still filling at
+\~8.7 ms/s and cannot distinguish that from a slow pipe.
+
+Two conditions are legal and must not be reported as defects. ISO 13818-1 2.4.3.4
+lets a source declare a new time base by setting `discontinuity_indicator`, after
+which the next PCR is a fresh value rather than the next point on the old ramp, so
+the difference across that boundary measures nothing: the value and release checks
+drop that one interval and count it separately, drift is summed over the intervals
+actually graded, and the jump is not mistaken for a 33-bit wrap. Counting it read a
+signalled splice as an 820 ms repetition breach and a continuity error at once.
+
+Separately, "not measured" and "passed" are different answers and only one of them
+belongs to a file. A file carries no arrival stamps, so release timing genuinely
+cannot be graded and the check says so. Under `--live` the stamps were expected, and
+a sample too small to mean anything is a truncated capture rather than a clean
+stream, so it fails: without that, a producer which emitted two packets and exited
+turned the gate green, and an exporter exiting early is common enough that the route
+is a real one rather than a hypothetical.
+
 `pcr-position` is a shape check because `export ts` is VBR by design. It is worth
-reporting even so: a consumer holding only the byte stream — which is every
-MPEG-TS tool — recovers the clock from where the PCR packets sit, so a layout
+reporting even so: a consumer holding only the byte stream, which is every
+MPEG-TS tool, recovers the clock from where the PCR packets sit, so a layout
 that clusters them and heaps the media bytes between the clusters is one such a
 consumer cannot follow, however exact the values are.
 
@@ -197,11 +226,14 @@ matrix (nightly, on demand, and on PRs touching `test/ts/`). TSDuck
 comes from the `nix develop` shell, so the run uses the same `tsp`/`tsanalyze` a
 local developer would.
 
-`.github/workflows/nightly.yml` runs `just test ts --live` as well. It stays off
-the PR path because release timing needs a real-time window to measure: the
-grader has to sit on the pipe for the length of the capture, which no per-PR gate
-should be paying for, and a scheduled arm on a quiet runner is a better place to
-notice the exporter drifting off its own clock anyway.
+`.github/workflows/nightly.yml` runs `just test ts --live --duration 120` as
+well. It stays off the PR path because release timing needs a real-time window to
+measure: the grader has to sit on the pipe for the length of the capture, which
+no per-PR gate should be paying for, and a scheduled arm on a quiet runner is a
+better place to notice the exporter drifting off its own clock anyway. The window
+is 120 s rather than the 20 s default because that is what the drift term costs
+to read: under a minute it catches the mux buffer still filling and cannot tell
+that from a pipe running slow.
 
 ## Caveats
 

--- a/test/ts/README.md
+++ b/test/ts/README.md
@@ -31,6 +31,11 @@ subscriber's stdout goes straight into `pcr-timing.py` instead of a capture file
 That is the only arm that can see release timing at all, and it is what nightly
 runs (see [CI](#ci)).
 
+The arm passes only when the grader's verdict *and* the publisher's exit status
+are clean. The grader can only speak for what reached it, and the sample floor
+rejects a window that came up short, so a publisher dying late in the run leaves
+enough behind to pass every check: a broken round-trip reported as a good one.
+
 `--analyze-only` needs only TSDuck + Python, so you can point it at any captured
 subscriber output:
 

--- a/test/ts/pcr-timing.py
+++ b/test/ts/pcr-timing.py
@@ -11,12 +11,6 @@ instrument pointed at another:
     release     when the bytes carrying them were handed over  (--live only)
     position    where the PCR packets sit among the media bytes
 
-`compliance.py` grades the first from a file, which is the right basis for what
-it checks and is why it states that wall-clock delivery timing is out of its
-scope. This grades all three from one pass, and reads a pipe so that `release`
-exists at all: a change to *when* bytes are handed over cannot be seen by any
-harness that needs no wall-clock capture.
-
 Every check is an invariant on the stream, not an assertion about how the stream
 was produced. `release` grades arrival against the PCR's *own* values rather than
 against a wall clock, so it needs no reference clock, no source file and no
@@ -30,6 +24,7 @@ the report-only (shape) checks to hard.
 import argparse
 import collections
 import json
+import select
 import statistics
 import sys
 import time
@@ -37,6 +32,11 @@ import time
 PKT = 188
 SYNC = 0x47
 HARD, SHAPE = "hard", "shape"
+TICKS_PER_MS = 27_000.0
+# The 33-bit PCR base counts 90 kHz ticks and the 9-bit extension counts 27 MHz ticks
+# within one of them, so the whole field restarts after this many 27 MHz ticks, roughly
+# every 26.5 hours.
+PCR_MODULUS = (1 << 33) * 300
 
 
 def percentile(xs, p):
@@ -51,7 +51,11 @@ def parse_pcr(p):
     """The 33+9-bit PCR of an adaptation field, in 27 MHz ticks, or None."""
     if (p[3] >> 4) & 0x3 not in (2, 3):  # adaptation_field_control
         return None
-    if p[4] == 0 or not (p[5] & 0x10):  # adaptation_field_length, PCR_flag
+    # A PCR occupies six bytes after the flags byte, so an adaptation field shorter than
+    # seven cannot hold one however the flag is set. Without this a stream that sets
+    # PCR_flag on a short field yields a value read out of stuffing or payload, and that
+    # sample then feeds all three timing checks.
+    if p[4] < 7 or not (p[5] & 0x10):  # adaptation_field_length, PCR_flag
         return None
     base = (p[6] << 25) | (p[7] << 17) | (p[8] << 9) | (p[9] << 1) | (p[10] >> 7)
     ext = ((p[10] & 0x01) << 8) | p[11]
@@ -68,7 +72,13 @@ class Scan:
         self.transport_error = 0
         self.cc_errors = []
         self.cc_on_empty = []
+        self.wraps = 0
+        self.new_base = set()  # positions in self.pcr that state a new time base
         self._cc = {}
+        self._dup = {}
+        self._new_base = set()  # PIDs whose next PCR states a new time base
+        self._pcr_raw = {}
+        self._pcr_offset = {}
 
     def feed(self, p, arrival=None):
         index = self.packets
@@ -80,22 +90,64 @@ class Scan:
             self.transport_error += 1
         pid = ((p[1] & 0x1F) << 8) | p[2]
 
-        ticks = parse_pcr(p)
-        if ticks is not None:
-            self.pcr.append((index, ticks, arrival, pid))
-
-        # ISO 13818-1 2.4.3.3: the continuity counter advances only on a packet
-        # carrying a payload, so an adaptation-only PCR packet must repeat the
-        # previous value rather than increment it.
+        # ISO 13818-1 2.4.3.3 allows the counter to jump when the adaptation field sets
+        # discontinuity_indicator, and allows one packet to be sent twice, repeating its
+        # counter. Both are legal, and treating either as an error fails a conforming
+        # stream on a hard check. Read the flag before the PCR, because 2.4.3.4 makes the
+        # same flag mean the clock may jump too, and the value and release checks both need
+        # to know which of their intervals spans that.
         cc = p[3] & 0x0F
         payload = bool((p[3] >> 4) & 0x1)
+        adaptation = bool((p[3] >> 4) & 0x2)
+        discontinuity = adaptation and p[4] > 0 and bool(p[5] & 0x80)
+
+        ticks = parse_pcr(p)
+        if ticks is not None:
+            # Unwrap, so the checks see a monotone timeline. A capture crossing the
+            # rollover would otherwise show one huge negative interval, which the value
+            # check accepts (it only rejects intervals that are too long) while the
+            # release check reads it as a day of lateness. A rollover drops the value by
+            # nearly the whole modulus, so only a drop past halfway is treated as one and
+            # a merely backwards PCR stays visible as the defect it is.
+            #
+            # A signalled discontinuity is the exception in both directions: the next PCR
+            # states a new time base, so a drop across it is neither a wrap to unwrap nor a
+            # backwards clock to report, and the interval spanning it is not a measurement
+            # of anything. Mark it instead, and let the checks drop that one interval.
+            if discontinuity or pid in self._new_base:
+                self._new_base.discard(pid)
+                self.new_base.add(len(self.pcr))
+                self._pcr_raw.pop(pid, None)
+            else:
+                prev_raw = self._pcr_raw.get(pid)
+                if prev_raw is not None and ticks < prev_raw - PCR_MODULUS // 2:
+                    self._pcr_offset[pid] = self._pcr_offset.get(pid, 0) + PCR_MODULUS
+                    self.wraps += 1
+            self._pcr_raw[pid] = ticks
+            self.pcr.append((index, ticks + self._pcr_offset.get(pid, 0), arrival, pid))
+        elif discontinuity:
+            # The flag rode a packet with no PCR in it, so the new base arrives with the
+            # next PCR on this PID rather than with this packet.
+            self._new_base.add(pid)
+
         prev = self._cc.get(pid)
         self._cc[pid] = cc
         if prev is None or pid == 0x1FFF:
             return
+        if discontinuity:
+            self._dup[pid] = False
+            return
         if payload:
-            if cc != (prev + 1) & 0x0F:
+            if cc == prev:
+                # Legal only once: a second repeat is a stuck counter, not a duplicate.
+                if self._dup.get(pid):
+                    self.cc_errors.append((index, pid, (prev + 1) & 0x0F, cc))
+                self._dup[pid] = not self._dup.get(pid)
+            elif cc == (prev + 1) & 0x0F:
+                self._dup[pid] = False
+            else:
                 self.cc_errors.append((index, pid, (prev + 1) & 0x0F, cc))
+                self._dup[pid] = False
         elif cc != prev:
             self.cc_on_empty.append((index, pid, prev, cc))
 
@@ -120,23 +172,43 @@ def scan_live(seconds):
     """
     scan = Scan()
     fd = sys.stdin.buffer
+    deadline = time.monotonic() + seconds
+
+    def read_exactly(n):
+        """Read n bytes, or return None once the capture window has expired.
+
+        A plain read blocks until the producer sends something, so a producer that
+        holds the pipe open and stops writing suspends the loop indefinitely and
+        --seconds never takes effect. That is the likeliest state to be in while
+        diagnosing an exporter or a network stall, which is when the tool has to
+        return a report rather than hang.
+        """
+        buf = b""
+        while len(buf) < n:
+            left = deadline - time.monotonic()
+            if left <= 0 or not select.select([fd], [], [], left)[0]:
+                return None
+            chunk = fd.read1(n - len(buf))
+            if not chunk:
+                return None
+            buf += chunk
+        return buf
 
     # Find the first sync byte, then stay aligned on it.
     while True:
-        b = fd.read(1)
+        b = read_exactly(1)
         if not b:
             return scan
         if b[0] == SYNC:
-            rest = fd.read(PKT - 1)
-            if len(rest) < PKT - 1:
+            rest = read_exactly(PKT - 1)
+            if not rest:
                 return scan
-            start = time.monotonic()
-            scan.feed(b + rest, start)
+            scan.feed(b + rest, time.monotonic())
             break
 
-    while time.monotonic() - start < seconds:
-        p = fd.read(PKT)
-        if len(p) < PKT:
+    while time.monotonic() < deadline:
+        p = read_exactly(PKT)
+        if not p:
             return scan
         scan.feed(p, time.monotonic())
     return scan
@@ -190,11 +262,30 @@ def check_pcr_single_pid(scan, args):
 
 
 def check_value_interval(scan, args):
-    """PCR values must be spaced within the repetition limit."""
-    iv = [(b[1] - a[1]) / 27_000.0 for a, b in zip(scan.pcr, scan.pcr[1:])]
+    """PCR values must be spaced within the repetition limit.
+
+    Within one time base. ISO 13818-1 2.4.3.4 lets a source declare a new one by setting
+    discontinuity_indicator, after which the next PCR is a fresh value rather than the next
+    point on the old ramp, so the difference across that boundary measures nothing. Counting
+    it fails a conforming stream: a signalled splice reads as one enormous interval, which is
+    the same class of false positive review found in the continuity check.
+    """
+    iv = [
+        (b[1] - a[1]) / TICKS_PER_MS
+        for i, (a, b) in enumerate(zip(scan.pcr, scan.pcr[1:]))
+        if (i + 1) not in scan.new_base
+    ]
+    spliced = sum(1 for i in range(1, len(scan.pcr)) if i in scan.new_base)
     if not iv:
         return ("pcr-value-interval", HARD, False, "no PCR intervals in the stream", {})
     over = [m for m in iv if m > args.repetition_ms]
+    # A PCR that goes backwards is as much a clock defect as one that arrives too late,
+    # and testing only the upper bound makes it invisible: the negative interval passes,
+    # and it drags the median and the over-limit share down with it. Rollover is already
+    # unwrapped in the scan, so a negative interval here is the stream's own doing. Zero
+    # is not: ISO 13818-1 2.4.3.3 allows a packet to be sent twice, and the duplicate
+    # repeats its PCR exactly, so testing `<= 0` would fail a conforming stream.
+    backwards = [m for m in iv if m < 0]
     detail = {
         "count": len(iv),
         "median_ms": round(statistics.median(iv), 3),
@@ -203,13 +294,19 @@ def check_value_interval(scan, args):
         "over_limit": len(over),
         "over_limit_pct": round(100.0 * len(over) / len(iv), 2),
         "sub_ms": sum(1 for m in iv if m < 1.0),
+        "non_positive": len(backwards),
+        "wraps_unwrapped": scan.wraps,
+        "signalled_discontinuities": spliced,
     }
+    backwards_note = f", {len(backwards)} non-positive" if backwards else ""
+    if spliced:
+        backwards_note += f", {spliced} signalled discontinuity not counted"
     return (
         "pcr-value-interval",
         HARD,
-        not over,
+        not over and not backwards,
         f"{len(over)}/{len(iv)} intervals over {args.repetition_ms:g} ms "
-        f"(median {detail['median_ms']:g} ms, worst {detail['max_ms']:g} ms)",
+        f"(median {detail['median_ms']:g} ms, worst {detail['max_ms']:g} ms{backwards_note})",
         detail,
     )
 
@@ -219,41 +316,109 @@ def check_release(scan, args):
 
     Graded against the stream's own values, so it holds at any clock rate: if two
     consecutive PCRs are 25 ms apart in value they must be ~25 ms apart in
-    arrival. Two statistics, because they fail independently — per-interval error,
+    arrival. Two statistics, because they fail independently: per-interval error,
     which is what a receiver PLL and any downstream re-timing stage sees, and
     accumulated drift, which must stay bounded or the pipe is not running at the
     media rate at all.
-    """
-    pts = [(ticks, arrival) for _, ticks, arrival, _ in scan.pcr if arrival is not None]
-    if len(pts) < 3:
-        return ("pcr-release-timing", HARD, True, "not measured (no arrival stamps)", {})
 
-    err = [((b[1] - a[1]) * 1000.0) - ((b[0] - a[0]) / 27_000.0) for a, b in zip(pts, pts[1:])]
+    Bounded is the whole of the drift requirement, and the bound is the sender's
+    latency budget. An exporter that buffers builds a standing lag once, at
+    startup, and then runs at the media rate; the lag is a constant offset, which
+    no receiver can see and which cannot grow past the budget the sender is
+    allowed to hold. A pipe running slow never stops accumulating and so breaches
+    any fixed bound given a long enough sample. So the total is the gate and the
+    lag's rate over the tail of the sample is reported beside it, which is what
+    distinguishes a lag that has settled from one still growing.
+    """
+    stamped = [i for i, (_, _, arrival, _) in enumerate(scan.pcr) if arrival is not None]
+    pts = [(scan.pcr[i][1], scan.pcr[i][2]) for i in stamped]
+    # scan.new_base indexes scan.pcr; pts drops the unstamped entries, so remap.
+    live_new_base = {j for j, i in enumerate(stamped) if i in scan.new_base}
+    # A file has no arrival stamps in it, so there is nothing to grade and saying so is
+    # the honest verdict. Live is the opposite case: arrivals were expected, and too few
+    # of them is a truncated capture rather than a clean stream. Passing that is how a
+    # gate reports success on a producer that died, which is the state this tool exists
+    # to catch, so the two have to be told apart rather than sharing one branch.
+    if not args.live:
+        if len(pts) < 3:
+            return ("pcr-release-timing", HARD, True, "not measured (no arrival stamps)", {})
+    else:
+        covered_ms = (pts[-1][0] - pts[0][0]) / TICKS_PER_MS if len(pts) >= 2 else 0.0
+        want_ms = 1000.0 * args.seconds * args.live_cover_pct / 100.0
+        short = len(pts) < args.live_min_pcr or covered_ms < want_ms
+        if short:
+            return (
+                "pcr-release-timing",
+                HARD,
+                False,
+                f"insufficient live sample: {len(pts)} PCR with arrival stamps spanning "
+                f"{covered_ms / 1000.0:.3f} s, against a floor of {args.live_min_pcr} PCR and "
+                f"{want_ms / 1000.0:g} s ({args.live_cover_pct:g} % of the {args.seconds:g} s "
+                f"window). A truncated capture cannot be graded and must not pass",
+                {
+                    "count": len(pts),
+                    "covered_s": round(covered_ms / 1000.0, 3),
+                    "required_pcr": args.live_min_pcr,
+                    "required_s": round(want_ms / 1000.0, 3),
+                },
+            )
+
+    # Same exclusion as the value check: an interval spanning a signalled new time base is
+    # not a release measurement, and counting it reports a splice as seconds of lateness.
+    graded = [
+        (((b[1] - a[1]) * 1000.0) - ((b[0] - a[0]) / TICKS_PER_MS), (b[0] - a[0]) / TICKS_PER_MS)
+        for i, (a, b) in enumerate(zip(pts, pts[1:]))
+        if (i + 1) not in live_new_base
+    ]
+    err = [e for e, _ in graded]
+    span = [s for _, s in graded]
+    if not err:
+        return ("pcr-release-timing", HARD, False, "no gradable release intervals", {})
     magnitude = [abs(e) for e in err]
-    drift = ((pts[-1][1] - pts[0][1]) * 1000.0) - ((pts[-1][0] - pts[0][0]) / 27_000.0)
+    # Accumulated drift is the sum of the intervals actually graded. That telescopes to the
+    # endpoint difference on an unspliced sample, and stays correct on a spliced one, where
+    # the endpoints straddle a time base the stream never claimed to be running on.
+    drift = sum(err)
     late = [e for e in err if e > args.release_ms]
     early = [e for e in err if e < -args.release_ms]
-    outside = len(late) + len(early)
     detail = {
         "count": len(err),
         "median_abs_ms": round(statistics.median(magnitude), 3),
         "p95_abs_ms": round(percentile(magnitude, 95), 3),
         "p99_abs_ms": round(percentile(magnitude, 99), 3),
         "max_abs_ms": round(max(magnitude), 3),
-        "outside_tolerance": outside,
-        "outside_tolerance_pct": round(100.0 * outside / len(err), 2),
+        "outside_tolerance": len(late) + len(early),
+        "outside_tolerance_pct": round(100.0 * (len(late) + len(early)) / len(err), 2),
         "released_early": len(early),
         "released_late": len(late),
         "total_drift_ms": round(drift, 1),
+        "drift_limit_ms": args.drift_ms,
     }
+    # Whether the lag has settled is the difference between a buffer that filled and a
+    # pipe running slow, and the two are only separable over a sample longer than the
+    # fill. Grade the last third: a settled lag adds nothing to it.
+    cut = (2 * len(err)) // 3
+    tail_span_ms = sum(span[cut:])
+    if tail_span_ms > 0:
+        detail["tail_drift_rate_ms_per_s"] = round(1000.0 * sum(err[cut:]) / tail_span_ms, 3)
+        detail["tail_span_s"] = round(tail_span_ms / 1000.0, 1)
+    # Per-interval error and accumulated drift fail independently, and bounding only the
+    # first leaves the second unbounded: a consistent 1 ms error on a 25 ms grid sits well
+    # inside a 10 ms tolerance while reaching nearly two seconds over a 45 s sample. The
+    # docstring claimed drift was bounded; until now only the per-interval error was.
+    drifted = abs(drift) > args.drift_ms
+    drift_note = f" > ±{args.drift_ms:g} ms" if drifted else ""
+    rate = detail.get("tail_drift_rate_ms_per_s")
+    tail_note = "" if rate is None else f", {rate:+g} ms/s over the last {detail['tail_span_s']:g} s"
+    over = detail["outside_tolerance_pct"] > args.release_pct_max
     return (
         "pcr-release-timing",
         HARD,
-        detail["outside_tolerance_pct"] <= args.release_pct_max,
+        not (over or drifted),
         f"{detail['outside_tolerance']}/{len(err)} releases outside ±{args.release_ms:g} ms of the "
         f"interval the PCR asserts ({detail['released_early']} early, {detail['released_late']} late; "
         f"p95 {detail['p95_abs_ms']:g} ms, worst {detail['max_abs_ms']:g} ms; "
-        f"drift {detail['total_drift_ms']:g} ms)",
+        f"drift {detail['total_drift_ms']:g} ms{drift_note}{tail_note})",
         detail,
     )
 
@@ -264,7 +429,7 @@ def check_position(scan, args):
     The grid is uniform in media time, so if position tracks time then the packet
     gap between consecutive PCRs is roughly uniform too. That needs no assumption
     that the stream is CBR, only that comparable spans of media time carry
-    comparable numbers of bytes. What it catches is a bimodal layout — PCR packets
+    comparable numbers of bytes. What it catches is a bimodal layout, PCR packets
     laid back-to-back with the media bytes they label heaped between the clusters.
     A consumer holding only the byte stream cannot recover the clock from such a
     layout, and one that re-stamps PCR from byte position regenerates exactly the
@@ -320,7 +485,7 @@ def coincidence(scan, args):
         return None
     rows = collections.Counter()
     for a, b in zip(pts, pts[1:]):
-        err = ((b[2] - a[2]) * 1000.0) - ((b[1] - a[1]) / 27_000.0)
+        err = ((b[2] - a[2]) * 1000.0) - ((b[1] - a[1]) / TICKS_PER_MS)
         when = "early" if err < -args.release_ms else "late" if err > args.release_ms else "on time"
         where = "adjacent" if (b[0] - a[0]) <= args.adjacent_packets else "spaced"
         rows[(where, when)] += 1
@@ -348,6 +513,28 @@ def main():
         type=float,
         default=0.0,
         help="share of intervals allowed outside the release tolerance (default 0)",
+    )
+    ap.add_argument(
+        "--live-min-pcr",
+        type=int,
+        default=20,
+        help="fewest PCR samples a --live run may grade before it is a truncated capture "
+        "rather than a result (default 20)",
+    )
+    ap.add_argument(
+        "--live-cover-pct",
+        type=float,
+        default=50.0,
+        help="share of the --seconds window a --live sample must span, or it is treated as "
+        "truncated (default 50)",
+    )
+    ap.add_argument(
+        "--drift-ms",
+        type=float,
+        default=500.0,
+        help="bound on accumulated release drift, being the standing lag the sender may "
+        "hold; set it to the sender's latency budget (moq export ts --latency-max, "
+        "itself 500ms by default)",
     )
     ap.add_argument(
         "--adjacent-packets", type=int, default=1, help="packet gap at or below which two PCRs count as clustered"

--- a/test/ts/pcr-timing.py
+++ b/test/ts/pcr-timing.py
@@ -1,0 +1,418 @@
+#!/usr/bin/env python3
+"""Grade an MPEG-TS stream's PCR against its own asserted clock.
+
+    moq ... export ts | ./pcr-timing.py --live --seconds 45
+    ./pcr-timing.py capture.ts
+
+A PCR is three claims at once, and a fix in one of them is invisible to an
+instrument pointed at another:
+
+    value       the intervals between PCR values         (ISO 13818-1 / TR 101 290)
+    release     when the bytes carrying them were handed over  (--live only)
+    position    where the PCR packets sit among the media bytes
+
+`compliance.py` grades the first from a file, which is the right basis for what
+it checks and is why it states that wall-clock delivery timing is out of its
+scope. This grades all three from one pass, and reads a pipe so that `release`
+exists at all: a change to *when* bytes are handed over cannot be seen by any
+harness that needs no wall-clock capture.
+
+Every check is an invariant on the stream, not an assertion about how the stream
+was produced. `release` grades arrival against the PCR's *own* values rather than
+against a wall clock, so it needs no reference clock, no source file and no
+declared mux rate; the price is that a clock running at the wrong rate stays
+internally consistent under it and has to be caught by `value` and `position`.
+
+Exit status is 0 when every hard check passes, 1 otherwise. `--strict` promotes
+the report-only (shape) checks to hard.
+"""
+
+import argparse
+import collections
+import json
+import statistics
+import sys
+import time
+
+PKT = 188
+SYNC = 0x47
+HARD, SHAPE = "hard", "shape"
+
+
+def percentile(xs, p):
+    s = sorted(xs)
+    if not s:
+        return float("nan")
+    k = min(len(s) - 1, max(0, int(round(p / 100.0 * (len(s) - 1)))))
+    return s[k]
+
+
+def parse_pcr(p):
+    """The 33+9-bit PCR of an adaptation field, in 27 MHz ticks, or None."""
+    if (p[3] >> 4) & 0x3 not in (2, 3):  # adaptation_field_control
+        return None
+    if p[4] == 0 or not (p[5] & 0x10):  # adaptation_field_length, PCR_flag
+        return None
+    base = (p[6] << 25) | (p[7] << 17) | (p[8] << 9) | (p[9] << 1) | (p[10] >> 7)
+    ext = ((p[10] & 0x01) << 8) | p[11]
+    return base * 300 + ext
+
+
+class Scan:
+    """One pass over the packets, collecting only what the checks need."""
+
+    def __init__(self):
+        self.pcr = []  # (packet_index, ticks, arrival_or_None, pid)
+        self.packets = 0
+        self.bad_sync = 0
+        self.transport_error = 0
+        self.cc_errors = []
+        self.cc_on_empty = []
+        self._cc = {}
+
+    def feed(self, p, arrival=None):
+        index = self.packets
+        self.packets += 1
+        if p[0] != SYNC:
+            self.bad_sync += 1
+            return
+        if p[1] & 0x80:
+            self.transport_error += 1
+        pid = ((p[1] & 0x1F) << 8) | p[2]
+
+        ticks = parse_pcr(p)
+        if ticks is not None:
+            self.pcr.append((index, ticks, arrival, pid))
+
+        # ISO 13818-1 2.4.3.3: the continuity counter advances only on a packet
+        # carrying a payload, so an adaptation-only PCR packet must repeat the
+        # previous value rather than increment it.
+        cc = p[3] & 0x0F
+        payload = bool((p[3] >> 4) & 0x1)
+        prev = self._cc.get(pid)
+        self._cc[pid] = cc
+        if prev is None or pid == 0x1FFF:
+            return
+        if payload:
+            if cc != (prev + 1) & 0x0F:
+                self.cc_errors.append((index, pid, (prev + 1) & 0x0F, cc))
+        elif cc != prev:
+            self.cc_on_empty.append((index, pid, prev, cc))
+
+
+def scan_file(path):
+    scan = Scan()
+    with open(path, "rb") as f:
+        while True:
+            p = f.read(PKT)
+            if len(p) < PKT:
+                return scan
+            scan.feed(p)
+
+
+def scan_live(seconds):
+    """Read stdin one packet at a time, stamping each read.
+
+    The granularity is deliberate: a coarser read cannot distinguish a run of
+    packets released together from a run released on a cadence, which is the
+    distinction `release` exists to measure. Each stamp is taken after its read
+    returns, so it is an upper bound on when the writer released those bytes.
+    """
+    scan = Scan()
+    fd = sys.stdin.buffer
+
+    # Find the first sync byte, then stay aligned on it.
+    while True:
+        b = fd.read(1)
+        if not b:
+            return scan
+        if b[0] == SYNC:
+            rest = fd.read(PKT - 1)
+            if len(rest) < PKT - 1:
+                return scan
+            start = time.monotonic()
+            scan.feed(b + rest, start)
+            break
+
+    while time.monotonic() - start < seconds:
+        p = fd.read(PKT)
+        if len(p) < PKT:
+            return scan
+        scan.feed(p, time.monotonic())
+    return scan
+
+
+# --- checks: each returns (name, severity, ok, headline, detail) -------------
+
+
+def check_sync(scan, args):
+    detail = {
+        "packets": scan.packets,
+        "bad_sync": scan.bad_sync,
+        "transport_error": scan.transport_error,
+    }
+    return (
+        "sync",
+        HARD,
+        not (scan.bad_sync or scan.transport_error),
+        f"{scan.packets} packets, {scan.bad_sync} bad sync bytes, "
+        f"{scan.transport_error} with transport_error_indicator",
+        detail,
+    )
+
+
+def check_continuity(scan, args):
+    detail = {
+        "discontinuities": len(scan.cc_errors),
+        "empty_packets_advancing_cc": len(scan.cc_on_empty),
+        "first_few": scan.cc_errors[:5],
+    }
+    return (
+        "continuity",
+        HARD,
+        not (scan.cc_errors or scan.cc_on_empty),
+        f"{len(scan.cc_errors)} continuity discontinuities, {len(scan.cc_on_empty)} payload-less "
+        f"packets advanced the counter (ISO 13818-1 2.4.3.3)",
+        detail,
+    )
+
+
+def check_pcr_single_pid(scan, args):
+    """Every PCR must ride the one PID the PMT declares."""
+    pids = collections.Counter(pid for _, _, _, pid in scan.pcr)
+    return (
+        "pcr-single-pid",
+        HARD,
+        len(pids) <= 1,
+        f"PCR carried on {len(pids)} PID(s): " + ", ".join(f"{k} ({v})" for k, v in pids.most_common()),
+        {"pids": {str(k): v for k, v in pids.items()}},
+    )
+
+
+def check_value_interval(scan, args):
+    """PCR values must be spaced within the repetition limit."""
+    iv = [(b[1] - a[1]) / 27_000.0 for a, b in zip(scan.pcr, scan.pcr[1:])]
+    if not iv:
+        return ("pcr-value-interval", HARD, False, "no PCR intervals in the stream", {})
+    over = [m for m in iv if m > args.repetition_ms]
+    detail = {
+        "count": len(iv),
+        "median_ms": round(statistics.median(iv), 3),
+        "p95_ms": round(percentile(iv, 95), 3),
+        "max_ms": round(max(iv), 3),
+        "over_limit": len(over),
+        "over_limit_pct": round(100.0 * len(over) / len(iv), 2),
+        "sub_ms": sum(1 for m in iv if m < 1.0),
+    }
+    return (
+        "pcr-value-interval",
+        HARD,
+        not over,
+        f"{len(over)}/{len(iv)} intervals over {args.repetition_ms:g} ms "
+        f"(median {detail['median_ms']:g} ms, worst {detail['max_ms']:g} ms)",
+        detail,
+    )
+
+
+def check_release(scan, args):
+    """The bytes carrying a PCR must be released at the time that PCR asserts.
+
+    Graded against the stream's own values, so it holds at any clock rate: if two
+    consecutive PCRs are 25 ms apart in value they must be ~25 ms apart in
+    arrival. Two statistics, because they fail independently — per-interval error,
+    which is what a receiver PLL and any downstream re-timing stage sees, and
+    accumulated drift, which must stay bounded or the pipe is not running at the
+    media rate at all.
+    """
+    pts = [(ticks, arrival) for _, ticks, arrival, _ in scan.pcr if arrival is not None]
+    if len(pts) < 3:
+        return ("pcr-release-timing", HARD, True, "not measured (no arrival stamps)", {})
+
+    err = [((b[1] - a[1]) * 1000.0) - ((b[0] - a[0]) / 27_000.0) for a, b in zip(pts, pts[1:])]
+    magnitude = [abs(e) for e in err]
+    drift = ((pts[-1][1] - pts[0][1]) * 1000.0) - ((pts[-1][0] - pts[0][0]) / 27_000.0)
+    late = [e for e in err if e > args.release_ms]
+    early = [e for e in err if e < -args.release_ms]
+    outside = len(late) + len(early)
+    detail = {
+        "count": len(err),
+        "median_abs_ms": round(statistics.median(magnitude), 3),
+        "p95_abs_ms": round(percentile(magnitude, 95), 3),
+        "p99_abs_ms": round(percentile(magnitude, 99), 3),
+        "max_abs_ms": round(max(magnitude), 3),
+        "outside_tolerance": outside,
+        "outside_tolerance_pct": round(100.0 * outside / len(err), 2),
+        "released_early": len(early),
+        "released_late": len(late),
+        "total_drift_ms": round(drift, 1),
+    }
+    return (
+        "pcr-release-timing",
+        HARD,
+        detail["outside_tolerance_pct"] <= args.release_pct_max,
+        f"{detail['outside_tolerance']}/{len(err)} releases outside ±{args.release_ms:g} ms of the "
+        f"interval the PCR asserts ({detail['released_early']} early, {detail['released_late']} late; "
+        f"p95 {detail['p95_abs_ms']:g} ms, worst {detail['max_abs_ms']:g} ms; "
+        f"drift {detail['total_drift_ms']:g} ms)",
+        detail,
+    )
+
+
+def check_position(scan, args):
+    """A PCR packet must sit among the media bytes whose arrival it describes.
+
+    The grid is uniform in media time, so if position tracks time then the packet
+    gap between consecutive PCRs is roughly uniform too. That needs no assumption
+    that the stream is CBR, only that comparable spans of media time carry
+    comparable numbers of bytes. What it catches is a bimodal layout — PCR packets
+    laid back-to-back with the media bytes they label heaped between the clusters.
+    A consumer holding only the byte stream cannot recover the clock from such a
+    layout, and one that re-stamps PCR from byte position regenerates exactly the
+    clustering the value domain was fixed to remove.
+    """
+    if len(scan.pcr) < 3:
+        return ("pcr-position", SHAPE, True, "not measured (too few PCRs)", {})
+    gap = [b[0] - a[0] for a, b in zip(scan.pcr, scan.pcr[1:])]
+    adjacent = sum(1 for g in gap if g <= args.adjacent_packets)
+    median = statistics.median(gap)
+    detail = {
+        "count": len(gap),
+        "median_packets": median,
+        "p95_packets": percentile(gap, 95),
+        "max_packets": max(gap),
+        "adjacent": adjacent,
+        "adjacent_pct": round(100.0 * adjacent / len(gap), 2),
+        # Dispersion about the middle of the distribution: near 1 for a uniform
+        # layout, large for cluster-and-hole. Guard a zero median.
+        "p95_over_median": round(percentile(gap, 95) / median, 1) if median else None,
+    }
+    return (
+        "pcr-position",
+        SHAPE,
+        detail["adjacent_pct"] <= args.adjacent_pct_max,
+        f"{detail['adjacent_pct']:g}% of PCR packets sit within {args.adjacent_packets} packet(s) of "
+        f"the previous one (median gap {median} packets, p95 {detail['p95_packets']}, worst {max(gap)})",
+        detail,
+    )
+
+
+CHECKS = [
+    check_sync,
+    check_continuity,
+    check_pcr_single_pid,
+    check_value_interval,
+    check_release,
+    check_position,
+]
+
+
+def coincidence(scan, args):
+    """Cross-tabulate release error against byte position, for one pass's PCRs.
+
+    `release` and `position` are separate invariants and a stream can fail either
+    alone, but when they fail *on the same PCRs* they have one cause rather than
+    two, and that is worth reporting rather than leaving to be inferred from two
+    aggregate percentages. Report-only: it explains a failure, it does not define
+    one.
+    """
+    pts = [(i, ticks, arrival) for i, ticks, arrival, _ in scan.pcr if arrival is not None]
+    if len(pts) < 3:
+        return None
+    rows = collections.Counter()
+    for a, b in zip(pts, pts[1:]):
+        err = ((b[2] - a[2]) * 1000.0) - ((b[1] - a[1]) / 27_000.0)
+        when = "early" if err < -args.release_ms else "late" if err > args.release_ms else "on time"
+        where = "adjacent" if (b[0] - a[0]) <= args.adjacent_packets else "spaced"
+        rows[(where, when)] += 1
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    ap.add_argument("path", nargs="?", help="TS file; omit with --live to read stdin")
+    ap.add_argument("--live", action="store_true", help="read stdin and stamp arrivals, grading release timing")
+    ap.add_argument("--seconds", type=float, default=45.0, help="live capture window (default 45)")
+    ap.add_argument(
+        "--repetition-ms", type=float, default=40.0, help="max PCR value interval, TR 101 290 (default 40)"
+    )
+    ap.add_argument(
+        "--release-ms",
+        type=float,
+        default=10.0,
+        help="tolerance on release timing against the asserted interval (default 10)",
+    )
+    ap.add_argument(
+        "--release-pct-max",
+        type=float,
+        default=0.0,
+        help="share of intervals allowed outside the release tolerance (default 0)",
+    )
+    ap.add_argument(
+        "--adjacent-packets", type=int, default=1, help="packet gap at or below which two PCRs count as clustered"
+    )
+    ap.add_argument(
+        "--adjacent-pct-max", type=float, default=1.0, help="share of clustered PCRs before pcr-position flags"
+    )
+    ap.add_argument("--strict", action="store_true", help="fail on shape checks too")
+    ap.add_argument("--report-json", help="write the full report here")
+    args = ap.parse_args()
+
+    if args.live:
+        scan = scan_live(args.seconds)
+    elif args.path:
+        scan = scan_file(args.path)
+    else:
+        ap.error("give a path or --live")
+
+    results = [check(scan, args) for check in CHECKS]
+    width = max(len(r[0]) for r in results)
+
+    print(f"### PCR timing report - {scan.packets} packets, {len(scan.pcr)} PCR")
+    print()
+    failed = 0
+    for name, severity, ok, headline, _ in results:
+        if ok:
+            verdict = "PASS"
+        elif severity == HARD or args.strict:
+            verdict = "FAIL"
+            failed += 1
+        else:
+            verdict = "WARN"
+        print(f"  {verdict:4}  {name:<{width}}  {headline}")
+    rows = coincidence(scan, args)
+    if rows:
+        total = sum(rows.values())
+        print()
+        print("  release timing by byte position (report only)")
+        for where in ("adjacent", "spaced"):
+            for when in ("early", "on time", "late"):
+                n = rows[(where, when)]
+                if n:
+                    print(f"    {where:<8} + {when:<7}  {n:6}  ({100.0 * n / total:5.1f}%)")
+
+    print()
+    print(f"{failed} check(s) failed" if failed else "all checks passed")
+
+    if args.report_json:
+        with open(args.report_json, "w") as f:
+            json.dump(
+                {
+                    "packets": scan.packets,
+                    "pcr_count": len(scan.pcr),
+                    "live": args.live,
+                    "checks": [
+                        {"name": n, "severity": s, "ok": ok, "headline": h, "detail": d}
+                        for n, s, ok, h, d in results
+                    ],
+                },
+                f,
+                indent=2,
+            )
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/ts/run.sh
+++ b/test/ts/run.sh
@@ -307,8 +307,21 @@ if [[ -n "$LIVE" ]]; then
         echo >&2
         echo "error: PCR timing analysis failed (see round-trip logs below)" >&2
         dump_logs
+        exit "$GRADE_RC"
     fi
-    exit "$GRADE_RC"
+    # The grader's verdict is not the whole run. It grades whatever reached it, and
+    # the sample floor only rejects a window that came up short: a publisher that
+    # dies late still leaves enough behind to pass every check. That is a broken
+    # round-trip reported as a good one, so the publisher's own status is a gate
+    # too. 124 is `timeout` killing a stalled `moq import ts`, which is a failure
+    # of the same kind rather than a clean end, so it is not excused here.
+    if [[ "$PUB_RC" -ne 0 ]]; then
+        echo >&2
+        echo "error: the publisher exited $PUB_RC; the graded stream is not a whole round-trip" >&2
+        dump_logs
+        exit 1
+    fi
+    exit 0
 fi
 
 sleep 3

--- a/test/ts/run.sh
+++ b/test/ts/run.sh
@@ -15,6 +15,16 @@
 #   ./run.sh --analyze-only cap.ts # skip the round-trip, just analyze a file
 #   ./run.sh --strict              # fail on broadcast-shape warnings too
 #   ./run.sh --with-eit            # add a synthetic EPG first, report which SI survived
+#   ./run.sh --live                # grade PCR release timing off the live pipe
+
+# `--live` swaps the analyzer, not the rig. compliance.py grades a captured file
+# on the stream's own PCR clock, which is the right basis for the IRD model it
+# builds and is why it needs no wall-clock capture -- and also why nothing it
+# checks can see *when* the exporter handed the bytes over. pcr-timing.py reads
+# the subscriber's stdout a packet at a time and stamps each read, so it grades
+# release timing and byte position alongside the values. Nightly runs this arm
+# (.github/workflows/nightly.yml); it is not a per-PR gate, because it needs a
+# real-time window to measure at all.
 set -euo pipefail
 
 DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
@@ -28,6 +38,7 @@ PORT="${TSC_PORT:-4443}"
 PROFILE="${TSC_PROFILE:-debug}"
 STRICT=""
 WITH_EIT="" # add a synthetic EPG to the source and report which SI survived
+LIVE=""     # grade the exporter's stdout as it arrives, rather than a capture
 PASSTHRU=() # forwarded to compliance.py (thresholds, --report-json, ...)
 
 while [[ $# -gt 0 ]]; do
@@ -58,6 +69,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --with-eit)
             WITH_EIT=1
+            shift
+            ;;
+        --live)
+            LIVE=1
             shift
             ;;
         *)
@@ -167,6 +182,10 @@ if [[ -n "$SOURCE" ]]; then
     }
 else
     echo "### generating ~${DURATION}s broadcast-like clip with ffmpeg"
+    # CBR with a 20 ms PCR, like a contribution feed. Not cosmetic: `regulate`
+    # paces on the source PCR, so a clip whose clock is coarse and whose rate is
+    # unconstrained is released unevenly and finishes early (measured: a 20 s clip
+    # in 17 s, and release jitter of its own). The harness then grades ffmpeg.
     ffmpeg -y -hide_banner -loglevel error \
         -f lavfi -i "testsrc=size=1280x720:rate=25" \
         -f lavfi -i "sine=frequency=1000:sample_rate=48000" \
@@ -174,7 +193,7 @@ else
         -c:v libx264 -profile:v high -preset veryfast -pix_fmt yuv420p \
         -x264-params "keyint=25:min-keyint=25:scenecut=0" -b:v 8M \
         -c:a aac -b:a 128k \
-        -f mpegts -pes_payload_size 0 "$SRC_TS"
+        -f mpegts -muxrate "$BITRATE" -pcr_period 20 -pes_payload_size 0 "$SRC_TS"
 fi
 
 # No capture in this repository carries EIT, so the import path's EIT handling is
@@ -201,21 +220,49 @@ fi
 # Start the subscriber first so it is waiting on the announce before the
 # publisher appears; a live broadcast has no history, so a late joiner would miss
 # the start of the stream (or the whole thing for a short clip).
-echo "### capturing subscriber output (export ts)"
-timeout -k 3 $((DURATION + 20)) \
-    "$MOQ" --client-connect "$URL" --broadcast "$BROADCAST" export ts >"$SUB_TS" 2>"$TMP/sub.log" &
-SUB_PID=$!
+#
+# In --live mode the grader reads that stdout directly rather than a capture: it
+# stamps each 188-byte read, which is the only way release timing survives at all
+# (a file has none left in it). It stops itself after its own window, so the
+# round-trip below still bounds the run.
+if [[ -n "$LIVE" ]]; then
+    echo "### grading subscriber output live (export ts | pcr-timing.py)"
+    # Both halves matter and `wait` can only report one, so record each. The
+    # exporter's own status is not incidental here: it decides whether the grader
+    # saw the whole window or graded a stream that ended under it.
+    (
+        # `set -e` would abort the subshell on the pipeline's own failure, which is
+        # exactly the status we are here to record.
+        set +e
+        timeout -k 3 $((DURATION + 20)) \
+            "$MOQ" --client-connect "$URL" --broadcast "$BROADCAST" export ts 2>"$TMP/sub.log" |
+            python3 "$DIR/pcr-timing.py" --live --seconds "$DURATION" --release-pct-max 1 $STRICT \
+                ${PASSTHRU[@]+"${PASSTHRU[@]}"} >"$TMP/timing.out" 2>&1
+        printf '%s\n' "${PIPESTATUS[0]} ${PIPESTATUS[1]}" >"$TMP/timing.rc"
+    ) &
+    SUB_PID=$!
+else
+    echo "### capturing subscriber output (export ts)"
+    timeout -k 3 $((DURATION + 20)) \
+        "$MOQ" --client-connect "$URL" --broadcast "$BROADCAST" export ts >"$SUB_TS" 2>"$TMP/sub.log" &
+    SUB_PID=$!
+fi
 sleep 1
 
 # Pace on the source PCR (real media time), not a fixed bitrate: a synthetic clip
 # compresses tiny, so bitrate pacing would rush the whole stream out in a blink.
+# `--wait-min 5` is what makes that pacing fine-grained enough to measure against:
+# at the default, `regulate` releases in ~50 ms chunks, which is jitter of its own
+# on top of whatever the exporter does (measured: p95 40 ms at the default, 1 ms
+# at 5). It is the publisher's granularity, not the exporter's, so the harness has
+# to be well inside it or it grades tsp.
 # Bounded like the subscriber: if the relay stalls after readiness, `moq import
 # ts` could otherwise block `wait "$PUB_PID"` forever. tsp/moq stderr lands in
 # pub.log, which the empty-capture handler below dumps on failure.
 echo "### publishing PCR-paced TS -> $BROADCAST"
 # shellcheck disable=SC2016  # $1..$4 are the child bash -c positionals, not ours.
 timeout -k 3 $((DURATION + 20)) bash -c '
-    tsp -I file "$1" -P regulate --pcr-synchronous |
+    tsp -I file "$1" -P regulate --pcr-synchronous --wait-min 5 |
         "$2" --client-connect "$3" --broadcast "$4" import ts
 ' _ "$SRC_TS" "$MOQ" "$URL" "$BROADCAST" >"$TMP/pub.log" 2>&1 &
 PUB_PID=$!
@@ -225,9 +272,6 @@ PUB_PID=$!
 # explain a truncated capture, so surface it alongside the logs on failure.
 wait "$PUB_PID" 2>/dev/null && PUB_RC=0 || PUB_RC=$?
 PUB_PID=""
-sleep 3
-kill_tree "$SUB_PID" 2>/dev/null || true
-SUB_PID=""
 
 # shellcheck disable=SC2329  # invoked from multiple failure paths below
 dump_logs() {
@@ -235,6 +279,41 @@ dump_logs() {
     sed 's/^/  pub: /' "$TMP/pub.log" >&2 || true
     sed 's/^/  sub: /' "$TMP/sub.log" >&2 || true
 }
+
+# ── live: the grader owns the verdict ───────────────────────────────────────
+if [[ -n "$LIVE" ]]; then
+    wait "$SUB_PID" 2>/dev/null || true
+    SUB_PID=""
+    if [[ ! -s "$TMP/timing.rc" ]]; then
+        echo "error: the live grader never reported a status" >&2
+        dump_logs
+        exit 1
+    fi
+    read -r EXPORT_RC GRADE_RC <"$TMP/timing.rc"
+    echo
+    cat "$TMP/timing.out"
+    # 124 is `timeout` reaching the end of the window, which is how the exporter is
+    # meant to stop; SIGPIPE (141) is the grader closing the pipe on its own window.
+    # Anything else ended the stream under the grader, so say so: it graded a
+    # shorter window than it was asked for, and the report alone doesn't show that.
+    # Not fatal, because the grader's verdict on what it did see is still the
+    # verdict, and a short window can only make the sample smaller, not kinder.
+    if [[ "$EXPORT_RC" -ne 0 && "$EXPORT_RC" -ne 124 && "$EXPORT_RC" -ne 141 ]]; then
+        echo >&2
+        echo "warning: the exporter exited $EXPORT_RC before the window closed" >&2
+        sed 's/^/  sub: /' "$TMP/sub.log" >&2 || true
+    fi
+    if [[ "$GRADE_RC" -ne 0 ]]; then
+        echo >&2
+        echo "error: PCR timing analysis failed (see round-trip logs below)" >&2
+        dump_logs
+    fi
+    exit "$GRADE_RC"
+fi
+
+sleep 3
+kill_tree "$SUB_PID" 2>/dev/null || true
+SUB_PID=""
 
 if [[ ! -s "$SUB_TS" ]]; then
     echo "error: subscriber captured no data" >&2


### PR DESCRIPTION
## Summary

Closes #3334, and folds in #3335's harness as the thing that proves it.

**Root cause.** `ts::Export` emitted one `Frame` per media frame, so a clock packet could only ever land *between* frames, never among the bytes it labels, and a grid slot could only be revealed by a frame *later* than itself. #2967 made the PCR values an exact 25 ms ramp, but neither the byte position nor the release instant of a clock packet was constrained by it, so the grid could not be recovered from the wire: consecutive clock packets sat one packet apart with the media heaped between the clusters, and their stamps were already in the past by the time the pacer saw them, so the sleep was a no-op.

**Fix.** Slice the output on the grid instead of on media frames.

- A span of the media timeline closes when a timestamp passes the watermark. Its bytes are laid across the grid slots running up to its *decode* time, one `Frame` per slot: the slot's clock packet, then the share of the bytes that slice of the interval earns. Packet count between two PCRs is then proportional to the difference between their values, each frame is stamped at its own slot boundary, and every byte still precedes the decode time of the unit it belongs to (T-STD).
- That makes the exporter run a constant distance behind the media clock, which is the mux buffer. Two things downstream assumed it didn't:
  - `Pacer` pinned its anchor on the first frame and never had room for a standing lag, so every later frame was due the instant it arrived and the sink wrote at the arrival cadence. It now slides the anchor back by however much a frame fell behind, up to `lead` in total (`Pacer::slack`).
  - `Delivery`'s arrival epoch only advanced when the export made it wait. The export now always has the next slot ready, so the epoch froze and the budget hurried roughly once a second, shedding the pacing it exists to protect. Reaching a scheduled instant advances it too. The trade: a one-off pre-queued backlog now paces out at the media rate rather than being shed, because from the sink it is indistinguishable from the mux buffer. Its size is bounded by the export's own `--latency-max`.
- A clock packet carries no payload, so it must repeat the continuity counter of whatever preceded it on its PID. Slicing puts clock packets *inside* a frame's packet run, whose counters were assigned when the frame was muxed rather than when the bytes go out, so the counter now comes from wire order.

**Measured**, same rig, `just test ts --live`:

| | before | after |
|---|---:|---:|
| release outside ±10 ms | 741 / 761 | **0 / 477** |
| release p95 \| worst | 135 ms \| 139 ms | **1.7 ms \| 4.2 ms** |
| PCR packets adjacent to the previous | 56.5% (issue) / 2.8% (rig) | **0.21%** |
| continuity discontinuities | (not comparable, see below) | **0** |
| PCR value interval | 25.000 ms | 25.000 ms |


**The standing lag is the mux buffer, not absorbed reorder depth.** The exporter now runs a constant distance behind the media clock, and two mechanisms predict the same curve: the buffer filling once, or `Pacer::absorb` eating each B-frame's reorder depth (it is reached from both branches of `pace`). Measured with the source re-encoded `bframes=0`, everything else identical: the lag still builds to 494 ms and settles (tail rate -0.008 ms/s), which reorder absorption cannot produce with no reorder depth in the stream. This agrees with the code, where slot boundaries are monotone by construction so the reordered branch is unreachable from `Delivery`, and `moq-srt` runs `lead = 0` where `absorb` is a no-op. Caveat: that run was on a heavily loaded machine and its per-interval jitter is correspondingly poor, so it is concordant rather than conclusive; the drift *rate* is a slope and survives the load, the absolute jitter does not.

**Known limit, not fixed here.** When tracks with different cadences interleave, a span is however long it took the next timestamp to arrive, which is nothing like the media a frame's bytes represent, so byte position is uniform on a single rendition but lumpy across two. Evening that out needs the muxer to hold a byte buffer and drain it at a measured rate. The reordered two-rendition fixture is covered by a test that asserts what does hold (no adjacency, stamps on the grid) and says why the rest doesn't.

**Harness.** `test/ts/pcr-timing.py` is @t0ms's script from #3335, taken at that branch's `e7f1e3cc`, which is the reviewed copy: this PR originally carried the version from before #3335's review passes. Two of the fixes in it bear on what this PR measures. The continuity check false-positived on legally duplicated packets and on `discontinuity_indicator` (ISO 13818-1 2.4.3.3), which matters here because this change *moves* counter assignment to wire order, so the check is grading the fix. The **0 after** stands either way (a checker that over-reports still reporting zero means zero), but the before figure was inflated by duplicates that were never defects, so it is withdrawn from the table above rather than quoted. Separately, `--seconds` did not bound a blocking read, so a producer holding the pipe open without writing hung the grader forever, which is exactly the shape this rig's early exit produces.

It is wired in under `run.sh --live` (their offer) and runs nightly, not per-PR: it needs a real-time window to measure anything. The nightly runs it at `--duration 120` rather than the 20 s default, because the drift bound cannot distinguish a mux buffer still filling from a pipe running slow over a 20 s sample. Two rig calibrations came out of running it, both measured: the generated clip is now CBR with a 20 ms PCR (unconstrained, `regulate` released it unevenly and finished a 20 s clip in 17 s), and `regulate` gets `--wait-min 5` (at the default it releases in ~50 ms chunks, p95 40 ms of jitter of its own).

**Unrelated bug surfaced by the live arm:** the subscriber exits partway through with `TS track layout changed after PAT/PMT was emitted: '0.avc3' removed`. It reproduces on `main` (the existing arm's duration-fidelity check reports the same 0.61 ratio and passes it), so it is not from this change. The live arm reports it as a warning and grades the window it did get.

## Public API changes

- `moq_mux::Pacer::slack()` - new, additive.
- No other `pub` item added, renamed, or changed signature. `ts::Export`'s surface (`new`/`with_ts`/`with_catalog_format`/`with_latency`/`next`/`poll_next`) is unchanged; what changed is what a `Frame` contains, which is documented on both.

## Test plan

- `just check`, `just test` (both clean at the time of the original push; the follow-up commit's `moq-cli` tests were run directly, 4/4, and CI is the gate for the rest).
- New: `pcr_rides_the_bytes_it_labels`, `pcr_stamps_step_by_the_grid`, `pcr_stays_among_the_bytes_across_reordered_tracks`, `payload_less_clock_packets_repeat_the_counter` (moq-mux); `absorbs_a_standing_delivery_lag`, `absorbed_lag_is_capped_by_the_lead`, `zero_lead_absorbs_nothing` (Pacer); `a_sink_that_cannot_keep_up_sheds_the_lag`, `a_buffered_producer_keeps_pacing` (moq-cli). `backlog_lag_is_bounded_by_the_latency_budget` is replaced by the first of those two, which encodes the rule that took its place.
- Follow-up commit: `pacing_resumes_after_a_hurry_without_a_wait` (moq-cli), covering a hurry that leaves the arrival epoch stale. `a_sink_that_cannot_keep_up_sheds_the_lag` is rewritten: it asserted that the frame after a hurry writes immediately, which was true only because of that stale epoch, and it now asserts the corrected pacing plus a stall loop proving a persistently slow sink still sheds.
- `just test ts` (the existing capture arm) and `just test ts --live` (the new one): all six checks pass.

## Cross-package sync

No wire-format change: the PCR grid, its values, and the SETUP/framing are untouched, so no draft under `drafts/` moves. This is where the bytes sit in the output stream, not what they say.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

