### PR TITLE
feat(audio,video): compile the device, render, and VAAPI code by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ linux-raw-sys = { version = "0.12.1", features = ["ioctl"] }
 # Permutation testing for the kio primitives (and everything built on them).
 # Only compiled under `--cfg loom`; see `just rs loom`.
 loom = { version = "0.7.2", features = ["futures"] }
-moq-audio = { version = "0.0.22", path = "rs/moq-audio" }
+moq-audio = { version = "0.0.22", path = "rs/moq-audio", default-features = false }
 moq-flate = { version = "0.1.2", path = "rs/moq-flate" }
 moq-hls = { version = "0.4.13", path = "rs/moq-hls", default-features = false }
 moq-json = { version = "0.3.9", path = "rs/moq-json" }

--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -370,11 +370,9 @@ moq --client-connect https://relay.example.com/anon --broadcast screen.hang \
     import capture --display --system-audio
 ```
 
-On Linux the NVENC (NVIDIA) encoder and the PipeWire screen capture are compiled
-in by default. VAAPI (Intel/AMD) is behind the off-by-default `vaapi` feature,
-since that backend has never been validated on real hardware. To build `capture`
-without any of them (software openh264 + V4L2 camera capture only), drop the
-default features. `capture` itself still needs libclang and the V4L2 headers for
+On Linux the NVENC (NVIDIA) and VAAPI (Intel/AMD) encoders and the PipeWire
+screen capture are compiled in by default. To build `capture` without any of
+them (software openh264 + V4L2 camera capture only), drop the default features. `capture` itself still needs libclang and the V4L2 headers for
 the camera, and ALSA for the microphone:
 
 ```bash

--- a/doc/lib/rs/crate/moq-audio.md
+++ b/doc/lib/rs/crate/moq-audio.md
@@ -50,15 +50,25 @@ rather than following it frame by frame.
 
 ## Installation
 
-Device I/O is off by default, so a service that only encodes or relays pulls in
-neither `cpal` nor (on Linux) the ALSA build dependency:
+Everything is on by default: AAC decode, device capture and playback, and echo
+cancellation. On Linux the device features link ALSA at build time (`libasound2-dev`
+on Debian and Ubuntu), so a service that only encodes or relays can drop them:
 
 ```bash
-cargo add moq-audio --features capture,playback,aec
+cargo add moq-audio --no-default-features --features aac
 ```
 
-`aec` implies both `capture` and `playback`, since the canceller taps the output
-mix as its reference.
+| Feature | Default | Pulls in |
+| --- | --- | --- |
+| `aac` | yes | AAC-LC decode via `symphonia`, pure Rust |
+| `capture` | yes | Microphones via `cpal`; macOS system audio via ScreenCaptureKit |
+| `playback` | yes | Speaker output via `cpal` |
+| `aec` | yes | Acoustic echo cancellation (`sonora`); implies `capture` and `playback`, since the canceller taps the output mix as its reference |
+| `pipewire` | no | cpal's native PipeWire host on Linux, linking `libpipewire-0.3` |
+| `pulseaudio` | no | cpal's native PulseAudio host on Linux, linking `libpulse` |
+
+Without a native host, cpal reaches a Linux sound server through ALSA's `default`
+device, which desktops route to PipeWire or PulseAudio via their ALSA plugin.
 
 ## Publishing
 

--- a/doc/lib/rs/crate/moq-video.md
+++ b/doc/lib/rs/crate/moq-video.md
@@ -55,26 +55,25 @@ slow path. AV1 is decode-only, via NVDEC.
 cargo add moq-video
 ```
 
-Capture and NVIDIA hardware codecs are on by default. VAAPI is not, since that
-backend has never been validated on real hardware, and neither are rendering
-and PipeWire screen capture, which pull in a graphics stack and a `libpipewire`
-build dependency respectively:
+Capture, the Linux hardware codecs, and the GPU renderer are on by default.
+PipeWire screen capture is not, since it links `libpipewire-0.3` at build time:
 
 ```bash
-cargo add moq-video --features render,pipewire
+cargo add moq-video --features pipewire
 ```
 
 | Feature | Default | Pulls in |
 | --- | --- | --- |
 | `capture` | yes | Native device capture (`v4l` and `zune-jpeg` on Linux) |
-| `nvidia` | yes | NVENC encode and NVDEC decode on Linux (`cudarc`, `moq-nvenc`) |
-| `vaapi` | no | Intel/AMD encode on Linux (`moq-vaapi`), unvalidated on hardware |
-| `render` | no | `wgpu`, the GPU renderer, and Linux DMA-BUF support |
+| `nvidia` | yes | NVENC encode and NVDEC decode on Linux (`cudarc`, `moq-nvenc`), dlopen'd at runtime |
+| `vaapi` | yes | Intel/AMD encode on Linux (`moq-vaapi`), dlopen'd at runtime; not yet validated on hardware |
+| `render` | yes | `wgpu`, the GPU renderer, and Linux DMA-BUF support |
 | `pipewire` | no | Wayland screen capture via xdg-desktop-portal and DMA-BUF |
 
 `--no-default-features` gives a codec-only build that still encodes and decodes
-H.264 with openh264 but omits native capture and the Linux GPU dependencies. A
-relay or language binding that only handles supplied frames needs none of them.
+H.264 with openh264 but omits native capture, the renderer, and the Linux GPU
+backends. A relay or language binding that only handles supplied frames needs
+none of them.
 
 ## Publishing
 

--- a/rs/justfile
+++ b/rs/justfile
@@ -383,9 +383,9 @@ fix-changed $FILES:
 # are already no-ops off Linux. moq-gst is excluded because it links
 # GStreamer via pkg-config, which the Windows runner doesn't have.
 #
-# `moq-cli/play` is named explicitly because it's off by default and is what
-# turns on moq-video's wgpu renderer and moq-audio's cpal output, neither of
-# which any default-feature build compiles.
+# `moq-cli/play` and `moq-cli/capture` are named explicitly because they are
+# off by default, and they are the only thing that compiles the cli's own
+# device and render code.
 
 # Compile the whole workspace on a Windows host. Must run ON Windows.
 windows *args:
@@ -397,17 +397,15 @@ windows *args:
 #
 # Nothing in CI runs this either; Mac runners cost too much for a per-PR gate.
 # The moq-video half has a release-time backstop, since libmoq's `libmoq-v*` tag
-# build compiles it on Apple Silicon. The moq-audio half has none: its
-# capture backend is behind an off-by-default feature no release build enables,
-# so this recipe is the only thing that ever compiles it.
+# build compiles it on Apple Silicon. The moq-audio half has none: libmoq and
+# moq-ffi take it codecs-only, so no release build compiles its capture
+# backend and this recipe is the only thing that ever does.
 #
 # Scoped to those two crates instead of the workspace, because they hold all
 # the Apple-gated code the Linux gate misses. moq-ffi (and through it the
 # Swift/Kotlin/Go wrappers) already compiles on macOS in swift.yml.
-# `--all-features` is required, not just tidy: moq-audio's capture backend sits
-# behind an off-by-default feature, so a plain check would skip the very code
-# this recipe exists for. moq-video's Linux-only nvidia/vaapi/pipewire
-# deps are no-ops here.
+# `--all-features` also compiles the off-by-default cpal hosts and PipeWire
+# capture, which are Linux-only and no-ops here, so it costs nothing extra.
 
 # Compile the Apple-only code paths. Must run ON macOS.
 macos *args:
@@ -459,7 +457,7 @@ audit:
 # part of the per-PR gate.
 #
 # `--all-features` is the only thing that compiles moq-cli's play/capture,
-# moq-audio's capture backend, quiche, and jemalloc. `--no-default-features` is
+# moq-video's PipeWire capture, quiche, and jemalloc. `--no-default-features` is
 # the only thing that compiles the `#[cfg(not(feature = ...))]` arms.
 
 # Compile the workspace at the feature extremes.

--- a/rs/libmoq/Cargo.toml
+++ b/rs/libmoq/Cargo.toml
@@ -20,13 +20,14 @@ crate-type = ["staticlib"]
 anyhow = { workspace = true, features = ["backtrace"] }
 bytes = { workspace = true }
 hang = { workspace = true }
-moq-audio = { workspace = true }
+# Codecs only: OBS and the other C consumers do their own device I/O.
+moq-audio = { workspace = true, features = ["aac"] }
 moq-json = { workspace = true }
 moq-mux = { workspace = true }
 moq-native = { workspace = true, default-features = true }
 moq-net = { workspace = true }
 # Enable the NVIDIA hardware codecs (default-off at the workspace level).
-moq-video = { workspace = true, features = ["nvidia"] }
+moq-video = { workspace = true, features = ["nvidia", "vaapi"] }
 # Blocking on `encode::Sink` from the synchronous C entry points; see
 # `video::block_on` for why not a tokio helper.
 pollster = { workspace = true }

--- a/rs/moq-audio/Cargo.toml
+++ b/rs/moq-audio/Cargo.toml
@@ -13,19 +13,25 @@ keywords = ["quic", "http3", "webtransport", "media", "audio"]
 categories = ["multimedia", "multimedia::audio", "multimedia::encoding"]
 
 [features]
-# AAC-LC decode via symphonia, on by default. Pure Rust, so it costs no
-# toolchain: the trade this crate already refused for Opus. Only a subscriber to
-# an ingest-sourced broadcast needs it (RTMP, SRT/TS, fmp4, and gstreamer all
-# publish AAC, while everything this crate encodes is Opus or PCM), so a
-# publish-only build can drop it and the two crates it pulls.
+# Everything is on by default. The features exist so a consumer can drop what
+# it cannot or does not want to build, not to hide code from the default
+# compile: `just check` lints default features only, so anything off here is
+# only ever compiled nightly. Workspace consumers opt out at the root manifest
+# (`default-features = false`) and pick per crate, which keeps cpal out of the
+# language bindings.
+default = ["aac", "capture", "playback", "aec"]
+# AAC-LC decode via symphonia. Pure Rust, so it costs no toolchain: the trade
+# this crate already refused for Opus. Only a subscriber to an ingest-sourced
+# broadcast needs it (RTMP, SRT/TS, fmp4, and gstreamer all publish AAC, while
+# everything this crate encodes is Opus or PCM), so a publish-only build can
+# drop it and the two crates it pulls.
 aac = ["dep:symphonia-codec-aac", "dep:symphonia-core"]
-default = ["aac"]
 # Device capture. Microphones go through cpal (pure-Rust: CoreAudio / WASAPI /
 # ALSA); macOS system audio goes through ScreenCaptureKit, which is where Apple
-# puts it. Off by default so audio-only consumers (e.g. moq-ffi) don't pull cpal
-# and, on Linux, the ALSA build dependency. On macOS it also pulls AVFoundation
-# for the TCC permission pre-check (the objc deps below are target-gated, so this
-# is a no-op elsewhere).
+# puts it. On Linux cpal links libasound, the one system build dependency in
+# this crate; drop `capture` and `playback` for a box without it. On macOS it
+# also pulls AVFoundation for the TCC permission pre-check (the objc deps below
+# are target-gated, so this is a no-op elsewhere).
 capture = [
     "dep:cpal",
     "dep:kio",
@@ -42,9 +48,8 @@ capture = [
     "dep:objc2-screen-capture-kit",
 ]
 # Device playback. Mixes any number of `playback::Sink`s into one cpal output
-# stream (CoreAudio / WASAPI / ALSA). Off by default for the same reason as
-# `capture`: a consumer that only encodes shouldn't pull cpal, or the ALSA build
-# dependency on Linux.
+# stream (CoreAudio / WASAPI / ALSA). Same libasound build dependency on Linux
+# as `capture`.
 playback = ["dep:cpal", "dep:fixed-resample", "dep:tokio", "dep:tracing"]
 # Reach devices through the Linux sound server rather than its ALSA plugin, for
 # the server's own device names and routing. cpal picks the host at runtime, so

--- a/rs/moq-audio/src/playback.rs
+++ b/rs/moq-audio/src/playback.rs
@@ -1,9 +1,9 @@
 //! Play decoded PCM out a speaker, via [`cpal`] (CoreAudio / WASAPI / ALSA).
 //!
 //! The playback counterpart to `capture`, and where a
-// `capture` is deliberately not a doc link: the module is behind the
-// off-by-default `capture` feature, so a link to it fails the `-D warnings`
-// rustdoc build of a playback-only build (what `moq-cli`'s `play` enables).
+// `capture` is deliberately not a doc link: the module is behind its own
+// feature, so a link to it fails the `-D warnings` rustdoc build of a
+// playback-only build (what `moq-cli`'s `play` enables).
 //! [`decode::Consumer`](crate::decode::Consumer) ends up:
 //!
 //! ```no_run

--- a/rs/moq-boy/Cargo.toml
+++ b/rs/moq-boy/Cargo.toml
@@ -30,7 +30,7 @@ moq-mux = { workspace = true }
 moq-native = { workspace = true, default-features = false, features = ["aws-lc-rs"] }
 moq-net = { workspace = true }
 # Enable the NVIDIA hardware codecs (default-off at the workspace level).
-moq-video = { workspace = true, features = ["nvidia"] }
+moq-video = { workspace = true, features = ["nvidia", "vaapi"] }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 doc = false
 
 [features]
-default = ["iroh", "quinn", "websocket", "nvidia", "pipewire"]
+default = ["iroh", "quinn", "websocket", "nvidia", "vaapi", "pipewire"]
 iroh = ["moq-native/iroh"]
 jemalloc = ["moq-native/jemalloc"]
 noq = ["moq-native/noq"]
@@ -60,8 +60,9 @@ nvidia = ["moq-video?/nvidia", "moq-transcode?/nvidia"]
 # feature tables name only `nvidia`.
 nvenc = ["nvidia"]
 nvdec = ["nvidia"]
-# Intel/AMD VAAPI hardware encoding (Linux). Off by default because the backend is
-# unvalidated on hardware; enable it explicitly alongside `capture` or `transcode`.
+# Intel/AMD VAAPI hardware encoding (Linux), on by default like `nvidia` and
+# trimmable the same way: libva is dlopen'd at runtime, so it costs the build
+# nothing. Only bites when `capture` or `transcode` pulls in moq-video.
 vaapi = ["moq-video?/vaapi", "moq-transcode?/vaapi"]
 # Screen capture for `capture --display` on Linux (xdg-desktop-portal + PipeWire),
 # on by default like the hardware codecs above and trimmable the same way. Only
@@ -82,7 +83,7 @@ bytes = { workspace = true }
 clap = { workspace = true }
 hang = { workspace = true }
 humantime = { workspace = true }
-moq-audio = { workspace = true, optional = true }
+moq-audio = { workspace = true, optional = true, features = ["aac"] }
 # `server` enables the HTTP egress server for `moq export hls`; the importer is always available.
 moq-hls = { workspace = true, features = ["server"] }
 moq-mux = { workspace = true }

--- a/rs/moq-ffi/Cargo.toml
+++ b/rs/moq-ffi/Cargo.toml
@@ -51,7 +51,8 @@ tracing = { workspace = true }
 url = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-moq-audio = { workspace = true, optional = true }
+# Codecs only: the language wrappers do their own device I/O.
+moq-audio = { workspace = true, optional = true, features = ["aac"] }
 moq-native = { workspace = true, default-features = true }
 # `nvidia` back on, matching rs/libmoq: the workspace turns moq-video's defaults
 # off for `capture` (V4L2, libclang), and the codecs are collateral rather than
@@ -60,7 +61,7 @@ moq-native = { workspace = true, default-features = true }
 # `target_os = "android"`, and nothing is paid at build time on Linux either:
 # all three are pure Rust and dlopen the driver, so the wrappers still link
 # GPU-less and start driverless.
-moq-video = { workspace = true, optional = true, features = ["nvidia"] }
+moq-video = { workspace = true, optional = true, features = ["nvidia", "vaapi"] }
 # Blocking on `encode::Sink` from the synchronous producer exports; see
 # `video::block_on` for why not a tokio helper.
 pollster = { workspace = true, optional = true }

--- a/rs/moq-ffi/src/video.rs
+++ b/rs/moq-ffi/src/video.rs
@@ -48,20 +48,20 @@ impl From<MoqVideoCodec> for moq_video::encode::Codec {
 
 /// Which encoder implementation to use.
 ///
-/// These bindings compile VideoToolbox (macOS), Media Foundation (Windows), and
-/// openh264 (software, everywhere). NVENC/NVDEC are a libmoq-only build option
-/// and VAAPI is opt-in everywhere, so Linux here is software-only.
+/// These bindings compile VideoToolbox (macOS), Media Foundation (Windows),
+/// openh264 (software, everywhere), and on Linux NVENC and VAAPI, which dlopen
+/// their driver at runtime and drop out of `Auto` when it is absent.
 #[derive(Clone, uniffi::Enum)]
 pub enum MoqVideoEncoderKind {
-	/// Prefer a platform hardware encoder, falling back to software. On Linux
-	/// that fallback is the only option these bindings have.
+	/// Prefer a platform hardware encoder, falling back to software.
 	Auto,
-	/// Hardware only; fails if none is available, which on Linux is always.
+	/// Hardware only; fails if none is available.
 	Hardware,
 	/// Software only (openh264, H.264 only).
 	Software,
 	/// A specific backend that moq-ffi compiles: `"videotoolbox"` (macOS),
-	/// `"mediafoundation"` (Windows), or `"openh264"` (software, everywhere).
+	/// `"mediafoundation"` (Windows), `"nvenc"` / `"vaapi"` (Linux), or
+	/// `"openh264"` (software, everywhere).
 	/// Naming one this build lacks fails with a no-encoder error, so reach for
 	/// this only when [`Auto`](Self::Auto) picks the wrong one.
 	Named { name: String },

--- a/rs/moq-transcode/Cargo.toml
+++ b/rs/moq-transcode/Cargo.toml
@@ -13,11 +13,11 @@ keywords = ["quic", "http3", "webtransport", "media", "video"]
 categories = ["multimedia", "multimedia::video", "multimedia::encoding"]
 
 [features]
-# The NVIDIA codecs are on by default, mirroring moq-video: NVDEC -> NVENC is
+# The hardware codecs are on by default, mirroring moq-video: NVDEC -> NVENC is
 # the whole point of a GPU transcode fleet, and it is the zero-copy GPU pipeline
 # (NVDEC decodes and scales in hardware, NVENC encodes the CUDA frame in place).
-# Disable for a slimmer self-compiled Linux build. VAAPI remains an opt-in.
-default = ["nvidia"]
+# Both dlopen their driver at runtime, so disabling them only slims the compile.
+default = ["nvidia", "vaapi"]
 # NVENC + NVDEC (Linux, dlopen'd at runtime; a no-op elsewhere).
 nvidia = ["moq-video/nvidia"]
 # Compatibility aliases for the pre-consolidation names, kept so a manifest that
@@ -25,8 +25,7 @@ nvidia = ["moq-video/nvidia"]
 # feature tables name only `nvidia`.
 nvenc = ["nvidia"]
 nvdec = ["nvidia"]
-# Intel/AMD VAAPI hardware encoder (Linux; opt-in because the backend is
-# unvalidated on hardware; libva dlopen'd at runtime).
+# Intel/AMD VAAPI hardware encoder (Linux; libva dlopen'd at runtime).
 vaapi = ["moq-video/vaapi"]
 
 [dependencies]

--- a/rs/moq-video/Cargo.toml
+++ b/rs/moq-video/Cargo.toml
@@ -13,11 +13,14 @@ keywords = ["quic", "http3", "webtransport", "media", "video"]
 categories = ["multimedia", "multimedia::video", "multimedia::encoding"]
 
 [features]
-# The NVIDIA codecs are enabled by default. Disable them (e.g.
-# `--no-default-features`) for a slimmer self-compiled Linux build that drops the
-# CUDA dependencies. Openh264 stays as the always-compiled software fallback;
-# disable only `capture` to omit the device stack while retaining codecs.
-default = ["capture", "nvidia"]
+# Everything that costs no system library at build time is on by default; the
+# features exist so a consumer can drop what it does not want, not to hide code
+# from the default compile (`just check` lints default features only). Openh264
+# stays as the always-compiled software fallback. `pipewire` is the exception:
+# it links libpipewire at build time. Workspace consumers opt out at the root
+# manifest (`default-features = false`) and pick per crate, so the relay and the
+# language bindings never build the device or render stacks.
+default = ["capture", "nvidia", "vaapi", "render"]
 # Native camera and screen capture. Enabled by default for direct consumers,
 # but workspace consumers opt in so codec-only bindings avoid device build
 # dependencies such as V4L2 and libclang.
@@ -35,21 +38,20 @@ nvidia = ["dep:cudarc", "dep:moq-nvenc", "dep:libloading"]
 # feature tables name only `nvidia`.
 nvenc = ["nvidia"]
 nvdec = ["nvidia"]
-# Intel/AMD VAAPI hardware encoder (Linux). Off by default because the backend has
-# never been validated on real hardware, not because of anything it costs the
-# build: moq-vaapi dlopen's libva, so an enabled-vaapi build needs no libva at
-# build time and still starts on a libva-less host, where automatic backend
-# selection falls back to the next encoder like the NVENC backend does.
+# Intel/AMD VAAPI hardware encoder (Linux). moq-vaapi dlopen's libva, so the
+# build needs no libva and still starts on a libva-less host, where automatic
+# backend selection falls back to the next encoder like the NVENC backend does.
+# The backend has not been validated on real hardware yet; `Kind::Named`
+# ("openh264") sidesteps it if it misbehaves.
 vaapi = ["dmabuf", "dep:moq-vaapi"]
 # Linux DMA-BUF surface vocabulary and CPU fallback support. Enabled by every
 # backend that can produce or consume one. It pulls no graphics API by itself.
 dmabuf = ["dep:libc", "dep:linux-raw-sys"]
 # GPU rendering of decoded frames (the `render` module): a wgpu pipeline that
-# converts a frame to RGBA and hands back a texture the caller presents. Off by
-# default because wgpu pulls a graphics stack (and its backend drivers) that a
-# relay or a headless publisher has no use for; only an application that actually
-# draws video turns it on. `dmabuf` adds the Linux surface vocabulary; Vulkan
-# itself still comes from wgpu.
+# converts a frame to RGBA and hands back a texture the caller presents. wgpu
+# loads Vulkan / Metal / D3D at runtime, so this costs compile time and nothing
+# else; a relay or headless publisher drops it. `dmabuf` adds the Linux surface
+# vocabulary; Vulkan itself still comes from wgpu.
 render = [
     "dmabuf",
     "dep:bytemuck",

--- a/rs/moq-video/README.md
+++ b/rs/moq-video/README.md
@@ -91,10 +91,10 @@ Two public entry points:
 - `encode::Producer` publishes frames you encoded yourself (`publish(&[Encoded])`),
   handling the catalog and framing. Each is published at its own timestamp.
 
-The NVENC and VAAPI backends are Linux-only and gated behind their respective
-features. Both `dlopen` the vendor driver at runtime (and fall back to software
-where the driver is absent), so a feature-enabled binary still links on a
-GPU-less builder and still starts on a GPU-less machine.
+The NVENC and VAAPI backends are Linux-only, behind the default-on `nvidia` and
+`vaapi` features. Both `dlopen` the vendor driver at runtime (and fall back to
+software where the driver is absent), so the binary still links on a GPU-less
+builder and still starts on a GPU-less machine.
 
 ## Decode
 

--- a/rs/moq-video/src/encode/backend/vaapi.rs
+++ b/rs/moq-video/src/encode/backend/vaapi.rs
@@ -1,4 +1,4 @@
-//! Intel/AMD VAAPI hardware backend via the opt-in `moq-vaapi` crate on Linux.
+//! Intel/AMD VAAPI hardware backend via the `moq-vaapi` crate on Linux.
 //!
 //! `moq-vaapi` is a focused VA-API H.264 encoder vendored and trimmed from
 //! cros-libva + discord/cros-codecs. It takes tightly-packed NV12 and emits an


### PR DESCRIPTION
## Summary

- Turn on every moq-audio and moq-video feature that costs no system library at build time: moq-audio now defaults to `aac`, `capture`, `playback`, and `aec`; moq-video adds `vaapi` and `render` to its defaults; moq-transcode adds `vaapi`. The features stay so a consumer can drop what it cannot build (ALSA on Linux for the cpal features), but they no longer hide code from the default compile.
- The motivating bug: `just check` lints default features only, so `rs/moq-audio/src/encode/capture.rs` and the rest of the capture, playback, and echo-cancellation code were only ever compiled by the nightly `--all-features` job. A `large_enum_variant` error sat there through a green PR check. After this change the per-PR gate compiles all of it; the remaining nightly-only surface is exclusive backends (`noq`, `quiche`, `ring`, `jemalloc`), the system-library ones (`pipewire`, `pulseaudio`), and moq-cli's `capture`/`play`/`transcode`.
- The root manifest takes moq-audio with `default-features = false`, the way it already takes moq-video, and each workspace consumer picks: moq-ffi and libmoq request `aac` only, so the language wrappers and OBS never link cpal; moq-cli requests `aac` and layers `capture`/`playback` through its own features as before. `cargo tree` on the Linux target confirms cpal and wgpu reach only moq-audio and moq-video themselves.
- `vaapi` also joins the moq-cli default list next to `nvidia` and `pipewire`, and the moq-ffi, libmoq, and moq-boy moq-video deps, since libva is dlopen'd at runtime and a build without it costs nothing. It has still not been validated on hardware, which the docs now say instead of using it as the reason to keep it off.
- moq-cli's `capture`, `play`, and `transcode` stay off by default; `quest/m2/cli-packaging.md` still owns that flip.

## Public API changes

None. No `pub` item was added, renamed, or removed. Default feature sets changed on moq-audio, moq-video, and moq-transcode, which is additive for callers: an existing `default-features = false` selection is untouched, and a default build gains modules. A Linux consumer building moq-audio with defaults now needs `libasound2-dev` or the equivalent, which the moq-audio doc page states along with the opt-out.

The stale moq-ffi doc comment that called Linux software-only is corrected: that crate has compiled NVENC since its moq-video dep asked for `nvidia`, and it now compiles VAAPI too.

## Test plan

- `just check` and `just test` (3544 Rust tests, plus the Python and JS suites the doc edits pulled in), on macOS. The check log shows wgpu and sonora compiling under clippy, which is the gap this closes.
- `cargo tree --target x86_64-unknown-linux-gnu` per crate: cpal only under moq-audio, wgpu only under moq-video, moq-vaapi under moq-video, moq-ffi, libmoq, and moq-boy, none under moq-cli or moq-relay.
- Not run here: a Linux build. The nix dev shell already carries alsa-lib for the cpal features and CI check runs inside it, so the per-PR gate is the Linux verification.

Cross-Package Sync: the moq-ffi change is a dependency feature selection with no API change, so the wrappers and their docs need nothing. `doc/lib/rs/crate/{moq-audio,moq-video}.md` and `doc/bin/cli.md` are updated for the new defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Fable 5.1)
