### PR TITLE
feat(moq-audio)!: let publish_capture carry a catalog extension

### DIFF
--- a/rs/moq-audio/src/encode/capture.rs
+++ b/rs/moq-audio/src/encode/capture.rs
@@ -7,6 +7,8 @@ use std::time::Duration;
 
 use rand::RngExt;
 
+use moq_mux::catalog::hang::CatalogExt;
+
 use super::producer::Reserved;
 use super::{Input, Options, Producer};
 use crate::capture;
@@ -191,20 +193,20 @@ impl Publication {
 	/// rendition on the first success. Until then the broadcast advertises no
 	/// audio, which [`Status::Starting`] reports. A source that never appears is
 	/// retried with capped backoff rather than blocking the controls.
-	pub fn new(
+	pub fn new<E: CatalogExt>(
 		broadcast: moq_net::broadcast::Producer,
-		catalog: moq_mux::catalog::Producer,
+		catalog: moq_mux::catalog::Producer<E>,
 		options: PublicationOptions,
-	) -> Result<(Self, Driver), Error> {
+	) -> Result<(Self, Driver<E>), Error> {
 		Self::build(broadcast, catalog, options, Supervisor::default())
 	}
 
-	fn build(
+	fn build<E: CatalogExt>(
 		mut broadcast: moq_net::broadcast::Producer,
-		catalog: moq_mux::catalog::Producer,
+		catalog: moq_mux::catalog::Producer<E>,
 		options: PublicationOptions,
 		supervisor: Supervisor,
-	) -> Result<(Self, Driver), Error> {
+	) -> Result<(Self, Driver<E>), Error> {
 		let reserved = Reserved::new(&mut broadcast, catalog, &options.encode)?;
 		let track_name: Arc<str> = reserved.name().into();
 		let desired = Desired {
@@ -330,9 +332,9 @@ impl Publication {
 /// The driver owns the broadcast producer so its identity remains alive through
 /// stop, failure, replacement, and restart. Dropping the final [`Publication`]
 /// ends the driver and releases that identity.
-pub struct Driver {
+pub struct Driver<E: CatalogExt = ()> {
 	_broadcast: moq_net::broadcast::Producer,
-	track: Option<Track>,
+	track: Option<Track<E>>,
 	/// The codec settings the rendition is built from once the layout is known.
 	encode: Options,
 	clock: moq_mux::Clock,
@@ -346,13 +348,13 @@ pub struct Driver {
 	park_on_failure: bool,
 }
 
-impl fmt::Debug for Driver {
+impl<E: CatalogExt> fmt::Debug for Driver<E> {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		f.debug_struct("Driver").finish_non_exhaustive()
 	}
 }
 
-impl Driver {
+impl<E: CatalogExt> Driver<E> {
 	/// Run capture until the final control handle drops or the MoQ track ends.
 	pub async fn run(self) -> Result<(), Error> {
 		self.run_with(DeviceSource).await
@@ -562,7 +564,7 @@ impl Driver {
 		}
 	}
 
-	fn producer_mut(&mut self) -> &mut Producer {
+	fn producer_mut(&mut self) -> &mut Producer<E> {
 		self.track
 			.as_mut()
 			.and_then(Track::producer)
@@ -602,15 +604,15 @@ enum DriveEvent {
 /// One per publication, moved twice in its life, so the size difference between
 /// the variants never costs a copy worth an allocation to avoid.
 #[allow(clippy::large_enum_variant)]
-enum Track {
+enum Track<E: CatalogExt = ()> {
 	/// Registered in the broadcast but not the catalog, because the rendition
 	/// describes a PCM layout no probe has returned yet.
-	Reserved(Reserved),
+	Reserved(Reserved<E>),
 	/// Probed, so the rendition is registered and samples can be encoded.
-	Encoding(Producer),
+	Encoding(Producer<E>),
 }
 
-impl Track {
+impl<E: CatalogExt> Track<E> {
 	fn track(&self) -> &moq_net::track::Producer {
 		match self {
 			Self::Reserved(reserved) => reserved.track(),
@@ -618,7 +620,7 @@ impl Track {
 		}
 	}
 
-	fn producer(&mut self) -> Option<&mut Producer> {
+	fn producer(&mut self) -> Option<&mut Producer<E>> {
 		match self {
 			Self::Reserved(_) => None,
 			Self::Encoding(producer) => Some(producer),
@@ -692,9 +694,9 @@ fn publish_state(
 ///
 /// This convenience function runs a controllable [`Publication`] with its
 /// initial source. Use [`Publication::new`] directly to retain controls.
-pub async fn publish_capture(
+pub async fn publish_capture<E: CatalogExt>(
 	broadcast: moq_net::broadcast::Producer,
-	catalog: moq_mux::catalog::Producer,
+	catalog: moq_mux::catalog::Producer<E>,
 	capture: capture::Config,
 	encode: Options,
 	clock: moq_mux::Clock,
@@ -793,8 +795,8 @@ trait Output {
 	fn write(&mut self, samples: capture::Samples, timestamp_us: u64) -> Result<(), Error>;
 }
 
-struct EncoderOutput<'a> {
-	producer: &'a mut Producer,
+struct EncoderOutput<'a, E: CatalogExt> {
+	producer: &'a mut Producer<E>,
 	clock: &'a moq_mux::Clock,
 	/// The source the supervisor was started with, so a published state can
 	/// never name an input this stream isn't actually reading.
@@ -804,7 +806,7 @@ struct EncoderOutput<'a> {
 	device: Option<capture::Device>,
 }
 
-impl Output for EncoderOutput<'_> {
+impl<E: CatalogExt> Output for EncoderOutput<'_, E> {
 	fn waiting(&mut self) {
 		self.device = None;
 		self.silence();
@@ -847,7 +849,7 @@ impl Output for EncoderOutput<'_> {
 	}
 }
 
-impl EncoderOutput<'_> {
+impl<E: CatalogExt> EncoderOutput<'_, E> {
 	/// Levels ride their own channel: they change every buffer, so folding them
 	/// into [`State`] would wake every [`Publication::changed`] waiter at the
 	/// capture rate and rebuild the whole snapshot to do it.


### PR DESCRIPTION
`encode::Producer` is already generic over `CatalogExt`, but `Publication` and `publish_capture` hardcode the default, so the turnkey capture path is closed to any consumer whose catalog carries an extension. Reaching it meant driving the capture and the encoder by hand, for no reason other than the signature.

*This PR is part of a series to update iroh-live to latest moq, see n0-computer/iroh-live#45. The code and this description were written by Claude Code.*

## Summary

Threads the parameter through `Publication::new`, `build`, `Driver`, `Track` and `EncoderOutput`, which is every type between the entry point and the producer that already had it.

The video side has never had this problem: `moq_video::encode::publish_capture` takes the catalog producer whole. This brings the audio side level with it.

## Breaking changes

`Driver` becomes `Driver<E: CatalogExt = ()>`.

The parameter defaults, so nothing that writes `Driver` in an expression position changes, and no call to `Publication::new` or `publish_capture` changes: the extension is inferred from the catalog producer passed in. What breaks is naming the type without the default, which is a struct field, a function signature, or an impl header holding a `Driver`. Those become `Driver<()>`.

We hit exactly one such site downstream and it was a one-word change.

## Test plan

- `cargo check -p moq-audio --all-features` and `cargo clippy --all-targets`, clean.
- `cargo test -p moq-audio`: 72 pass.
- Used downstream in iroh-live, which publishes a catalog carrying its own extension through `publish_capture`, which is the case that motivated this.

## Note on rebasing

This was written before #3337 reworked `Publication` to outlive a missing input, and has been re-applied on top of that design rather than merged with the old one: the retry, the `Reserved` registration and `Status::Starting` are all upstream's, and this only adds the type parameter to them.
