### PR TITLE
chore(dart): commit the formatter's escaping of the moq_ffi heading

### DIFF
--- a/dart/moq_ffi/README.md
+++ b/dart/moq_ffi/README.md
@@ -1,4 +1,4 @@
-# moq_ffi
+# moq\_ffi
 
 Raw Dart and Flutter bindings for the MoQ protocol stack. Most applications
 should use the higher-level [`moq`](https://pub.dev/packages/moq) package.


### PR DESCRIPTION
`nix develop --command just fix` on a clean `main` rewrites one file:

```diff
-# moq_ffi
+# moq\_ffi
```

`_fix-common` runs `bun remark . --quiet --output` over the whole repo, and remark escapes the underscore in `dart/moq_ffi/README.md`'s heading. The committed file never carried that escape, so every contributor who ran `just fix` picked up an unrelated one-line modification and had to revert it by hand. Two agent sessions hit it today and both reverted rather than smuggling it into an unrelated PR.

This commits the formatter's own output so the tree is formatter-clean. `\_` is a standard CommonMark escape, so the heading still renders as `moq_ffi` on pub.dev.

## Scope

This is the only file in the repo that drifted. `just fix` reformats everything remark sees in one pass, and `.remarkignore` excludes only `node_modules/`, build directories, the kramdown-rfc drafts, `doc/draft/`, and `quest/`. The run rewrote nothing else, so no sibling README under `dart/` or anywhere else has the same problem.

## Does the markdown lint run in PR CI?

Yes, but it cannot catch this. `_check-common` runs `bun remark . --quiet --frail` unconditionally, and both `just check` and `just check-all` end with `_check-common`, so it is on the PR path. (The root CLAUDE.md note about local `just rs ci` skipping root markdown lints is about that narrower recipe, not this one.)

The gap is that `--frail` raises the exit code on lint *messages*, and reformatting is not a message. Only `--output` formats, and nothing ever compares its result against what is on disk:

```console
$ printf '# moq_ffi\n' | bun remark --quiet --frail
# moq\_ffi
$ echo $?
0
```

remark is the only lint in `_check-common` without a real check mode. `shfmt --diff`, `taplo format --check`, `nixfmt --check`, and `just --fmt --check` all have one; `remark-cli` does not ship a `--check`, so it was wired up with `--frail` and the drift went unnoticed for as long as the file has existed.

That is a real hole rather than a one-off, so it gets a quest of its own rather than being fixed here: this PR stays a one-line formatter fix, and the tooling change lands separately.

## Testing

`nix develop --command just check` passes, and `just fix` is now a no-op on the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by claude-opus-5)