### PR TITLE
build: give the Markdown lint a real check mode

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "devDependencies": {
         "@biomejs/biome": "^2.5.10",
         "concurrently": "^10.0.5",
+        "markdown-extensions": "^2.0.0",
         "publint": "^0.3.24",
         "remark-cli": "^12.0.1",
         "remark-frontmatter": "^5.0.0",

--- a/justfile
+++ b/justfile
@@ -435,6 +435,17 @@ _markdown $ACTION:
     mirror=$(mktemp -d)
     trap 'rm -rf "$mirror"' EXIT
 
+    extension_list=$(bun -e \
+        'import extensions from "markdown-extensions"; console.log(extensions.join("\n"))')
+    patterns=()
+    while IFS= read -r extension; do
+        [[ -n "$extension" ]] && patterns+=("*.$extension")
+    done <<< "$extension_list"
+    ((${#patterns[@]})) || {
+        echo "error: remark reported no Markdown extensions" >&2
+        exit 1
+    }
+
     # Untracked files are in scope so a new doc is linted before it is staged;
     # --exclude-standard keeps build output out.
     files=()
@@ -443,7 +454,7 @@ _markdown $ACTION:
         files+=("$file")
         mkdir -p "$mirror/$(dirname "$file")"
         cp "$file" "$mirror/$file"
-    done < <(git ls-files -z --cached --others --exclude-standard -- '*.md')
+    done < <(git ls-files -z --cached --others --exclude-standard -- "${patterns[@]}")
     ((${#files[@]})) || exit 0
 
     # The config rides along so every .remarkignore pattern resolves against the
@@ -483,22 +494,28 @@ _markdown-test:
     git -C "$fixture" init --quiet
     cp .remarkrc.mjs .remarkignore "$fixture/"
     ln -s "$repo/node_modules" "$fixture/node_modules"
-    printf '# dirty_heading\n' > "$fixture/dirty.md"
-    git -C "$fixture" add dirty.md
+    for file in dirty.md dirty.markdown; do
+        printf '# dirty_heading\n' > "$fixture/$file"
+        git -C "$fixture" add "$file"
+    done
 
-    original=$(<"$fixture/dirty.md")
+    original='# dirty_heading'
     if just --justfile "$repo/justfile" --working-directory "$fixture" \
         _markdown check > "$fixture/check.log" 2>&1; then
         fail "formatter-only drift must fail the check"
     fi
-    [[ "$(<"$fixture/dirty.md")" == "$original" ]] \
-        || fail "the check modified its input"
-    grep -q 'dirty.md' "$fixture/check.log" \
-        || fail "the check did not name the drifted file"
+    for file in dirty.md dirty.markdown; do
+        [[ "$(<"$fixture/$file")" == "$original" ]] \
+            || fail "the check modified $file"
+        grep -q "$file" "$fixture/check.log" \
+            || fail "the check did not name $file"
+    done
 
     just --justfile "$repo/justfile" --working-directory "$fixture" _markdown fix
-    [[ "$(<"$fixture/dirty.md")" == '# dirty\_heading' ]] \
-        || fail "the fix did not format the file"
+    for file in dirty.md dirty.markdown; do
+        [[ "$(<"$fixture/$file")" == '# dirty\_heading' ]] \
+            || fail "the fix did not format $file"
+    done
     just --justfile "$repo/justfile" --working-directory "$fixture" _markdown check
 
     echo "markdown: check/fix regression ok"

--- a/justfile
+++ b/justfile
@@ -409,12 +409,71 @@ _shell $ACTION:
             ;;
     esac
 
+# remark-cli has no `--check`. `--frail` raises the exit code on lint messages,
+# and only `--output` formats, so a file that is merely misformatted passes both
+# ways. Format a scratch mirror and diff that, so the check stays read-only
+# while `fix` still writes in place.
+
+# Run Markdown lints over the worktree, either checking formatting or applying it.
+[private]
+_markdown $ACTION:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    case "$ACTION" in
+        check) ;;
+        fix)
+            bun remark . --quiet --output
+            exit 0
+            ;;
+        *)
+            echo "invalid markdown action: $ACTION" >&2
+            exit 2
+            ;;
+    esac
+
+    mirror=$(mktemp -d)
+    trap 'rm -rf "$mirror"' EXIT
+
+    # Untracked files are in scope so a new doc is linted before it is staged;
+    # --exclude-standard keeps build output out.
+    files=()
+    while IFS= read -r -d '' file; do
+        [[ -f "$file" ]] || continue
+        files+=("$file")
+        mkdir -p "$mirror/$(dirname "$file")"
+        cp "$file" "$mirror/$file"
+    done < <(git ls-files -z --cached --others --exclude-standard -- '*.md')
+    ((${#files[@]})) || exit 0
+
+    # The config rides along so every .remarkignore pattern resolves against the
+    # mirror root exactly as it does here, and node_modules is where the plugins
+    # named by .remarkrc.mjs come from.
+    cp .remarkrc.mjs .remarkignore "$mirror/"
+    ln -s "$PWD/node_modules" "$mirror/node_modules"
+
+    status=0
+    (cd "$mirror" && bun remark . --quiet --frail --output) || status=$?
+
+    stale=()
+    for file in "${files[@]}"; do
+        cmp -s "$file" "$mirror/$file" || stale+=("$file")
+    done
+
+    if ((${#stale[@]})); then
+        echo "error: these files are not formatted, run 'just fix':" >&2
+        printf '       %s\n' "${stale[@]}" >&2
+        status=1
+    fi
+
+    exit "$status"
+
 # Repository-wide lints, shared by `check` and `check-all`.
 [private]
 _check-common:
     just _changed-test
     bun install --frozen-lockfile
-    bun remark . --quiet --frail
+    just _markdown check
     just _shell check
     @if command -v taplo >/dev/null 2>&1; then RUST_LOG=error taplo format --check; fi
     @if command -v nixfmt >/dev/null 2>&1; then nixfmt --check $(find . -name '*.nix' -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*' -not -path './.direnv/*'); fi
@@ -467,7 +526,7 @@ fix-all:
 [private]
 _fix-common:
     bun install
-    bun remark . --quiet --output
+    just _markdown fix
     just _shell fix
     @if command -v taplo >/dev/null 2>&1; then RUST_LOG=error taplo format; fi
     @if command -v nixfmt >/dev/null 2>&1; then nixfmt $(find . -name '*.nix' -not -path './node_modules/*' -not -path './target/*' -not -path './.venv/*' -not -path './.direnv/*'); fi

--- a/justfile
+++ b/justfile
@@ -468,11 +468,47 @@ _markdown $ACTION:
 
     exit "$status"
 
+# Check Markdown formatting detection without touching the caller's worktree.
+[private]
+_markdown-test:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    fail() { echo "markdown: _markdown-test: $1" >&2; exit 1; }
+
+    repo=$PWD
+    fixture=$(mktemp -d)
+    trap 'rm -rf "$fixture"' EXIT
+
+    git -C "$fixture" init --quiet
+    cp .remarkrc.mjs .remarkignore "$fixture/"
+    ln -s "$repo/node_modules" "$fixture/node_modules"
+    printf '# dirty_heading\n' > "$fixture/dirty.md"
+    git -C "$fixture" add dirty.md
+
+    original=$(<"$fixture/dirty.md")
+    if just --justfile "$repo/justfile" --working-directory "$fixture" \
+        _markdown check > "$fixture/check.log" 2>&1; then
+        fail "formatter-only drift must fail the check"
+    fi
+    [[ "$(<"$fixture/dirty.md")" == "$original" ]] \
+        || fail "the check modified its input"
+    grep -q 'dirty.md' "$fixture/check.log" \
+        || fail "the check did not name the drifted file"
+
+    just --justfile "$repo/justfile" --working-directory "$fixture" _markdown fix
+    [[ "$(<"$fixture/dirty.md")" == '# dirty\_heading' ]] \
+        || fail "the fix did not format the file"
+    just --justfile "$repo/justfile" --working-directory "$fixture" _markdown check
+
+    echo "markdown: check/fix regression ok"
+
 # Repository-wide lints, shared by `check` and `check-all`.
 [private]
 _check-common:
     just _changed-test
     bun install --frozen-lockfile
+    just _markdown-test
     just _markdown check
     just _shell check
     @if command -v taplo >/dev/null 2>&1; then RUST_LOG=error taplo format --check; fi

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "^2.5.10",
 		"concurrently": "^10.0.5",
+		"markdown-extensions": "^2.0.0",
 		"publint": "^0.3.24",
 		"remark-cli": "^12.0.1",
 		"remark-frontmatter": "^5.0.0",


### PR DESCRIPTION
## Summary

- Make Markdown linting detect formatter-only drift without modifying the caller's worktree.
- Mirror every Markdown extension supported by the locked remark toolchain, including untracked files.
- Declare the extension metadata package directly so root imports work with Bun's isolated linker.
- Add an isolated regression covering `.md` and `.markdown`, read-only checks, reported paths, repair, and a clean recheck.

## Root cause

`--frail` only raises the exit code for lint messages. Formatting changes are not messages, and remark-cli has no check mode, so misformatted files passed.

## Public API changes

None.

## Test plan

- `just _markdown-test`
- `just _markdown check`
- Exact-head `just check` and `just test` in CI
- Exact-head WASM and Smoke workflows in CI

(Written by GPT-5)
