### PR TITLE
fix(moq-video): name the libspa transfer functions older headers lack

### DIFF
--- a/rs/moq-video/src/capture/pipewire.rs
+++ b/rs/moq-video/src/capture/pipewire.rs
@@ -1275,6 +1275,17 @@ fn color_from_pipewire(range: u32, matrix: u32, size: Size) -> Result<Option<Col
 	}))
 }
 
+/// `SPA_VIDEO_TRANSFER_BT2020_10` and `SPA_VIDEO_TRANSFER_BT601`, spelled out.
+///
+/// Both were appended to libspa's `spa_video_transfer_function`, so a header
+/// older than they are does not define the names and `spa::sys` does not export
+/// them. The values travel on the wire either way, and a build against an older
+/// libspa still has to recognise a stream carrying one. libspa's own
+/// documentation notes that both are functionally the same transfer function as
+/// `BT709`, which is why all three are accepted together.
+const SPA_VIDEO_TRANSFER_BT2020_10: spa::sys::spa_video_transfer_function = 13;
+const SPA_VIDEO_TRANSFER_BT601: spa::sys::spa_video_transfer_function = 16;
+
 fn validate_pipewire_description(color: Color, primaries: u32, transfer: u32) -> Result<(), Error> {
 	let expected_primaries = match color {
 		Color::Bt601Limited | Color::Bt601Full => spa::sys::SPA_VIDEO_COLOR_PRIMARIES_SMPTE170M,
@@ -1289,8 +1300,8 @@ fn validate_pipewire_description(color: Color, primaries: u32, transfer: u32) ->
 		transfer,
 		spa::sys::SPA_VIDEO_TRANSFER_UNKNOWN
 			| spa::sys::SPA_VIDEO_TRANSFER_BT709
-			| spa::sys::SPA_VIDEO_TRANSFER_BT601
-			| spa::sys::SPA_VIDEO_TRANSFER_BT2020_10
+			| SPA_VIDEO_TRANSFER_BT601
+			| SPA_VIDEO_TRANSFER_BT2020_10
 	) {
 		return Err(Error::Codec(anyhow::anyhow!(
 			"unsupported PipeWire NV12 transfer function {transfer}"


### PR DESCRIPTION
## Summary

`moq-video`'s PipeWire capture accepts `SPA_VIDEO_TRANSFER_BT601` and `SPA_VIDEO_TRANSFER_BT2020_10` alongside `BT709` when validating an NV12 stream's color description. Both enumerators were appended to libspa's `spa_video_transfer_function` late: they first appear in the 1.5.81 pre-release, so PipeWire 1.6.0 is the first stable release whose `spa/param/video/color.h` defines them. Every earlier header lacks them, including 0.3.65 (Debian and Raspberry Pi OS Bookworm), 1.0.x (Ubuntu 24.04), and 1.4.x (Debian Trixie).

The `pipewire` crate generates `spa::sys` from the installed headers with bindgen, so on those systems `spa::sys::SPA_VIDEO_TRANSFER_BT601` and `spa::sys::SPA_VIDEO_TRANSFER_BT2020_10` simply do not exist and `cargo build -p moq-video --features pipewire` fails with two unresolved-name errors in `capture/pipewire.rs`. Guarding the two arms out would compile but is the wrong fix: the values travel on the wire regardless of the local header version, and a stream produced by a newer compositor still has to be recognised.

## Change

Define the two constants locally with their numeric values (13 and 16, matching the enum order in `color.h`) and use them in the `matches!` instead of the `spa::sys` re-exports. A doc comment explains why the names are spelled out and cites libspa's own note that both are functionally the same transfer function as `BT709`, which is why all three were accepted together to begin with. Nothing else in the crate changes.

## Testing

On a machine with PipeWire 1.6.8 headers:

- `cargo check -p moq-video --features pipewire`
- `cargo clippy -p moq-video --features pipewire --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `cargo check -p moq-video` without the feature, to confirm nothing else moved

The numeric values were verified by counting the enumerators in the installed `spa/param/video/color.h`, and the absence of the names in earlier releases was verified against the 0.3.65, 1.0.0, 1.2.0, 1.4.0, and 1.4.8 tags.
