### PR TITLE
fix(moq-video): decode an avc1 track with no avcC as Annex-B

### DIFF
--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -296,6 +296,57 @@ mod tests {
 		round_trip(h264_software_encoder(gray_size()), decoder, "openh264");
 	}
 
+	/// A browser encoding through WebCodecs with `avc: { format: "annexb" }` keeps
+	/// the `avc1` codec string while writing its parameter sets in band, and that
+	/// is what `@moq/publish` sends: an avc1 label, no avcC description, and
+	/// Annex-B payloads. The decoder used to refuse such a track for its missing
+	/// description. It now reads the payload as Annex-B, the only framing a
+	/// description-less track could carry and still decode.
+	#[test]
+	fn avc1_without_avcc_decodes_as_annexb() {
+		// The catalog shape observed from @moq/publish: `"codec": "avc1.640028"`
+		// and no `description`.
+		let h264 = hang::catalog::H264 {
+			inline: false,
+			profile: 0x64,
+			constraints: 0x00,
+			level: 0x28,
+		};
+		let catalog = hang::catalog::VideoConfig::new(h264);
+		assert_eq!(catalog.codec.to_string(), "avc1.640028");
+		assert!(catalog.description.is_none());
+
+		let mut decoder = super::Decoder::new(&catalog, &decode_config(super::Kind::Software))
+			.expect("a description-less avc1 track opens rather than erroring");
+		assert!(
+			matches!(decoder.conversion, super::Conversion::Passthrough),
+			"a description-less avc1 track is read as Annex-B"
+		);
+
+		// openh264 emits Annex-B access units with SPS/PPS inline ahead of each
+		// IDR, which is the bitstream WebCodecs produces in `annexb` format.
+		let mut encoder = h264_software_encoder(gray_size());
+		let mut decoded = Vec::new();
+		for i in 0..5u64 {
+			let keyframe = i == 0;
+			if keyframe {
+				encoder.keyframe();
+			}
+			for encoded in encoder.encode(&gray_frame(i)).unwrap() {
+				assert!(
+					encoded.payload.starts_with(&[0, 0, 0, 1]) || encoded.payload.starts_with(&[0, 0, 1]),
+					"the test feeds Annex-B, not length-prefixed NALs"
+				);
+				decoded.extend(decoder.decode(&encoded.payload, encoded.timestamp, keyframe).unwrap());
+			}
+		}
+
+		assert!(!decoded.is_empty(), "decoder produced no frames");
+		for out in &decoded {
+			assert_gray(&out.surface.to_i420().unwrap(), 320, 240);
+		}
+	}
+
 	#[test]
 	fn av1_is_supported_by_hardware_only() {
 		let catalog = hang::catalog::VideoConfig::new(hang::catalog::AV1::default());

--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -7,6 +7,13 @@
 //! already Annex-B inline) and AV1 OBU temporal units untouched. Gates output
 //! until the first keyframe so the backend never sees a delta frame it can't
 //! decode.
+//!
+//! A track that says avc1 or hvc1 and carries no description is read as Annex-B
+//! rather than refused. The two codec strings describe the framing, and a
+//! browser encoding with WebCodecs' `annexb` output keeps the avc1 label while
+//! putting its parameter sets in band, which is what `@moq/publish` does today.
+//! Length-prefixed payloads without their parameter sets could not be decoded
+//! anyway, so the lenient reading only ever turns an error into a picture.
 
 use std::time::Duration;
 
@@ -93,34 +100,38 @@ impl Decoder {
 	pub fn new(catalog: &VideoConfig, config: &Config) -> Result<Self, Error> {
 		let (codec, conversion) = match &catalog.codec {
 			VideoCodec::H264(h264) => {
-				let conversion = if h264.inline {
-					Conversion::Passthrough
-				} else {
-					let avcc = catalog.description.as_ref().ok_or_else(|| {
-						Error::Codec(anyhow::anyhow!("avc1 H.264 track is missing its avcC description"))
-					})?;
-					let params = h264::Avcc::parse(avcc).map_err(moq_mux::Error::from)?;
-					let keyframe_prefix = annexb::build_prefix(params.sps.iter().chain(params.pps.iter()));
-					Conversion::LengthPrefixed {
-						length_size: params.length_size,
-						keyframe_prefix,
+				let conversion = match (h264.inline, catalog.description.as_ref()) {
+					(true, _) => Conversion::Passthrough,
+					(false, Some(avcc)) => {
+						let params = h264::Avcc::parse(avcc).map_err(moq_mux::Error::from)?;
+						let keyframe_prefix = annexb::build_prefix(params.sps.iter().chain(params.pps.iter()));
+						Conversion::LengthPrefixed {
+							length_size: params.length_size,
+							keyframe_prefix,
+						}
+					}
+					(false, None) => {
+						tracing::warn!("avc1 track has no avcC description; reading it as Annex-B");
+						Conversion::Passthrough
 					}
 				};
 				(Codec::H264, conversion)
 			}
 			VideoCodec::H265(h265) => {
-				let conversion = if h265.in_band {
-					Conversion::Passthrough
-				} else {
-					let hvcc = catalog.description.as_ref().ok_or_else(|| {
-						Error::Codec(anyhow::anyhow!("hvc1 H.265 track is missing its hvcC description"))
-					})?;
-					let params = h265::Hvcc::parse(hvcc).map_err(moq_mux::Error::from)?;
-					let keyframe_prefix =
-						annexb::build_prefix(params.vps.iter().chain(params.sps.iter()).chain(params.pps.iter()));
-					Conversion::LengthPrefixed {
-						length_size: params.length_size,
-						keyframe_prefix,
+				let conversion = match (h265.in_band, catalog.description.as_ref()) {
+					(true, _) => Conversion::Passthrough,
+					(false, Some(hvcc)) => {
+						let params = h265::Hvcc::parse(hvcc).map_err(moq_mux::Error::from)?;
+						let keyframe_prefix =
+							annexb::build_prefix(params.vps.iter().chain(params.sps.iter()).chain(params.pps.iter()));
+						Conversion::LengthPrefixed {
+							length_size: params.length_size,
+							keyframe_prefix,
+						}
+					}
+					(false, None) => {
+						tracing::warn!("hvc1 track has no hvcC description; reading it as Annex-B");
+						Conversion::Passthrough
 					}
 				};
 				(Codec::H265, conversion)

--- a/rs/moq-video/src/decode/decoder.rs
+++ b/rs/moq-video/src/decode/decoder.rs
@@ -8,12 +8,12 @@
 //! until the first keyframe so the backend never sees a delta frame it can't
 //! decode.
 //!
-//! A track that says avc1 or hvc1 and carries no description is read as Annex-B
-//! rather than refused. The two codec strings describe the framing, and a
-//! browser encoding with WebCodecs' `annexb` output keeps the avc1 label while
-//! putting its parameter sets in band, which is what `@moq/publish` does today.
-//! Length-prefixed payloads without their parameter sets could not be decoded
-//! anyway, so the lenient reading only ever turns an error into a picture.
+//! A track that says avc1 and carries no description is read as Annex-B rather
+//! than refused. A browser encoding with WebCodecs' `annexb` output keeps the
+//! avc1 label while putting its parameter sets in band, which is what
+//! `@moq/publish` does today. Length-prefixed payloads without their parameter
+//! sets could not be decoded anyway, so the lenient reading only ever turns an
+//! error into a picture.
 
 use std::time::Duration;
 
@@ -118,20 +118,18 @@ impl Decoder {
 				(Codec::H264, conversion)
 			}
 			VideoCodec::H265(h265) => {
-				let conversion = match (h265.in_band, catalog.description.as_ref()) {
-					(true, _) => Conversion::Passthrough,
-					(false, Some(hvcc)) => {
-						let params = h265::Hvcc::parse(hvcc).map_err(moq_mux::Error::from)?;
-						let keyframe_prefix =
-							annexb::build_prefix(params.vps.iter().chain(params.sps.iter()).chain(params.pps.iter()));
-						Conversion::LengthPrefixed {
-							length_size: params.length_size,
-							keyframe_prefix,
-						}
-					}
-					(false, None) => {
-						tracing::warn!("hvc1 track has no hvcC description; reading it as Annex-B");
-						Conversion::Passthrough
+				let conversion = if h265.in_band {
+					Conversion::Passthrough
+				} else {
+					let hvcc = catalog.description.as_ref().ok_or_else(|| {
+						Error::Codec(anyhow::anyhow!("hvc1 H.265 track is missing its hvcC description"))
+					})?;
+					let params = h265::Hvcc::parse(hvcc).map_err(moq_mux::Error::from)?;
+					let keyframe_prefix =
+						annexb::build_prefix(params.vps.iter().chain(params.sps.iter()).chain(params.pps.iter()));
+					Conversion::LengthPrefixed {
+						length_size: params.length_size,
+						keyframe_prefix,
 					}
 				};
 				(Codec::H265, conversion)
@@ -296,12 +294,8 @@ mod tests {
 		round_trip(h264_software_encoder(gray_size()), decoder, "openh264");
 	}
 
-	/// A browser encoding through WebCodecs with `avc: { format: "annexb" }` keeps
-	/// the `avc1` codec string while writing its parameter sets in band, and that
-	/// is what `@moq/publish` sends: an avc1 label, no avcC description, and
-	/// Annex-B payloads. The decoder used to refuse such a track for its missing
-	/// description. It now reads the payload as Annex-B, the only framing a
-	/// description-less track could carry and still decode.
+	/// A description-less avc1 track from WebCodecs carries Annex-B payloads with
+	/// its parameter sets in band, the only framing that can decode without avcC.
 	#[test]
 	fn avc1_without_avcc_decodes_as_annexb() {
 		// The catalog shape observed from @moq/publish: `"codec": "avc1.640028"`


### PR DESCRIPTION
## Summary

- Read a description-less `avc1` rendition as Annex-B instead of refusing the track.
- Preserve the existing avcC conversion path and all H.265 behavior.
- Add a deterministic software encode/decode regression for the catalog shape published by `@moq/publish` 0.4.5.

## Root cause

WebCodecs accepts `avc: { format: "annexb" }` while keeping the reported codec string as `avc1.*`. `@moq/publish` 0.4.5 passes that label through without a `description`, so the native decoder treated the rendition as length-prefixed avc1 but had no avcC parameter sets and rejected it before decoding a frame. The payloads are actually Annex-B with inline SPS and PPS.

The fallback is limited to avc1 with no description. Valid avc1 tracks with avcC keep the existing length-prefixed conversion, and avc3 remains passthrough.

## Public API changes

None. This broadens the inputs accepted by the existing decoder.

## Test plan

- `avc1_without_avcc_decodes_as_annexb` constructs the observed catalog shape, confirms Annex-B input, and decodes real openh264 output to verified frames.
- `cargo fmt --all --check`
- Required GitHub Check, Test, and Swift jobs.

(written by GPT-5.6 Sol)
