### PR TITLE
fix(moq-net): give control streams a send order above the media

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10650,9 +10650,9 @@ dependencies = [
 
 [[package]]
 name = "web-transport-quiche"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "153ece42b1d6e86015fcac192b6d4aae0ac8595045e844ac075169b22f1d37c6"
+checksum = "723f409f2e2d440a53e3c44e64af9b4f9d0c8d49e815c7194b4c581df981632e"
 dependencies = [
  "boring",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,7 +175,7 @@ web-transport-iroh = "0.7"
 # Keep the `qlog` passthrough feature available for moq-native to forward.
 web-transport-noq = { version = "0.3.0", default-features = false }
 web-transport-proto = "0.6"
-web-transport-quiche = "0.6"
+web-transport-quiche = "0.7"
 web-transport-quinn = "0.12"
 web-transport-trait = "0.4.0"
 web-transport-wasm = "0.5"

--- a/rs/moq-net/src/coding/stream.rs
+++ b/rs/moq-net/src/coding/stream.rs
@@ -1,6 +1,22 @@
 use crate::Error;
 use crate::coding::{Reader, Writer};
 
+/// The send order every control stream is opened at.
+///
+/// Control streams carry announces, subscribe responses and track info: tens of
+/// bytes each, and nothing downstream can proceed until they arrive. Left at the
+/// transport's default of 0 they lose to every media stream, because a group
+/// stream's send order is `u8::MAX - rank` and quinn schedules strictly by
+/// priority, round-robining only within one level. On a link saturated by the
+/// media itself the top-ranked group always has bytes pending, so the scheduler
+/// never reaches 0 and a subscriber cannot learn anything new from its publisher
+/// for as long as the saturation lasts.
+///
+/// `u8::MAX` ties with the most urgent group rather than preempting it, so
+/// relative media ordering is untouched and a control message takes a
+/// round-robin share: a packet or two, which is all it needs.
+const CONTROL_SEND_ORDER: u8 = u8::MAX;
+
 /// A [Writer] and [Reader] pair for a single stream.
 pub struct Stream<S: web_transport_trait::Session, V> {
 	pub writer: Writer<S::SendStream, V>,
@@ -15,7 +31,8 @@ impl<S: web_transport_trait::Session, V> Stream<S, V> {
 	{
 		let (send, recv) = session.open_bi().await.map_err(Error::from_transport)?;
 
-		let writer = Writer::new(send, version.clone());
+		let mut writer = Writer::new(send, version.clone());
+		writer.set_priority(CONTROL_SEND_ORDER);
 		let reader = Reader::new(recv, version);
 
 		Ok(Stream { writer, reader })
@@ -28,7 +45,10 @@ impl<S: web_transport_trait::Session, V> Stream<S, V> {
 	{
 		let (send, recv) = session.accept_bi().await.map_err(Error::from_transport)?;
 
-		let writer = Writer::new(send, version.clone());
+		// The accepted half answers on this stream (track info, subscribe
+		// responses), so it needs the same priority as one we opened.
+		let mut writer = Writer::new(send, version.clone());
+		writer.set_priority(CONTROL_SEND_ORDER);
 		let reader = Reader::new(recv, version);
 
 		Ok(Stream { writer, reader })
@@ -40,5 +60,30 @@ impl<S: web_transport_trait::Session, V> Stream<S, V> {
 			writer: self.writer.with_version(version.clone()),
 			reader: self.reader.with_version(version),
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::lite::{Version, test_transport::SinkSession};
+
+	/// Opening a control stream must set its send order, or a saturated link
+	/// starves it: quinn schedules strictly by priority and round-robins only
+	/// within a level, so a rank-0 group with bytes pending is enough to keep
+	/// the scheduler from ever reaching the transport's default of 0.
+	#[tokio::test]
+	async fn open_prioritises_the_stream() {
+		let gate = kio::Producer::new(true);
+		let session = SinkSession::gated_bi(gate.consume());
+		let log = session.log.clone();
+
+		let _stream = Stream::open(&session, Version::Lite05).await.unwrap();
+
+		assert_eq!(
+			log.priorities(),
+			vec![CONTROL_SEND_ORDER],
+			"a control stream left at the transport default loses to every group",
+		);
 	}
 }

--- a/rs/moq-net/src/coding/stream.rs
+++ b/rs/moq-net/src/coding/stream.rs
@@ -86,4 +86,22 @@ mod tests {
 			"a control stream left at the transport default loses to every group",
 		);
 	}
+
+	/// The accepted half answers on the stream it was handed (track info, subscribe
+	/// responses), so it needs the same order as one we opened. A fix that only
+	/// covered `open` would leave every reply behind the media.
+	#[tokio::test]
+	async fn accept_prioritises_the_stream() {
+		let gate = kio::Producer::new(true);
+		let session = SinkSession::accepted_bi(gate.consume());
+		let log = session.log.clone();
+
+		let _stream = Stream::accept(&session, Version::Lite05).await.unwrap();
+
+		assert_eq!(
+			log.priorities(),
+			vec![CONTROL_SEND_ORDER],
+			"an accepted control stream left at the transport default loses to every group",
+		);
+	}
 }

--- a/rs/moq-net/src/lite/test_transport.rs
+++ b/rs/moq-net/src/lite/test_transport.rs
@@ -302,6 +302,9 @@ pub struct SinkSession {
 	/// Set by [`Self::gated_bi`]. `None` parks `open_bi` itself forever, which is all
 	/// a test driving only uni streams needs.
 	bi_gate: Option<kio::Consumer<bool>>,
+	/// Set by [`Self::accepted_bi`]. `None` parks `accept_bi` forever, which is what
+	/// every session that only ever opens its own streams expects.
+	accept_gate: Option<kio::Consumer<bool>>,
 	/// Set by [`Self::gated_uni`]. `None` writes immediately.
 	uni_gate: Option<kio::Consumer<bool>>,
 	/// The ALPN to report, for a test that needs a specific negotiated version rather
@@ -318,6 +321,7 @@ impl SinkSession {
 		Self {
 			log,
 			bi_gate: None,
+			accept_gate: None,
 			uni_gate: None,
 			protocol: None,
 			stats: Arc::new(Mutex::new(SinkStats::default())),
@@ -350,6 +354,23 @@ impl SinkSession {
 		Self {
 			log: Log::default(),
 			bi_gate: Some(gate),
+			accept_gate: None,
+			uni_gate: None,
+			protocol: None,
+			stats: Arc::new(Mutex::new(SinkStats::default())),
+		}
+	}
+
+	/// Accept bidi streams from the peer, holding every write until `gate` flips to true.
+	///
+	/// The accepted half of a control stream carries the answers (track info,
+	/// subscribe responses), so a test of what must be true before the first byte of
+	/// a reply reaches the wire needs a session that hands out accepted streams.
+	pub fn accepted_bi(gate: kio::Consumer<bool>) -> Self {
+		Self {
+			log: Log::default(),
+			bi_gate: None,
+			accept_gate: Some(gate),
 			uni_gate: None,
 			protocol: None,
 			stats: Arc::new(Mutex::new(SinkStats::default())),
@@ -365,6 +386,7 @@ impl SinkSession {
 		Self {
 			log: Log::default(),
 			bi_gate: None,
+			accept_gate: None,
 			uni_gate: Some(gate),
 			protocol: None,
 			stats: Arc::new(Mutex::new(SinkStats::default())),
@@ -382,7 +404,16 @@ impl web_transport_trait::Session for SinkSession {
 	}
 
 	async fn accept_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {
-		std::future::pending().await
+		let Some(gate) = self.accept_gate.clone() else {
+			return std::future::pending().await;
+		};
+
+		let send = SinkSend {
+			log: self.log.clone(),
+			gate: Some(gate),
+			finished: false,
+		};
+		Ok((send, PendingRecv))
 	}
 
 	async fn open_bi(&self) -> Result<(Self::SendStream, Self::RecvStream), Self::Error> {


### PR DESCRIPTION
## Summary

- Give both outgoing halves of MoQ control bidirectional streams send order `u8::MAX`, tying the most urgent media instead of remaining at the transport default of 0.
- Fix control starvation on saturated links. Quinn schedules higher send orders first and only round-robins within a level, so an always-writable media stream could otherwise prevent announces, subscribe responses, and track info from being sent.
- Update `web-transport-quiche` to 0.7.0. Version 0.6.0 forwarded the trait's higher-is-first value directly to quiche's lower-is-first urgency API, which would have inverted this fix on the optional quiche backend.
- Cover both locally opened and peer-opened control streams so replies cannot silently regress to the default priority.

## Public API changes

None. The priority constant and accepted-stream test helper are internal.

## Test plan

- `cargo fmt --all --check`
- `cargo clippy --locked -p moq-net --all-targets -- -D warnings`
- `cargo check --locked -p moq-native --no-default-features --features quiche`
- `cargo nextest run --locked -p moq-net` (933 passed)
- GitHub CI: Check, Test, WASM, OBS, and Swift

## Cross-package sync

No wire format or public API changed, so no JS, draft, or documentation update is needed.

(written by GPT-5)
