### PR TITLE
chore(quest): plan the web P2P questline

### DIFF
--- a/quest/m2/README.md
+++ b/quest/m2/README.md
@@ -32,6 +32,7 @@ can act on. Each still carries its own plan and regression test.
 - [#2847](/quest/m2/2847-the-quinn-backends-send-bandwidth-estimate-is-cwnd-rtt.md) - quinn backend: bump to the releases that report the controller bandwidth estimate instead of cwnd/rtt
 - [Relay memory](/quest/m2/relay-memory/README.md) - relay memory scales with what it serves, not what the fleet knows
 - [PoP skipping](/quest/m2/pop-skipping/README.md) - short cold paths for unpopular broadcasts without losing warm backhaul dedup
+- [Route cost in the JS origin](/quest/m2/route-cost.md) - the browser origin ranks routes by cost and hops like Rust instead of newest-first
 - [E2EE](/quest/m2/e2ee/README.md) - TypeScript and Rust peers interoperate over encrypted broadcasts no relay can decrypt
 - [SEI](/quest/m2/sei/README.md) - H.26x SEI moves into its own track, readable without subscribing to video
 - [Processor](/quest/m2/processor/README.md) - a customer-run worker publishes an on-demand contribution with scoped access

--- a/quest/m2/route-cost.md
+++ b/quest/m2/route-cost.md
@@ -13,8 +13,10 @@ than dropped.
 carries the hop chain; neither reaches `OriginState.remote`, which keeps
 providers newest-first. Carry both on the provider, rank with the same order
 as `route_order` in `rs/moq-net/src/model/origin.rs` (cost, chain length, a
-deterministic tiebreak), including its treatment of a route without a cost as
-the most expensive, and re-pick when the chosen route is retracted.
+deterministic tiebreak), including `Cost::UNKNOWN` for an announce that
+carries no cost (free to reach, cold path at the ceiling, so hop count decides
+as it did before route cost existed), and re-pick when the chosen route is
+retracted.
 
 Tests in `js/net` with the mock transport pair: two sessions announcing the
 same path at different costs, the cheaper one serves, its retraction moves

--- a/quest/m2/route-cost.md
+++ b/quest/m2/route-cost.md
@@ -1,0 +1,25 @@
+# [S] Route cost in the JS origin
+
+## Goal
+
+The `@moq/net` origin serves a path through the best route it knows, ranked by
+cost and then hop count the way Rust's origin does, instead of the newest
+announce. The lite-06 route cost that arrives on every announce is read rather
+than dropped.
+
+## Plan
+
+`announce.ts` already decodes `Cost { warm, cold }` and `hop.ts` already
+carries the hop chain; neither reaches `OriginState.remote`, which keeps
+providers newest-first. Carry both on the provider, rank with the same order
+as `route_order` in `rs/moq-net/src/model/origin.rs` (cost, chain length, a
+deterministic tiebreak), including its treatment of a route without a cost as
+the most expensive, and re-pick when the chosen route is retracted.
+
+Tests in `js/net` with the mock transport pair: two sessions announcing the
+same path at different costs, the cheaper one serves, its retraction moves
+the consumer to the other.
+
+## Related
+
+- [Web P2P](/quest/m3/p2p/README.md) - the watcher-side route pick that line needs

--- a/quest/m3/README.md
+++ b/quest/m3/README.md
@@ -19,6 +19,7 @@ its verdict lands and the follow-on work becomes concrete.
 - [Multipath spike](/quest/m3/multipath-spike.md) - whether bonded contribution over multipath QUIC is worth building, given it needs noq on both ends
 - [QUIC GCC](/quest/m3/quic-gcc.md) - a measured verdict on delay-based congestion control for media egress
 - [QUIC FEC](/quest/m3/quic-fec.md) - a measured verdict on transport-level FEC vs retransmission
+- [Web P2P](/quest/m3/p2p/README.md) - a measured verdict on browsers serving each other over LAN-only data channels to offload the relay
 - [GOP overhead](/quest/m3/gop-overhead.md) - price the I-frames a short GOP pays for, deciding whether a long GOP plus a keyframe request is worth designing
 - [#697](/quest/m3/697-conferencing-demo.md) - Conferencing Demo
 - [#703](/quest/m3/703-experimental-webgpu-renderer.md) - Experimental WebGPU renderer

--- a/quest/m3/p2p/README.md
+++ b/quest/m3/p2p/README.md
@@ -1,0 +1,85 @@
+# Web P2P
+
+## Goal
+
+A measured verdict on whether moq-lite over WebRTC data channels is good enough
+for browsers on one LAN to serve each other, so a room full of watchers costs
+the relay one egress stream instead of one per tab. Opt-in and LAN only: ICE
+gathers host candidates and nothing else, never STUN or TURN, so a connection
+can only form between peers that already share a network.
+
+Two endpoint pairs must work: browser to browser, and browser to a native node
+on the LAN. A browser reaches a native node over WebTransport when it can and
+over a data channel when it cannot. Native nodes keep preferring QUIC among
+themselves, over the existing mDNS mesh or an advertised iroh endpoint.
+
+Non-goals: NAT traversal, multi-hop browser meshes, RTP media, and operating
+without a relay. Offline LAN operation remains the native mesh's job.
+
+## Plan
+
+### The relay is the rendezvous
+
+No browser exposes mDNS or DNS-SD to a page, and Chrome's Local Network Access
+work moves the other way. But every opted-in peer already holds a session to
+the same relay, so discovery and signaling ride that session as ordinary moq
+broadcasts under a reserved `.p2p/` prefix, the same shape
+[carrier voice](/quest/m3/carrier-voice/README.md) uses for call setup. The
+relay learns nothing new. Trust is the relay's token scope: a peer that may
+publish under `.p2p/` is as trusted as any other publisher the token admits,
+so the prototype needs no E2EE.
+
+LAN scoping needs no code either. With an empty ICE server list a browser
+offers host candidates only, obfuscated as `.local` mDNS names it resolves for
+its peers. The native side must resolve those names itself.
+
+### Two stream mappings, both measured
+
+Data channels are SCTP streams, so moq-lite streams can map one-to-one onto
+channels, or qmux can multiplex everything over a single channel the way the
+WebSocket binding does. The first keeps groups independent but fights Chrome's
+1024-stream cap and 256 KiB message limit; the second is nearly free but
+reintroduces head-of-line blocking across groups. Both ship in the browser and
+native transports and the verdict compares them against WebTransport on the
+same LAN, in Chrome and Firefox, whose SCTP stacks differ.
+
+### What the browser cannot do yet
+
+The `@moq/net` origin never forwards what a peer announced, so a watcher tab
+cannot re-serve a broadcast it receives from the relay. The prototype measures
+the two topologies that work without transit: a publishing tab serving LAN
+watchers directly, and watcher tabs pulling from a `moq-cli` hop that already
+transits. Route selection between the relay and a LAN peer is
+[cost ranking in the JS origin](/quest/m2/route-cost.md), which is product
+work and lives in m2. A go verdict promotes this line to m2 with a JS transit
+quest and the productization work; a no-go is a written abandonment.
+
+### Risks the verdict records
+
+- Chrome 147 prompts for local network access on a WebTransport dial to a
+  private address from a public origin; the same gate is proposed for WebRTC.
+  The fallback order covers a denial, but join time suffers.
+- Firefox bug 1698141: Firefox-initiated LAN P2P to Chrome can fail on mDNS
+  candidate parsing.
+- Networks that filter multicast (client isolation, VLAN hops) break `.local`
+  resolution and therefore every browser connection.
+- Chrome caps an association at 1024 SCTP streams with 256 KiB messages and
+  interleaves fragments only behind a flag, so the per-stream mapping's numbers
+  are browser-specific.
+
+## Quests
+
+- [Data channel transport](/quest/m3/p2p/transport.md) - `@moq/p2p` speaks moq-lite over an RTCPeerConnection in both mappings, behind the WebTransport shape `@moq/net` already consumes
+- [Signaling over the relay](/quest/m3/p2p/signal.md) - opted-in peers find each other under `.p2p/` and end up with established sessions on the shared origin
+- [Native data channel transport](/quest/m3/p2p/webrtc.md) - `moq-tokio` holds a moq-net session with a browser over str0m, resolving `.local` candidates
+- [moq-cli joins the LAN](/quest/m3/p2p/cli.md) - `--p2p` advertises WebTransport, iroh, and WebRTC reachability and accepts browsers as a transit hop
+- [Watch opts in](/quest/m3/p2p/watch.md) - one attribute turns it on in the demo and the watcher picks the cheapest route
+- [Verdict](/quest/m3/p2p/verdict.md) - the Playwright harness, the numbers, and the go/no-go
+
+## Related
+
+- [Route cost in the JS origin](/quest/m2/route-cost.md) - the watcher-side route pick this line needs
+- [E2EE](/quest/m2/e2ee/README.md) - what a LAN peer would need if the token scope stopped being the trust boundary
+- [Cluster discovery flags](/quest/m2/cluster-flags.md) - the flag shape `--p2p` should follow
+- [qmux on the QUIC core](/quest/m2/quic/qmux.md) - the qmux mapping rides whatever stream core that line selects
+- [Carrier voice](/quest/m3/carrier-voice/README.md) - signaling as an application protocol over moq, the pattern reused here

--- a/quest/m3/p2p/cli.md
+++ b/quest/m3/p2p/cli.md
@@ -1,0 +1,37 @@
+# [M] moq-cli joins the LAN
+
+## Goal
+
+`moq-cli --p2p` joins `.p2p/` on its relay session, advertises how it can be
+reached, and accepts LAN browsers over data channels as a transit hop between
+them and the relay. Native peers that both advertise iroh dial each other
+directly over `iroh://`.
+
+## Plan
+
+`--p2p` (`MOQ_P2P`) needs a relay session (`--connect`) and a listener
+(`--listen`); shape the flag so the value carries those prerequisites rather
+than adding startup checks, per
+[cluster discovery flags](/quest/m2/cluster-flags.md).
+
+The roster entry mirrors the `info.json` schema from
+[signaling](/quest/m3/p2p/signal.md): the listener's LAN addresses as
+WebTransport URLs, ordered the way `mdns::Peer::urls` orders them, with the
+listener's certificate fingerprint; the iroh endpoint id when `--iroh` is on;
+and `webrtc: true`. The generated certificate must satisfy the browser's
+`serverCertificateHashes` rules (ECDSA P-256, under fourteen days); verify the
+generator does. Offers and answers go through the same per-pair broadcasts,
+mirrored in Rust.
+
+Every accepted browser session attaches to the shared origin with
+`with_publisher` and `with_subscriber`, as the LAN mesh does, so the node is
+a hop: it subscribes upstream once and serves each browser from the same
+origin. Native pairs where both advertise iroh use the existing iroh client,
+lower id dialing.
+
+Docs: a "Web P2P" section in `doc/bin/cli.md` beside the LAN cluster one.
+
+## Required
+
+- [Native data channel transport](/quest/m3/p2p/webrtc.md)
+- [Signaling over the relay](/quest/m3/p2p/signal.md) - the roster and offer schema this mirrors

--- a/quest/m3/p2p/signal.md
+++ b/quest/m3/p2p/signal.md
@@ -1,0 +1,50 @@
+# [M] Signaling over the relay
+
+## Goal
+
+An opted-in browser discovers the other opted-in peers on its relay session
+and ends up holding an established `@moq/net` connection to every one it can
+reach on the LAN, wired into the shared origin in both directions. No STUN, no
+TURN, no new relay behavior.
+
+## Plan
+
+`Peers` in `@moq/p2p` takes the shared origin and an enabled signal, nothing
+else: publishing into the origin reaches the relay, and the origin's announce
+stream is the roster. Tests inject a peer connection factory so `bun test`
+covers pairing with a fake.
+
+Prefix: `.p2p/` under the session's root path, so the token scope decides who
+may join. Identity: a random 64-bit hex id per tab, like the mDNS instance
+name. Roster: each peer publishes `.p2p/<id>` with an `info.json` snapshot
+track listing the moq ALPNs it accepts, `webrtc: true`, and for native peers
+an optional `webtransport: { url, fingerprint }` and `iroh` endpoint id. This
+schema is shared with [moq-cli](/quest/m3/p2p/cli.md).
+
+Pairing: the lower id dials. The dialer publishes `.p2p/<target>/<self>` with
+a `signal` stream track carrying the offer and then each ICE candidate as it
+arrives; the target answers on `.p2p/<self>/<target>`. Every peer subscribes
+to its own `.p2p/<self>/` prefix. The peer connection is built with an empty
+`iceServers` list; data-channel-only pages get `.local` host candidates from
+every browser and resolve the peer's for free.
+
+Native entries: when `info.webtransport` is present the dialer first tries
+`Connection.connect` with the fingerprint pinned and a short timeout, then
+falls through to WebRTC. Chrome 147 may prompt for local network access on
+that dial; a denial falls through the same way.
+
+Lifecycle: a retracted `.p2p/<id>` announce closes that peer's session. An
+ICE failure is terminal for the pair until either side re-announces; no
+retry loop. Each established connection goes through `Connection.connect`
+with the supplied transport on the dialing side and `Connection.accept` on
+the answering side, both with `publish: origin.consume()` and
+`subscribe: origin`. Because the JS origin serves only what the tab publishes
+locally, transit stays a follow-up.
+
+## Required
+
+- [Data channel transport](/quest/m3/p2p/transport.md)
+
+## Related
+
+- [Carrier voice protocol](/quest/m3/carrier-voice/README.md) - the same signaling-as-broadcasts shape

--- a/quest/m3/p2p/transport.md
+++ b/quest/m3/p2p/transport.md
@@ -1,0 +1,49 @@
+# [M] Data channel transport
+
+## Goal
+
+`@moq/p2p` exports a transport with the DOM `WebTransport` shape over an
+`RTCPeerConnection`, in two modes, that `Connection.connect` and
+`Connection.accept` in `@moq/net` consume without change. The moq-lite draft
+gains the two bindings.
+
+## Plan
+
+`@moq/qmux` and `MockTransport` are the models: the contract is the DOM
+interface, and `transportOf` in `js/net` gains a `webrtc` arm so stats and
+logs name it. The negotiated moq ALPN is handed to the transport by the caller
+(signaling agrees it before the peer connection exists), because `accept()`
+reads `transport.protocol` to pick the SETUP flavor.
+
+Mode `qmux`: one reliable ordered channel. A small object with the
+`WebSocketStream` shape (`opened`, `closed`, `close`) wraps the channel and is
+handed to `Session` or `Session.accept` with the protocol override; the
+readable enqueues one `Uint8Array` per message with `binaryType` set to
+`arraybuffer`, the writable calls `send` per record and derives `desiredSize`
+from `bufferedAmount` against `bufferedAmountLowThreshold`. Records above the
+negotiated `maxMessageSize` (256 KiB in Chrome) are chunked.
+
+Mode `stream`: one channel per moq stream, opened with a `protocol` string
+naming the direction so a unidirectional stream is a channel only one side
+writes. The first channel is the SETUP stream. `finish` closes the channel;
+`reset` and `stop` carry their codes on one reserved control channel, since
+DCEP has no error code. A separate `ordered: false, maxRetransmits: 0` channel
+carries moq-lite datagrams and reports the negotiated message size as
+`maxDatagramSize`. Chrome frees a stream id only after the close event, so the
+transport counts open channels and parks `createUnidirectionalStream` near
+the 1024 cap rather than failing.
+
+Tests: framing, chunking, and the control channel run under `bun test`
+against an in-memory channel pair; the real thing runs under the Playwright
+driver in `test/p2p`, two peer connections in one page over both modes,
+completing SETUP through `accept()` and `connect()`.
+
+Draft: `draft-lcurley-moq-lite.md` Transports gains rows for qmux over
+RTCDataChannel (one record per message, no datagrams, like WebSocket) and
+RTCDataChannel per stream (with the control and datagram channels), and the
+sentence declaring P2P out of scope goes. `just drafts check` passes.
+
+## Related
+
+- [Signaling over the relay](/quest/m3/p2p/signal.md) - supplies the peer connection and the agreed ALPN
+- [Native data channel transport](/quest/m3/p2p/webrtc.md) - the same two mappings in Rust

--- a/quest/m3/p2p/verdict.md
+++ b/quest/m3/p2p/verdict.md
@@ -1,0 +1,39 @@
+# [M] Verdict
+
+## Goal
+
+A written verdict with numbers, no threshold agreed in advance: moq-lite over
+data channels against WebTransport on the same LAN, in both stream mappings,
+browser to browser and browser to native, in Chrome and Firefox with Safari
+best effort. A go promotes the line to m2 with a JS transit quest and the
+productization work; a no-go is a written abandonment that keeps the numbers.
+
+## Plan
+
+Harness under `test/p2p`, shaped like the `test/wasm` Playwright driver: a
+local relay, `moq-bench` publishing synthetic frames of known size and rate
+through it, and `moq-cli --p2p` as the LAN hop. The page measures each path
+and writes a JSON report the verdict PR quotes.
+
+Matrix:
+
+- browser to native: the same `moq-cli` hop over WebTransport, qmux channel,
+  and per-stream channels;
+- browser to browser: a publishing tab to a watcher tab directly in both
+  mappings, against the same pair through the relay over WebTransport.
+
+Metrics: sustained throughput ceiling, per-frame latency p50 and p99 from the
+timestamp `moq-bench` stamps into each keyframe (same host, so one clock),
+recovery after a dropped group in the per-stream mapping, join time including
+the WebTransport-first fallback, and behavior as open channels approach
+Chrome's cap. Record the browser versions and the Firefox mDNS caveat beside
+each row.
+
+State the boundary beside the result: loopback and one wifi segment say
+nothing about multicast-filtered venues or many-tab fan-out on real access
+points.
+
+## Required
+
+- [moq-cli joins the LAN](/quest/m3/p2p/cli.md)
+- [Signaling over the relay](/quest/m3/p2p/signal.md)

--- a/quest/m3/p2p/watch.md
+++ b/quest/m3/p2p/watch.md
@@ -1,0 +1,25 @@
+# [S] Watch opts in
+
+## Goal
+
+One attribute turns web P2P on in the demo. A watcher tab keeps subscribing
+through the shared origin and reaches each broadcast over the cheapest route
+the origin knows, relay or LAN peer.
+
+## Plan
+
+`hang-watch` and `hang-publish` gain a `p2p` attribute that constructs
+`Peers` on the shared connection's origin; `demo/web` exposes the toggle. The
+route pick is the origin's, from
+[cost ranking](/quest/m2/route-cost.md): a LAN peer announces at cost zero
+with a shorter hop chain than the relay path, so it wins, and its retraction
+falls back to the relay.
+
+Two topologies work without JS transit and the demo shows both: a publishing
+tab serving watcher tabs on the LAN directly, and watcher tabs pulling from a
+`moq-cli --p2p` hop.
+
+## Required
+
+- [Signaling over the relay](/quest/m3/p2p/signal.md)
+- [Route cost in the JS origin](/quest/m2/route-cost.md)

--- a/quest/m3/p2p/webrtc.md
+++ b/quest/m3/p2p/webrtc.md
@@ -1,0 +1,41 @@
+# [L] Native data channel transport
+
+## Goal
+
+`moq-tokio` gains a `webrtc` feature: a data channel transport implementing
+moq-net's poll `Session` in both mappings over str0m, resolving browsers'
+`.local` candidates with mdns-sd, so `Client` and `Server` can hold a moq-net
+session with a browser peer.
+
+## Plan
+
+str0m is already a dependency through `moq-rtc` and mdns-sd through the
+`mdns` feature; no new stack. The feature is off by default in `moq-tokio`
+and on in `moq-cli`, like iroh.
+
+ICE: a full agent with host candidates on every non-loopback interface as raw
+addresses, a dual-stack socket per session. Remote `.local` candidates are
+resolved with an mdns-sd query before `add_remote_candidate`. `moq-rtc`'s run
+loop, socket reader, and local-candidate pick are the right shape but bind a
+single wildcard IPv4 socket and advertise loopback; lift the driver into a
+module both crates share rather than copying it.
+
+Signaling is the caller's: the transport exposes the local description and a
+stream of local candidates, and accepts the remote description and candidates,
+as plain async methods. No callbacks.
+
+Mode `qmux`: implement `qmux::transport::{Transport, Writer, Reader}` over one
+reliable ordered str0m channel, the way `ws::Upgraded` does, and feed
+`qmux::Session` through `transport::Async` like `websocket.rs`.
+
+Mode `stream`: a native `poll::Session` where each moq stream is a str0m
+channel, with the control channel for reset codes and the unreliable datagram
+channel from the draft. `max_datagram_size` is the negotiated message size.
+
+Tests: an in-process str0m pair over loopback runs moq-net's session tests in
+both modes. Browser interop is the verdict's job.
+
+## Related
+
+- [Data channel transport](/quest/m3/p2p/transport.md) - the browser side of the same bindings
+- [moq-cli joins the LAN](/quest/m3/p2p/cli.md) - the first consumer


### PR DESCRIPTION
Adds `quest/m3/p2p`, a measured go/no-go on moq-lite over LAN-only WebRTC data channels so browsers on one network can serve each other and offload the relay, plus one m2 quest (`quest/m2/route-cost.md`) for cost-ranked routes in the JS origin that the watcher-side route pick needs.

## Decisions settled in the planning interview

- **Driver**: relay bandwidth offload, not offline operation. The relay stays and is the rendezvous: signaling rides ordinary moq broadcasts under a reserved `.p2p/` prefix, so trust is the relay's token scope and the relay learns nothing new.
- **LAN only** with no code: an empty ICE server list yields host candidates only, which browsers obfuscate as `.local` mDNS names and resolve for each other. The native side resolves them with `mdns-sd`, already a dependency.
- **Both endpoint pairs**: browser<->browser, and browser<->native where the browser tries WebTransport with a pinned fingerprint first and falls back to a data channel. Native peers keep preferring QUIC among themselves (mDNS mesh or an advertised iroh endpoint).
- **Two stream mappings, both measured**: qmux over one channel (the WebSocket binding's shape, nearly free, head-of-line blocking across groups) and one channel per moq stream with a control channel for reset codes and an unreliable channel for datagrams. Both ship in `@moq/p2p` and in `moq-tokio`'s `webrtc` feature over str0m.
- **Native peer** is `moq-cli --p2p`, which already transits between its relay session and LAN sessions through the shared origin.
- **Verdict** is report-only, no threshold agreed up front: Chrome and Firefox required, Safari best effort, Playwright harness under `test/p2p` with `moq-bench` as the source.

## What the facts forced

The `@moq/net` origin never forwards what a peer announced, so a watcher tab cannot re-serve a relay broadcast today. The prototype measures the two topologies that work without JS transit (publishing tab -> LAN watchers, watchers -> `moq-cli` hop); a go verdict promotes the line to m2 with a JS transit quest. The lite-06 route cost is decoded and dropped in JS, hence the m2 quest.

Risks recorded in the questline: Chrome 147's local network access prompt on WebTransport dials to private addresses (proposed for WebRTC too), Firefox bug 1698141 on mDNS candidates toward Chrome, multicast-filtered networks, and Chrome's 1024 SCTP stream cap with 256 KiB messages.

`quest check` passes (258 documents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Fable 5.1)
