### PR TITLE
build(deps): bump wnaf to 0.14.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11461,13 +11461,14 @@ dependencies = [
 
 [[package]]
 name = "wnaf"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+checksum = "795ca18b3fdb5e62bf982199278341ddcf7ebf7d32e25e212ad05d496e95f6fa"
 dependencies = [
  "ff",
  "group",
  "hybrid-array",
+ "primefield",
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem

[Nightly run 33869939139](https://github.com/moq-dev/moq/actions/runs/33869939139) failed on the `Audit` step:

```
error[yanked]: detected yanked crate (try `cargo update -p wnaf`)
    ┌─ Cargo.lock:983:1
983 │ wnaf 0.14.0 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ yanked version
```

Nothing in this repo changed. `wnaf 0.14.0` was yanked from crates.io and `0.14.1` published on 2026-09-03, one day before the run. It reaches us transitively: `wnaf` -> `primeorder` -> `p256`/`p384` -> `moq-token`. This is exactly the class of break the nightly `just rs audit` gate exists to catch, since an advisory or yank lands without a commit here.

## Fix

`cargo update -p wnaf`. Lockfile only; `0.14.1` is semver-compatible. It picked up a dependency on `primefield`, which was already in the lock.

Waiting for Dependabot was the alternative, but its 7-day cooldown would leave nightly red until ~2026-09-10.

## Verification

`just rs audit` locally:

```
advisories ok: 0 errors, 0 warnings, 8 notes
      bans ok: 0 errors, 77 warnings, 0 notes
  licenses ok: 0 errors, 0 warnings, 990 notes
   sources ok: 0 errors, 0 warnings, 0 notes
```

(was `advisories FAILED: 1 errors`)

The remaining nightly steps -- `Features`, `OBS` -- and the whole PR gate passed in that run; this is the only failure.

(Written by Claude Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)