### PR TITLE
fix(rs): compile the lib tests at --no-default-features

### DIFF
--- a/rs/justfile
+++ b/rs/justfile
@@ -459,10 +459,14 @@ audit:
 # `--all-features` is the only thing that compiles moq-cli's play/capture,
 # moq-video's PipeWire capture, quiche, and jemalloc. `--no-default-features` is
 # the only thing that compiles the `#[cfg(not(feature = ...))]` arms.
+#
+# Both carry `--all-targets`. A `#[cfg(test)]` module leans on whatever the
+# default features happened to import, so a test that only compiles by accident
+# is invisible to a lib-only check.
 
 # Compile the workspace at the feature extremes.
 features:
-    {{ cargo_compile }} check --locked --workspace --no-default-features
+    {{ cargo_compile }} check --locked --workspace --all-targets --no-default-features
     {{ cargo_compile }} clippy --locked --workspace --all-targets --all-features -- -D warnings
     RUSTDOCFLAGS="-D warnings" {{ cargo_compile }} doc --locked --workspace --all-features --no-deps
     {{ cargo_compile }} nextest run --locked --workspace --all-targets --all-features

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -2,7 +2,6 @@ use super::origin::*;
 use super::producer::*;
 use super::server::MoqServer;
 use super::session::MoqClient;
-use crate::audio::{MoqAudioCodec, MoqAudioEncoderInput, MoqAudioEncoderOutput, MoqAudioFormat, MoqAudioFrame};
 use crate::consumer::MoqBroadcastConsumer;
 use crate::consumer::MoqFetchGroupOptions;
 use crate::consumer::MoqRouteWatch;
@@ -130,8 +129,11 @@ async fn raw_track_activity() {
 		.unwrap();
 }
 
+#[cfg(feature = "audio")]
 #[tokio::test]
 async fn raw_audio_activity() {
+	use crate::audio::*;
+
 	const SAMPLE_RATE: u32 = 48_000;
 	const FRAME_DURATION_MS: u32 = 20;
 	const FRAME_SAMPLES: usize = (SAMPLE_RATE * FRAME_DURATION_MS / 1_000) as usize;

--- a/rs/moq-video/src/encode/producer.rs
+++ b/rs/moq-video/src/encode/producer.rs
@@ -524,7 +524,7 @@ mod tests {
 	use moq_mux::catalog::Stream as _;
 
 	use super::*;
-	use crate::encode::{Config, Encoder};
+	use crate::encode::{Codec, Config, Encoder};
 
 	/// Encode a handful of synthetic frames for `codec` and publish them through a real
 	/// [`Producer`], returning the catalog rendition's track name and config.


### PR DESCRIPTION
## Summary

Two `#[cfg(test)]` modules referenced items that only exist under a default feature, so they compiled by accident and broke the moment default features were off.

- **Root cause, `rs/moq-video/src/encode/producer.rs`**: the test module names `Codec` but only ever got it through `use super::*`, and the parent's `use super::encoder::Codec` is gated on `#[cfg(feature = "capture")]`. With `--no-default-features` the glob supplies nothing and the module fails with E0433/E0425. Fixed by naming `Codec` in the test module's own explicit import, next to the `Config`/`Encoder` it already had.
- **Root cause, `rs/moq-ffi/src/test.rs`**: `raw_audio_activity` had a crate-level `use crate::audio::{...}` and calls `publish_audio`, both gated on the `audio` feature. Fixed to the pattern the `video` tests in the same file already use: `#[cfg(feature = "audio")]` on the test plus a function-local `use`.
- **Why neither was caught**: nothing in the repo ever compiled a test target without default features. `just rs features` ran its `--no-default-features` line as a bare `check`, unlike the `--all-features` lines beside it which all carry `--all-targets`. Added the flag so the nightly gate covers test targets.

The moq-ffi break was found by the justfile change itself, not reported.

No regression test: the fix *is* the compile, and the gate that would have caught it is the third bullet.

## Public API changes

None. Both source changes are inside `#[cfg(test)]` modules.

## Test plan

Run via `nix develop`:

| Check | Result |
|---|---|
| `cargo test -p moq-video --no-default-features --lib` | 80 passed |
| `cargo test -p moq-video --lib` | 91 passed, 5 ignored |
| `cargo check --workspace --all-targets --no-default-features` | clean |
| `cargo test -p moq-ffi --lib raw_audio_activity` | passed |
| `cargo fmt --check`, `just --fmt --check` | clean |

Not verified: I never got a clean negative reproduction of the moq-video failure on this machine. Reverting the import and re-running was defeated twice by a saturated host (a 50-minute `nix develop` that never spawned cargo, then a full disk outside the shell). The mechanism is confirmed directly by the compiler output on the moq-ffi side, which is the same failure class, and by the positive compile after the fix.

## Cross-package sync

No rows apply: no wire format, `moq-ffi` API, CLI surface, or catalog change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 5)