### PR TITLE
fix: repair dev, which the last main merge left uncompilable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4766,7 +4766,6 @@ dependencies = [
  "axum-server",
  "bytes",
  "hang",
- "humantime",
  "moq-audio",
  "moq-hls",
  "moq-msf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,9 +130,9 @@ moq-net = { version = "0.2.18", path = "rs/moq-net" }
 # driver at runtime. Compiles on any platform (macOS included) but only actually
 # used by moq-video on Linux.
 moq-nvenc = { version = "0.0.4", path = "rs/moq-nvenc" }
-moq-sock = { version = "0.0.1", path = "rs/moq-sock" }
 moq-rtc = { version = "0.2.8", path = "rs/moq-rtc" }
 moq-rtmp = { version = "0.2.8", path = "rs/moq-rtmp" }
+moq-sock = { version = "0.0.1", path = "rs/moq-sock" }
 moq-srt = { version = "0.2.8", path = "rs/moq-srt" }
 moq-stats = { version = "0.1.8", path = "rs/moq-stats" }
 moq-token = { version = "0.7.3", path = "rs/moq-token" }

--- a/rs/moq-cli/Cargo.toml
+++ b/rs/moq-cli/Cargo.toml
@@ -83,7 +83,6 @@ axum = { workspace = true }
 axum-server = { workspace = true }
 bytes = { workspace = true }
 hang = { workspace = true }
-humantime = { workspace = true }
 moq-audio = { workspace = true, optional = true, features = ["aac"] }
 # `server` enables the HTTP egress server for `moq export hls`; the importer is always available.
 moq-hls = { workspace = true, features = ["server"] }

--- a/rs/moq-tokio/tests/broadcast.rs
+++ b/rs/moq-tokio/tests/broadcast.rs
@@ -602,7 +602,6 @@ async fn broadcast_moq_lite_05_default_timescale() {
 		.expect("server task failed");
 }
 
-/// Wait for the next announce event, failing the test on a timeout or a closed origin.
 /// Draft-20's current-group join (section 5.1.6), which splits one group across two
 /// streams: the subscriber asks for the next Object plus a fill of the current group, and
 /// the publisher serves the head on a fill fetch stream and the rest on the subscription's
@@ -614,10 +613,9 @@ async fn broadcast_moq_lite_05_default_timescale() {
 #[tracing_test::traced_test]
 #[tokio::test]
 async fn broadcast_moq_transport_20_current_group_join() {
-	let pub_origin = Origin::random().produce();
-	let mut broadcast = pub_origin
-		.create_broadcast("test", moq_net::broadcast::Route::new().with_announce(true))
-		.expect("create broadcast");
+	let pub_origin = moq_tokio::origin::spawn(Hop::random());
+	let mut broadcast = pub_origin.create_broadcast("test").expect("create broadcast");
+	let announce_broadcast = pub_origin.announce("test", Default::default()).expect("announce");
 	let mut track = broadcast.create_track("video", None).expect("create track");
 
 	// The group is left open, so the subscriber joins part way through it: the two head
@@ -629,20 +627,22 @@ async fn broadcast_moq_transport_20_current_group_join() {
 			.expect("write head");
 	}
 
-	let mut server_config = moq_native::ServerConfig::default();
+	let mut server_config = moq_tokio::listen::Config::default();
 	server_config.bind = Some("[::]:0".to_string());
 	server_config.tls.generate = vec!["localhost".into()];
 	server_config.version = vec!["moq-transport-20".parse().unwrap()];
-	let mut server = server_config.init().expect("init server");
+	let server = server_config.init(Default::default()).expect("init server");
+	let mut server = server.listen().await.expect("failed to listen");
 	let addr = server.local_addr().expect("local addr");
 
-	let sub_origin = Origin::random().produce();
-	let mut announcements = sub_origin.consume().announced();
+	let sub_origin = moq_tokio::origin::spawn(Hop::random());
+	let sub_consumer = sub_origin.consume();
+	let mut announcements = sub_consumer.announced();
 
-	let mut client_config = moq_native::ClientConfig::default();
-	client_config.tls.disable_verify = Some(true);
+	let mut client_config = moq_tokio::connect::Config::default();
+	client_config.tls.insecure = Some(true);
 	client_config.version = vec!["moq-transport-20".parse().unwrap()];
-	let client = client_config.init().expect("init client");
+	let client = client_config.init(Default::default()).expect("init client");
 	let url: url::Url = format!("moqt://localhost:{}", addr.port()).parse().unwrap();
 
 	let server_handle = tokio::spawn(async move {
@@ -650,18 +650,24 @@ async fn broadcast_moq_transport_20_current_group_join() {
 		let session = request.with_publisher(&pub_origin).ok().await?;
 		let _broadcast = broadcast;
 		let _track = track;
+		let _announce = announce_broadcast;
 		let _ = session.closed().await;
 		Ok::<_, anyhow::Error>(())
 	});
 
 	let client = client.with_subscriber(sub_origin);
-	let session = tokio::time::timeout(TIMEOUT, client.connect(url))
+	let (_client, connection) = tokio::time::timeout(TIMEOUT, connect_once(client, url))
 		.await
 		.expect("connect timed out")
 		.expect("connect failed");
 
 	let announced = next_announce(&mut announcements).await;
-	let remote = announced.broadcast.expect("expected an announce");
+	assert_eq!(announced.prefix.as_path().as_str(), "test");
+	assert!(announced.active, "expected an announce");
+	let remote = tokio::time::timeout(TIMEOUT, sub_consumer.request_broadcast("test"))
+		.await
+		.expect("request timed out")
+		.expect("announced broadcast resolves");
 
 	let mut subscriber = tokio::time::timeout(TIMEOUT, async { remote.track("video").unwrap().subscribe(None).await })
 		.await
@@ -696,10 +702,11 @@ async fn broadcast_moq_transport_20_current_group_join() {
 	assert_eq!(read(&mut joined).await.as_deref(), Some(b"tail-2".as_ref()));
 	assert_eq!(read(&mut joined).await, None, "the stitched group ends once");
 
-	drop(session);
+	drop(connection);
 	server_handle.await.expect("server panicked").expect("server failed");
 }
 
+/// Wait for the next announce event, failing the test on a timeout or a closed origin.
 async fn next_announce(announcements: &mut moq_net::announce::Consumer) -> moq_net::announce::Update {
 	tokio::time::timeout(TIMEOUT, announcements.next())
 		.await


### PR DESCRIPTION
## Summary

`dev` does not pass `just check`, so every branch based on it fails CI (including #3396). Three independent pieces of fallout from `Merge main into dev` (6947217fc), where a conflict-free textual merge was not a semantic one.

### 1. `rs/moq-tokio/tests/broadcast.rs` does not compile

The merge brought main's new `broadcast_moq_transport_20_current_group_join` test in verbatim. On main that test lives in `rs/moq-native/tests/broadcast.rs` and predates both #3225 (announcements are prefix routes) and the moq-native to moq-tokio split, so it references four things that no longer exist on dev:

- `Origin::random().produce()` → `moq_tokio::origin::spawn(Hop::random())`
- `create_broadcast(path, broadcast::Route::new().with_announce(true))` → `create_broadcast(path)` plus a separate `announce(path, ..)`
- `moq_native::{ServerConfig,ClientConfig}` → `moq_tokio::{listen,connect}::Config` (with `tls.disable_verify` → `tls.insecure`, and `init()` → `init(..)` + `listen()`)
- `announce::Update::broadcast` → `Update { prefix, route, active }`, resolved through `request_broadcast`

The merge also glued `next_announce`'s doc comment onto the new test's, leaving `next_announce` undocumented and the test's own doc opening on an unrelated sentence.

Ported onto dev's API, matching the neighbouring tests. The assertions the test exists for (group 0 stitched from the fill fetch stream plus the subgroup stream, in order, ending exactly once) are unchanged.

### 2. `cargo shear`: an unused `humantime`

`rs/moq-cli` declares `humantime` and no source file uses it. The usage-rs migration (#3030) replaced clap's `value_parser = humantime::parse_duration` with usage-rs' own duration parsing and dropped the dependency in the same commit; main still had the clap spelling, so the merge took main's side of the manifest and put the dependency back without any of the uses.

### 3. `cargo sort`: `moq-sock` out of order

`moq-sock` sits above `moq-rtc` and `moq-rtmp` in the root `[workspace.dependencies]`. `cargo sort --workspace --check --no-format` fails on it.

Each of the three is independently fatal, and the second and third only surface once the first stops failing the build, which is why they came out one CI round at a time.

## Test plan

- `cargo check -p moq-tokio --tests` clean.
- `cargo test -p moq-tokio --test broadcast broadcast_moq_transport_20_current_group_join` passes.
- `cargo check -p moq-cli` clean without the dependency.
- `cargo shear` reports no issues; `cargo sort --workspace --check --no-format` clean.
- `cargo fmt -p moq-tokio` clean.

`Test`, `WASM`, `Swift`, and `OBS` already pass on this branch; `Check` is what these three fix.

## Note

#3396 carries its own copy of fix 1 (`38be5113b`), so whichever lands first, the other needs a rebase. Fixes 2 and 3 are only here, and #3396 cannot go green without them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)