### PR TITLE
docs(quest): require hop-path validation before banning Hop ID 0

### DIFF
--- a/quest/m1/3049-moq-net-outbound-hop-path-construction-is-never.md
+++ b/quest/m1/3049-moq-net-outbound-hop-path-construction-is-never.md
@@ -1,0 +1,76 @@
+# [M] moq-net: outbound HOP_PATH construction is never validated
+
+## Goal
+
+A hop chain is validated where it is emitted, not only where it is parsed, so
+moq-net cannot construct an advertisement that a conforming receiver must
+close the session over.
+
+Every outbound path enforces the rule once: the entries exactly fill `Length`,
+the list is non-empty, and no non-zero Hop ID appears twice. Publisher route
+selection skips a route that cannot be legally advertised instead of emitting
+it, and the moq-lite ingress cannot introduce a duplicate that later reaches an
+IETF cluster peer.
+
+Boundaries: a route that is invalid to advertise may still be fine to serve
+locally, so it is dropped from advertisement rather than from the origin. The
+per-path ingress guards added by [#3042](https://github.com/moq-dev/moq/issues/3042)
+stay working; this replaces the need for the next route source to remember the
+rule again.
+
+## Plan
+
+Use the public issue's scope and implementation notes below as the starting
+plan. Reconcile paths and assumptions with the current tree before
+implementation.
+
+### Issue context
+
+`HopPath::validate` runs only on decode, so nothing stops us building and
+sending an outbound HOP_PATH that a conforming receiver must reject.
+
+`ietf::cluster::HopPath::validate` rejects an empty list and a repeated
+non-zero Hop ID, but it is only called from `param_decode`. `Advert::forward`
+appends our own Hop ID and wraps the result without revalidating, and the
+encode path does not check either. A `broadcast::Route` whose `hops` already
+carry a duplicate therefore goes out as-is.
+
+That matters because `draft-lcurley-moq-cluster` requires the receiver to treat
+it as fatal: "A receiver MUST close the session with a PROTOCOL_VIOLATION if
+the entries do not exactly fill `Length`, if the list is empty, or if a
+non-zero Hop ID appears twice." So a malformed chain we construct does not
+degrade our own routing, it closes the downstream session.
+
+Routes reach the model from more than one place, and only the IETF decode path
+is checked:
+
+- The moq-lite ingress builds hop chains itself. `OriginList` caps length but
+  does not reject duplicates, so a lite chain may legally carry one and, once
+  shared through the origin, be forwarded to an IETF cluster peer.
+- `broadcast::Route` is public with a public `hops` field, so any in-process
+  producer can attach one.
+
+[#3042](https://github.com/moq-dev/moq/issues/3042) closed the two reachable
+cases it introduced, both at ingress: `ietf::Subscriber::route` discards a chain
+already carrying the identity assigned to the peer, and `lite::Subscriber`'s two
+responder-append sites do the same. Those are per-path guards. The general gap
+is that validity is enforced where a chain is parsed rather than where one is
+emitted.
+
+### Design notes
+
+Validate in the outbound constructor (`Advert::forward`, or the encode path) and
+have publisher route selection skip a route that cannot be legally advertised.
+Making the invalid state unrepresentable is preferable to a check callers must
+remember: a constructor that can only produce a valid chain means the next route
+source gets the rule for free.
+
+Found by Codex during adversarial review of #3042.
+
+## Closes
+
+- [#3049](https://github.com/moq-dev/moq/issues/3049) - close this issue when the quest finishes
+
+## Related
+
+- [#3060](/quest/m1/3060-moq-net-ban-hop-id-0-from-hop-chains.md) - bans Hop ID 0 from chains outright, and builds on this

--- a/quest/m1/3060-moq-net-ban-hop-id-0-from-hop-chains.md
+++ b/quest/m1/3060-moq-net-ban-hop-id-0-from-hop-chains.md
@@ -52,7 +52,12 @@ The section's honest summary today, `Declaring 0 therefore trades loop detection
 
 Every `== Origin::UNKNOWN` / `!= Origin::UNKNOWN` test that exists to ask "does this chain entry name anybody" is gone, across `lite/subscriber.rs`, `ietf/{subscriber,publisher,cluster}.rs`, and `model/{origin,broadcast}.rs`. The marker survives only where it means "this field is absent". Any survivor in the first category means 0 is still special somewhere and the change is incomplete.
 
-Targets `dev`: it changes published `moq-net` API alongside moq-dev/moq#3049, and lands on top of it.
+Targets `dev`: it changes published `moq-net` API alongside
+[#3049](/quest/m1/3049-moq-net-outbound-hop-path-construction-is-never.md), and lands on top of it.
+
+## Required
+
+- [#3049](/quest/m1/3049-moq-net-outbound-hop-path-construction-is-never.md) - validates hop chains where they are emitted; this quest lands on top of it
 
 ## Closes
 

--- a/quest/m1/README.md
+++ b/quest/m1/README.md
@@ -64,5 +64,6 @@ with the current dev tree before starting.
 - [#3208](/quest/m1/3208-make-2-5-ms-opus-frame-durations-work-across-bindings.md) - Make 2.5 ms Opus frame durations work across bindings
 - [#2152](/quest/m1/2152-libmoq-c-abi-catch-up-with-the-moq-ffi-surface.md) - libmoq: C ABI catch-up with the moq-ffi surface
 - [#2933](/quest/m1/2933-moq-ffi-moqroute-round-trip-erases-a-routes-cold-cost.md) - moq-ffi: MoqRoute round-trip erases a route's cold cost
+- [#3049](/quest/m1/3049-moq-net-outbound-hop-path-construction-is-never.md) - moq-net: validate a hop chain where it is emitted, not only where it is parsed
 - [#3060](/quest/m1/3060-moq-net-ban-hop-id-0-from-hop-chains.md) - moq-net: ban Hop ID 0 from hop chains
 - [#2248](/quest/m1/2248-moq-mux-rebase-fmp4-export-timestamps-for-late-subscribers.md) - moq-mux: rebase fMP4 export timestamps for late subscribers


### PR DESCRIPTION
## Problem

`quest/m1/3060-moq-net-ban-hop-id-0-from-hop-chains.md` has no `## Required`
section, so the readiness check reads it as startable. Its own issue says
otherwise:

> Targets `dev`: it changes published `moq-net` API alongside moq-dev/moq#3049, and lands on top of it.

[#3049](https://github.com/moq-dev/moq/issues/3049) is open and had no quest
anywhere in the tree, so that dependency lived only in issue prose. Anything
walking `quest/m1` for ready work would pick 3060 up and build on a validation
story that is not there yet.

## Change

- Add `quest/m1/3049-moq-net-outbound-hop-path-construction-is-never.md`: validate a hop chain where it is emitted, not only where it is parsed. `HopPath::validate` runs only from `param_decode` today, so `Advert::forward` can append our Hop ID onto a chain that already carries a duplicate and send it, and the draft requires the receiver to answer that with `PROTOCOL_VIOLATION`. A chain we build wrong closes the downstream session rather than degrading our own routing.
- Rank it directly above 3060 in the m1 index, since it blocks it.
- Give 3060 a `## Required` bullet pointing at it, and point its dev-targeting note at the quest rather than a bare issue number.

Sized `[M]`. The quest records the design steer from the issue: validate in the
outbound constructor and have publisher route selection skip a route that
cannot be legally advertised, rather than dropping the route outright, since a
route that is invalid to advertise may still be fine to serve locally.

## Verification

`cargo run --package quest -- check` passes: 242 documents ok, so links
resolve, the index matches the file tree, headings stay in the allowed set, and
`Required` stays acyclic.

Markdown only, no code touched. `just fix` could not complete locally because
Biome rejects the nested `biome.jsonc` in agent worktrees checked out under
`.claude/worktrees/`; that is a local environment condition unrelated to this
diff, and this branch changes no JS.

Cross-Package Sync has no row for `quest/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLtoPv9B3779kGxLFTUGHR

(written by claude-opus-5[1m])