### PR TITLE
fix(claude): fetch and resolve stale branches before spawn-quest triages

### DIFF
--- a/.claude/skills/spawn-quest/SKILL.md
+++ b/.claude/skills/spawn-quest/SKILL.md
@@ -8,9 +8,20 @@ Before you begin, read `quest/AGENTS.md` completely.
 Resolve the first argument to a questline directory under `quest/`, defaulting
 to `quest/` itself: `m0` means `quest/m0`.
 
+`git fetch origin` **before** looking at claims. The remote branch is the
+coordination mechanism, so stale remote-tracking refs mean offering a quest
+another agent already claimed, and the spawned agent finds out only when its
+push is rejected.
+
 Read every quest in the scope, not just the summaries in each `README.md`. Drop
-the ones a recent branch or open PR already claims, and say when a branch is
-stale (old, no open PR) so it can be reused or deleted.
+the ones a recent branch or open PR already claims.
+
+Resolve a stale branch (old, no open PR) before keeping its quest in the start
+pool, rather than only mentioning it. Left in place it makes the agent's claim
+push fail as non-fast-forward, which the agent then reports as a lost race that
+never happened. Inspect its tip: reuse the work, or delete the ref only when it
+is confirmed stale, is not checked out, and has no unmerged commits. Otherwise
+treat the quest as claimed and take it out of the pool.
 
 Put every quest to the user in priority order - the depth-first walk of the
 scope's `Quests` lists - with a recommendation and the one fact behind it.
@@ -27,8 +38,7 @@ unblock it.
 
 ## Spawning
 
-`git fetch origin` once, then settle a base branch **per quest** and pass it
-to that quest's agent. Apply the Branch Targeting rules in `CLAUDE.md`: `dev`
+Settle a base branch **per quest** and pass it to that quest's agent. Apply the Branch Targeting rules in `CLAUDE.md`: `dev`
 only for a semver break in a published API, `main` for everything else. One
 scope mixes both, so a single base for the whole wave puts some PR on the
 wrong branch. Never let an agent derive its own base: an agent branching from


### PR DESCRIPTION
## What

Follow-up to #3403, which merged before these two review findings were addressed. Both are in the skill's triage half rather than its spawning half.

**`git fetch origin` ran too late.** It was documented in the Spawning section, which comes after the claim scan. The remote branch is the coordination mechanism, so a stale remote-tracking ref means offering the user a quest another agent already holds, and the spawned agent finds out only when its claim push is rejected. That wastes the user's selection and an agent slot. The fetch now comes before the scan.

**A stale branch was something to mention, not something to resolve.** The skill said to say when a branch is stale so it could be reused or deleted, then never told anyone to do it. Left in place, the agent's instruction to cut the same branch fresh and push without force fails as non-fast-forward, and the agent reports that as a lost claim race that never happened. A stale *local* branch blocks branch creation even earlier. The skill now says to inspect the tip and either reuse the work or delete the ref, and only when it is confirmed stale, not checked out, and carrying no unmerged commits; anything else is treated as claimed and leaves the pool.

The second rule is what `start-quest` already does, so this brings the two skills into agreement rather than inventing a policy. It is also not hypothetical in this repository: there are six stale `quest/m1/perf/*` branches right now, and a `/spawn-quest m1` run that offered one of them would have produced exactly the false race report described above.

## Checks

`just fix` and `just check` both exit 0. The diff is one Markdown file under `.claude/`, so the dispatch correctly reports `js: no JS changes; skipping` and runs no Rust, Python, or quest validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 5)