### PR TITLE
fix(moq-hls): stop rebuilding renditions on catalog estimate churn

### DIFF
--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -446,7 +446,12 @@ mod tests {
 
 	/// A catalog with one video and one audio rendition, both servable.
 	fn catalog_with_both() -> moq_mux::catalog::hang::Catalog {
-		let mut audio = hang::catalog::AudioConfig::new(hang::catalog::AudioCodec::Opus, 48_000, 2);
+		let mut audio = hang::catalog::AudioConfig::new(
+			hang::catalog::AudioCodec::AAC(hang::catalog::AAC { profile: 2 }),
+			44_100,
+			2,
+		);
+		audio.description = Some(bytes::Bytes::from_static(&[0x12, 0x10]));
 		audio.bitrate = Some(96_000);
 
 		let mut catalog = moq_mux::catalog::hang::Catalog::default();
@@ -483,6 +488,16 @@ mod tests {
 
 		let video = renditions.get(Kind::Video, "video0").expect("video rendition");
 		let audio = renditions.get(Kind::Audio, "audio0").expect("audio rendition");
+		let audio_init = audio.init().await.unwrap().expect("AAC init segment");
+		let wire = moq_mux::container::fmp4::Wire::from_init(&audio_init).unwrap();
+		let codec = &wire.trak().mdia.minf.stbl.stsd.codecs[0];
+		let moq_mux::container::fmp4::mp4_atom::Codec::Mp4a(mp4a) = codec else {
+			panic!("expected mp4a, got {codec:?}");
+		};
+		assert_eq!(
+			mp4a.esds.es_desc.dec_config.avg_bitrate, 96_000,
+			"the muxer keeps the declared catalog bitrate"
+		);
 		assert_eq!(video.bandwidth(), 2_000_000, "the catalog carries no video bitrate yet");
 		assert_eq!(audio.bandwidth(), 96_000);
 		assert!(matches!(
@@ -515,6 +530,11 @@ mod tests {
 			"the master playlist advertises the estimate"
 		);
 		assert_eq!(audio.bandwidth(), 110_000);
+		assert_eq!(
+			audio.init().await.unwrap().expect("cached AAC init segment"),
+			audio_init,
+			"an estimate update preserves the cached init segment"
+		);
 		assert!(next_event(&mut cursor).await.is_none(), "no rendition churn");
 
 		// A bitrate the publisher retracts falls back to the advertised default.
@@ -551,7 +571,7 @@ mod tests {
 
 		// A resolution change and a sample-rate change both invalidate the init segment.
 		catalog.video.renditions.get_mut("video0").unwrap().coded_width = Some(640);
-		catalog.audio.renditions.get_mut("audio0").unwrap().sample_rate = 44_100;
+		catalog.audio.renditions.get_mut("audio0").unwrap().sample_rate = 48_000;
 		renditions.sync(&upstream, &catalog);
 
 		let rebuilt = renditions.get(Kind::Video, "video0").expect("video rendition");

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -469,6 +469,16 @@ mod tests {
 			.flatten()
 	}
 
+	/// The average bitrate encoded in a synthesized AAC init segment.
+	fn aac_avg_bitrate(init: &bytes::Bytes) -> u32 {
+		let wire = moq_mux::container::fmp4::Wire::from_init(init).unwrap();
+		let codec = &wire.trak().mdia.minf.stbl.stsd.codecs[0];
+		let moq_mux::container::fmp4::mp4_atom::Codec::Mp4a(mp4a) = codec else {
+			panic!("expected mp4a, got {codec:?}");
+		};
+		mp4a.esds.es_desc.dec_config.avg_bitrate
+	}
+
 	// A publisher's estimator republishes the catalog every time its measured bitrate or jitter
 	// moves, writing those two fields and nothing else. That must not churn the rendition:
 	// rebuilding resets the playlist window, the cached init segment and EXT-X-MEDIA-SEQUENCE,
@@ -489,13 +499,9 @@ mod tests {
 		let video = renditions.get(Kind::Video, "video0").expect("video rendition");
 		let audio = renditions.get(Kind::Audio, "audio0").expect("audio rendition");
 		let audio_init = audio.init().await.unwrap().expect("AAC init segment");
-		let wire = moq_mux::container::fmp4::Wire::from_init(&audio_init).unwrap();
-		let codec = &wire.trak().mdia.minf.stbl.stsd.codecs[0];
-		let moq_mux::container::fmp4::mp4_atom::Codec::Mp4a(mp4a) = codec else {
-			panic!("expected mp4a, got {codec:?}");
-		};
 		assert_eq!(
-			mp4a.esds.es_desc.dec_config.avg_bitrate, 96_000,
+			aac_avg_bitrate(&audio_init),
+			96_000,
 			"the muxer keeps the declared catalog bitrate"
 		);
 		assert_eq!(video.bandwidth(), 2_000_000, "the catalog carries no video bitrate yet");
@@ -541,6 +547,36 @@ mod tests {
 		catalog.video.renditions.get_mut("video0").unwrap().bitrate = None;
 		renditions.sync(&upstream, &catalog);
 		assert_eq!(video.bandwidth(), 2_000_000);
+	}
+
+	#[tokio::test]
+	async fn estimate_before_first_init_reaches_aac_descriptor() {
+		let origin = produce_origin();
+		let _broadcast = origin.create_broadcast("live").expect("publish allowed");
+		let _announce = origin.announce("live", Default::default()).expect("publish allowed");
+		settle().await;
+		let upstream = empty_upstream(&origin, "live").await;
+
+		let mut catalog = catalog_with_both();
+		catalog.audio.renditions.get_mut("audio0").unwrap().bitrate = None;
+		let renditions = renditions::Producer::new(Config::default().window);
+		renditions.sync(&upstream, &catalog);
+		let audio = renditions.get(Kind::Audio, "audio0").expect("audio rendition");
+
+		catalog.audio.renditions.get_mut("audio0").unwrap().bitrate = Some(110_000);
+		renditions.sync(&upstream, &catalog);
+		assert!(
+			Arc::ptr_eq(&audio, &renditions.get(Kind::Audio, "audio0").unwrap()),
+			"the estimate updates the existing rendition"
+		);
+		let init = audio.init().await.unwrap().expect("AAC init segment");
+
+		assert_eq!(audio.bandwidth(), 110_000);
+		assert_eq!(
+			aac_avg_bitrate(&init),
+			110_000,
+			"the latest estimate reaches an init that was not cached yet"
+		);
 	}
 
 	// The other half: a change that alters how the rendition decodes still rebuilds it, so the

--- a/rs/moq-hls/src/export/mod.rs
+++ b/rs/moq-hls/src/export/mod.rs
@@ -159,14 +159,14 @@ impl Broadcaster {
 			match rendition.kind {
 				Kind::Video => video.push(master::VideoVariant {
 					name: rendition.name.clone(),
-					bandwidth: rendition.bandwidth,
+					bandwidth: rendition.bandwidth(),
 					width: rendition.width,
 					height: rendition.height,
 					codec: rendition.codec.clone(),
 				}),
 				Kind::Audio => audio.push(master::AudioVariant {
 					name: rendition.name.clone(),
-					bandwidth: rendition.bandwidth,
+					bandwidth: rendition.bandwidth(),
 					codec: rendition.codec.clone(),
 				}),
 			}
@@ -433,6 +433,145 @@ mod tests {
 		let renditions = renditions::Producer::new(Config::default().window);
 		renditions.sync(&upstream, &catalog);
 		assert!(renditions.get(Kind::Video, "video").is_none());
+	}
+
+	/// An upstream over an empty published broadcast, for the `sync` reconciliation tests.
+	async fn empty_upstream(origin: &moq_net::origin::Producer, path: &str) -> Upstream {
+		let source = moq_mux::Source::new(origin.consume(), path);
+		Upstream {
+			broadcast: source.broadcast().await.unwrap(),
+			source,
+		}
+	}
+
+	/// A catalog with one video and one audio rendition, both servable.
+	fn catalog_with_both() -> moq_mux::catalog::hang::Catalog {
+		let mut audio = hang::catalog::AudioConfig::new(hang::catalog::AudioCodec::Opus, 48_000, 2);
+		audio.bitrate = Some(96_000);
+
+		let mut catalog = moq_mux::catalog::hang::Catalog::default();
+		catalog.timeline = Some(hang::catalog::Timeline::new(hang::timeline::DEFAULT_NAME));
+		catalog.video.renditions.insert("video0".to_string(), video_config());
+		catalog.audio.renditions.insert("audio0".to_string(), audio);
+		catalog
+	}
+
+	/// The next rendition event, or `None` if the set is quiet.
+	async fn next_event(cursor: &mut renditions::Consumer) -> Option<renditions::Event> {
+		tokio::time::timeout(Duration::from_millis(50), cursor.next())
+			.await
+			.ok()
+			.flatten()
+	}
+
+	// A publisher's estimator republishes the catalog every time its measured bitrate or jitter
+	// moves, writing those two fields and nothing else. That must not churn the rendition:
+	// rebuilding resets the playlist window, the cached init segment and EXT-X-MEDIA-SEQUENCE,
+	// and makes every recording cursor see a Removed followed by an Added.
+	#[tokio::test]
+	async fn estimate_only_catalog_update_keeps_the_rendition() {
+		let origin = produce_origin();
+		let _broadcast = origin.create_broadcast("live").expect("publish allowed");
+		let _announce = origin.announce("live", Default::default()).expect("publish allowed");
+		settle().await;
+		let upstream = empty_upstream(&origin, "live").await;
+
+		let mut catalog = catalog_with_both();
+		let renditions = renditions::Producer::new(Config::default().window);
+		let mut cursor = renditions.subscribe();
+		renditions.sync(&upstream, &catalog);
+
+		let video = renditions.get(Kind::Video, "video0").expect("video rendition");
+		let audio = renditions.get(Kind::Audio, "audio0").expect("audio rendition");
+		assert_eq!(video.bandwidth(), 2_000_000, "the catalog carries no video bitrate yet");
+		assert_eq!(audio.bandwidth(), 96_000);
+		assert!(matches!(
+			next_event(&mut cursor).await,
+			Some(renditions::Event::Added(_))
+		));
+		assert!(matches!(
+			next_event(&mut cursor).await,
+			Some(renditions::Event::Added(_))
+		));
+
+		// Exactly what `catalog::Rendition::estimate` writes back.
+		let video_config = catalog.video.renditions.get_mut("video0").unwrap();
+		video_config.bitrate = Some(1_800_000);
+		video_config.jitter = Some(Duration::from_millis(33));
+		catalog.audio.renditions.get_mut("audio0").unwrap().bitrate = Some(110_000);
+		renditions.sync(&upstream, &catalog);
+
+		assert!(
+			Arc::ptr_eq(&video, &renditions.get(Kind::Video, "video0").unwrap()),
+			"the video rendition survives an estimate-only update"
+		);
+		assert!(
+			Arc::ptr_eq(&audio, &renditions.get(Kind::Audio, "audio0").unwrap()),
+			"the audio rendition survives an estimate-only update"
+		);
+		assert_eq!(
+			video.bandwidth(),
+			1_800_000,
+			"the master playlist advertises the estimate"
+		);
+		assert_eq!(audio.bandwidth(), 110_000);
+		assert!(next_event(&mut cursor).await.is_none(), "no rendition churn");
+
+		// A bitrate the publisher retracts falls back to the advertised default.
+		catalog.video.renditions.get_mut("video0").unwrap().bitrate = None;
+		renditions.sync(&upstream, &catalog);
+		assert_eq!(video.bandwidth(), 2_000_000);
+	}
+
+	// The other half: a change that alters how the rendition decodes still rebuilds it, so the
+	// cached init segment can never describe media it no longer matches.
+	#[tokio::test]
+	async fn decoder_config_change_rebuilds_the_rendition() {
+		let origin = produce_origin();
+		let _broadcast = origin.create_broadcast("live").expect("publish allowed");
+		let _announce = origin.announce("live", Default::default()).expect("publish allowed");
+		settle().await;
+		let upstream = empty_upstream(&origin, "live").await;
+
+		let mut catalog = catalog_with_both();
+		let renditions = renditions::Producer::new(Config::default().window);
+		let mut cursor = renditions.subscribe();
+		renditions.sync(&upstream, &catalog);
+
+		let video = renditions.get(Kind::Video, "video0").expect("video rendition");
+		let audio = renditions.get(Kind::Audio, "audio0").expect("audio rendition");
+		assert!(matches!(
+			next_event(&mut cursor).await,
+			Some(renditions::Event::Added(_))
+		));
+		assert!(matches!(
+			next_event(&mut cursor).await,
+			Some(renditions::Event::Added(_))
+		));
+
+		// A resolution change and a sample-rate change both invalidate the init segment.
+		catalog.video.renditions.get_mut("video0").unwrap().coded_width = Some(640);
+		catalog.audio.renditions.get_mut("audio0").unwrap().sample_rate = 44_100;
+		renditions.sync(&upstream, &catalog);
+
+		let rebuilt = renditions.get(Kind::Video, "video0").expect("video rendition");
+		assert!(!Arc::ptr_eq(&video, &rebuilt), "the video rendition is rebuilt");
+		assert_eq!(rebuilt.width, Some(640));
+		assert!(
+			!Arc::ptr_eq(&audio, &renditions.get(Kind::Audio, "audio0").unwrap()),
+			"the audio rendition is rebuilt"
+		);
+
+		// Both cursors see the replacement as a removal followed by an addition.
+		let mut removed = 0;
+		let mut added = 0;
+		while let Some(event) = next_event(&mut cursor).await {
+			match event {
+				renditions::Event::Removed { .. } => removed += 1,
+				renditions::Event::Added(_) => added += 1,
+			}
+		}
+		assert_eq!((removed, added), (2, 2));
 	}
 
 	// The whole fetch-on-demand path in process: a broadcast publishes media through the

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -2,6 +2,7 @@
 //! demand.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, SystemTime};
 
 use bytes::Bytes;
@@ -17,6 +18,14 @@ use crate::Result;
 /// Fallback advertised bitrates when the catalog doesn't carry one.
 const DEFAULT_VIDEO_BITRATE: u64 = 2_000_000;
 const DEFAULT_AUDIO_BITRATE: u64 = 128_000;
+
+/// The fallback advertised bitrate for a rendition of this kind.
+fn default_bandwidth(kind: Kind) -> u64 {
+	match kind {
+		Kind::Video => DEFAULT_VIDEO_BITRATE,
+		Kind::Audio => DEFAULT_AUDIO_BITRATE,
+	}
+}
 
 /// Upper bound on the groups fetched for one segment, so a corrupt timeline can't turn one
 /// HTTP request into an endless fetch loop.
@@ -57,10 +66,40 @@ impl std::str::FromStr for Kind {
 }
 
 /// The rendition's catalog config, kept whole so a [`Muxer`] can be built per request.
+///
+/// Normalized on the way in, so equality answers "decodes and muxes the same" rather than "is
+/// byte-identical": see [`normalize_video`] / [`normalize_audio`].
 #[derive(PartialEq)]
 enum Config {
 	Video(VideoConfig),
 	Audio(AudioConfig),
+}
+
+/// Clear the video fields that don't change how the rendition decodes or is muxed, so a config
+/// the publisher only re-measured or re-labelled compares equal to the one already being served.
+///
+/// A denylist rather than an allowlist on purpose: a field the catalog gains later counts as
+/// decode-relevant until someone decides otherwise, so the failure mode is a needless rebuild
+/// rather than serving an init segment that no longer describes the media.
+fn normalize_video(config: &VideoConfig) -> VideoConfig {
+	let mut config = config.clone();
+	config.bitrate = None;
+	config.jitter = None;
+	config.label = None;
+	config.stalled = None;
+	// The muxer ignores a non-finite framerate, and NaN never equals itself, so a catalog
+	// carrying one would otherwise look different from itself on every republish.
+	config.framerate = config.framerate.filter(|fps| fps.is_finite());
+	config
+}
+
+/// The audio counterpart of [`normalize_video`].
+fn normalize_audio(config: &AudioConfig) -> AudioConfig {
+	let mut config = config.clone();
+	config.bitrate = None;
+	config.jitter = None;
+	config.label = None;
+	config
 }
 
 /// A single HLS rendition: master-playlist metadata, its view of the broadcast timeline (which
@@ -70,8 +109,9 @@ pub struct Rendition {
 	pub name: String,
 	/// Whether this rendition is video or audio.
 	pub kind: Kind,
-	/// Advertised bitrate for the master playlist `BANDWIDTH` attribute.
-	pub bandwidth: u64,
+	/// Advertised bitrate for the master playlist `BANDWIDTH` attribute; read through
+	/// [`bandwidth`](Self::bandwidth), refreshed in place by [`refresh`](Self::refresh).
+	bandwidth: AtomicU64,
 	/// Coded width, for the master playlist `RESOLUTION` (video only).
 	pub width: Option<u32>,
 	/// Coded height, for the master playlist `RESOLUTION` (video only).
@@ -94,12 +134,34 @@ pub struct Rendition {
 }
 
 impl Rendition {
+	/// Whether `config` describes the same media this rendition is already serving, i.e. whether
+	/// it decodes and muxes identically. Fields the publisher revises without touching the media
+	/// (its bitrate and jitter estimates, a label) are ignored here and picked up by
+	/// [`refresh`](Self::refresh) instead.
 	pub(crate) fn matches_video(&self, config: &VideoConfig) -> bool {
-		self.config == Config::Video(config.clone())
+		self.config == Config::Video(normalize_video(config))
 	}
 
+	/// The audio counterpart of [`matches_video`](Self::matches_video).
 	pub(crate) fn matches_audio(&self, config: &AudioConfig) -> bool {
-		self.config == Config::Audio(config.clone())
+		self.config == Config::Audio(normalize_audio(config))
+	}
+
+	/// The advertised bitrate in bits per second, for the master playlist `BANDWIDTH` attribute
+	/// and the DASH `bandwidth`. Falls back to a per-kind default when the catalog carries none.
+	pub fn bandwidth(&self) -> u64 {
+		self.bandwidth.load(Ordering::Relaxed)
+	}
+
+	/// Take the advertised bitrate from a catalog update that
+	/// [`matches`](Self::matches_video) this rendition.
+	///
+	/// The publisher's estimator republishes the catalog whenever its measured bitrate moves, so
+	/// this is the common update by far: rebuilding the rendition for it would reset the playlist
+	/// window, the cached init segment, and `EXT-X-MEDIA-SEQUENCE` several times a minute.
+	pub(crate) fn refresh(&self, bitrate: Option<u64>) {
+		self.bandwidth
+			.store(bitrate.unwrap_or(default_bandwidth(self.kind)), Ordering::Relaxed);
 	}
 
 	/// Build a video rendition over the broadcast's timeline `section`.
@@ -107,11 +169,11 @@ impl Rendition {
 		Self {
 			name,
 			kind: Kind::Video,
-			bandwidth: config.bitrate.unwrap_or(DEFAULT_VIDEO_BITRATE),
+			bandwidth: AtomicU64::new(config.bitrate.unwrap_or(DEFAULT_VIDEO_BITRATE)),
 			width: config.coded_width,
 			height: config.coded_height,
 			codec: config.codec.to_string(),
-			config: Config::Video(config.clone()),
+			config: Config::Video(normalize_video(config)),
 			section,
 			live: Arc::new(segments::Producer::new(upstream.local(config.broadcast.as_ref()))),
 			source: upstream.source.clone(),
@@ -125,11 +187,11 @@ impl Rendition {
 		Self {
 			name,
 			kind: Kind::Audio,
-			bandwidth: config.bitrate.unwrap_or(DEFAULT_AUDIO_BITRATE),
+			bandwidth: AtomicU64::new(config.bitrate.unwrap_or(DEFAULT_AUDIO_BITRATE)),
 			width: None,
 			height: None,
 			codec: config.codec.to_string(),
-			config: Config::Audio(config.clone()),
+			config: Config::Audio(normalize_audio(config)),
 			section,
 			live: Arc::new(segments::Producer::new(upstream.local(config.broadcast.as_ref()))),
 			source: upstream.source.clone(),
@@ -296,7 +358,7 @@ impl Rendition {
 		mpd::Representation {
 			name: self.name.clone(),
 			kind: self.kind,
-			bandwidth: self.bandwidth,
+			bandwidth: self.bandwidth(),
 			codec: self.codec.clone(),
 			width: self.width,
 			height: self.height,

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -66,10 +66,6 @@ impl std::str::FromStr for Kind {
 }
 
 /// The rendition's catalog config, kept whole so a [`Muxer`] can be built per request.
-///
-/// Normalized on the way in, so equality answers "decodes and muxes the same" rather than "is
-/// byte-identical": see [`normalize_video`] / [`normalize_audio`].
-#[derive(PartialEq)]
 enum Config {
 	Video(VideoConfig),
 	Audio(AudioConfig),
@@ -139,12 +135,18 @@ impl Rendition {
 	/// (its bitrate and jitter estimates, a label) are ignored here and picked up by
 	/// [`refresh`](Self::refresh) instead.
 	pub(crate) fn matches_video(&self, config: &VideoConfig) -> bool {
-		self.config == Config::Video(normalize_video(config))
+		let Config::Video(current) = &self.config else {
+			return false;
+		};
+		normalize_video(current) == normalize_video(config)
 	}
 
 	/// The audio counterpart of [`matches_video`](Self::matches_video).
 	pub(crate) fn matches_audio(&self, config: &AudioConfig) -> bool {
-		self.config == Config::Audio(normalize_audio(config))
+		let Config::Audio(current) = &self.config else {
+			return false;
+		};
+		normalize_audio(current) == normalize_audio(config)
 	}
 
 	/// The advertised bitrate in bits per second, for the master playlist `BANDWIDTH` attribute
@@ -173,7 +175,7 @@ impl Rendition {
 			width: config.coded_width,
 			height: config.coded_height,
 			codec: config.codec.to_string(),
-			config: Config::Video(normalize_video(config)),
+			config: Config::Video(config.clone()),
 			section,
 			live: Arc::new(segments::Producer::new(upstream.local(config.broadcast.as_ref()))),
 			source: upstream.source.clone(),
@@ -191,7 +193,7 @@ impl Rendition {
 			width: None,
 			height: None,
 			codec: config.codec.to_string(),
-			config: Config::Audio(normalize_audio(config)),
+			config: Config::Audio(config.clone()),
 			section,
 			live: Arc::new(segments::Producer::new(upstream.local(config.broadcast.as_ref()))),
 			source: upstream.source.clone(),

--- a/rs/moq-hls/src/export/rendition.rs
+++ b/rs/moq-hls/src/export/rendition.rs
@@ -1,8 +1,7 @@
 //! One rendition: playlists from its view of the broadcast timeline, segments fetched on
 //! demand.
 
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
 use std::time::{Duration, SystemTime};
 
 use bytes::Bytes;
@@ -107,7 +106,7 @@ pub struct Rendition {
 	pub kind: Kind,
 	/// Advertised bitrate for the master playlist `BANDWIDTH` attribute; read through
 	/// [`bandwidth`](Self::bandwidth), refreshed in place by [`refresh`](Self::refresh).
-	bandwidth: AtomicU64,
+	bitrate: RwLock<Option<u64>>,
 	/// Coded width, for the master playlist `RESOLUTION` (video only).
 	pub width: Option<u32>,
 	/// Coded height, for the master playlist `RESOLUTION` (video only).
@@ -152,7 +151,7 @@ impl Rendition {
 	/// The advertised bitrate in bits per second, for the master playlist `BANDWIDTH` attribute
 	/// and the DASH `bandwidth`. Falls back to a per-kind default when the catalog carries none.
 	pub fn bandwidth(&self) -> u64 {
-		self.bandwidth.load(Ordering::Relaxed)
+		self.bitrate().unwrap_or(default_bandwidth(self.kind))
 	}
 
 	/// Take the advertised bitrate from a catalog update that
@@ -162,8 +161,12 @@ impl Rendition {
 	/// this is the common update by far: rebuilding the rendition for it would reset the playlist
 	/// window, the cached init segment, and `EXT-X-MEDIA-SEQUENCE` several times a minute.
 	pub(crate) fn refresh(&self, bitrate: Option<u64>) {
-		self.bandwidth
-			.store(bitrate.unwrap_or(default_bandwidth(self.kind)), Ordering::Relaxed);
+		*self.bitrate.write().expect("bitrate lock poisoned") = bitrate;
+	}
+
+	/// The latest catalog bitrate, preserving `None` for muxer-specific fallback behavior.
+	fn bitrate(&self) -> Option<u64> {
+		*self.bitrate.read().expect("bitrate lock poisoned")
 	}
 
 	/// Build a video rendition over the broadcast's timeline `section`.
@@ -171,7 +174,7 @@ impl Rendition {
 		Self {
 			name,
 			kind: Kind::Video,
-			bandwidth: AtomicU64::new(config.bitrate.unwrap_or(DEFAULT_VIDEO_BITRATE)),
+			bitrate: RwLock::new(config.bitrate),
 			width: config.coded_width,
 			height: config.coded_height,
 			codec: config.codec.to_string(),
@@ -189,7 +192,7 @@ impl Rendition {
 		Self {
 			name,
 			kind: Kind::Audio,
-			bandwidth: AtomicU64::new(config.bitrate.unwrap_or(DEFAULT_AUDIO_BITRATE)),
+			bitrate: RwLock::new(config.bitrate),
 			width: None,
 			height: None,
 			codec: config.codec.to_string(),
@@ -399,9 +402,18 @@ impl Rendition {
 	}
 
 	fn muxer(&self) -> Result<Muxer> {
+		let bitrate = self.bitrate();
 		Ok(match &self.config {
-			Config::Video(config) => Muxer::video(config)?,
-			Config::Audio(config) => Muxer::audio(config)?,
+			Config::Video(config) => {
+				let mut config = config.clone();
+				config.bitrate = bitrate;
+				Muxer::video(&config)?
+			}
+			Config::Audio(config) => {
+				let mut config = config.clone();
+				config.bitrate = bitrate;
+				Muxer::audio(&config)?
+			}
 		})
 	}
 

--- a/rs/moq-hls/src/export/renditions.rs
+++ b/rs/moq-hls/src/export/renditions.rs
@@ -304,6 +304,11 @@ impl Producer {
 	/// Reconcile the rendition set with a complete catalog snapshot. Removed or reconfigured
 	/// renditions are closed (so cursors over them end) before replacements become visible.
 	///
+	/// "Reconfigured" means the media itself changed (see [`Rendition::matches_video`]). A
+	/// rendition whose entry only carries a revised estimate is kept as-is and just takes the
+	/// new advertised bitrate, since the publisher republishes the catalog every time its
+	/// measured bitrate or jitter moves.
+	///
 	/// Renditions are only servable when the catalog advertises the broadcast's timeline (its
 	/// root `timeline` section): without one there is nothing to render playlists from, so the
 	/// whole catalog is skipped with a warning.
@@ -371,7 +376,10 @@ impl Producer {
 
 		for (name, video) in &catalog.video.renditions {
 			let key = (Kind::Video, name.clone());
-			if current.contains_key(&key) {
+			if let Some(rendition) = current.get(&key) {
+				// Survived the stale pass, so it decodes the same: keep its window, its cached
+				// init segment and its media sequence, and just take the new advertised bitrate.
+				rendition.refresh(video.bitrate);
 				continue;
 			}
 			let rendition = Arc::new(Rendition::video(name.clone(), video, upstream, section.clone()));
@@ -380,7 +388,8 @@ impl Producer {
 		}
 		for (name, audio) in &catalog.audio.renditions {
 			let key = (Kind::Audio, name.clone());
-			if current.contains_key(&key) {
+			if let Some(rendition) = current.get(&key) {
+				rendition.refresh(audio.bitrate);
 				continue;
 			}
 			let rendition = Arc::new(Rendition::audio(name.clone(), audio, upstream, section.clone()));


### PR DESCRIPTION
## Root cause

`Rendition::matches_video` / `matches_audio` compared the entire `hang::catalog::VideoConfig` / `AudioConfig` by `PartialEq`, and `renditions::Producer::sync` used that to compute the stale set.

Meanwhile the publisher side (`catalog::Rendition::estimate`, `rs/moq-mux/src/catalog/tracks.rs`) writes the auto-detected `bitrate` and `jitter` back into that same catalog entry and republishes whenever the measurement moves. Those two fields live on the config being compared, so every estimate looked like a reconfigured rendition to the export side:

- the pooled `Arc<Rendition>` was `close()`d and replaced by a fresh one,
- which reset its segment window, its cached `init.mp4`, its latched `EXT-X-TARGETDURATION` and its `EXT-X-MEDIA-SEQUENCE` bookkeeping,
- and made every `renditions::Consumer` (the recorder cursor, which diffs by `Arc::ptr_eq`) report a `Removed` followed by an `Added`.

Confirmed by `estimate_only_catalog_update_keeps_the_rendition`, which fails on the pre-fix code at `the video rendition survives an estimate-only update` (a different `Arc`), while `decoder_config_change_rebuilds_the_rendition` passes both before and after.

## Fix

Normalize temporary config clones during comparison, clearing the fields that do not change how the rendition decodes or is muxed, so matching answers "decodes and muxes the same" rather than "is byte-identical":

- `bitrate` and `jitter`: exactly what `Estimate` / `set_estimate` rewrite.
- `label` and `stalled`: advisory publisher hints this crate never reads.
- a non-finite `framerate`: the muxer already filters it out (`usable_video_framerate`), and NaN never equals itself, so a catalog carrying one looked different from itself on every republish.

The full construction config remains stored for muxing. Everything except the live bitrate stays identity-bearing, so a real decoder-config change (codec, container, description, coded dimensions, sample rate / channel count, the sibling `broadcast` reference, a usable framerate) rebuilds the rendition exactly as today. This is deliberately a denylist rather than an allowlist: a field the catalog gains later counts as decode-relevant until someone decides otherwise, so the failure mode is a needless rebuild rather than serving an init segment that no longer describes the media.

The latest catalog bitrate is synchronized separately and used by both manifest rendering and each future muxer construction. This preserves a declared AAC bitrate, lets an estimate received before the first request reach the synthesized `DecoderConfigDescriptor`, and leaves an already cached init segment stable. The master playlist's `BANDWIDTH` and the DASH `bandwidth` continue to track later estimates without replacing the rendition.

## Breaking change

`Rendition::bandwidth` goes from a `pub u64` field to a `pub fn bandwidth(&self) -> u64` over synchronized live state, since it now has to change on a live rendition. That's a semver break on published `moq-hls 0.4.x`, hence `dev` rather than `main`. Nothing outside `rs/moq-hls` reads it today.

## Tests

- `estimate_only_catalog_update_keeps_the_rendition`: two `sync`s where the second differs only in `bitrate` / `jitter`. Asserts the same `Arc` survives for both a video and an audio rendition, that `bandwidth()` picks up the new value (and falls back to the per-kind default when the publisher retracts it), that a declared AAC bitrate reaches the parsed init descriptor, that the cached init stays stable, and that the `renditions::Consumer` stays quiet.
- `estimate_before_first_init_reaches_aac_descriptor`: starts an AAC rendition without a bitrate, applies an estimate without replacing its `Arc`, then verifies the first synthesized init descriptor and advertised bandwidth both use the estimate.
- `decoder_config_change_rebuilds_the_rendition`: a `coded_width` change and a `sample_rate` change still swap the `Arc` and still surface as `Removed` + `Added` on the cursor.

## Cross-package sync

No wire, catalog, or CLI surface changed, so no row of the sync table applies.

(Written by Claude Opus 5 and GPT-5)
