### PR TITLE
docs(quest): finish the reviewed planning contracts

### DIFF
--- a/quest/m2/3087-relay-mtls-peers-bypass-auth-api-mode-so-proxy-grants.md
+++ b/quest/m2/3087-relay-mtls-peers-bypass-auth-api-mode-so-proxy-grants.md
@@ -46,7 +46,8 @@ same path are indistinguishable at the endpoint.
 - Tests: a proxy-mode mTLS peer refused by an empty reply, scoped by a narrow
   grant, and admitted unrestricted in token mode; `host` present on the proxy
   request; `mtls=true` unchanged with `mtls_name` carrying the SAN name over
-  both QUIC and WebSocket, and absent for a nameless cert.
+  both QUIC and WebSocket, the CN for a certificate with no DNS SAN, and
+  absent for a nameless cert.
   Update the mTLS and auth API sections of `doc/bin/relay/auth.md`.
 
 ## Required

--- a/quest/m2/709-automatic-letsencrypt-support.md
+++ b/quest/m2/709-automatic-letsencrypt-support.md
@@ -24,24 +24,39 @@ dependency.
   to Let's Encrypt production, with staging documented for rate-limit-safe
   trials). Setting it replaces `listen.tls.cert` / `listen.tls.key`, and
   supplying both is a config error. It also feeds `web.https` when that
-  section's cert and key are unset, so one certificate serves the host.
+  section's cert and key are unset, so one certificate serves the host;
+  explicit `web.https` paths win, and the docs say so, since an operator may
+  deliberately front HTTPS with a different certificate.
 - **Challenge.** HTTP-01 only. The relay's `web.http` router gains
   `/.well-known/acme-challenge/{token}`, answered from the in-flight
   authorization, and config validation requires `web.http` to be bound while
   `[acme]` is set, since the challenge must reach port 80 and `listen.tls`
-  is UDP. TLS-ALPN-01 is deliberately not offered: it needs a new TCP :443
+  is UDP. The relay cannot prove external reachability, so the contract is
+  documented instead: the ACME server connects to port 80 of every configured
+  domain, and the operator either binds `web.http` there or forwards 80 to
+  it. A challenge that never arrives surfaces as the bounded first-issuance
+  failure below, naming the domain and the port. TLS-ALPN-01 is deliberately not offered: it needs a new TCP :443
   acceptor that collides with `web.https`. DNS-01 is not offered either, so a
   wildcard in `acme.domains` is a config error rather than a first start that
   blocks forever on an issuance HTTP-01 cannot complete.
-- **Delivery.** The issuer writes the PEM chain and key under `acme.dir` and
-  the existing `notify` file watcher swaps them in on the next handshake, so
-  no new `moq-tokio` surface is needed and per-worker rotation rides
+- **Delivery.** The issuer writes the key and the PEM chain as one file
+  under `acme.dir`, and the existing `notify` file watcher swaps it in on the
+  next handshake, so no new `moq-tokio` surface is needed and per-worker
+  rotation rides
   [TLS rotation atomicity](/quest/m1/2924-moq-relay-tls-rotation-is-not-atomic-across-thread-per.md).
-  Writes are atomic renames into the watched directory, which the watcher
-  already treats as a reload. The account key and the serving key are created
+  One file is what makes the rotation atomic: the watcher reloads both paths
+  on every event and refuses a mismatched pair, so separate key and chain
+  files would open a window where a new chain meets the old key, and a
+  restart inside that window could not build TLS at all. The TLS loader
+  therefore accepts a combined PEM for both `cert` and `key`, and the ACME
+  output is a single atomic rename into the watched directory. A reload that
+  fails keeps serving the last complete pair. With `[acme]` set, failing to
+  establish the file watcher is a startup error, since a relay that cannot
+  reload would silently serve its certificate to expiry. The account key and the serving key are created
   owner-only (`0600`, the mode `doc/bin/relay/auth.md` already requires of
-  private keys) before any bytes land, never with the umask default, so a
-  group-searchable `acme.dir` cannot leak a key to another local user. Only the quinn and noq backends on the tokio
+  private keys) before any bytes land, never with the umask default, and a
+  missing `acme.dir` is created `0700`, so a group-searchable parent cannot
+  leak a key to another local user. Only the quinn and noq backends on the tokio
   runtime reload certificates today: quiche snapshots its TLS material when
   the listener is built, and the io_uring workers read the certificate once at
   bind. Config validation refuses `[acme]` with those until they can rotate,
@@ -49,11 +64,18 @@ dependency.
   refusal is part of whatever gives them a reload path.
 - **Startup.** With no cached certificate the relay blocks accepting QUIC
   until the first issuance succeeds; a self-signed placeholder cannot serve
-  browsers, so there is nothing honest to serve meanwhile. With a cached
-  certificate it starts immediately and renews in the background. A cached
+  browsers, so there is nothing honest to serve meanwhile. The attempt is
+  bounded per the repository's retry rule: capped exponential backoff with
+  jitter inside a startup budget (a few minutes, configurable), after which
+  the relay exits with the last real ACME error, the domain, and the port it
+  expected the challenge on. With a cached certificate it starts immediately
+  and renews in the background. A cached
   certificate whose SANs do not cover every configured domain counts as
   missing: an operator who adds or replaces a hostname while reusing
   `acme.dir` gets a fresh issuance, not a wait for the renewal threshold.
+  The directory URL that issued the cached certificate is persisted beside
+  it, and a changed `acme.directory` (staging to production, say) also counts
+  as missing, so a staging certificate is never served as if trusted.
 - **Renewal.** A daily jittered check reads the cached certificate's expiry
   with the `x509-parser` already used for peer expiry and renews once a
   third of its lifetime remains, Let's Encrypt's own rule for 90-day
@@ -67,13 +89,16 @@ dependency.
 
 Tests: an in-process ACME test server (or the Pebble container behind a
 feature flag) issues on first run, a restart with a valid cached certificate
-performs no challenge, a cached certificate missing a configured domain is
-reissued at startup, a certificate near expiry renews and the QUIC
-listener serves the new chain without restart, a renewal failure leaves the
-old certificate serving, both generated keys are mode `0600`, and the config
-rejects `[acme]` alongside explicit
-paths, without `web.http`, with a wildcard domain, or on a backend that
-cannot reload.
+performs no challenge, a cached certificate missing a configured domain or
+issued by a different directory is reissued at startup, an unreachable
+directory fails the first start inside the budget with an actionable error,
+a certificate near expiry renews and both the quinn and noq listeners serve
+the new chain through a fresh handshake without restart (the `web.https`
+reload is a separate test), a renewal failure leaves the old certificate
+serving, a reload of a half-written pair keeps the old one, both generated
+keys are mode `0600` after issuance and after renewal, and the config
+rejects `[acme]` alongside explicit paths, without `web.http`, with a
+wildcard domain, or on a backend that cannot reload.
 
 ## Closes
 

--- a/quest/m2/709-automatic-letsencrypt-support.md
+++ b/quest/m2/709-automatic-letsencrypt-support.md
@@ -68,8 +68,10 @@ dependency.
   bounded per the repository's retry rule: capped exponential backoff with
   jitter inside a startup budget (a few minutes, configurable), after which
   the relay exits with the last real ACME error, the domain, and the port it
-  expected the challenge on. With a cached certificate it starts immediately
-  and renews in the background. A cached
+  expected the challenge on. With a usable cached certificate it starts
+  immediately and renews in the background. Usable means not yet expired:
+  an expired cache serves exactly as badly as none, so it blocks the same
+  way and goes through the same bounded first issuance. A cached
   certificate whose SANs do not cover every configured domain counts as
   missing: an operator who adds or replaces a hostname while reusing
   `acme.dir` gets a fresh issuance, not a wait for the renewal threshold.
@@ -79,9 +81,14 @@ dependency.
 - **Renewal.** A daily jittered check reads the cached certificate's expiry
   with the `x509-parser` already used for peer expiry and renews once a
   third of its lifetime remains, Let's Encrypt's own rule for 90-day
-  certificates. A failed renewal logs and waits for the next check; it never
-  restarts the relay or discards the serving certificate. The account key is
-  reused across runs so renewals do not create accounts.
+  certificates. Each renewal attempt owns its own retry sequence per the
+  repository's retry rule: capped exponential backoff with jitter inside a
+  bounded budget, stopping early on an explicit non-retryable ACME response
+  (a rejected order, a rate limit with a stated wait), so a transient
+  directory blip does not burn a day of the renewal window. A renewal that
+  exhausts its budget logs and waits for the next check; it never restarts
+  the relay or discards the serving certificate. The account key is reused
+  across runs so renewals do not create accounts.
 - **Docs.** `doc/bin/relay/config.md` gains the section; `doc/setup/prod.md`
   makes ACME the recommended path and keeps the external-certificate path;
   `doc/bin/relay/http.md` notes the challenge route; the packaging TOML and
@@ -92,6 +99,9 @@ feature flag) issues on first run, a restart with a valid cached certificate
 performs no challenge, a cached certificate missing a configured domain or
 issued by a different directory is reissued at startup, an unreachable
 directory fails the first start inside the budget with an actionable error,
+a restart with an expired cached certificate blocks and reissues rather than
+serving it, a transient renewal error retries within the attempt and a
+non-retryable response stops it early,
 a certificate near expiry renews and both the quinn and noq listeners serve
 the new chain through a fresh handshake without restart (the `web.https`
 reload is a separate test), a renewal failure leaves the old certificate

--- a/quest/m2/709-automatic-letsencrypt-support.md
+++ b/quest/m2/709-automatic-letsencrypt-support.md
@@ -62,22 +62,26 @@ dependency.
   bind. Config validation refuses `[acme]` with those until they can rotate,
   rather than letting a relay serve an expired certificate; lifting the
   refusal is part of whatever gives them a reload path.
-- **Startup.** With no cached certificate the relay blocks accepting QUIC
-  until the first issuance succeeds; a self-signed placeholder cannot serve
-  browsers, so there is nothing honest to serve meanwhile. The attempt is
-  bounded per the repository's retry rule: capped exponential backoff with
-  jitter inside a startup budget (a few minutes, configurable), after which
-  the relay exits with the last real ACME error, the domain, and the port it
-  expected the challenge on. With a usable cached certificate it starts
-  immediately and renews in the background. Usable means not yet expired:
-  an expired cache serves exactly as badly as none, so it blocks the same
-  way and goes through the same bounded first issuance. A cached
-  certificate whose SANs do not cover every configured domain counts as
-  missing: an operator who adds or replaces a hostname while reusing
-  `acme.dir` gets a fresh issuance, not a wait for the renewal threshold.
-  The directory URL that issued the cached certificate is persisted beside
-  it, and a changed `acme.directory` (staging to production, say) also counts
-  as missing, so a staging certificate is never served as if trusted.
+- **Startup.** With no usable cached certificate, bind `web.http` first and
+  serve only the challenge route while issuance is pending. Reuse that bound
+  listener for the normal router after issuance, so there is no
+  close-and-rebind race. QUIC, HTTPS, the other HTTP routes, health, and the
+  readiness notification stay unavailable until the certificate and key are
+  persisted; a self-signed placeholder cannot serve browsers, so there is
+  nothing honest to serve meanwhile. The attempt is bounded per the
+  repository's retry rule: capped exponential backoff with jitter inside a
+  startup budget (a few minutes, configurable), after which the relay exits
+  with the last real ACME error, the domain, and the port it expected the
+  challenge on. With a usable cached certificate it starts immediately and
+  renews in the background. Usable means not yet expired: an expired cache
+  serves exactly as badly as none, so it blocks the same way and goes through
+  the same bounded first issuance. A cached certificate whose SANs do not
+  cover every configured domain counts as missing: an operator who adds or
+  replaces a hostname while reusing `acme.dir` gets a fresh issuance, not a
+  wait for the renewal threshold. The directory URL that issued the cached
+  certificate is persisted beside it, and a changed `acme.directory` (staging
+  to production, say) also counts as missing, so a staging certificate is
+  never served as if trusted.
 - **Renewal.** A daily jittered check reads the cached certificate's expiry
   with the `x509-parser` already used for peer expiry and renews once a
   third of its lifetime remains, Let's Encrypt's own rule for 90-day
@@ -95,20 +99,25 @@ dependency.
   the nix module expose `acme.dir` under the state directory.
 
 Tests: an in-process ACME test server (or the Pebble container behind a
-feature flag) issues on first run, a restart with a valid cached certificate
-performs no challenge, a cached certificate missing a configured domain or
-issued by a different directory is reissued at startup, an unreachable
-directory fails the first start inside the budget with an actionable error,
-a restart with an expired cached certificate blocks and reissues rather than
-serving it, a transient renewal error retries within the attempt and a
-non-retryable response stops it early,
-a certificate near expiry renews and both the quinn and noq listeners serve
-the new chain through a fresh handshake without restart (the `web.https`
-reload is a separate test), a renewal failure leaves the old certificate
-serving, a reload of a half-written pair keeps the old one, both generated
-keys are mode `0600` after issuance and after renewal, and the config
-rejects `[acme]` alongside explicit paths, without `web.http`, with a
-wildcard domain, or on a backend that cannot reload.
+feature flag) issues on first run while only the HTTP-01 route answers, then
+the same listener serves the normal router without a rebind; a restart with a
+valid cached certificate performs no challenge, a cached certificate missing
+a configured domain or issued by a different directory is reissued at
+startup, an unreachable directory fails the first start inside the budget
+with an actionable error, a restart with an expired cached certificate blocks
+and reissues rather than serving it, a transient renewal error retries within
+the attempt and a non-retryable response stops it early, a certificate near
+expiry renews and both the quinn and noq listeners serve the new chain through
+a fresh handshake without restart (the `web.https` reload is a separate test),
+a renewal failure leaves the old certificate serving, a reload of a
+half-written pair keeps the old one, both generated keys are mode `0600` after
+issuance and after renewal, and the config rejects `[acme]` alongside explicit
+paths, without `web.http`, with a wildcard domain, or on a backend that cannot
+reload.
+
+## Required
+
+- [TLS rotation atomicity](/quest/m1/2924-moq-relay-tls-rotation-is-not-atomic-across-thread-per.md) - every supported worker must share one reloadable identity before ACME can promise renewal
 
 ## Closes
 

--- a/quest/m2/drain/README.md
+++ b/quest/m2/drain/README.md
@@ -13,8 +13,9 @@ the new software boot.
 
 GOAWAY only reaches MoQ sessions, and only the Rust client acts on it today:
 `moq_tokio::Connection` migrates, while `js/net` decodes and logs the message
-without closing or migrating the session, and the wire message is
-lite04+/IETF only besides. So the stop deadline is the
+and at most closes the session afterwards (the IETF path does, the lite path
+does not), leaving any reconnect to the ordinary close-triggered backoff
+rather than migrating. The wire message is lite04+/IETF only besides. So the stop deadline is the
 real backstop - for pre-lite04 versions, for client SDKs deployed before
 client-goaway ships, and for in-process ingest gateways (RTMP/SRT/WHIP/WHEP),
 which have no GOAWAY equivalent at all: their grace is the DNS-drain window
@@ -35,7 +36,7 @@ enough phase/session state to prove which bound ended a drain.
 
 **client-goaway.** The JS reconnector migrates like the Rust one, preserving
 the app-visible session while resolving DNS again before dialing, and the Rust
-path is pinned by a test. This is a
+path gains the regression test it lacks. This is a
 scale-down prerequisite, not merely a deploy improvement. RTMP/SRT/WHIP/WHEP
 cannot receive MoQ GOAWAY, so their contract remains DNS withdrawal followed
 by the stop deadline and encoder reconnect.

--- a/quest/m2/drain/client-goaway.md
+++ b/quest/m2/drain/client-goaway.md
@@ -66,20 +66,20 @@ down in its effect cleanup, and `Connection.Shared`
   caller configured with that URL shares the migrated connection. The app's
   handle and shared origin are unchanged; only the pool key moves, and a
   caller still asking for the original URL gets a fresh entry. When the
-  target key already holds a live entry, that entry wins for every new
-  lookup: the original key is tombstoned so a later caller for either URL
-  lands on the target's entry, while the migrating entry keeps serving the
-  handles it already handed out and retires when the last of them releases.
-  Two connections to one relay for that overlap is the honest cost; entry
-  removal is identity-guarded so neither cleanup can delete the other's
-  entry.
+  target key already holds a live entry, that entry wins: the migrating entry
+  is removed from the pool without replacing the target entry. Existing
+  handles keep its migrated connection, but a new lookup for the original URL
+  dials fresh and a target lookup joins the target entry. The migrated entry
+  retires when its last existing handle releases it. Two connections to one
+  relay for that overlap is the honest cost; entry removal is identity-guarded
+  so neither cleanup can delete another entry.
 - Tests against the in-tree relay: an empty-URI drain migrates without a
   dropped group, a GOAWAY without a timeout hands over at the configured cap,
   a redirect moves the pool key and origins, a redirect onto an already
-  pooled key tombstones the original key while existing handles drain, each guard refusal
-  closes rather than reconnects, and the draft-14 to -16 route decodes the
-  URI.
+  pooled key keeps existing handles on both entries but makes a new caller for
+  the original URL dial fresh, each guard refusal closes rather than
+  reconnects, and the draft-14 to -16 route decodes the URI.
 
-## Related
+## Required
 
-- [Redirect guard by name](/quest/m1/2624-moq-native-goaway-redirect-guard-classifies-hosts-by-name.md) - the Rust guard classifies local hosts by name; the JS port inherits the same gap until it lands
+- [Redirect guard by name](/quest/m1/2624-moq-native-goaway-redirect-guard-classifies-hosts-by-name.md) - pin validated DNS results before enabling cross-host redirects by default

--- a/quest/m2/drain/client-goaway.md
+++ b/quest/m2/drain/client-goaway.md
@@ -6,7 +6,8 @@ The JavaScript client migrates on GOAWAY the way the Rust client already
 does: it dials the replacement while the old session keeps serving, follows a
 redirect URI under the same guard, and keeps the app-visible handle and its
 origins across the swap. The Rust client's fleet-drain path (an empty-URI
-GOAWAY redialed through a fresh DNS resolve) is pinned by a regression test.
+GOAWAY redialed through a fresh DNS resolve) gains the regression test it
+lacks today.
 
 ## Plan
 
@@ -36,16 +37,18 @@ guard stays [its own quest](/quest/m1/2624-moq-native-goaway-redirect-guard-clas
 
 ### JavaScript is greenfield
 
-On `dev`, `js/net` logs the lite GOAWAY URI, logs the IETF draft-17+ URI, and
-does not decode the body at all on the draft-14 to -16 shared control stream.
-`Reload` reconnects only on `closed`, tears the old connection down in its
-effect cleanup, and `Connection.Shared` (`js/net/src/connection/pool.ts`)
-pools by URL href.
+On `dev`, `js/net` logs the lite GOAWAY URI and keeps that session open,
+logs the IETF draft-17+ URI and then closes the session when its control
+loop ends, and on the draft-14 to -16 shared control stream reads the message
+body but returns without decoding it. Nothing migrates: `Reload` reconnects
+only after `closed` fires, through its backoff, tears the old connection
+down in its effect cleanup, and `Connection.Shared`
+(`js/net/src/connection/pool.ts`) pools by URL href.
 
 - Surface the peer's GOAWAY on `Established` as a drain signal carrying the
   resolved URI and the timeout, decoded on every wire the client speaks,
-  including the draft-14 to -16 adapter route that currently returns before
-  reading the body.
+  including the draft-14 to -16 adapter route that currently returns without
+  decoding the body it has already read.
 - `Reload` mirrors `Draining`: on GOAWAY it dials the target immediately,
   swaps the origin wiring (`forwardAnnounced`, `publish`, `subscribe`) once
   the replacement is established, and leaves the old session to close on its

--- a/quest/m2/plan-hls-identity.md
+++ b/quest/m2/plan-hls-identity.md
@@ -18,7 +18,7 @@ deployment (moq.pro) that already keys recordings itself. Until that is
 decided this quest stays a plan quest; do not start
 [HLS generation](/quest/m2/hls-generation.md) against a guess.
 
-What the pass settled, so it is not re-derived:
+The pass settled the following points, so they do not need to be re-derived:
 
 - The requirement is unchanged: a CDN edge needs one URL to mean the same
   bytes on every edge, so the ID has to be minted by the publisher and travel
@@ -50,5 +50,7 @@ What the pass settled, so it is not re-derived:
   publisher session downstream.
 - If a wire epoch is chosen it folds into lite-06-wip, is minted at random
   on `broadcast::Info` with an application override so an archive replays a
-  recording under its recorded value, and reaches moq-transport as a
-  SUBSCRIBE_OK parameter.
+  recording under its recorded value. On moq-lite it rides TRACK_INFO (lite's
+  SUBSCRIBE_OK carries only the resolved group); on moq-transport, which has
+  no TRACK_INFO, it rides a SUBSCRIBE_OK parameter, and the adapter maps
+  both onto the same `track::Info` field.

--- a/quest/m2/pop-skipping/peer-reconfigure.md
+++ b/quest/m2/pop-skipping/peer-reconfigure.md
@@ -31,7 +31,10 @@ Decisions:
   to the same representation, and its equality covers every field, so an
   `egress`-only or `token`-only update is a change and the token is never
   dropped. Unknown fields reject the whole list, so a typo keeps the
-  last-good topology exactly as a malformed URL does.
+  last-good topology exactly as a malformed URL does, and so does an object
+  whose `url` still carries `?cost=` or `?jwt=`: policy has one home per
+  form, and a mixed entry is rejected rather than given a precedence a
+  migration could silently get wrong.
 - Gossip and mDNS keep advertising URLs only. Their allowlist admits `?cost=`
   alone, and the draft already makes a declared price an assertion the
   receiver may override, so a peer never needs to push structured policy at us.
@@ -56,5 +59,6 @@ declared value visible on the far side; a `connect_api` update that changes
 only `egress` or only `token` redials that peer and no other; an identical
 object render is a no-op; equivalent URL and object forms of one peer
 deduplicate while differing policies for one identity conflict; an unknown
-field keeps the previous list. Update `doc/bin/relay/cluster.md` and
+field, or an object whose `url` carries `?cost=` or `?jwt=`, keeps the
+previous list. Update `doc/bin/relay/cluster.md` and
 `doc/bin/relay/config.md` with the object form.

--- a/quest/m2/pop-skipping/peer-reconfigure.md
+++ b/quest/m2/pop-skipping/peer-reconfigure.md
@@ -26,15 +26,22 @@ Decisions:
   `url` (required, still the canonical identity), `cost` (what this relay
   charges to pull from the peer, the routing input), `egress` (what it declares
   in SETUP as its own price toward the peer, defaulting to `cost`), and
-  `token` (replaces an inline `?jwt=`). Unknown fields reject the whole list,
-  so a typo keeps the last-good topology exactly as a malformed URL does.
+  `token` (replaces an inline `?jwt=`). `DialTarget` grows `egress` and a
+  normalized credential, with an inline `?jwt=` and an object `token` parsed
+  to the same representation, and its equality covers every field, so an
+  `egress`-only or `token`-only update is a change and the token is never
+  dropped. Unknown fields reject the whole list, so a typo keeps the
+  last-good topology exactly as a malformed URL does.
 - Gossip and mDNS keep advertising URLs only. Their allowlist admits `?cost=`
   alone, and the draft already makes a declared price an assertion the
   receiver may override, so a peer never needs to push structured policy at us.
 - Any field change replaces the session, the rule [moq#2874](https://github.com/moq-dev/moq/pull/2874)
   set for `?cost=`. A URL entry and an object entry that normalize to the same
-  `DialTarget` are the same entry. Reconciling cost in place without a redial
-  is deliberately not done: it would be a second code path for one field.
+  `DialTarget` are one entry, deduplicated as `parse_peer_list` already does;
+  two entries for one identity with differing policy are the conflict that
+  rejects the list, whatever their forms. Reconciling cost in place without a
+  redial is deliberately not done: it would be a second code path for one
+  field.
 - No per-peer wire version. ALPN negotiation picks the best common version per
   session and the global `--version` list is the only pin; a per-peer
   override is a fleet cutover concern that stays downstream.
@@ -46,7 +53,8 @@ side reads the charged value while SETUP carries the declared one.
 Tests: the asymmetric link in both directions, two relays each pricing the
 other differently, with routes ranked per side from the charged value and the
 declared value visible on the far side; a `connect_api` update that changes
-only `egress` redials that peer and no other; an identical object render is a
-no-op; an object and URL form of one peer coexisting is a conflict; an unknown
+only `egress` or only `token` redials that peer and no other; an identical
+object render is a no-op; equivalent URL and object forms of one peer
+deduplicate while differing policies for one identity conflict; an unknown
 field keeps the previous list. Update `doc/bin/relay/cluster.md` and
 `doc/bin/relay/config.md` with the object form.


### PR DESCRIPTION
## Summary

Follow-up to #3402, which merged before its final review fixes reached the branch.

- Complete the ACME plan's startup, cache, retry, atomic rotation, permission, and backend contracts, and require shared TLS rotation before implementation.
- Correct the JavaScript GOAWAY baseline and pool-collision behavior, and require the hostname redirect guard before enabling cross-host redirects by default.
- Preserve `mtls=true` while carrying certificate identity separately, normalize every structured peer policy field, and clarify the candidate epoch mapping across wire protocols.

## Public API changes

- None. Quest documents only.

## Test plan

- `nix develop --command env -u RUSTC_WRAPPER just check` (242 quest documents; Markdown, shell, and repository checks passed)
- `nix develop --command env -u RUSTC_WRAPPER just test` (no affected JS, Rust, or Python packages; skipped cleanly)

(Written by GPT-5)
