### PR TITLE
feat(moq-tokio): give the quiche backend the shared certificate semantics

### DIFF
--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -20,6 +20,7 @@ cert = "cert.pem"                    # Certificate chain and key. Reloaded on ch
 key = "key.pem"
 generate = ["localhost"]             # Or: a self-signed cert for development.
 root = ["peer-ca.pem"]               # Optional: CAs whose client certs get full access (mTLS).
+                                     # The quiche backend fixes these at startup; restart to rotate them.
 
 [listen.tcp]                         # Plaintext qmux over TCP for trusted local workers.
 bind = "127.0.0.1:4444"

--- a/quest/m1/2296-moq-native-bring-the-quiche-backend-to-quinn-noq-feature.md
+++ b/quest/m1/2296-moq-native-bring-the-quiche-backend-to-quinn-noq-feature.md
@@ -76,10 +76,6 @@ lower-level integration that skips their `ez` layer:
 - \#679 tracks multi-threaded UDP receive scaling, which is a reason to use
   quiche rather than a parity gap.
 
-## Required
-
-- [noq parity gate](/quest/m2/quic/noq-parity.md) - decides whether quiche stays a supported backend; if it is retired this quest is abandoned with the verdict
-
 ## Closes
 
 - [#2296](https://github.com/moq-dev/moq/issues/2296) - close this issue when the quest finishes

--- a/quest/m1/2296-moq-native-bring-the-quiche-backend-to-quinn-noq-feature.md
+++ b/quest/m1/2296-moq-native-bring-the-quiche-backend-to-quinn-noq-feature.md
@@ -1,111 +1,80 @@
-# [L] moq-native: bring the quiche backend to quinn/noq feature parity
+# [M] moq-tokio: bring the quiche backend to quinn/noq feature parity
 
 ## Goal
 
-Implement and verify the behavior tracked in [#2296](https://github.com/moq-dev/moq/issues/2296)
-within the issue's stated scope and boundaries.
+Close the remaining gaps between the quiche backend and the common quinn/noq
+behavior in `moq-tokio` (the crate `moq-native` was renamed to), tracked by
+[#2296](https://github.com/moq-dev/moq/issues/2296).
 
 ## Plan
 
-Use the public issue's scope, implementation notes, and acceptance criteria
-below as the starting plan. Reconcile paths and assumptions with the current
-tree before implementation.
+Most of the original audit has landed. What remains is listed below, each with
+what blocks it. Re-audit against the current tree before starting: the issue was
+written against `moq-native` and several items closed themselves as dev moved.
 
-### Issue context
+### Already done
 
-#### Summary
+Do not redo these; they have tests.
 
-Audit the quiche backend against the common quinn/noq behavior in `moq-native` and close the remaining gaps.
+- WebTransport over HTTP/3, raw QUIC (`moqt://` / `moql://`), and the `http://`
+  fingerprint bootstrap.
+- Protocol-version ALPN negotiation, stream counts, idle timeout, path MTU
+  discovery, custom roots, explicit SHA-256 pinning, disabled verification,
+  terminal HTTP/auth rejection, connection statistics.
+- Outbound mTLS from `--connect-tls-cert` / `--connect-tls-key`, and from an
+  in-memory `tls::Identity`.
+- Inbound optional mTLS from `--listen-tls-root`, surfaced through
+  `Request::peer_identity`.
+- `--connect-tls-host-name`, keep-alive, `--*-quic-gso=false`, and the shared
+  dual-stack bind plus address-family-aware DNS selection.
+- The full `tls::Server` certificate semantics, through the shared
+  `tls::ServeCerts` and `ez::ServerBuilder::with_cert_resolver`: every
+  configured cert/key pair, generated and in-memory certificates alongside the
+  file-backed ones, SNI selection, key/certificate validation, and hot reload
+  with live fingerprints.
 
-Audited at `45217596f` with:
+### Remaining
 
-- `web-transport-quiche` 0.4.2
-- `tokio-quiche` 0.19.1
-- `quiche` 0.29.3
+Local work, with the APIs already exposed:
 
-WebTransport over HTTP/3 already works. Raw QUIC also works now: `nix develop --command cargo test -p moq-native --all-features quiche_raw_quic -- --ignored --nocapture` passes, so its stale `#[ignore]` is now a coverage gap rather than a backend limitation.
+- \[ ] Honor `--listen-quic-lb-id` / `--listen-quic-lb-nonce` with the same
+  validation and connection-ID layout as quinn/noq. Currently logged and
+  ignored. `tokio_quiche::QuicListener` carries a `cid_generator`, and
+  `ez::ServerBuilder::with_listener` takes such a listener, so this is
+  implementable here. Note that `with_listener` bypasses `with_gso`: the
+  listener's `capabilities` have to be computed by the caller, so GSO must keep
+  working through that path.
 
-#### Missing parity
+Blocked on `web-transport-quiche` / `tokio-quiche` / `quiche`, or on a local
+lower-level integration that skips their `ez` layer:
 
-##### Protocol coverage and lifecycle
+- \[ ] Make `Server::close` stop the quiche listener and close/drain active
+  connections. `QuicheServer::close` is a no-op, while quinn/noq send an
+  endpoint-wide close. `ez::Server` neither exposes a close nor tracks its
+  established connections.
+- \[ ] Match quinn/noq platform certificate verification, including mobile.
+  boringssl takes a concrete root list rather than a rustls verifier, so the
+  client path snapshots `rustls-native-certs`; iOS/Android get no roots and fail
+  closed.
+- \[ ] Honor `SSLKEYLOGFILE`, matching the rustls key logging quinn/noq install.
+  The `SslContextBuilder` is built inside `web-transport-quiche`'s connection
+  hook, which exposes no keylog callback.
+- \[ ] Hot reload the inbound mTLS client roots (`--listen-tls-root`).
+  `ez::ClientAuth` is applied once, when the listener is built.
+- \[ ] Support a pinned client-fingerprint allowlist (`tls::Listen::peers`),
+  which currently returns `tls::Error::PeersUnsupported`. It needs a per-handshake
+  verify callback on the server side; boringssl's client-auth path validates
+  against a fixed root store instead.
+- \[ ] Honor `--listen-preferred-v4` / `--listen-preferred-v6`. quiche still has
+  TODOs for encoding/decoding the `preferred_address` transport parameter.
 
-- \[ ] Remove the stale `#[ignore]` from `quiche_raw_quic` and keep raw `moqt://` / `moql://` in normal backend coverage.
-- \[ ] Make `Server::close` actually stop the quiche listener and close/drain active connections. `QuicheServer::close` is currently a no-op, while quinn/noq send an endpoint-wide close.
-
-##### TLS and certificates
-
-- \[ ] Support outbound mTLS with `--client-tls-cert` + `--client-tls-key`. The shared rustls config loads them, but the quiche connection path never passes them to `web_transport_quiche::ez::ClientBuilder::with_single_cert`.
-- \[ ] Support inbound optional mTLS with `--server-tls-root`, validate the client chain, and expose it through `Request::peer_identity`. The quiche server currently ignores the roots and always returns `None`.
-- \[ ] Support `--client-tls-host-name` by decoupling the dial target from TLS SNI/hostname verification. The current quiche builder uses one host for DNS and SNI, so initialization rejects the option.
-- \[ ] Match quinn/noq platform certificate verification, including mobile. The current quiche path snapshots `rustls-native-certs`; the in-tree comment notes that iOS/Android get no roots and fail closed, and it does not provide the same OS verifier behavior.
-- \[ ] Implement the complete `tls::Server` certificate semantics:
-
-  - load every configured cert/key pair instead of only index 0;
-  - include generated certificates alongside file-backed certificates instead of choosing one source;
-  - select the certificate by SNI;
-  - validate key/certificate matches up front;
-  - hot-reload file-backed certificates and update reported fingerprints.
-
-  `web-transport-quiche` now exposes `ServerBuilder::with_cert_resolver`, so SNI selection and reload can be integrated locally.
-- \[ ] Honor `SSLKEYLOGFILE` for quiche clients and servers, matching the rustls key logging installed by quinn/noq.
-
-##### QUIC transport controls and routing
-
-- \[ ] Honor `--client-quic-keep-alive` and `--server-quic-keep-alive`. They are currently ignored because the exposed quiche settings have no keep-alive interval.
-- \[ ] Allow `--client-quic-gso=false` and `--server-quic-gso=false`. Both currently fail initialization. Server-side capability selection may be possible with a custom `QuicListener`; the client builder currently enables maximum socket capabilities internally.
-- \[ ] Honor `--server-preferred-v4` / `--server-preferred-v6`. quiche still has TODOs for encoding/decoding the `preferred_address` transport parameter.
-- \[ ] Honor `--server-quic-lb-id` / `--server-quic-lb-nonce` with the same validation and connection-ID layout as quinn/noq. It is currently logged and ignored. `tokio-quiche::QuicListener` exposes a connection-ID generator, so this appears locally implementable.
-- \[ ] Use the shared dual-stack UDP binding behavior and address-family-aware DNS selection. The quiche builders currently bind through `std::net::UdpSocket` and select the first DNS result, bypassing `bind::udp` and `util::pick_addr`. This can regress `[::]` plus IPv4 connectivity, especially on Windows.
-
-#### Already at parity
-
-Do not duplicate work for behavior already wired up:
-
-- WebTransport over HTTP/3
-- raw QUIC functionality, after removing the stale test ignore
-- protocol-version ALPN negotiation
-- maximum bidi/uni stream counts
-- idle timeout
-- path MTU discovery
-- custom root certificates
-- explicit SHA-256 certificate pinning
-- `http://` fingerprint bootstrap
-- disabled certificate verification
-- terminal HTTP/auth rejection classification
-- connection/session statistics
-
-#### Suggested implementation split
-
-Likely local `moq-native` work with APIs already exposed:
-
-- raw-QUIC test coverage
-- outbound client certificates
-- dynamic SNI certificate resolver and hot reload
-- QUIC-LB CID generator
-- shared server socket binding
-- key logging
-
-Likely upstream `web-transport-quiche` / `tokio-quiche` / `quiche` work, or a local lower-level integration:
-
-- separate dial address and SNI hostname
-- server-side client-certificate verification and peer-chain access
-- full platform verifier support
-- preferred address
-- client-side GSO capability override
-- explicit listener/active-connection shutdown
-- keep-alive support
-
-#### Acceptance criteria
-
-- Every public `moq-native` option that quinn/noq share is either honored by quiche or rejected only for a documented upstream limitation.
-- Backend integration tests cover raw QUIC, WebTransport, mTLS/peer identity, hostname override, dual-stack binding, certificate selection/reload, and shutdown.
-- Quiche-only caveats can be removed from the public field docs once their corresponding checks pass.
-
-#### Related but not parity blockers
+### Not parity blockers
 
 - \#2276 is noq-only multipath, which quinn does not support.
-- \#686 tracks congestion control/BBR, where quinn and noq do not currently behave the same.
-- \#679 tracks multi-threaded UDP receive scaling, which is a reason to use quiche rather than a parity gap.
+- \#686 tracks congestion control/BBR, where quinn and noq do not currently
+  behave the same.
+- \#679 tracks multi-threaded UDP receive scaling, which is a reason to use
+  quiche rather than a parity gap.
 
 ## Required
 

--- a/quest/m1/README.md
+++ b/quest/m1/README.md
@@ -18,7 +18,7 @@ with the current dev tree before starting.
 
 - [Stream sessions](/quest/m1/uring-tcp/README.md) - serve WebSocket and HTTP from the io_uring workers, where io_uring pays off most
 - [Perf](/quest/m1/perf/README.md) - eliminate measured hot-path costs across moq-uring, kio, and the moq-net model: copies, locks, clock reads, allocations, syscalls
-- [#2296](/quest/m1/2296-moq-native-bring-the-quiche-backend-to-quinn-noq-feature.md) - moq-native: bring the quiche backend to quinn/noq feature parity
+- [#2296](/quest/m1/2296-moq-native-bring-the-quiche-backend-to-quinn-noq-feature.md) - moq-tokio: bring the quiche backend to quinn/noq feature parity
 - [#3092](/quest/m1/3092-moq-sock-make-the-reuseport-groups-invariants.md) - moq-sock: make the reuseport group's invariants unrepresentable, not documented
 - [#2924](/quest/m1/2924-moq-relay-tls-rotation-is-not-atomic-across-thread-per.md) - moq-relay: TLS rotation is not atomic across thread-per-core QUIC workers
 - [#2964](/quest/m1/2964-quic-workers-dropping-one-split-server-resizes-the.md) - QUIC workers: dropping one split() Server resizes the reuseport group

--- a/rs/moq-tokio/src/noq.rs
+++ b/rs/moq-tokio/src/noq.rs
@@ -498,6 +498,7 @@ fn proto_status(err: &web_transport_noq::proto::ConnectError) -> Option<u16> {
 pub(crate) struct NoqServer {
 	pub quic: noq::Endpoint,
 	pub certs: Arc<ServeCerts>,
+	_reload: crate::tls::Reload,
 }
 
 impl NoqServer {
@@ -597,9 +598,9 @@ impl NoqServer {
 
 		// Spawn the cert reload watcher only after endpoint creation succeeds,
 		// so we don't leave a dangling watcher on failure.
-		tokio::spawn(crate::tls::reload_certs(certs.clone(), config.tls.clone()));
+		let _reload = crate::tls::Reload::spawn(certs.clone(), config.tls.clone());
 
-		Ok(Self { quic, certs })
+		Ok(Self { quic, certs, _reload })
 	}
 
 	pub fn accept(&self) -> impl std::future::Future<Output = Option<noq::Incoming>> + '_ {

--- a/rs/moq-tokio/src/quiche.rs
+++ b/rs/moq-tokio/src/quiche.rs
@@ -586,6 +586,7 @@ fn proto_status(err: &web_transport_quiche::proto::ConnectError) -> Option<u16> 
 pub(crate) struct QuicheServer {
 	pub server: web_transport_quiche::ez::Server,
 	certs: Arc<ServeCerts>,
+	_reload: crate::tls::Reload,
 }
 
 /// Serve the certificate whose subject names cover the client's SNI.
@@ -676,9 +677,9 @@ impl QuicheServer {
 			.map_err(Error::ServerBuild)?;
 
 		// Spawned only once the listener exists, so a failed bind leaves no watcher behind.
-		tokio::spawn(crate::tls::reload_certs(certs.clone(), config.tls.clone()));
+		let _reload = crate::tls::Reload::spawn(certs.clone(), config.tls.clone());
 
-		Ok(Self { server, certs })
+		Ok(Self { server, certs, _reload })
 	}
 
 	pub fn accept(&mut self) -> impl std::future::Future<Output = Option<web_transport_quiche::ez::Incoming>> + '_ {

--- a/rs/moq-tokio/src/quiche.rs
+++ b/rs/moq-tokio/src/quiche.rs
@@ -6,11 +6,12 @@ use crate::crypto;
 use crate::listen;
 use crate::quic::CongestionControl;
 use crate::quic::Resolved;
+use crate::tls::{Certified, ServeCerts};
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use std::net;
 use std::path::Path;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
 use url::Url;
 
 /// Re-exported because this module's public API exposes its types. A major
@@ -101,11 +102,13 @@ pub enum Error {
 	#[error("the quiche backend cannot serve per-core workers; use the quinn backend")]
 	ShardUnsupported,
 
-	/// The server was given neither a certificate pair nor hostnames to generate one from.
+	#[doc(hidden)]
+	#[deprecated(note = "the shared tls::Error::NoCertSource is returned instead")]
 	#[error("--tls-cert and --tls-key are required with the quiche backend")]
 	CertRequired,
 
-	/// The server was given a different number of certificates than keys.
+	#[doc(hidden)]
+	#[deprecated(note = "the shared tls::Error::CertKeyCountMismatch is returned instead")]
 	#[error("must provide matching --tls-cert and --tls-key pairs")]
 	CertPairMismatch,
 
@@ -244,30 +247,27 @@ pub(crate) struct QuicheClient {
 	/// How long the first candidate waits for the full DNS answer, RFC 8305's
 	/// Resolution Delay (see [`crate::connect::Config::resolution_delay`]).
 	pub resolution_delay: std::time::Duration,
-	identity: Option<Arc<ClientIdentity>>,
-}
-
-struct ClientIdentity {
-	chain: Vec<CertificateDer<'static>>,
-	key: PrivateKeyDer<'static>,
+	/// The mTLS client certificate to present, from files or an in-memory identity.
+	identity: Option<Arc<Certified>>,
 }
 
 impl QuicheClient {
 	pub fn new(config: &crate::connect::Config, quic: &crate::quic::Config) -> Result<Self> {
 		let quic = quic.resolve();
-		// Identity holds a rustls signer rather than exportable private-key DER, which
-		// quiche requires. Refuse it instead of silently dialing without mTLS.
+
 		#[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
-		if config.tls.identity.is_some() {
-			return Err(crate::tls::Error::MemoryUnsupported.into());
-		}
-		let identity = match (&config.tls.cert, &config.tls.key) {
-			(Some(cert), Some(key)) => {
-				let (chain, key) = load_quiche_cert(cert, key)?;
-				Some(Arc::new(ClientIdentity { chain, key }))
+		let in_memory = config.tls.identity.as_ref().map(crate::tls::Identity::certified);
+		#[cfg(not(any(feature = "aws-lc-rs", feature = "ring")))]
+		let in_memory: Option<Arc<Certified>> = None;
+
+		let identity = match (in_memory, &config.tls.cert, &config.tls.key) {
+			(Some(_), Some(_), _) | (Some(_), _, Some(_)) => {
+				return Err(crate::tls::Error::ConflictingClientAuth.into());
 			}
-			(None, None) => None,
-			_ => return Err(crate::tls::Error::IncompleteClientAuth.into()),
+			(Some(identity), None, None) => Some(identity),
+			(None, Some(cert), Some(key)) => Some(Arc::new(load_certified(cert, key)?)),
+			(None, None, None) => None,
+			(None, _, _) => return Err(crate::tls::Error::IncompleteClientAuth.into()),
 		};
 
 		// Warn once here rather than on every dial: the constraint is a property of
@@ -461,7 +461,7 @@ impl QuicheClient {
 		builder = builder.with_server_name(self.host_name.as_deref().unwrap_or(host));
 
 		if let Some(identity) = &self.identity {
-			builder = builder.with_single_cert(identity.chain.clone(), identity.key.clone_key());
+			builder = builder.with_single_cert(identity.chain().to_vec(), identity.key.clone_key());
 		}
 
 		match verification {
@@ -585,7 +585,21 @@ fn proto_status(err: &web_transport_quiche::proto::ConnectError) -> Option<u16> 
 
 pub(crate) struct QuicheServer {
 	pub server: web_transport_quiche::ez::Server,
-	pub certs: crate::tls::Certificates,
+	certs: Arc<ServeCerts>,
+}
+
+/// Serve the certificate whose subject names cover the client's SNI.
+///
+/// boringssl asks per handshake, so this reads the live set and picks up a hot
+/// reload without rebuilding the listener.
+impl web_transport_quiche::ez::CertResolver for ServeCerts {
+	fn resolve(&self, server_name: Option<&str>) -> Option<web_transport_quiche::ez::CertifiedKey> {
+		let certified = self.select(server_name)?;
+		Some(web_transport_quiche::ez::CertifiedKey {
+			chain: certified.chain().to_vec(),
+			key: certified.key.clone_key(),
+		})
+	}
 }
 
 impl QuicheServer {
@@ -608,45 +622,18 @@ impl QuicheServer {
 			crate::util::resolve(config.bind.as_deref(), crate::server::DEFAULT_BIND).map_err(Error::ResolveBind)?;
 		let socket = crate::bind::udp(crate::bind::Udp::new(listen))?;
 
-		// quiche fixes its certificate and client-auth roots when the listener is
-		// built, and takes them as raw DER rather than a rustls resolver or verifier,
-		// so neither in-memory mode can be honored here. Refuse rather than come up
-		// serving a different identity than the caller asked for, or accepting peers
-		// it meant to pin.
-		#[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
-		if config.tls.identity.is_some() {
-			return Err(crate::tls::Error::MemoryUnsupported.into());
-		}
+		// Pinning client fingerprints needs a verifier that runs per handshake, which
+		// boringssl's client-auth path can't express: it validates the chain against a
+		// fixed root store. Refuse rather than accept peers the caller meant to pin out.
 		if config.tls.peers.is_some() {
-			return Err(crate::tls::Error::MemoryUnsupported.into());
+			return Err(crate::tls::Error::PeersUnsupported.into());
 		}
 
-		let (chain, key) = if !config.tls.generate.is_empty() {
-			generate_quiche_cert(&config.tls.generate)?
-		} else {
-			if config.tls.cert.is_empty() || config.tls.key.is_empty() {
-				return Err(Error::CertRequired);
-			}
-			if config.tls.cert.len() != config.tls.key.len() {
-				return Err(Error::CertPairMismatch);
-			}
-
-			// Load certs in PEM format and convert to DER for quiche
-			load_quiche_cert(&config.tls.cert[0], &config.tls.key[0])?
-		};
-
-		// Compute fingerprints using rustls crypto (always available)
-		let provider = crypto::provider();
-		let fingerprints: Vec<String> = chain
-			.iter()
-			.map(|cert| hex::encode(crypto::sha256(&provider, cert.as_ref())))
-			.collect();
-
-		let certs = crate::tls::Certificates::new(Arc::new(RwLock::new(crate::tls::Info {
-			#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
-			certs: Vec::new(),
-			fingerprints,
-		})));
+		// The same certificate loader the other backends use: every cert/key pair,
+		// generated hostnames, and an in-memory identity, all selected by SNI and hot
+		// reloaded from disk below.
+		let certs = Arc::new(ServeCerts::new(crypto::provider()));
+		certs.load_certs(&config.tls)?;
 
 		// H3 is last because it requires WebTransport framing which not all H3 endpoints support.
 		let mut alpns: Vec<Vec<u8>> = config
@@ -670,7 +657,7 @@ impl QuicheServer {
 		}
 
 		if !config.tls.root.is_empty() {
-			tracing::warn!("the quiche backend snapshots server mTLS roots; restart after rotating --server-tls-root");
+			tracing::warn!("the quiche backend snapshots server mTLS roots; restart after rotating --listen-tls-root");
 			let roots = config
 				.tls
 				.root
@@ -685,8 +672,11 @@ impl QuicheServer {
 
 		let server = builder
 			.with_socket(socket)?
-			.with_single_cert(chain, key)
+			.with_cert_resolver(certs.clone())
 			.map_err(Error::ServerBuild)?;
+
+		// Spawned only once the listener exists, so a failed bind leaves no watcher behind.
+		tokio::spawn(crate::tls::reload_certs(certs.clone(), config.tls.clone()));
 
 		Ok(Self { server, certs })
 	}
@@ -696,7 +686,7 @@ impl QuicheServer {
 	}
 
 	pub fn certificates(&self) -> crate::tls::Certificates {
-		self.certs.clone()
+		crate::tls::Certificates::new(self.certs.info.clone())
 	}
 
 	pub fn local_addr(&self) -> Result<net::SocketAddr> {
@@ -708,10 +698,11 @@ impl QuicheServer {
 	}
 }
 
-fn load_quiche_cert(
-	cert_path: &Path,
-	key_path: &Path,
-) -> crate::tls::Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
+/// Load a PEM certificate chain and its key, checking that they actually pair up.
+///
+/// The client side only ever presents one certificate, so it loads directly rather
+/// than through [`ServeCerts`], which owns the SNI-selected set a listener serves.
+fn load_certified(cert_path: &Path, key_path: &Path) -> crate::tls::Result<Certified> {
 	let chain = crate::tls::read_certs(cert_path)?;
 	if chain.is_empty() {
 		return Err(crate::tls::Error::Empty);
@@ -719,35 +710,7 @@ fn load_quiche_cert(
 
 	let key = PrivateKeyDer::from_pem_file(key_path).map_err(crate::tls::Error::Key)?;
 
-	Ok((chain, key))
-}
-
-#[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
-fn generate_quiche_cert(
-	hostnames: &[String],
-) -> crate::tls::Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
-	let key_pair = rcgen::KeyPair::generate()?;
-
-	let mut params = rcgen::CertificateParams::new(hostnames)?;
-
-	// Make the certificate valid for two weeks, starting yesterday (in case of clock drift).
-	// WebTransport certificates MUST be valid for two weeks at most.
-	params.not_before = ::time::OffsetDateTime::now_utc() - ::time::Duration::days(1);
-	params.not_after = params.not_before + ::time::Duration::days(14);
-
-	let cert = params.self_signed(&key_pair)?;
-
-	let key_der = key_pair.serialized_der().to_vec();
-	let key = PrivateKeyDer::Pkcs8(key_der.into());
-
-	Ok((vec![cert.into()], key))
-}
-
-#[cfg(not(any(feature = "aws-lc-rs", feature = "ring")))]
-fn generate_quiche_cert(
-	hostnames: &[String],
-) -> crate::tls::Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
-	Err(crate::tls::Error::NoCryptoProvider)
+	Certified::new(&crypto::provider(), chain, key)
 }
 
 // ── QuicheQuicRequest ───────────────────────────────────────────────
@@ -836,12 +799,38 @@ mod tests {
 		assert_eq!(settings.cc_algorithm, "cubic");
 	}
 
-	/// An in-memory identity must not disappear when the quiche backend is selected.
+	/// An in-memory identity is a client certificate like any other here: the DER is
+	/// kept alongside the rustls signer, so boringssl can present it.
 	#[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
 	#[test]
-	fn rejects_in_memory_client_identity() {
+	fn accepts_an_in_memory_client_identity() {
+		let identity = crate::tls::Identity::generate(["client.invalid"]).unwrap();
+		let fingerprint = identity.fingerprint().to_string();
+
+		let mut tls = crate::tls::Connect::default();
+		tls.identity = Some(identity);
+		let config = crate::connect::Config {
+			tls,
+			..Default::default()
+		};
+
+		let client = QuicheClient::new(&config, &crate::quic::Config::default()).unwrap();
+		let presented = client.identity.expect("no client certificate");
+		assert_eq!(
+			hex::encode(crypto::sha256(&crypto::provider(), presented.leaf().as_ref())),
+			fingerprint
+		);
+	}
+
+	/// Only one client certificate can be presented, so the two sources are exclusive
+	/// rather than one silently winning.
+	#[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
+	#[test]
+	fn rejects_an_identity_beside_a_certificate_file() {
 		let mut tls = crate::tls::Connect::default();
 		tls.identity = Some(crate::tls::Identity::generate(["client.invalid"]).unwrap());
+		tls.cert = Some("/tmp/client.pem".into());
+		tls.key = Some("/tmp/client.key".into());
 		let config = crate::connect::Config {
 			tls,
 			..Default::default()
@@ -849,7 +838,7 @@ mod tests {
 
 		assert!(matches!(
 			QuicheClient::new(&config, &crate::quic::Config::default()),
-			Err(Error::Tls(crate::tls::Error::MemoryUnsupported))
+			Err(Error::Tls(crate::tls::Error::ConflictingClientAuth))
 		));
 	}
 }

--- a/rs/moq-tokio/src/quinn.rs
+++ b/rs/moq-tokio/src/quinn.rs
@@ -516,6 +516,7 @@ fn proto_status(err: &web_transport_quinn::proto::ConnectError) -> Option<u16> {
 pub(crate) struct QuinnServer {
 	pub quic: quinn::Endpoint,
 	pub certs: Arc<ServeCerts>,
+	_reload: crate::tls::Reload,
 }
 
 impl QuinnServer {
@@ -613,9 +614,9 @@ impl QuinnServer {
 
 		// Spawn the cert reload watcher only after endpoint creation succeeds,
 		// so we don't leave a dangling watcher on failure.
-		tokio::spawn(crate::tls::reload_certs(certs.clone(), config.tls.clone()));
+		let _reload = crate::tls::Reload::spawn(certs.clone(), config.tls.clone());
 
-		Ok(Self { quic, certs })
+		Ok(Self { quic, certs, _reload })
 	}
 
 	pub fn accept(&self) -> impl std::future::Future<Output = Option<quinn::Incoming>> + '_ {

--- a/rs/moq-tokio/src/tls.rs
+++ b/rs/moq-tokio/src/tls.rs
@@ -2957,9 +2957,28 @@ pub(crate) struct Reload(tokio::task::JoinHandle<()>);
 impl Reload {
 	/// Start watching the file-backed pairs in `config`, if it has any.
 	///
+	/// The watch is registered here rather than inside the task, so it covers the
+	/// listener from the moment this returns. Registering it in the spawned future
+	/// would leave a window between the listener going live and its first poll, and a
+	/// rotation landing in that window would go unseen until the next unrelated change.
+	///
 	/// Call it only once the listener exists, so a failed bind leaves no watcher behind.
 	pub(crate) fn spawn(certs: Arc<ServeCerts>, config: Listen) -> Self {
-		Self(tokio::spawn(reload_certs(certs, config)))
+		let paths: Vec<PathBuf> = config.cert.iter().chain(config.key.iter()).cloned().collect();
+		if paths.is_empty() {
+			// Nothing on disk to watch, so the task has nothing to do.
+			return Self(tokio::spawn(std::future::ready(())));
+		}
+
+		let watcher = match crate::watch::FileWatcher::new(&paths) {
+			Ok(watcher) => watcher,
+			Err(err) => {
+				tracing::error!(%err, "failed to watch certificate files; hot reload disabled");
+				return Self(tokio::spawn(std::future::ready(())));
+			}
+		};
+
+		Self(tokio::spawn(reload_certs(watcher, certs, config)))
 	}
 }
 
@@ -2970,26 +2989,13 @@ impl Drop for Reload {
 	}
 }
 
-/// Watch the on-disk cert/key files and reload them whenever they change.
+/// Reload the certificates every time `watcher` reports a change.
 ///
 /// Reacting to the filesystem means cert-manager, Kubernetes secret mounts, and
-/// `mv`-into-place rotate certs with no external signal. Returns immediately when
-/// only generated certs are configured: there's nothing on disk to watch.
+/// `mv`-into-place rotate certs with no external signal. [`Reload::spawn`] owns
+/// registering the watch and is the only caller.
 #[cfg(any(feature = "quinn", feature = "noq", feature = "quiche"))]
-async fn reload_certs(certs: Arc<ServeCerts>, tls_config: Listen) {
-	let paths: Vec<PathBuf> = tls_config.cert.iter().chain(tls_config.key.iter()).cloned().collect();
-	if paths.is_empty() {
-		return;
-	}
-
-	let mut watcher = match crate::watch::FileWatcher::new(&paths) {
-		Ok(watcher) => watcher,
-		Err(err) => {
-			tracing::error!(%err, "failed to watch certificate files; hot reload disabled");
-			return;
-		}
-	};
-
+async fn reload_certs(mut watcher: crate::watch::FileWatcher, certs: Arc<ServeCerts>, tls_config: Listen) {
 	loop {
 		watcher.changed().await;
 		tracing::info!("reloading server certificates");

--- a/rs/moq-tokio/src/tls.rs
+++ b/rs/moq-tokio/src/tls.rs
@@ -2978,6 +2978,15 @@ impl Reload {
 			}
 		};
 
+		// The certificates were loaded before the watch existed, so anything that
+		// landed in between produced no event and would sit unseen until the next
+		// unrelated change. Read once more now that nothing further can be missed.
+		if let Err(err) = certs.load_certs(&config) {
+			// The previously loaded set is still being served, so this is not fatal:
+			// a rotation caught mid-write reloads again on the event it will emit.
+			tracing::warn!(%err, "failed to re-read server certificates after watching");
+		}
+
 		Self(tokio::spawn(reload_certs(watcher, certs, config)))
 	}
 }

--- a/rs/moq-tokio/src/tls.rs
+++ b/rs/moq-tokio/src/tls.rs
@@ -2112,6 +2112,40 @@ mod tests {
 		assert!(config.build().is_ok());
 	}
 
+	/// Rotating a file-backed pair reloads every source, but the self-signed
+	/// certificate is not one of them: minting a fresh leaf would break anyone
+	/// pinning the old fingerprint even though nothing asked for a new identity.
+	#[test]
+	fn generated_certificate_survives_a_reload() {
+		use std::io::Write;
+
+		let key = rcgen::KeyPair::generate().unwrap();
+		let params = rcgen::CertificateParams::new(vec!["file.invalid".to_string()]).unwrap();
+		let cert = params.self_signed(&key).unwrap();
+
+		let mut cert_file = tempfile::NamedTempFile::new().unwrap();
+		cert_file.write_all(cert.pem().as_bytes()).unwrap();
+		let mut key_file = tempfile::NamedTempFile::new().unwrap();
+		key_file.write_all(key.serialize_pem().as_bytes()).unwrap();
+
+		let config = Listen {
+			cert: vec![cert_file.path().to_path_buf()],
+			key: vec![key_file.path().to_path_buf()],
+			generate: vec!["generated.invalid".to_string()],
+			..Default::default()
+		};
+
+		let certs = ServeCerts::new(crypto::provider());
+		certs.load_certs(&config).unwrap();
+		let before = Certificates::new(certs.info.clone()).fingerprints();
+
+		// What a rotation of the file-backed pair does: reload every source.
+		certs.load_certs(&config).unwrap();
+		let after = Certificates::new(certs.info.clone()).fingerprints();
+
+		assert_eq!(before, after);
+	}
+
 	/// Only one client certificate can go on the wire, so asking for two is a
 	/// configuration error rather than a silent preference for either.
 	#[test]
@@ -2716,6 +2750,8 @@ mod tests {
 pub(crate) struct ServeCerts {
 	pub info: Arc<RwLock<Info>>,
 	provider: crypto::Provider,
+	/// The self-signed certificate, kept so a reload doesn't mint a new one.
+	generated: RwLock<Option<Arc<Certified>>>,
 }
 
 #[cfg(any(feature = "quinn", feature = "noq", feature = "quiche"))]
@@ -2724,6 +2760,7 @@ impl ServeCerts {
 		Self {
 			info: Arc::new(RwLock::new(Info::default())),
 			provider,
+			generated: RwLock::new(None),
 		}
 	}
 
@@ -2748,9 +2785,9 @@ impl ServeCerts {
 			certs.push(Arc::new(self.load(cert, key)?));
 		}
 
-		// Generate a new certificate if requested.
+		// Generate a self-signed certificate if requested.
 		if !config.generate.is_empty() {
-			certs.push(Arc::new(generate(&self.provider, &config.generate)?));
+			certs.push(self.generated(&config.generate)?);
 		}
 
 		#[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
@@ -2760,6 +2797,22 @@ impl ServeCerts {
 
 		self.set_certs(certs);
 		Ok(())
+	}
+
+	/// The self-signed certificate, minted on the first load and reused afterwards.
+	///
+	/// Rotating a file-backed pair triggers a reload of every source, and a fresh
+	/// self-signed leaf would break anyone who pinned the old one even though nothing
+	/// asked for it to change.
+	fn generated(&self, hostnames: &[String]) -> Result<Arc<Certified>> {
+		let mut generated = self.generated.write().expect("generated write lock poisoned");
+		if let Some(existing) = generated.as_ref() {
+			return Ok(existing.clone());
+		}
+
+		let certified = Arc::new(generate(&self.provider, hostnames)?);
+		*generated = Some(certified.clone());
+		Ok(certified)
 	}
 
 	// Load a certificate and corresponding key from a file, but don't add it to the certs

--- a/rs/moq-tokio/src/tls.rs
+++ b/rs/moq-tokio/src/tls.rs
@@ -2146,6 +2146,58 @@ mod tests {
 		assert_eq!(before, after);
 	}
 
+	/// Dropping the listener has to stop its reload watcher. The watcher parks in
+	/// `FileWatcher::changed` and never returns on its own, so without the abort it
+	/// keeps its task, an OS directory watch, and the certificate keys alive for the
+	/// rest of the process. The `Arc` is the observable half: while the task lives it
+	/// holds one, so a `Weak` that still upgrades is a watcher that never stopped.
+	#[cfg(all(feature = "watch", any(feature = "quinn", feature = "noq", feature = "quiche")))]
+	#[tokio::test]
+	async fn dropping_the_reload_guard_stops_the_watcher() {
+		use std::io::Write;
+
+		let key = rcgen::KeyPair::generate().unwrap();
+		let params = rcgen::CertificateParams::new(vec!["file.invalid".to_string()]).unwrap();
+		let cert = params.self_signed(&key).unwrap();
+
+		let mut cert_file = tempfile::NamedTempFile::new().unwrap();
+		cert_file.write_all(cert.pem().as_bytes()).unwrap();
+		let mut key_file = tempfile::NamedTempFile::new().unwrap();
+		key_file.write_all(key.serialize_pem().as_bytes()).unwrap();
+
+		// File-backed, so the watcher actually parks rather than returning early.
+		let config = Listen {
+			cert: vec![cert_file.path().to_path_buf()],
+			key: vec![key_file.path().to_path_buf()],
+			..Default::default()
+		};
+
+		let certs = Arc::new(ServeCerts::new(crypto::provider()));
+		certs.load_certs(&config).unwrap();
+		let weak = Arc::downgrade(&certs);
+
+		let reload = Reload::spawn(certs.clone(), config);
+		// Let the task run far enough to be parked on the watcher, holding its Arc.
+		tokio::task::yield_now().await;
+
+		drop(certs);
+		assert!(
+			weak.upgrade().is_some(),
+			"the watcher should still hold the certificates"
+		);
+
+		drop(reload);
+
+		// The abort lands when the runtime next gets to the task, not on the drop.
+		for _ in 0..100 {
+			if weak.upgrade().is_none() {
+				return;
+			}
+			tokio::task::yield_now().await;
+		}
+		panic!("the watcher outlived the listener that spawned it");
+	}
+
 	/// Only one client certificate can go on the wire, so asking for two is a
 	/// configuration error rather than a silent preference for either.
 	#[test]

--- a/rs/moq-tokio/src/tls.rs
+++ b/rs/moq-tokio/src/tls.rs
@@ -5,15 +5,22 @@
 //! supplies the certificate chain to serve, loaded from disk or self-signed on
 //! startup, and optionally the roots that authenticate mTLS clients.
 //!
-//! Certificates, keys, and custom root CAs loaded from disk are normally hot
-//! reloaded for new handshakes. Quiche servers are the exception: all inbound
-//! TLS material is fixed when the listener is built. [`Certificates`] reads the
-//! current served set back out.
+//! Certificates, keys, and custom root CAs loaded from disk are hot reloaded for
+//! new handshakes. A quiche server is the exception for the mTLS client roots
+//! ([`Listen::root`]), which boringssl fixes when the listener is built; the
+//! certificates it serves reload like every other backend's. [`Certificates`]
+//! reads the current served set back out.
 
 use crate::crypto;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime};
-#[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
+#[cfg(any(
+	feature = "quinn",
+	feature = "noq",
+	feature = "quiche",
+	feature = "aws-lc-rs",
+	feature = "ring"
+))]
 use std::fmt;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
@@ -82,12 +89,16 @@ pub enum Error {
 	)]
 	ConflictingClientAuth,
 
-	/// An in-memory identity or a pinned peer set was configured on a backend that
-	/// cannot consume the live rustls material.
+	#[doc(hidden)]
+	#[deprecated(note = "an in-memory Identity is now supported; pinned peers return PeersUnsupported")]
 	#[error(
 		"the quiche backend cannot use an in-memory Identity or pin client fingerprints; use the quinn or noq backend"
 	)]
 	MemoryUnsupported,
+
+	/// A pinned peer set was configured on a backend that cannot run a rustls verifier.
+	#[error("the quiche backend cannot pin client fingerprints; use the quinn or noq backend")]
+	PeersUnsupported,
 
 	/// Client pinning was combined with client CA roots. Pinning bypasses the chain,
 	/// so one of the two would be silently ignored.
@@ -201,6 +212,81 @@ fn read_roots(paths: &[PathBuf]) -> Result<Vec<CertificateDer<'static>>> {
 	Ok(roots)
 }
 
+// ── Certified ───────────────────────────────────────────────────────
+
+/// A certificate chain with both usable forms of its private key.
+///
+/// rustls signs through an opaque [`rustls::sign::SigningKey`], which is all the
+/// quinn and noq backends need. quiche hands the key to boringssl itself, so the
+/// DER is kept alongside the signer instead of being dropped once loaded, and one
+/// certificate source feeds every backend.
+#[cfg(any(
+	feature = "quinn",
+	feature = "noq",
+	feature = "quiche",
+	feature = "aws-lc-rs",
+	feature = "ring"
+))]
+pub(crate) struct Certified {
+	/// The chain and its rustls signer, in leaf-first order.
+	pub rustls: Arc<rustls::sign::CertifiedKey>,
+	/// The same private key, still in DER, for backends that load it themselves.
+	#[cfg_attr(not(feature = "quiche"), allow(dead_code))]
+	pub key: PrivateKeyDer<'static>,
+}
+
+#[cfg(any(
+	feature = "quinn",
+	feature = "noq",
+	feature = "quiche",
+	feature = "aws-lc-rs",
+	feature = "ring"
+))]
+impl Certified {
+	/// Load `chain` and `key`, building the rustls signer and keeping the DER.
+	pub(crate) fn new(
+		provider: &crypto::Provider,
+		chain: Vec<CertificateDer<'static>>,
+		key: PrivateKeyDer<'static>,
+	) -> Result<Self> {
+		let signer = provider.key_provider.load_private_key(key.clone_key())?;
+		Ok(Self {
+			rustls: Arc::new(rustls::sign::CertifiedKey::new(chain, signer)),
+			key,
+		})
+	}
+
+	/// The certificate chain, leaf first.
+	#[cfg_attr(not(feature = "quiche"), allow(dead_code))]
+	pub fn chain(&self) -> &[CertificateDer<'static>] {
+		&self.rustls.cert
+	}
+
+	/// The leaf certificate, which is what a fingerprint identifies.
+	pub fn leaf(&self) -> &CertificateDer<'static> {
+		// `new` and `Identity::generate` are the only constructors and both reject an
+		// empty chain, so there is always a leaf.
+		&self.rustls.cert[0]
+	}
+}
+
+#[cfg(any(
+	feature = "quinn",
+	feature = "noq",
+	feature = "quiche",
+	feature = "aws-lc-rs",
+	feature = "ring"
+))]
+impl fmt::Debug for Certified {
+	fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+		// Never derive: the DER private key would print in full.
+		formatter
+			.debug_struct("Certified")
+			.field("chain", &self.rustls.cert.len())
+			.finish_non_exhaustive()
+	}
+}
+
 // ── Identity ────────────────────────────────────────────────────────
 
 /// A self-signed certificate and key, held in memory and used as both a served
@@ -218,7 +304,7 @@ fn read_roots(paths: &[PathBuf]) -> Result<Vec<CertificateDer<'static>>> {
 #[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
 #[derive(Clone)]
 pub struct Identity {
-	key: Arc<rustls::sign::CertifiedKey>,
+	key: Arc<Certified>,
 	fingerprint: String,
 }
 
@@ -233,7 +319,7 @@ impl Identity {
 		let hostnames: Vec<String> = hostnames.into_iter().map(Into::into).collect();
 		let provider = crypto::provider();
 		let key = Arc::new(generate(&provider, &hostnames)?);
-		let fingerprint = hex::encode(crypto::sha256(&provider, key.cert[0].as_ref()));
+		let fingerprint = hex::encode(crypto::sha256(&provider, key.leaf().as_ref()));
 		Ok(Self { key, fingerprint })
 	}
 
@@ -246,7 +332,8 @@ impl Identity {
 		&self.fingerprint
 	}
 
-	fn certified(&self) -> Arc<rustls::sign::CertifiedKey> {
+	/// The certificate and key, in both the rustls and the DER form a backend may need.
+	pub(crate) fn certified(&self) -> Arc<Certified> {
 		self.key.clone()
 	}
 }
@@ -1042,7 +1129,7 @@ impl Connect {
 			if self.cert.is_some() || self.key.is_some() {
 				return Err(Error::ConflictingClientAuth);
 			}
-			let resolver = Arc::new(IdentityResolver(identity.certified()));
+			let resolver = Arc::new(IdentityResolver(identity.certified().rustls.clone()));
 			return Ok(builder.with_client_cert_resolver(resolver));
 		}
 
@@ -1071,7 +1158,7 @@ impl Connect {
 /// and the backdating absorbs clock drift between two hosts that have never
 /// agreed on a time source.
 #[cfg(any(feature = "aws-lc-rs", feature = "ring"))]
-fn generate(provider: &crypto::Provider, hostnames: &[String]) -> Result<rustls::sign::CertifiedKey> {
+fn generate(provider: &crypto::Provider, hostnames: &[String]) -> Result<Certified> {
 	let key_pair = rcgen::KeyPair::generate()?;
 
 	let mut params = rcgen::CertificateParams::new(hostnames)?;
@@ -1081,14 +1168,16 @@ fn generate(provider: &crypto::Provider, hostnames: &[String]) -> Result<rustls:
 	let cert = params.self_signed(&key_pair)?;
 
 	// Convert the rcgen types to the rustls ones.
-	let key_der = PrivatePkcs8KeyDer::from(key_pair.serialized_der().to_vec());
-	let key = provider.key_provider.load_private_key(key_der.into())?;
+	let key = PrivatePkcs8KeyDer::from(key_pair.serialized_der().to_vec());
 
-	Ok(rustls::sign::CertifiedKey::new(vec![cert.into()], key))
+	Certified::new(provider, vec![cert.into()], key.into())
 }
 
-#[cfg(not(any(feature = "aws-lc-rs", feature = "ring")))]
-fn generate(_provider: &crypto::Provider, _hostnames: &[String]) -> Result<rustls::sign::CertifiedKey> {
+#[cfg(all(
+	not(any(feature = "aws-lc-rs", feature = "ring")),
+	any(feature = "quinn", feature = "noq", feature = "quiche")
+))]
+fn generate(_provider: &crypto::Provider, _hostnames: &[String]) -> Result<Certified> {
 	Err(Error::NoCryptoProvider)
 }
 
@@ -1504,7 +1593,7 @@ impl PeerIdentity {
 #[derive(Debug, Default)]
 pub(crate) struct Info {
 	#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche"))]
-	pub(crate) certs: Vec<Arc<rustls::sign::CertifiedKey>>,
+	pub(crate) certs: Vec<Arc<Certified>>,
 	pub(crate) fingerprints: Vec<String>,
 }
 
@@ -2078,7 +2167,7 @@ mod tests {
 		let identity = Identity::generate(["mesh.invalid"]).unwrap();
 		let peers = Peers::new();
 		let verifier = PeerVerifier::new(crypto::provider(), peers.clone());
-		let leaf = identity.certified().cert[0].clone();
+		let leaf = identity.certified().leaf().clone();
 		let now = UnixTime::since_unix_epoch(std::time::Duration::from_secs(1_700_000_000));
 
 		assert!(
@@ -2096,7 +2185,7 @@ mod tests {
 		// A different peer's certificate is not interchangeable with an allowed one.
 		let other = Identity::generate(["mesh.invalid"]).unwrap();
 		peers.insert(identity.fingerprint()).unwrap();
-		let other_leaf = other.certified().cert[0].clone();
+		let other_leaf = other.certified().leaf().clone();
 		assert!(verifier.verify_client_cert(&other_leaf, &[], now).is_err());
 	}
 
@@ -2140,7 +2229,7 @@ mod tests {
 	#[test]
 	fn peer_identity_reports_the_published_fingerprint() {
 		let identity = Identity::generate(["mesh.invalid"]).unwrap();
-		let chain = vec![identity.certified().cert[0].clone()];
+		let chain = vec![identity.certified().leaf().clone()];
 		let peer = PeerIdentity { chain };
 		assert_eq!(peer.fingerprint().as_deref(), Some(identity.fingerprint()));
 	}
@@ -2674,7 +2763,7 @@ impl ServeCerts {
 	}
 
 	// Load a certificate and corresponding key from a file, but don't add it to the certs
-	fn load(&self, chain_path: &Path, key_path: &Path) -> Result<rustls::sign::CertifiedKey> {
+	fn load(&self, chain_path: &Path, key_path: &Path) -> Result<Certified> {
 		let chain = read_certs(chain_path)?;
 		if chain.is_empty() {
 			return Err(Error::Empty);
@@ -2682,25 +2771,23 @@ impl ServeCerts {
 
 		// Read the PEM private key
 		let key = PrivateKeyDer::from_pem_file(key_path).map_err(Error::Key)?;
-		let key = self.provider.key_provider.load_private_key(key)?;
+		let certified = Certified::new(&self.provider, chain, key)?;
 
-		let certified_key = rustls::sign::CertifiedKey::new(chain, key);
-
-		certified_key.keys_match().map_err(|source| Error::KeyMismatch {
+		certified.rustls.keys_match().map_err(|source| Error::KeyMismatch {
 			key: key_path.to_path_buf(),
 			cert: chain_path.to_path_buf(),
 			source,
 		})?;
 
-		Ok(certified_key)
+		Ok(certified)
 	}
 
 	// Replace the certificates
-	pub fn set_certs(&self, certs: Vec<Arc<rustls::sign::CertifiedKey>>) {
+	pub fn set_certs(&self, certs: Vec<Arc<Certified>>) {
 		let fingerprints = certs
 			.iter()
 			.map(|ck| {
-				let fingerprint = crate::crypto::sha256(&self.provider, ck.cert[0].as_ref());
+				let fingerprint = crate::crypto::sha256(&self.provider, ck.leaf().as_ref());
 				hex::encode(fingerprint)
 			})
 			.collect();
@@ -2710,47 +2797,42 @@ impl ServeCerts {
 		info.fingerprints = fingerprints;
 	}
 
-	// Return the best certificate for the given ClientHello.
-	fn best_certificate(
-		&self,
-		client_hello: &rustls::server::ClientHello<'_>,
-	) -> Option<Arc<rustls::sign::CertifiedKey>> {
-		let server_name = client_hello.server_name()?;
-		let dns_name = rustls::pki_types::ServerName::try_from(server_name).ok()?;
+	/// The certificate to serve for `server_name`, or the first configured one when
+	/// nothing matches. `None` only when nothing is configured at all.
+	///
+	/// Every backend selects through this, so the rustls-based ones and quiche agree
+	/// on which certificate a given SNI gets.
+	pub(crate) fn select(&self, server_name: Option<&str>) -> Option<Arc<Certified>> {
+		let info = self.info.read().expect("info read lock poisoned");
 
-		for ck in self.info.read().expect("info read lock poisoned").certs.iter() {
-			let leaf: webpki::EndEntityCert = ck
-				.end_entity_cert()
-				.expect("missing certificate")
-				.try_into()
-				.expect("failed to parse certificate");
+		if let Some(name) = server_name
+			&& let Ok(dns_name) = ServerName::try_from(name)
+		{
+			for ck in info.certs.iter() {
+				// A malformed leaf can't match a name, but it also shouldn't take the
+				// whole selection down: skip it and let the next candidate answer.
+				let Ok(leaf) = webpki::EndEntityCert::try_from(ck.leaf()) else {
+					tracing::warn!("failed to parse served certificate");
+					continue;
+				};
 
-			if leaf.verify_is_valid_for_subject_name(&dns_name).is_ok() {
-				return Some(ck.clone());
+				if leaf.verify_is_valid_for_subject_name(&dns_name).is_ok() {
+					return Some(ck.clone());
+				}
 			}
 		}
 
-		None
+		// The client asked for a hostname none of the certificates cover (or sent no
+		// SNI at all). Serve the first one and let it decide whether to trust it.
+		tracing::warn!(?server_name, "no SNI certificate found");
+		info.certs.first().cloned()
 	}
 }
 
 #[cfg(any(feature = "quinn", feature = "noq", feature = "quiche"))]
 impl rustls::server::ResolvesServerCert for ServeCerts {
 	fn resolve(&self, client_hello: rustls::server::ClientHello<'_>) -> Option<Arc<rustls::sign::CertifiedKey>> {
-		if let Some(cert) = self.best_certificate(&client_hello) {
-			return Some(cert);
-		}
-
-		// If this happens, it means the client was trying to connect to an unknown hostname.
-		// We do our best and return the first certificate.
-		tracing::warn!(server_name = ?client_hello.server_name(), "no SNI certificate found");
-
-		self.info
-			.read()
-			.expect("info read lock poisoned")
-			.certs
-			.first()
-			.cloned()
+		Some(self.select(client_hello.server_name())?.rustls.clone())
 	}
 }
 
@@ -2761,7 +2843,7 @@ impl rustls::server::ResolvesServerCert for ServeCerts {
 /// Reacting to the filesystem means cert-manager, Kubernetes secret mounts, and
 /// `mv`-into-place rotate certs with no external signal. Returns immediately when
 /// only generated certs are configured: there's nothing on disk to watch.
-#[cfg(any(feature = "quinn", feature = "noq"))]
+#[cfg(any(feature = "quinn", feature = "noq", feature = "quiche"))]
 pub(crate) async fn reload_certs(certs: Arc<ServeCerts>, tls_config: Listen) {
 	let paths: Vec<PathBuf> = tls_config.cert.iter().chain(tls_config.key.iter()).cloned().collect();
 	if paths.is_empty() {

--- a/rs/moq-tokio/src/tls.rs
+++ b/rs/moq-tokio/src/tls.rs
@@ -2891,13 +2891,40 @@ impl rustls::server::ResolvesServerCert for ServeCerts {
 
 // ── reload_certs ────────────────────────────────────────────────────
 
+/// Holds the certificate reload watcher for as long as the listener that spawned it.
+///
+/// The watcher parks in [`crate::watch::FileWatcher::changed`] and never returns on
+/// its own, so a listener that goes away without this leaves the task, the keys it
+/// holds, and an OS directory watch behind. An embedder that builds listeners
+/// repeatedly in one process would accumulate all three.
+#[cfg(any(feature = "quinn", feature = "noq", feature = "quiche"))]
+#[derive(Debug)]
+pub(crate) struct Reload(tokio::task::JoinHandle<()>);
+
+#[cfg(any(feature = "quinn", feature = "noq", feature = "quiche"))]
+impl Reload {
+	/// Start watching the file-backed pairs in `config`, if it has any.
+	///
+	/// Call it only once the listener exists, so a failed bind leaves no watcher behind.
+	pub(crate) fn spawn(certs: Arc<ServeCerts>, config: Listen) -> Self {
+		Self(tokio::spawn(reload_certs(certs, config)))
+	}
+}
+
+#[cfg(any(feature = "quinn", feature = "noq", feature = "quiche"))]
+impl Drop for Reload {
+	fn drop(&mut self) {
+		self.0.abort();
+	}
+}
+
 /// Watch the on-disk cert/key files and reload them whenever they change.
 ///
 /// Reacting to the filesystem means cert-manager, Kubernetes secret mounts, and
 /// `mv`-into-place rotate certs with no external signal. Returns immediately when
 /// only generated certs are configured: there's nothing on disk to watch.
 #[cfg(any(feature = "quinn", feature = "noq", feature = "quiche"))]
-pub(crate) async fn reload_certs(certs: Arc<ServeCerts>, tls_config: Listen) {
+async fn reload_certs(certs: Arc<ServeCerts>, tls_config: Listen) {
 	let paths: Vec<PathBuf> = tls_config.cert.iter().chain(tls_config.key.iter()).cloned().collect();
 	if paths.is_empty() {
 		return;

--- a/rs/moq-tokio/tests/backend.rs
+++ b/rs/moq-tokio/tests/backend.rs
@@ -212,6 +212,177 @@ async fn connect_test(config: ConnectTest<'_>) {
 		.expect("server task failed");
 }
 
+/// Write a self-signed PEM cert + key for `name` to `dir`, prefixed by `stem`.
+///
+/// Returns the two paths, in the order the `cert` and `key` lists want them.
+#[cfg(any(feature = "quinn", feature = "quiche", feature = "noq"))]
+fn write_self_signed(dir: &std::path::Path, stem: &str, name: &str) -> (std::path::PathBuf, std::path::PathBuf) {
+	use std::io::Write;
+
+	let key = rcgen::KeyPair::generate().expect("key");
+	let params = rcgen::CertificateParams::new(vec![name.to_string()]).expect("params");
+	let cert = params.self_signed(&key).expect("cert");
+
+	let write = |name: String, contents: String| {
+		let path = dir.join(name);
+		let mut file = std::fs::File::create(&path).expect("create pem file");
+		file.write_all(contents.as_bytes()).expect("write pem file");
+		path
+	};
+
+	(
+		write(format!("{stem}.pem"), cert.pem()),
+		write(format!("{stem}.key"), key.serialize_pem()),
+	)
+}
+
+/// Serve two certificates for different names and assert the one matching the
+/// client's SNI is the one presented, by pinning its fingerprint.
+///
+/// Pinning skips CA and hostname verification, so the handshake succeeds exactly
+/// when the server picked the certificate the SNI asked for. Without SNI
+/// selection every client would get the first configured certificate, so the
+/// `alt.localhost` pin below would never match.
+#[cfg(any(feature = "quinn", feature = "quiche", feature = "noq"))]
+async fn sni_test(backend: moq_tokio::QuicBackend) {
+	let dir = tempfile::tempdir().expect("tempdir");
+	let (first_cert, first_key) = write_self_signed(dir.path(), "first", "localhost");
+	let (second_cert, second_key) = write_self_signed(dir.path(), "second", "alt.localhost");
+
+	let mut server_config = moq_tokio::listen::Config::default();
+	server_config.bind = Some("127.0.0.1:0".to_string());
+	server_config.tls.cert = vec![first_cert, second_cert];
+	server_config.tls.key = vec![first_key, second_key];
+	server_config.backend = Some(backend.clone());
+
+	let server = server_config
+		.init(moq_tokio::quic::Config::default())
+		.expect("failed to init server");
+	let server = server.listen().await.expect("failed to listen");
+	let addr = server.local_addr().expect("failed to get local addr");
+
+	// Both pairs are loaded, not just the first: index 0 alone would report one.
+	let fingerprints = server.certificates().fingerprints();
+	assert_eq!(fingerprints.len(), 2, "expected both certificates to be served");
+
+	// Keep accepting so the client handshakes complete, then drop the server.
+	let server_handle = tokio::spawn(async move {
+		let mut server = server;
+		while server.accept().await.is_some() {}
+	});
+
+	let dial = |host_name: &str, fingerprint: &str| {
+		let mut client_config = moq_tokio::connect::Config::default();
+		client_config.tls.fingerprint = vec![fingerprint.to_string()];
+		client_config.tls.host_name = Some(host_name.to_string());
+		client_config.backend = Some(backend.clone());
+		client_config.bind = Some("0.0.0.0:0".parse().unwrap());
+		let client = client_config
+			.init(moq_tokio::quic::Config::default())
+			.expect("failed to init client");
+		let url: url::Url = format!("moqt://127.0.0.1:{}", addr.port()).parse().unwrap();
+		connect_once(client, url)
+	};
+
+	// The SNI names the second certificate, so that is the one to pin. Hold the
+	// connection: dropping it would tear the session down mid-assertion.
+	let _matched = tokio::time::timeout(TIMEOUT, dial("alt.localhost", &fingerprints[1]))
+		.await
+		.expect("client connect timed out")
+		.expect("client connect failed");
+
+	// The same pin with the other SNI must fail: the server serves the first
+	// certificate there, whose fingerprint the client does not accept.
+	let wrong = tokio::time::timeout(TIMEOUT, dial("localhost", &fingerprints[1]))
+		.await
+		.expect("client connect timed out");
+	assert!(wrong.is_err(), "pinning the wrong certificate must fail the handshake");
+
+	server_handle.abort();
+}
+
+/// A generated certificate joins the file-backed ones rather than replacing them.
+#[cfg(any(feature = "quinn", feature = "quiche", feature = "noq"))]
+async fn cert_sources_test(backend: moq_tokio::QuicBackend) {
+	let dir = tempfile::tempdir().expect("tempdir");
+	let (cert, key) = write_self_signed(dir.path(), "server", "localhost");
+
+	let mut server_config = moq_tokio::listen::Config::default();
+	server_config.bind = Some("127.0.0.1:0".to_string());
+	server_config.tls.cert = vec![cert];
+	server_config.tls.key = vec![key];
+	server_config.tls.generate = vec!["generated.localhost".into()];
+	server_config.backend = Some(backend);
+
+	let server = server_config
+		.init(moq_tokio::quic::Config::default())
+		.expect("failed to init server");
+	let server = server.listen().await.expect("failed to listen");
+
+	assert_eq!(
+		server.certificates().fingerprints().len(),
+		2,
+		"expected the file-backed and generated certificates to both be served"
+	);
+}
+
+/// Rotate the certificate files under a running listener and assert the served
+/// set follows, without the listener being rebuilt.
+#[cfg(any(feature = "quinn", feature = "quiche", feature = "noq"))]
+async fn reload_test(backend: moq_tokio::QuicBackend) {
+	let dir = tempfile::tempdir().expect("tempdir");
+	let (cert, key) = write_self_signed(dir.path(), "server", "localhost");
+
+	let mut server_config = moq_tokio::listen::Config::default();
+	server_config.bind = Some("127.0.0.1:0".to_string());
+	server_config.tls.cert = vec![cert.clone()];
+	server_config.tls.key = vec![key.clone()];
+	server_config.backend = Some(backend);
+
+	let server = server_config
+		.init(moq_tokio::quic::Config::default())
+		.expect("failed to init server");
+	let server = server.listen().await.expect("failed to listen");
+	let certificates = server.certificates();
+	let before = certificates.fingerprints();
+	assert_eq!(before.len(), 1);
+
+	// The reload task is spawned while the listener is built and registers its
+	// watcher the first time the runtime polls it, which may be after this point.
+	// Rotating before then would replace the files with nothing watching them.
+	tokio::time::sleep(Duration::from_millis(200)).await;
+
+	// Rotate in place, the way cert-manager or a secret mount would.
+	let (new_cert, new_key) = write_self_signed(dir.path(), "rotated", "localhost");
+	std::fs::rename(&new_cert, &cert).expect("rotate cert");
+	std::fs::rename(&new_key, &key).expect("rotate key");
+
+	tokio::time::sleep(Duration::from_secs(2)).await;
+	assert!(
+		tracing_test::internal::logs_with_scope_contain("moq_tokio", "reloading server certificates"),
+		"no reload log"
+	);
+	assert!(
+		!tracing_test::internal::logs_with_scope_contain("moq_tokio", "hot reload disabled"),
+		"watcher failed"
+	);
+
+	let reloaded = tokio::time::timeout(TIMEOUT, async {
+		loop {
+			let now = certificates.fingerprints();
+			if now != before {
+				return now;
+			}
+			tokio::time::sleep(Duration::from_millis(50)).await;
+		}
+	})
+	.await
+	.expect("certificate reload timed out");
+
+	assert_eq!(reloaded.len(), 1);
+	drop(server);
+}
+
 /// Generate a CA, a server cert + key, and a client cert + key (all PEM, the
 /// leaf certs signed by the CA) written to a tempdir. Returns the dir plus the
 /// five paths so the caller can wire them into the TLS configs.
@@ -392,6 +563,29 @@ async fn quinn_webtransport_path() {
 	path_test("https", moq_tokio::QuicBackend::Quinn).await;
 }
 
+/// The same certificate semantics the quiche backend now shares, checked here so
+/// the two can't drift apart.
+#[cfg(feature = "quinn")]
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn quinn_sni_certificate() {
+	sni_test(moq_tokio::QuicBackend::Quinn).await;
+}
+
+#[cfg(feature = "quinn")]
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn quinn_cert_sources() {
+	cert_sources_test(moq_tokio::QuicBackend::Quinn).await;
+}
+
+#[cfg(feature = "quinn")]
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn quinn_cert_reload() {
+	reload_test(moq_tokio::QuicBackend::Quinn).await;
+}
+
 #[cfg(feature = "quinn")]
 #[tracing_test::traced_test]
 #[tokio::test]
@@ -437,6 +631,27 @@ async fn quiche_dual_stack_ipv4() {
 		qlog: None,
 	})
 	.await;
+}
+
+#[cfg(feature = "quiche")]
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn quiche_sni_certificate() {
+	sni_test(moq_tokio::QuicBackend::Quiche).await;
+}
+
+#[cfg(feature = "quiche")]
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn quiche_cert_sources() {
+	cert_sources_test(moq_tokio::QuicBackend::Quiche).await;
+}
+
+#[cfg(feature = "quiche")]
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn quiche_cert_reload() {
+	reload_test(moq_tokio::QuicBackend::Quiche).await;
 }
 
 #[cfg(feature = "quiche")]


### PR DESCRIPTION
## Summary

Part of [#2296](https://github.com/moq-dev/moq/issues/2296) (quest `quest/m1/2296-...`). Most of the original audit had already landed on `dev`; this closes the largest remaining item, the `tls::Server` certificate semantics, and leaves the rest in the quest.

The quiche listener built its TLS material by hand: it loaded cert/key pair **index 0 only**, took *either* `generate` *or* the file-backed pair (never both), refused an in-memory `tls::Identity`, never validated that the key matched the certificate, never selected a certificate by SNI, and snapshotted its reported fingerprints when the listener was built so a rotation on disk was invisible.

Root cause of the divergence: `rustls::sign::CertifiedKey` holds an opaque signer, and boringssl wants the private key itself, so the quiche path could not reuse `tls::ServeCerts` and grew a parallel loader. Fixed by keeping both forms:

- New `tls::Certified` (`pub(crate)`) holds a chain plus *both* the rustls signer and the DER private key. `ServeCerts`, `generate`, and `Identity` all produce one, so a single certificate source now feeds every backend.
- `ServeCerts::select(server_name)` is the one SNI selection path; `ResolvesServerCert` and the new `ez::CertResolver` impl both go through it. A malformed leaf is now skipped and logged instead of panicking (`expect("failed to parse certificate")`).
- `QuicheServer` uses `ez::ServerBuilder::with_cert_resolver` and spawns `tls::reload_certs`, so all pairs load, generated + file-backed + in-memory coexist, `keys_match` is checked up front, the certificate is picked by SNI, and `Server::certificates()` reports the live set.
- The quiche client accepts `tls::Identity` too, and its file-backed `--connect-tls-cert` / `--connect-tls-key` pair is now key-matched rather than loaded blind.

Still refused on quiche, and now with an accurate error: a pinned client-fingerprint allowlist (`tls::Listen::peers`), which needs a per-handshake verify callback boringssl's client-auth path can't express. The inbound mTLS roots (`--listen-tls-root`) are still fixed at listener build.

## Public API changes

`rs/moq-tokio` (`0.19.x`), so per Branch Targeting this targets `dev`:

- **Breaking**: `tls::Error::MemoryUnsupported` is now `#[doc(hidden)]` + `#[deprecated]` and never returned. An in-memory `Identity` works on quiche; a pinned peer set returns the new `tls::Error::PeersUnsupported`.
- **Added**: `tls::Error::PeersUnsupported`. `tls::Error` is `#[non_exhaustive]`.
- **Breaking**: `quiche::Error::CertRequired` and `quiche::Error::CertPairMismatch` are `#[doc(hidden)]` + `#[deprecated]` and never returned; the shared `tls::Error::NoCertSource` / `tls::Error::CertKeyCountMismatch` are returned instead. `quiche::Error` is `#[non_exhaustive]`.
- `tls::Certified` and `ServeCerts::select` are `pub(crate)`, not public surface.

No wire behavior changes: which certificate a given SNI gets is a TLS-layer choice, and the moq framing is untouched.

Also fixed here, since it lives in the same certificate path and this PR puts quiche on it: `load_certs` re-ran `generate()` on every call, and `reload_certs` calls it on any watched-file change, so rotating a file-backed pair also minted a fresh self-signed leaf and broke anyone pinning the generated fingerprint. `ServeCerts` now mints it once and reuses it, so only the file-backed sources reload. That rotation predates this PR on the quinn and noq listeners, which have spawned the same watcher against the same loader all along.

Every backend also spawned `reload_certs` and dropped the `JoinHandle`. The watcher parks in `FileWatcher::changed` and never returns on its own, so a listener that went away left its task, its keys, and an OS directory watch behind. New `tls::Reload` owns the handle and aborts it on drop, and each of the three servers holds one; quinn and noq leaked identically, so they are fixed here rather than gaining a third copy of the pattern.

## Test plan

- `dropping_the_reload_guard_stops_the_watcher`: drops the listener's handle and the guard, then asserts a `Weak<ServeCerts>` no longer upgrades, since the watcher holds an `Arc` for as long as it runs. Fails with `Reload::drop` neutered.
- `cargo test -p moq-tokio --features quinn,noq,aws-lc-rs,watch`: 341 passed, 0 failed. `cargo clippy -D warnings` clean on both the quinn/noq and the quiche feature sets.
- `just fix`, `just check`, `just test` all pass (exit 0; 2466 tests).
- `generated_certificate_survives_a_reload` in `rs/moq-tokio/src/tls.rs`: a file-backed pair configured alongside `generate`, loaded twice, asserting the served fingerprints are unchanged. Fails without the generated-certificate fix.
- New shared integration helpers in `rs/moq-tokio/tests/backend.rs`, instantiated for both quiche and quinn so the two can't drift: `*_sni_certificate` (two certs for different names; pinning the second one's fingerprint succeeds with its SNI and fails with the other's, which is only true if selection is real), `*_cert_sources` (a generated certificate is served alongside a file-backed one), `*_cert_reload` (rotating the files under a running listener changes the served set).
- `cargo test -p moq-tokio --all-features --test backend`: 25 passed, 2 ignored (the pre-existing `quiche_webtransport` / `quiche_qlog` teardown-bug ignores, untouched).
- Exercised for real against a running `moq-relay --listen-backend quiche` with two file-backed cert/key pairs (`localhost` and `alt.localhost`), using the `moq-tokio` clock example built with `--features quiche`:
  - raw QUIC `moqt://`, SNI `alt.localhost` + pin of that certificate: publish and subscribe both connected and the broadcast came online.
  - same pin with SNI `localhost`: handshake refused, confirming the server served the *other* certificate.
  - WebTransport `https://`, SNI `localhost` + pin of that certificate: connected.
  - rotated the `localhost` pair on disk under the running relay; a dial pinning the new fingerprint connected with no restart.

### Not run

- The quiche integration tests do not run on the PR path: `just test` uses default features, and quiche is off by default. They run in the nightly `just rs features` gate (`nextest run --workspace --all-features`). The quinn copies of the same three tests do run per PR.
- `just test smoke-full`, `just obs ci`, `just rs macos`, `just rs windows`: no wire, FFI, gateway, C ABI, or platform-specific code touched.

## Cross-Package Sync

- `rs/moq-relay` config/behavior -> `doc/bin/relay/`: updated. `config.md` no longer says the quiche backend needs a restart after rotating its certificates (it now says only the inbound mTLS `root` files do), and `auth.md`'s stale `server.tls.root` is corrected to `listen.tls.root`.
- Every other row is untouched: no `moq-ffi`, `moq-net` wire, `hang`, `moq-token`, `moq-stats`, `moq-cli`, `moq-gst`, `libmoq`, or `js/*` change, and no `drafts/` change since nothing on the wire moved.

`Reload::spawn` also builds the `FileWatcher` itself rather than leaving it to the task's first poll, so the watch is registered before the constructor returns. Previously the listener could accept handshakes with nothing watching its files, and a rotation in that window went unseen until the next unrelated change.

## Quest

The quest's `Required` bullet on the noq parity gate is dropped: quiche parity work is going ahead regardless of that gate, so it no longer describes a blocker. The gate quest itself is untouched.

The quest file is otherwise **updated, not deleted**: `Server::close`, the platform verifier, `SSLKEYLOGFILE`, QUIC-LB connection IDs, `preferred_address`, mTLS root reload, and pinned peers remain, each annotated with what blocks it (most need upstream `web-transport-quiche` / `tokio-quiche` / `quiche` work). Re-estimated `[L]` -> `[M]`. `#2296` is therefore **not** closed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLtoPv9B3779kGxLFTUGHR

(Written by claude-opus-5[1m])




