### PR TITLE
fix(moq-video): make moq-video compile on dev again

### DIFF
--- a/rs/moq-video/src/encode/backend/v4l2.rs
+++ b/rs/moq-video/src/encode/backend/v4l2.rs
@@ -145,7 +145,7 @@ impl V4l2 {
 		)?;
 		device.set_control(V4L2_CID_MPEG_VIDEO_H264_LEVEL, h264_level(config)?)?;
 		device.set_control(V4L2_CID_MPEG_VIDEO_GOP_SIZE, config.gop as i32)?;
-		set_bitrate(&device, config.resolved_bitrate())?;
+		set_bitrate(&device, config.resolved_bitrate().as_bps())?;
 		// Constant rate is what a live uplink wants: the congestion controller
 		// already owns the rate, and a variable-rate encoder would spend it on the
 		// wrong frames.
@@ -829,7 +829,7 @@ fn h264_level(config: &Config) -> Result<i32, Error> {
 	let size = config.size();
 	let per_frame = size.width.div_ceil(16) * size.height.div_ceil(16);
 	let per_second = per_frame as u64 * config.framerate as u64;
-	let kbps = config.resolved_bitrate().div_ceil(1_000);
+	let kbps = config.resolved_bitrate().as_bps().div_ceil(1_000);
 	LEVELS
 		.iter()
 		.find(|level| {
@@ -916,9 +916,9 @@ mod tests {
 	#[test]
 	fn the_level_clears_the_bitrate() {
 		let mut config = config(1280, 720, 30);
-		config.bitrate = Some(14_000_000);
+		config.bitrate = Some(moq_net::bandwidth::Rate::from_bps(14_000_000));
 		assert_eq!(h264_level(&config).unwrap(), 9); // 3.1
-		config.bitrate = Some(14_000_001);
+		config.bitrate = Some(moq_net::bandwidth::Rate::from_bps(14_000_001));
 		assert_eq!(h264_level(&config).unwrap(), 10); // 3.2
 	}
 

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -216,7 +216,7 @@ impl DmaBufExport {
 
 	/// Split the descriptor from the lease that keeps the producer's buffer alive,
 	/// for a consumer that has to own the two separately. Only the renderer does.
-	#[cfg_attr(not(feature = "render"), expect(dead_code))]
+	#[cfg(feature = "render")]
 	pub(crate) fn into_parts(self) -> (OwnedFd, Arc<dyn DmaBufFrame>) {
 		(self.fd, self.inner)
 	}


### PR DESCRIPTION
## Root cause

`Config::resolved_bitrate()` returns `moq_net::bandwidth::Rate` on `dev`. The V4L2 stateful M2M encoder (#3332) was written on `main`, where that method still returned `u64`, and arrived on `dev` through the merge `175b477a0`. Nothing recompiled `moq-video` afterwards, so three call sites never type-checked:

- `v4l2.rs:148` passes the `Rate` straight into `fn set_bitrate(_, bitrate: u64)`
- `v4l2.rs:832` calls `.div_ceil(1_000)` on it, which `Rate` does not have
- `the_level_clears_the_bitrate` assigns a bare integer to `Config::bitrate`, now `Option<Rate>`

**`moq-video` does not compile on `dev` today.** Every other backend (mediafoundation, nvenc, openh264, vaapi, videotoolbox) already goes through `.as_bps()`; v4l2 is the only one that does not.

## Why it was not caught

`just check` scopes to the crates the branch changed plus their dependents, so this only fires for a branch whose scope selects `moq-video`. A `moq-net` change does (#3419 is red on exactly these two errors); a `moq-sock` or `moq-relay` change does not. So the break has been sitting on `dev` failing an arbitrary subset of PRs for reasons unrelated to their diffs.

## Fix

Add `.as_bps()` at both source sites and construct a `Rate` in the test, matching what every other backend already does. No behavior change: `Rate` is a newtype over `u64` bits per second, and `from_bps`/`as_bps` round-trip it.

## Verification

- `just rs check-changed rs/moq-video/src/encode/backend/v4l2.rs` exits 0 (clippy `-D warnings`, all targets).
- `cargo nextest run -p moq-video`: 29 tests pass, including `the_level_clears_the_bitrate`, which is the test that stopped compiling.
- Both errors reproduce on an untouched `origin/dev`.

Not run: `just rs macos` / `just rs windows` (no such host, and V4L2 is Linux-only), and no hardware V4L2 encoder is present on this machine, so the level-table logic is covered by its unit tests rather than a live encode. Cross-Package Sync has no row for `moq-video`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLtoPv9B3779kGxLFTUGHR

(written by claude-opus-5[1m])