### PR TITLE
docs(quest): record four findings from the m1 quest wave

### DIFF
--- a/quest/m0/README.md
+++ b/quest/m0/README.md
@@ -17,7 +17,10 @@ regression test per Root Cause First.
 
 - [#2405](/quest/m0/2405-js-net-connect-logs-on-every-connection-at-the-wrong.md) - js/net: connect logs print the JWT in the relay URL
 - [Adapter namespace map](/quest/m0/rs-adapter-namespace-map.md) - moq-net: a duplicate PUBLISH_NAMESPACE on draft-14/15 strands the first request, and the map never shrinks
+- [Resume info](/quest/m0/resume-info-newest.md) - moq-net: resume reports segment zero's track info, so a replaced broadcast rescales timestamps on the predecessor's timescale
 - [#3080](/quest/m0/3080-fix-watch-audio-ring-truncate-can-race-the-worklet-reader.md) - watch: an audio ring truncate can race the worklet reader for one quantum
 - [#2833](/quest/m0/2833-moq-export-ts-a-rewound-timeline-stalls-the-si-table.md) - moq export ts: a rewound timeline stalls SI tables, PCR, and pacing until the media clock catches up
 - [#2799](/quest/m0/2799-moq-video-capture-negotiates-twice-so-a-window-resize.md) - moq-transcode: the ladder follows a source resolution change instead of keeping the one it started with
 - [Group charge](/quest/m0/group-charge.md) - charge real per-group cost so MOQ_CACHE_CAPACITY bounds real memory
+- [uring all-features](/quest/m0/uring-all-features-build.md) - moq-uring does not compile with `--all-features`, so the nightly features gate fails on it
+- [Go smoke client](/quest/m0/smoke-go-client.md) - the interop matrix has no Go client, so nothing in CI exercises the Go wrapper

--- a/quest/m0/resume-info-newest.md
+++ b/quest/m0/resume-info-newest.md
@@ -1,0 +1,47 @@
+# [M] moq-net: resume resolves track info from segment zero, not the newest
+
+## Goal
+
+`resume::Consumer::poll_info` reports the track info of the generation whose
+frames a reader will actually receive. A track republished on a live path
+serves the successor's `priority`, `maxAge`, and `timescale`, not the
+predecessor's.
+
+Boundaries: this is the Rust half of the same defect `js/net` fixed by keying
+its `TRACK_INFO` cache on the routing front. The wire format does not change,
+so no draft moves.
+
+## Plan
+
+`resume::Consumer::poll_info` (`rs/moq-net/src/model/resume.rs`) resolves info
+from **segment zero**, while every data read routes to the **newest** segment.
+When a broadcast is replaced on a path, those are different generations, so a
+subscriber can be handed the predecessor's metadata alongside the successor's
+frames.
+
+`timescale` is the damaging field: the reader converts frame timestamps with
+it, so a mismatched generation silently rescales every timestamp rather than
+failing. `priority` and `maxAge` are wrong but survivable.
+
+`origin.rs`'s `run_front` already re-resolves the successor's info on
+`Step::Splice` and then discards it, which is the natural place for the fix to
+hang off.
+
+### How it was found
+
+Isolated while fixing the `js/net` half. Against a real relay, a publisher
+wrote 1234 ticks on a successor's MICRO grid and the subscriber received
+`1000us`: the JS fix alone was not enough, because the relay's own stale
+metadata rescaled the frames. With the Rust side still wrong, the same
+mismatch is reachable from any client.
+
+### Not covered by an existing tracker
+
+[#2991](/quest/m1/2991-net-coalesce-dynamic-tracks-and-preserve-sequences-across.md)
+is about sequence continuity across replacement, not info resolution. #2610's
+epoch remedy was removed from the draft by #3225, so there is no wire-level
+generation marker to lean on; the fix is local.
+
+## Related
+
+- [#2991](/quest/m1/2991-net-coalesce-dynamic-tracks-and-preserve-sequences-across.md) - sequence continuity across the same replacement

--- a/quest/m0/smoke-go-client.md
+++ b/quest/m0/smoke-go-client.md
@@ -1,0 +1,37 @@
+# [M] The interop matrix has no Go client
+
+## Goal
+
+`test/smoke` publishes from and subscribes with Go, so a regression in
+`go/wrapper` fails CI instead of shipping.
+
+Boundaries: the Go wrapper only, through the same harness the other bindings
+use. No new transport or feature coverage; this closes a hole in the matrix
+rather than widening it.
+
+## Plan
+
+`just test smoke-full` runs 21 cells today: rust, python and js publishers
+against rust, python, js, js-native-node, js-native-bun, c and gst
+subscribers. Go appears in neither axis, so nothing in CI exercises the Go
+wrapper end to end. Its only coverage is `go/wrapper`'s own tests, which run
+against the library rather than across a session.
+
+That gap is load-bearing: `moq-ffi` changes are required to run `smoke-full`
+(Cross-Package Sync), and a passing run currently proves nothing about Go even
+though `go/wrapper` is generated from the same core.
+
+Add a Go publisher and a Go subscriber to `test/smoke/smoke.sh` alongside the
+existing clients. `smoke.sh` resolves dependencies from committed lock data,
+so the Go client must build with the repository's pinned toolchain and module
+graph rather than resolving at run time.
+
+### How it was found
+
+Adding `context.Context` cancellation to every blocking Go operation. The PR
+ran `smoke-full` and it passed 21/21, which said nothing at all about the Go
+code the PR changed.
+
+## Related
+
+- [Native Go context](/quest/m1/go-native-context.md) - the Go wrapper work whose verification this gap limits

--- a/quest/m0/uring-all-features-build.md
+++ b/quest/m0/uring-all-features-build.md
@@ -1,0 +1,29 @@
+# [S] moq-uring does not compile with --all-features
+
+## Goal
+
+`cargo clippy -p moq-uring --all-features --all-targets` compiles, so the
+nightly `just rs features` gate covers `moq-uring` instead of failing on it.
+
+## Plan
+
+Enabling both `noq` and `quinn` puts two `quinn_proto` versions in scope, and
+`rs/moq-uring/src/quic/quinn/connection.rs`'s test module refers to
+`quinn_proto` unqualified, so the reference is ambiguous and the test target
+does not build. `--all-features --lib` is clean; only `--all-targets` trips it.
+
+Disambiguate the reference in the test module. Check whether the same
+unqualified path appears anywhere else that only compiles under one of the two
+features, since the ambiguity is invisible until both are on at once.
+
+This is dev-only: `moq-uring` does not exist on main.
+
+### How it was found
+
+Verified while adding qlog support to the io_uring workers: reproduced on a
+stashed tree at the merge base, so it predates that work. It is unrelated to
+qlog and was deliberately not fixed there.
+
+## Related
+
+- [Worker metrics](/quest/m1/uring-metrics.md) - other moq-uring runtime work in the same crate

--- a/quest/m1/README.md
+++ b/quest/m1/README.md
@@ -61,6 +61,7 @@ with the current dev tree before starting.
 - [#3126](/quest/m1/3126-moq-bench-every-readme-example-fails-to-parse-and.md) - moq-bench: every README example fails to parse, and cumulative latency percentiles cannot be windowed to steady state
 - [#816](/quest/m1/816-expose-transportconfig.md) - QUIC flow-control windows on quic::Client and quic::Server, applied or refused per backend
 - [#3188](/quest/m1/3188-make-every-blocking-go-operation-cancellable-with-context.md) - Make every blocking Go operation cancellable with context.Context
+- [Native Go context](/quest/m1/go-native-context.md) - the Go generator emits context.Context itself, retiring the hand-rolled cancellation token
 - [#3208](/quest/m1/3208-make-2-5-ms-opus-frame-durations-work-across-bindings.md) - Make 2.5 ms Opus frame durations work across bindings
 - [#2152](/quest/m1/2152-libmoq-c-abi-catch-up-with-the-moq-ffi-surface.md) - libmoq: C ABI catch-up with the moq-ffi surface
 - [Plan: route cold cost](/quest/m1/plan-route-cold-cost.md) - settle how a route's cold cost crosses the bindings without being rewritten on the way back

--- a/quest/m1/go-native-context.md
+++ b/quest/m1/go-native-context.md
@@ -1,0 +1,35 @@
+# [M] Go bindings take context.Context natively
+
+## Goal
+
+`uniffi-bindgen-go` emits `context.Context` as the first parameter of every
+generated blocking call, so `go/wrapper` stops carrying a hand-rolled
+cancellation token and the generated layer cancels the native task directly.
+
+## Plan
+
+Today every affected `moq-ffi` method takes a trailing
+`Option<Arc<MoqCancel>>` purely so the Go wrapper has something to cancel:
+`uniffi-bindgen-go` renders a Rust `async fn` as a blocking Go call with no
+cancellation handle at all. The token works and costs the other bindings
+nothing (it is additive, with a UniFFI argument default), but it exists only
+to work around the generator.
+
+A fork of `kixelated/uniffi-bindgen-go` adding native `context.Context`
+support already exists locally, on branch `codex/context-cancel-3188`.
+Landing it means publishing that branch and pinning the new rev in
+`flake.nix`, after which the token becomes redundant for Go and can be removed
+from the `moq-ffi` surface.
+
+Decide first whether the fork is worth carrying. Keeping the token is a
+supported outcome: it is already shipped and costs nothing outside Go, and a
+pinned generator fork is a maintenance obligation on every UniFFI bump. Nobody
+should start this until that call is made.
+
+## Required
+
+- The `context.Context` support in `kixelated/uniffi-bindgen-go` is published and pinned in `flake.nix`
+
+## Related
+
+- [Go smoke client](/quest/m0/smoke-go-client.md) - what would actually verify a change to the Go bindings


### PR DESCRIPTION
Four findings surfaced by the m1 quest wave (#3408, #3410, #3412, #3414, #3415, #3418, #3419, #3420, #3422). Each was found by a PR that correctly declined to fix it in scope, and none had an issue or quest tracking it.

## m0

**[Resume info](/quest/m0/resume-info-newest.md) `[M]`** — `resume::Consumer::poll_info` resolves track info from segment **zero**, while every data read routes to the **newest** segment. A broadcast replaced on a live path therefore serves the predecessor's `priority`, `maxAge`, and `timescale`. `timescale` is the damaging one: the reader converts frame timestamps with it, so a mismatched generation silently rescales rather than failing.

Found while fixing the `js/net` half (#3422). Against a real relay, a publisher wrote 1234 ticks on a successor's MICRO grid and the subscriber got `1000us` — the JS fix alone was not enough, because the relay's own stale metadata did the rescaling. Ranked with the other `moq-net` defect. Not covered by #2991 (sequence continuity only), and #2610's epoch remedy was removed from the draft by #3225.

**[uring all-features](/quest/m0/uring-all-features-build.md) `[S]`** — `cargo clippy -p moq-uring --all-features --all-targets` does not compile: `quinn_proto` is ambiguous once `noq` and `quinn` are both on, and `quinn/connection.rs`'s test module refers to it unqualified. `--lib` is clean, so only `--all-targets` trips it. Reproduced on a stashed tree at the merge base while working #3420, so it predates that work and fails the nightly `just rs features` gate today.

**[Go smoke client](/quest/m0/smoke-go-client.md) `[M]`** — `just test smoke-full` runs 21 cells and Go is in neither axis. `moq-ffi` changes are *required* to run `smoke-full` by Cross-Package Sync, so #3412 ran it, passed 21/21, and thereby proved nothing about the Go code it changed.

Both close the list, per m0's own Plan ("hardening, tooling, and test debt close the list").

## m1

**[Native Go context](/quest/m1/go-native-context.md) `[M]`** — #3412's `MoqCancel` token exists only because `uniffi-bindgen-go` renders a Rust `async fn` as a blocking Go call with no cancellation handle. A fork adding native `context.Context` support exists on branch `codex/context-cancel-3188`; landing it retires the token from the `moq-ffi` surface.

Filed with a plain-text `## Required` bullet rather than as ready work, per the quest model's rule for an external release that unblocks repository work. **Keeping the token is a supported outcome** — it already ships, costs nothing outside Go, and a pinned generator fork is an obligation on every UniFFI bump. The quest says so explicitly so nobody starts it before that call is made.

## Verification

`cargo run --package quest -- check`: 238 documents ok — links resolve, the index matches the file tree, headings stay in the allowed set, and `Required` stays acyclic.

Markdown only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLtoPv9B3779kGxLFTUGHR

(written by claude-opus-5[1m])