### PR TITLE
docs(quest): land the review fixes auto-merge left out of #3416

### DIFF
--- a/quest/m1/3056-watch-video-decoder-captures-the-rewind-generation-at.md
+++ b/quest/m1/3056-watch-video-decoder-captures-the-rewind-generation-at.md
@@ -14,8 +14,12 @@ Rescoped in the 2026-09 planning pass: undeclared rewinds are going away
 mismatch below no longer produces the sixty-second park, but the bug it
 describes still applies to a declared discontinuity, where a stale frame must
 not be presented at all. Fix it the first way the issue suggests: call
-`decoder.reset()` and re-`configure()` in `#onDiscontinuity`, and drop the
-output-time generation guard, which then has nothing left to catch. The
+`decoder.reset()` and re-`configure()` in `#onDiscontinuity`, so queued chunks
+never surface. Keep the post-await generation guard as well: `reset()` cannot
+cancel an output callback that already holds a frame and is parked in
+`#park()` or `sync.wait()`, and `sync.reset()` releases exactly that wait, so
+the guard is what stops a stale callback writing `timestamp` and `frame`
+after the reset. The
 regression needs a real WebCodecs decoder, so it lives in a browser harness
 rather than a bun unit test.
 

--- a/quest/m1/plan-binding-rate-control.md
+++ b/quest/m1/plan-binding-rate-control.md
@@ -3,8 +3,10 @@
 ## Goal
 
 A settled shape for how a non-Rust publisher follows the connection's send
-estimate, so an OBS, Python, Swift, Kotlin, or Go publisher stops encoding at
-its configured bitrate regardless of congestion. Run `/plan-quest`; the settled
+estimate with its configured bitrate as the ceiling, the contract
+`moq_video::encode::Options::{bitrate, bandwidth}` already gives Rust, so an
+OBS, Python, Swift, Kotlin, or Go publisher stops holding that ceiling through
+congestion. Run `/plan-quest`; the settled
 plan becomes the implementing quest that closes the issue.
 
 ## Plan

--- a/quest/m2/2279-hang-typed-scte-35-ad-cue-signaling-carried-opaquely.md
+++ b/quest/m2/2279-hang-typed-scte-35-ad-cue-signaling-carried-opaquely.md
@@ -26,15 +26,23 @@ bytes. Not a `moq-json` stream of typed records.
   tests use the same rule.
 - **Framing.** Each frame is one complete `splice_info_section`, byte for
   byte, in the group of the media it applies to, stamped with the splice
-  time's wire timestamp. Cues are sparse, so most groups are empty; a joiner
-  at a keyframe gets that GOP's cues.
+  time's wire timestamp. A section with no splice time (`splice_null`,
+  `private_command`, `bandwidth_reservation`, an immediate `splice_insert`)
+  keeps the arrival media clock the importer stamps it with today and lands
+  in the group current at arrival, so raw commands stay available. Cues are
+  sparse, so most groups are empty; a joiner at a keyframe gets that GOP's
+  cues.
 - **Typed decode is a helper, not the wire.** A parser for `splice_insert`,
   `time_signal`, and segmentation descriptors (a maintained crate if one is
   adequate) lives beside the section in Rust and JS, and `js/watch` raises a
   cue event from it. Applications that want the rest parse the bytes.
 - **The TS lanes stay.** The importer keeps the verbatim `mpegts` track for
   contribution fidelity and additionally emits the sidecar; the exporter must
-  not double-emit, and section-framed export still needs the video clock.
+  not double-emit. Section-framed export takes its clock from the video
+  rendition today and rejects an audio-only program
+  (`scte35_without_video_export_is_rejected`); extend it to derive the clock
+  from the mapped audio rendition, or the audio-only mapping above is a
+  promise export cannot keep.
 
 Wire and catalog schema: a new optional section, additive, so it lands on
 `main`, with `drafts/draft-lcurley-moq-hang.md` updated in the same PR as the

--- a/quest/m2/2279-hang-typed-scte-35-ad-cue-signaling-carried-opaquely.md
+++ b/quest/m2/2279-hang-typed-scte-35-ad-cue-signaling-carried-opaquely.md
@@ -18,7 +18,12 @@ bytes. Not a `moq-json` stream of typed records.
 - **A `scte35` catalog section**, as its own `CatalogExt` like the `mpegts`
   one, naming one sidecar track per rendition that carries cues. Cues from a
   TS program attach to its video rendition, or to its audio rendition when
-  there is no video; the import already stamps them with video PTS.
+  there is no video. One timestamp contract for both: a cue's wire timestamp
+  is its `splice_time` (or the section's arrival time when it has none)
+  converted to the owning rendition's clock, so the importer, which stamps
+  from the video `last_pts` today, learns to stamp from audio PTS for an
+  audio-only program, and the draft, both implementations, and the export
+  tests use the same rule.
 - **Framing.** Each frame is one complete `splice_info_section`, byte for
   byte, in the group of the media it applies to, stamped with the splice
   time's wire timestamp. Cues are sparse, so most groups are empty; a joiner

--- a/quest/m2/emsg.md
+++ b/quest/m2/emsg.md
@@ -20,8 +20,10 @@ decodes it with its own library, and a new scheme stays forward-compatible.
 Carry them on a sidecar of the video rendition (the audio rendition when there
 is none) following the rule in [SEI section](/quest/m2/sei/sei.md): the
 rendition's group sequence, each box stamped with the wire timestamp of its
-presentation time, raw bytes. Export rebuilds the box in the fragment whose
-media time contains it.
+presentation time, raw bytes; a box before the first `moof` takes the
+pre-media placement that rule defines. Export rebuilds the box in the
+fragment whose media time contains it, and the pre-media ones before the first
+fragment.
 
 Test version 0 and version 1 boxes, an emsg before the first moof, several on
 one fragment, an unknown scheme, a zero duration, and a round trip that is

--- a/quest/m2/flv-script.md
+++ b/quest/m2/flv-script.md
@@ -15,7 +15,8 @@ through the same channel.
 Carry the tag payload byte-faithfully rather than decoding AMF into a fixed
 vocabulary, so a custom message type needs no further work, on a sidecar of
 the video rendition following the rule in [SEI section](/quest/m2/sei/sei.md):
-the rendition's group sequence and the tag's timestamp on the wire.
+the rendition's group sequence and the tag's timestamp on the wire, with a
+tag before the first media tag taking that rule's pre-media placement.
 Where `onMetaData` duplicates something the catalog already models (dimensions,
 framerate, bitrate), prefer the value the bitstream actually carries and treat
 the script tag as opaque data, not a second source of truth for configuration.

--- a/quest/m2/hls-generation.md
+++ b/quest/m2/hls-generation.md
@@ -18,10 +18,13 @@ inline-parameter-set codec (`avc3`) that restarts at a new resolution keeps
 its URL while `Rendition::init` caches the old init for the life of the
 pooled rendition, and the segment window's `push`
 (`rs/moq-hls/src/export/segments.rs`) resets only the playlist. Version the
-init URL with a hash of the rendition config (codec string, dimensions, and
-the parameter sets the init carries), so a reconfigure changes the URL and
-the cached init is invalidated with it. A hash rather than a counter because
-two edges rendering the same broadcast must agree without coordinating.
+init URL with a hash of the init segment bytes `Muxer::init` actually
+produces, so every input that shapes the init (codec string, dimensions,
+parameter sets, the catalog `Cmaf` init, audio sample rate and channel count,
+codec description, the effective timescale) is covered without a field list
+that can drift, and a reconfigure changes the URL and invalidates the cached
+init with it. A hash rather than a counter because two edges rendering the
+same broadcast must agree without coordinating.
 
 **A publisher restart** reuses segment numbers: `moq-net` splices a
 re-attached source into the existing broadcast by hop ID so consumers never
@@ -36,8 +39,9 @@ playlist renderers in `rs/moq-hls/src/export` emit it in `init.mp4` and
 segment URLs and the export resets its window when it changes. There is no
 DASH renderer in the tree, so nothing here promises an MPD. Absent means unversioned URLs, never
 a wall-clock or a relay-local counter. The cache-header half stays downstream:
-the edge restores its long `max-age` once the paths it accepts are the ones the
-renderers emit.
+the edge restores its long `max-age` only on generation-bearing URLs once the
+paths it accepts are the ones the renderers emit, and unversioned URLs keep
+`no-store`, since a restart reuses their segment numbers for different bytes.
 
 Acceptance: a mid-broadcast reconfigure that cannot be decoded against the
 previous init gets a new init URL on both edges; a supplied generation appears

--- a/quest/m2/id3.md
+++ b/quest/m2/id3.md
@@ -14,7 +14,9 @@ Define the catalog section and frame contract for complete ID3 tags,
 following the sidecar rule in [SEI section](/quest/m2/sei/sei.md): the ID3
 track belongs to the program's video rendition (its audio rendition when there
 is no video), uses that rendition's group sequence, and stamps each frame with
-the wire timestamp of the tag's presentation time. Carry original tag bytes,
+the wire timestamp of the tag's presentation time. An ID3-only program has no
+rendition to follow, so its track stands alone: one group per tag, stamped from
+the tag's own PTS, with the section saying it accompanies no rendition. Carry original tag bytes,
 and in the section the raw stream-level PMT descriptor loop plus any
 application or program registration metadata the exporter needs to reproduce
 the input. Do not parse the tag into a fixed

--- a/quest/m2/path-patterns/origin.md
+++ b/quest/m2/path-patterns/origin.md
@@ -34,9 +34,11 @@ either hides paths the subscriber may use or leaks the ones it must not, and
 `request_broadcast` resolves against the route table regardless. The
 enforcing shape is a pattern-scoped grant on the consumer handle, narrowed at
 resolution and announce fan-out alike, and changed at runtime through
-[relay revalidation](/quest/m2/path-patterns/relay-auth.md); prove the deafen
-case (a grant excluding one audio path under a room prefix) in the model-layer
-tests here.
+[relay revalidation](/quest/m2/path-patterns/relay-auth.md). Narrowing a live
+grant must also end the subscriptions it no longer covers, not only refuse new
+ones. Prove the deafen case in the model-layer tests here: subscribe under a
+room prefix, revalidate with a grant that excludes that audio path, and assert
+the existing subscription closes and no further objects arrive.
 
 ## Required
 

--- a/quest/m2/plan-revalidation-updates.md
+++ b/quest/m2/plan-revalidation-updates.md
@@ -24,7 +24,18 @@ fields the auth API can legitimately change therefore behave inconsistently:
   announcing under a root the API no longer assigns, but it is a silent hard
   disconnect for what may be a benign rename.
 
-Decide deliberately, per field: update in place, close, or refuse the change.
+Two things are fixed before this decision is made. The
+[relay auth](/quest/m2/path-patterns/relay-auth.md) quest already requires a
+re-check to compare the full versioned grant, reject unsupported, mixed,
+invalid, and out-of-scope grants, and resize a live session with no prefix-only
+widening window; this plan inherits that invariant rather than restating a
+weaker one. And "the alias becomes the token's `root`" describes today's v0
+behavior only: under v1 grants a literal root aliases or rebases the patterns
+and never becomes one, so the canonical alias transformation has to be stated
+before deciding whether an alias change closes or updates a session.
+
+Then decide deliberately, per field: update in place, close, or refuse the
+change.
 Then the implementing quest applies it in `rs/moq-relay/src/auth.rs` with a
 test per field and documents the contract in `doc/bin/relay/auth.md`.
 

--- a/quest/m2/relay-memory.md
+++ b/quest/m2/relay-memory.md
@@ -3,7 +3,10 @@
 ## Goal
 
 A relay's memory scales with what it serves, not with what the mesh knows,
-and the numbers behind that claim are current.
+and the numbers behind that claim are current. Two costs to keep apart when
+measuring: the route table and per-announcement state (`RouteEntry` plus
+`ServeState`) scale with announcements and routes, while the served-content
+cache a `ServeState` materializes scales with demand.
 
 ## Plan
 

--- a/quest/m2/sei/sei.md
+++ b/quest/m2/sei/sei.md
@@ -17,6 +17,12 @@ wire timestamp of the media it accompanies, and carries raw bytes. A 1080p and
 a 360p rendition carry different SEI, so there is one sidecar per video
 rendition, and group 7 of the sidecar holds the SEI for group 7 of its video.
 
+Metadata that precedes the first media unit (an `emsg` before the first
+`moof`, an FLV script tag before the first media tag) rides the rendition's
+first group, ordered before that group's media, stamped with its own
+presentation time when it has one and otherwise with the first media frame's,
+and an exporter emits it before the first media unit.
+
 Within a group the frame's wire timestamp is the key, so an application
 syncing to presentation time reads it directly instead of joining against the
 video track it deliberately did not subscribe to. Several access units can

--- a/quest/m3/teleop/correlation.md
+++ b/quest/m3/teleop/correlation.md
@@ -19,8 +19,12 @@ operator's command to a robot's frame; `timeline.rs`'s `set_wall` is what can.
 
 So the contract is: the robot anchors its video and telemetry timelines, the
 operator anchors its command track, and a recording joins the three on
-`wall + pts`. State the assumption beside the API, and report the anchor's
-presence so a consumer can tell "unsynced" from "synced".
+`wall + pts`, resolving each sample against the latest anchor at or before it
+(the catalog `wall` until a timeline record after a discontinuity carries a
+new one). State the clock assumption beside the API. Report only whether an
+anchor is present; presence says nothing about whether the hosts are synced,
+and a join across unsynced hosts looks valid while being wrong, so synchronization
+is a declared deployment property, never inferred from the data.
 
 This is also the answer to Kyber's headline claim of continuous drift
 computation onto one unified timeline. Worth answering on the merits:


### PR DESCRIPTION
## What

[#3416](https://github.com/moq-dev/moq/pull/3416) merged at an earlier head than the branch tip: auto-merge took `fbf3775` while the branch had two more commits pushed. This carries those two commits onto `main`, unchanged from what was reviewed on that PR:

- the third Codex round: untimed SCTE-35 commands keep the arrival media clock, audio-only export derives its clock from the mapped audio rendition, and an ID3-only program gets a standalone self-timed track;
- the CodeRabbit round: keep the post-await generation guard beside `decoder.reset()`, the rate-control goal states the configured bitrate as the ceiling, one SCTE-35 timestamp contract, pre-media placement in the shared sidecar rule, the init URL hashes the bytes `Muxer::init` produces, unversioned URLs stay `no-store`, narrowing a live grant ends the subscriptions it no longer covers, the revalidation plan inherits relay-auth's full-grant invariant and names the alias transformation, relay-memory separates route-table from served-content cost, and correlation resolves anchors per record and reports presence only.

Every thread on #3416 already has its reply; nothing new is decided here.

## Checks

- `cargo run -p quest -- check` passed on this exact content as the #3416 branch head (233 documents ok). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Fable 5.1)