### PR TITLE
docs(quest): settle scope narrowing in place, and mark pre-media sidecar placement

### DIFF
--- a/quest/m2/plan-revalidation-updates.md
+++ b/quest/m2/plan-revalidation-updates.md
@@ -3,8 +3,11 @@
 ## Goal
 
 A settled contract for which fields a revalidation reply can change on a live
-session and which force a reconnect. Scope narrowing is settled (close, and
-the client reconnects into the narrower grant); `tier` and `alias` are not.
+session and which force a reconnect. Scope narrowing is settled by the
+[relay auth](/quest/m2/path-patterns/relay-auth.md) contract: the session
+stays up, resized to the narrower grant, and only the subscriptions and
+publications the grant no longer covers are closed; `tier` and `alias` are
+not settled.
 Run `/plan-quest`; the settled plan becomes the implementing quest that closes
 the issue.
 

--- a/quest/m2/sei/sei.md
+++ b/quest/m2/sei/sei.md
@@ -19,9 +19,12 @@ rendition, and group 7 of the sidecar holds the SEI for group 7 of its video.
 
 Metadata that precedes the first media unit (an `emsg` before the first
 `moof`, an FLV script tag before the first media tag) rides the rendition's
-first group, ordered before that group's media, stamped with its own
-presentation time when it has one and otherwise with the first media frame's,
-and an exporter emits it before the first media unit.
+first group, stamped with its own presentation time when it has one and
+otherwise with the first media frame's. A timestamp cannot order it before
+that frame, since a tag at timestamp zero and the first frame share one, so
+the sidecar frame's placement field, the same one that records prefix versus
+suffix SEI, carries an explicit before-first-media value, and an exporter
+emits those frames before the first media unit.
 
 Within a group the frame's wire timestamp is the key, so an application
 syncing to presentation time reads it directly instead of joining against the


### PR DESCRIPTION
## What

Two Codex findings that landed on [#3425](https://github.com/moq-dev/moq/pull/3425) after it merged, both text inconsistencies in the quests that PR carried:

- `quest/m2/plan-revalidation-updates.md` said scope narrowing closes the session while the relay-auth contract it now inherits resizes it. The Goal now states the settled behavior: the session stays up, resized, and only the subscriptions and publications the narrower grant no longer covers are closed, matching `path-patterns/origin.md`.
- `quest/m2/sei/sei.md` ordered a pre-media sidecar item by timestamp, which cannot distinguish it from a timestamp-zero item at the first frame. The sidecar frame's placement field (already needed for prefix versus suffix SEI) gains an explicit before-first-media value.

## Checks

- `cargo run -p quest -- check` on the branch. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Fable 5.1)