### PR TITLE
chore: ignore Claude Code's scratch directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,15 @@
 # Ignore local Claude Code config
 *.local.json
 
+# Claude Code scratch space. These are untracked working directories, and
+# `just _changed` counts untracked files, so leaving them visible pushes the
+# changed-file list past its cap and silently turns every scoped `just check`
+# into `check-all`. The worktrees also carry their own biome.jsonc, which the
+# unscoped run then rejects as a nested root config.
+/.claude/cache/
+/.claude/tmp/
+/.claude/worktrees/
+
 # IDE
 .idea
 


### PR DESCRIPTION
## Problem

`_changed` deliberately counts untracked files ("a brand new crate or module is the whole change"). Claude Code writes its cache, temp files, and agent worktrees under `.claude/`, and `.gitignore` had no `.claude` entries beyond `*.local.json`.

On a machine that has run agents, that is not a small number:

```
untracked file count: 23633
of which under .claude/: 23633
  23497 .claude/cache/bench-chat
    118 .claude/tmp/bench-chat
      1 .claude/worktrees/...
```

That is well past `changed_max` (~1500 paths), so `_changed` answers `ALL` and `just check` hands off to `check-all` — every time, no matter how small the diff. And `check-all` then *fails*, because each agent worktree under `.claude/worktrees/` contains its own `biome.jsonc`:

```
× Found a nested root configuration, but there's already a root configuration.
  i The other configuration was found in /home/kixelated/work/moq.
error: "biome" exited with code 1
```

So the scoped checks were simultaneously far slower than designed and incapable of passing. This is local-only — CI checks out a clean tree — which is why it never showed up as a red build, just as a confusing local one.

## Fix

Ignore the three scratch directories. Anchored with a leading `/` so they only match at the repository root, and scoped to the three ephemeral subdirectories rather than `.claude/` wholesale — `.claude/skills/` and the rest of the tracked config stay visible.

## Verification

On the same working tree, before and after:

| | untracked files | `just check` |
|---|---|---|
| before | 23,633 | falls back to `check-all`, then fails on biome |
| after | 0 | scopes normally, **exit 0** |

First `just check` that has passed on this machine all session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLtoPv9B3779kGxLFTUGHR

(written by claude-opus-5[1m])