### PR TITLE
docs(quest): import the post-grooming issues as quests

### DIFF
--- a/quest/README.md
+++ b/quest/README.md
@@ -11,8 +11,8 @@ Milestones sort by kind, which tracks urgency here: m0 fixes what is broken,
 m1 is the dev branch line, m2 grows the surface, m3 explores. The 2026-08
 grooming turned every surviving GitHub issue into a quest and migrated the
 upstream-facing questlines from the downstream moq.pro tree; issues opened
-since are imported in periodic grooming passes, and an issue already fixed on
-`dev` stays open until `dev` merges. New work joins the milestone matching its
+since are imported in periodic grooming passes (the last one on 2026-09-05),
+and an issue already fixed on `dev` stays open until `dev` merges. New work joins the milestone matching its
 kind, at its priority rank.
 
 ## Quests

--- a/quest/m0/3291-moq-net-zero-budget-shedding-drops-discontinuity-markers.md
+++ b/quest/m0/3291-moq-net-zero-budget-shedding-drops-discontinuity-markers.md
@@ -1,0 +1,37 @@
+# [S] moq-net: a zero-budget subscriber still receives discontinuity markers
+
+## Goal
+
+On `dev`, a live-edge subscriber (`max_age` budget of zero, the default)
+still receives an empty group, so the codec reset it marks reaches the
+decoder. Today `is_stale` sheds the empty group the moment a newer group
+exists, the container consumer sees a plain sequence gap, `discontinuity()`
+never bumps, and the decoder is fed the new epoch without a reset.
+
+## Plan
+
+A dev-only regression from the interaction of max-age shedding (#3251) with
+the idle-capture markers (#3214): an empty group's reach is bounded by its
+successor's start, so its age equals the successor's span and a zero budget
+sheds it. With undeclared rewinds going away
+([Monotonic timeline](/quest/m1/monotonic-timeline.md)), the declared marker
+is the only reset signal there is, so losing it is not an option.
+
+Exempt a finished empty group from `is_stale`: it costs nothing to deliver
+and carries the reset. The alternative, having the container layer infer a
+discontinuity from any sequence gap, would fire on every ordinary shed and
+reset decoders that need no reset. State the exemption in the moq-lite draft's
+expiration text if the wording implies every group ages alike.
+
+Test: a producer emits group 1, an empty group, then group 2; a zero-budget
+subscriber observes `[1, 0, 1]` at the transport layer and the container
+consumer's `discontinuity()` bumps once. Fix on `dev`.
+
+## Closes
+
+- [#3291](https://github.com/moq-dev/moq/issues/3291) - close this issue when the quest finishes
+
+## Related
+
+- [Monotonic timeline](/quest/m1/monotonic-timeline.md) - makes the declared marker the only reset signal
+- [#3161](/quest/m1/3161-retention-should-reclaim-idle-open-groups-now-that-expiry.md) - the other open-group lifecycle rule in the same area

--- a/quest/m0/3326-moq-audio-forward-gap-stamps-resampled-output.md
+++ b/quest/m0/3326-moq-audio-forward-gap-stamps-resampled-output.md
@@ -21,9 +21,8 @@ codec rate, since there is no resampler otherwise.
 Track the source timestamp of the samples fed to the resampler alongside the
 samples, so `starts_at` reads the held samples' real origin instead of
 deriving it. A gap larger than the resampler's hold then produces two
-correctly stamped chunks with a hole between them, which is the shape
-[#2981](/quest/m0/2981-moq-audio-nothing-in-the-decode-or-playback-path-models-a.md)
-defines for gaps.
+correctly stamped chunks with a hole between them, which is the shape the
+`dev` gap quest for the decode path (#2981) defines for gaps.
 
 Tests: the 10 ms then 1 s case stamps the first chunk at `0`; contiguous
 packets are unchanged; the activity label follows the corrected stamp.
@@ -31,7 +30,3 @@ packets are unchanged; the activity label follows the corrected stamp.
 ## Closes
 
 - [#3326](https://github.com/moq-dev/moq/issues/3326) - close this issue when the quest finishes
-
-## Related
-
-- [#2981](/quest/m0/2981-moq-audio-nothing-in-the-decode-or-playback-path-models-a.md) - what a gap means in the decode path

--- a/quest/m0/3326-moq-audio-forward-gap-stamps-resampled-output.md
+++ b/quest/m0/3326-moq-audio-forward-gap-stamps-resampled-output.md
@@ -1,0 +1,37 @@
+# [S] moq-audio: a forward timestamp gap stamps resampled output correctly
+
+## Goal
+
+Resampled audio that spans a forward gap in the source timeline is stamped
+where its first sample actually belongs. Today a 10 ms packet at `t = 0`
+followed by a packet at `t = 1s` produces a chunk stamped near `990 ms` whose
+first samples come from `t = 0`, placing that audio almost a second late and,
+since `Frame::activity` is picked by the frame's stamp, labelling active audio
+as withheld.
+
+## Plan
+
+`decode::Consumer::starts_at` derives the chunk's start by subtracting the
+samples the resampler still holds from the new packet's timestamp, which
+assumes the held samples immediately precede it. A forward gap breaks that
+and does not bump the container discontinuity counter, so nothing resets the
+state. Only reachable when `decode::Config::sample_rate` differs from the
+codec rate, since there is no resampler otherwise.
+
+Track the source timestamp of the samples fed to the resampler alongside the
+samples, so `starts_at` reads the held samples' real origin instead of
+deriving it. A gap larger than the resampler's hold then produces two
+correctly stamped chunks with a hole between them, which is the shape
+[#2981](/quest/m0/2981-moq-audio-nothing-in-the-decode-or-playback-path-models-a.md)
+defines for gaps.
+
+Tests: the 10 ms then 1 s case stamps the first chunk at `0`; contiguous
+packets are unchanged; the activity label follows the corrected stamp.
+
+## Closes
+
+- [#3326](https://github.com/moq-dev/moq/issues/3326) - close this issue when the quest finishes
+
+## Related
+
+- [#2981](/quest/m0/2981-moq-audio-nothing-in-the-decode-or-playback-path-models-a.md) - what a gap means in the decode path

--- a/quest/m0/3359-moq-net-subscribe-error-sends-hardcoded-404.md
+++ b/quest/m0/3359-moq-net-subscribe-error-sends-hardcoded-404.md
@@ -1,0 +1,38 @@
+# [S] moq-net: SUBSCRIBE_ERROR carries a registered error code
+
+## Goal
+
+An IETF subscribe the publisher cannot serve is rejected with the error code
+the negotiated draft registers for that reason, never a literal `404`, and
+`Error::NotFound`'s wire value agrees with it. The moq-interop-runner's
+`subscribe-error` and `subscribe-before-announce` cases pass without the
+peer's compatibility branch, which is being removed upstream.
+
+## Plan
+
+Both not-found paths in `rs/moq-net/src/ietf/publisher.rs` call
+`reject_subscribe(.., 404, ..)`, and `reject_subscribe` takes a bare `u64`
+because SUBSCRIBE_ERROR (`0x05`) has no named code type. `TrackStatusCode`
+in `ietf/track.rs` is the wrong registry (TRACK_STATUS). Separately
+`Error::NotFound` maps to `13` in `rs/moq-net/src/error.rs`, so one relay
+signals not-found as `404` on one path and `13` on the other.
+
+Add a named SUBSCRIBE_ERROR code type mapped to the registered values, and
+make it version-aware in the style of the existing `Encode<Version>` /
+`Decode<Version>` impls, since the registry moved between draft-14 and
+draft-19. Use it at both call sites and route `Error::NotFound` through the
+same mapping so the two paths agree. This is the SUBSCRIBE_ERROR half of the
+per-protocol code mapping that
+[#3001](/quest/m1/3001-ietf-stream-resets-send-moq-lite-error-codes-so-routine.md)
+asks for on stream resets; build one table both draw from rather than two.
+
+Tests: the rejection code per negotiated version for a missing broadcast and
+a missing track, and the interop-runner cases against a strict peer.
+
+## Closes
+
+- [#3359](https://github.com/moq-dev/moq/issues/3359) - close this issue when the quest finishes
+
+## Related
+
+- [#3001](/quest/m1/3001-ietf-stream-resets-send-moq-lite-error-codes-so-routine.md) - the stream-reset half of the same per-protocol code mapping

--- a/quest/m0/3360-js-watch-broadcast-is-undefined-at-initialization.md
+++ b/quest/m0/3360-js-watch-broadcast-is-undefined-at-initialization.md
@@ -1,4 +1,4 @@
-# [S] js/watch: `MoqWatch.broadcast` exists from construction
+# [S] js/watch: MoqWatch.broadcast exists from construction
 
 ## Goal
 

--- a/quest/m0/3360-js-watch-broadcast-is-undefined-at-initialization.md
+++ b/quest/m0/3360-js-watch-broadcast-is-undefined-at-initialization.md
@@ -1,0 +1,30 @@
+# [S] js/watch: `MoqWatch.broadcast` exists from construction
+
+## Goal
+
+`moqWatch.broadcast` is usable the moment the element exists, as its
+declared type `broadcast: Broadcast` promises. On 0.5.2 a framework effect
+that reads `moqWatch.broadcast.catalog` right after binding the element hits
+`broadcast is undefined`; it worked on 0.3.2.
+
+## Plan
+
+Either the field is created in the constructor, so it is never undefined,
+or the type stops lying. Prefer the first: `connection` and `backend` are
+constructed eagerly, and a `Broadcast` whose inputs are signals can exist
+before any URL is set, so make `broadcast` the same. If some part of it
+genuinely cannot exist before `connectedCallback`, split that part out and
+keep the field itself eager.
+
+The issue's side question is a real gap too: `catalog` is a getter, not a
+signal, and `observedAttributes` carries `catalog-format` but not `catalog`,
+so a framework cannot react to catalog changes. Expose the catalog as a
+`Getter` on the element and document in `doc/lib/js` how to read a custom
+catalog section from it.
+
+Regression: construct the element, read `broadcast.catalog` before connecting
+it, and subscribe to the catalog signal across a catalog update.
+
+## Closes
+
+- [#3360](https://github.com/moq-dev/moq/issues/3360) - close this issue when the quest finishes

--- a/quest/m0/3361-js-watch-fails-on-firefox-esr.md
+++ b/quest/m0/3361-js-watch-fails-on-firefox-esr.md
@@ -1,4 +1,4 @@
-# [S] js/watch: `<moq-watch>` fails on Firefox ESR
+# [S] js/watch: moq-watch fails on Firefox ESR
 
 ## Goal
 

--- a/quest/m0/3361-js-watch-fails-on-firefox-esr.md
+++ b/quest/m0/3361-js-watch-fails-on-firefox-esr.md
@@ -1,0 +1,27 @@
+# [S] js/watch: `<moq-watch>` fails on Firefox ESR
+
+## Goal
+
+`@moq/watch` plays on Firefox 140 ESR, as 0.3.2 did. On 0.5.2 the element
+dies in an effect with `TypeError: can't access property "Consumer", (void 0)
+is undefined` before playing anything.
+
+## Plan
+
+`(void 0).Consumer` is a module namespace read before that module finished
+evaluating, which is what an import cycle looks like under an evaluator
+that handles cycles differently from Chrome, or a bundle whose output order
+Firefox ESR's module loader resolves differently. It can also be a WebCodecs
+or WebTransport feature the ESR line lacks, surfacing as an undefined
+namespace after a failed dynamic import. Reproduce on Firefox ESR with the
+Svelte page from the issue, bisect between 0.3.2 and 0.5.2, and fix the
+cause: break the cycle or gate the feature with the same detection
+`@moq/watch/support` already does for other capabilities, so the element
+reports what is missing rather than throwing from an effect.
+
+Firefox is not in the browser harness. Add it to `test/wasm`'s Playwright
+matrix if the harness can drive it, or record why it cannot.
+
+## Closes
+
+- [#3361](https://github.com/moq-dev/moq/issues/3361) - close this issue when the quest finishes

--- a/quest/m0/3363-js-watch-audio-only-stream-does-not-resume.md
+++ b/quest/m0/3363-js-watch-audio-only-stream-does-not-resume.md
@@ -1,0 +1,32 @@
+# [S] js/watch: an audio-only stream resumes every time the publisher unmutes
+
+## Goal
+
+A subscriber on an audio-only broadcast keeps playing each time the publisher
+toggles `muted` back to `false`, not only the first time. Today the second and
+every later unmute is detected, played, and immediately closed, until the
+publisher reloads its page, which buys exactly one more resume.
+
+## Plan
+
+Reproduce with `just relay`, a `<moq-watch>` on a `hang`, and a `<moq-publish>`
+started `invisible` and `muted`, toggling `muted` a few times. Two candidate
+mechanisms, and the fix depends on which one it is:
+
+- The publisher side retracts and re-creates the audio rendition or its
+  track on each toggle, and `js/watch` treats the second appearance of the
+  same rendition name as the end of the one it was playing (a stale
+  `closed` handler from the first subscription evicting the second, the
+  shape [#2985](/quest/m1/2985-js-net-path-keyed-publisher-state-goes-stale-when-a.md)
+  describes on the publisher side).
+- The watch audio backend keys its "already started" state on the rendition
+  and never re-arms after the track ends, so the resubscribe races its own
+  teardown.
+
+Find which by logging track lifetimes on both ends, fix it where the state
+goes stale rather than by retrying the subscribe, and add a `js/watch` test
+that unmutes three times and asserts audio frames keep arriving after each.
+
+## Closes
+
+- [#3363](https://github.com/moq-dev/moq/issues/3363) - close this issue when the quest finishes

--- a/quest/m0/README.md
+++ b/quest/m0/README.md
@@ -16,8 +16,14 @@ regression test per Root Cause First.
 ## Quests
 
 - [#2405](/quest/m0/2405-js-net-connect-logs-on-every-connection-at-the-wrong.md) - js/net: connect logs print the JWT in the relay URL
+- [#3361](/quest/m0/3361-js-watch-fails-on-firefox-esr.md) - js/watch: `<moq-watch>` throws from an effect on Firefox ESR, a regression since 0.3.2
+- [#3360](/quest/m0/3360-js-watch-broadcast-is-undefined-at-initialization.md) - js/watch: `MoqWatch.broadcast` is undefined at construction although its type says otherwise
+- [#3363](/quest/m0/3363-js-watch-audio-only-stream-does-not-resume.md) - js/watch: an audio-only stream resumes only the first time the publisher unmutes
+- [#3359](/quest/m0/3359-moq-net-subscribe-error-sends-hardcoded-404.md) - moq-net: SUBSCRIBE_ERROR sends a literal 404 instead of the draft's registered code
 - [Adapter namespace map](/quest/m0/rs-adapter-namespace-map.md) - moq-net: a duplicate PUBLISH_NAMESPACE on draft-14/15 strands the first request, and the map never shrinks
 - [#3080](/quest/m0/3080-fix-watch-audio-ring-truncate-can-race-the-worklet-reader.md) - watch: an audio ring truncate can race the worklet reader for one quantum
+- [#3326](/quest/m0/3326-moq-audio-forward-gap-stamps-resampled-output.md) - moq-audio: a forward timestamp gap stamps resampled output almost a second late
+- [#3291](/quest/m0/3291-moq-net-zero-budget-shedding-drops-discontinuity-markers.md) - moq-net (dev): zero-budget shedding drops the empty group that marks a codec reset
 - [#2833](/quest/m0/2833-moq-export-ts-a-rewound-timeline-stalls-the-si-table.md) - moq export ts: a rewound timeline stalls SI tables, PCR, and pacing until the media clock catches up
 - [#2799](/quest/m0/2799-moq-video-capture-negotiates-twice-so-a-window-resize.md) - moq-transcode: the ladder follows a source resolution change instead of keeping the one it started with
 - [Group charge](/quest/m0/group-charge.md) - charge real per-group cost so MOQ_CACHE_CAPACITY bounds real memory

--- a/quest/m2/3247-moq-audio-cpal-allocates-on-the-audio-thread.md
+++ b/quest/m2/3247-moq-audio-cpal-allocates-on-the-audio-thread.md
@@ -1,0 +1,34 @@
+# [S] moq-audio: no allocator call on the audio thread when cpal reports an error
+
+## Goal
+
+A cpal stream error raised from the real-time render thread reaches
+`moq-audio` without an allocation or a free on that thread. Today cpal's
+`From<coreaudio::Error>` runs `format!` on the render thread before our
+callback sees the error, and the callback then drops the owned `Error`,
+freeing on the same thread; either can block on the allocator lock and cause
+a dropout, exactly when playback is already degraded.
+
+## Plan
+
+`FailureReporter::report` in `rs/moq-audio/src/playback/driver.rs` is already
+allocation-free (atomics and `Thread::unpark`). What remains is upstream and
+the hand-off:
+
+- Raise it with cpal: allocation-free error emission on the RT paths (a
+  `&'static str` message, or deferring the `format!` to a non-RT thread),
+  which is where the dominant allocation lives. Carry the upstream PR as
+  part of this quest and pin the release that includes it.
+- Pre-check in `moq-audio` what can be checked before `stream.play()`, so
+  fewer errors are raised from the render path at all.
+- Document the residual constraint beside the driver: the callback owns the
+  `Error`, so the overflow path still drops it on the callback thread, and no
+  bounded hand-off removes that entirely.
+
+Test: an allocation-counting harness around the error callback, the same
+shape the capture-callback quest used, proving no allocation or free after
+construction on the paths this repo controls.
+
+## Closes
+
+- [#3247](https://github.com/moq-dev/moq/issues/3247) - close this issue when the quest finishes

--- a/quest/m2/README.md
+++ b/quest/m2/README.md
@@ -67,6 +67,7 @@ can act on. Each still carries its own plan and regression test.
 - [Cluster flags](/quest/m2/cluster-flags.md) - a discovery mechanism carries its own prerequisites, so an incomplete cluster config cannot be expressed
 - [Plan: revalidation updates](/quest/m2/plan-revalidation-updates.md) - settle which fields an auth re-check may update on a live session and which force a reconnect
 - [#3137](/quest/m2/3137-moqsrc-bound-the-pending-rendition-subscriptions-a.md) - moqsrc: bound the pending rendition subscriptions a catalog can open
+- [#3247](/quest/m2/3247-moq-audio-cpal-allocates-on-the-audio-thread.md) - moq-audio: cpal allocates and frees on the audio thread when it reports a stream error
 - [#3115](/quest/m2/3115-moqsink-the-publication-has-no-generation-so-a-flush.md) - moqsink: a flushing restart after EOS opens a new publication generation
 - [#709](/quest/m2/709-automatic-letsencrypt-support.md) - the relay provisions and renews its own ACME certificate over HTTP-01, persisted on disk
 - [Room SDK](/quest/m2/room-sdk.md) - a headless room package: a room is a path prefix, no service, no storage


### PR DESCRIPTION
## What

The grooming pass the quest audit (#3416) asked for, over the open issues that had no quest. Of the 45 listed there, the grooming PR (#3239) already accounts for most as fixed-on-`dev` (they close with the merge) or stale. The rest triage as:

- **Fixed on `dev` since, so they close with the merge, no quest**: #3171 (#3176), #3172 (#3177), #3173 (#3180), #3174 (#3178), #3260 (#3282).
- **Kept open as a bare report, no quest**: #2812, which #3345 already judged unreproducible.
- **Imported, seven quests with a plan each**:
  - m0: #3361 (Firefox ESR regression), #3360 (`broadcast` undefined at construction), #3363 (audio-only stream resumes once), #3359 (SUBSCRIBE_ERROR sends 404; builds one code table with the stream-reset half in #3001), #3326 (resampler stamps across a forward gap), #3291 (`dev`: zero-budget shedding drops the discontinuity marker; exempts a finished empty group from `is_stale`, which is the only reset signal once rewinds go).
  - m2: #3247 (cpal allocates on the audio thread; upstream fix plus pre-checks plus a documented residual).

The root README's grooming sentence now dates the last pass.

## Checks

- `cargo run -p quest -- check` on the branch. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Fable 5.1)