### PR TITLE
chore(moq-audio,moq-cli): assert publish_capture stays Send off macOS

### DIFF
--- a/rs/moq-audio/src/capture.rs
+++ b/rs/moq-audio/src/capture.rs
@@ -284,8 +284,8 @@ pub(crate) async fn open(config: &Config) -> Result<Stream, Failure> {
 
 /// An open microphone.
 ///
-/// Holds the live `cpal` stream, which is `!Send`, so build and use it on a
-/// single task. Buffers arrive from the realtime callback over an async channel.
+/// Holds the live `cpal` stream, which keeps capturing until it is dropped.
+/// Buffers arrive from the realtime callback over an async channel.
 pub(crate) struct Microphone {
 	// Kept alive to keep capturing; dropping it stops the stream.
 	_stream: cpal::Stream,
@@ -346,10 +346,9 @@ async fn failure(errors: &kio::Consumer<Option<cpal::Error>>) -> Option<Failure>
 impl Microphone {
 	/// Open (and start) the requested microphone.
 	///
-	/// The cpal calls block inline rather than going through [`blocking`]: a
-	/// `cpal::Stream` is `!Send` and so can't be built on another thread and
-	/// moved here. They return as soon as the device starts; the await is the
-	/// first-buffer wait below.
+	/// The cpal calls run inline rather than going through [`blocking`]: they
+	/// return as soon as the device starts, so the only real wait is the
+	/// first-buffer await below.
 	async fn open(selector: Option<&str>, config: &Config) -> Result<Self, Failure> {
 		// Fail fast on a denied/restricted mic (macOS TCC) instead of opening a
 		// stream that silently delivers nothing. A no-op on other platforms.

--- a/rs/moq-audio/src/encode/capture.rs
+++ b/rs/moq-audio/src/encode/capture.rs
@@ -712,6 +712,23 @@ pub async fn publish_capture<E: CatalogExt>(
 	.await
 }
 
+/// Off macOS, [`publish_capture`]'s future must stay `Send` so a server can
+/// `tokio::spawn` it. This is never called; it exists only to fail compilation
+/// if the future ever regains a `!Send` component. macOS is exempt: the TCC
+/// prompt and ScreenCaptureKit both hold ObjC handles across an await.
+#[cfg(not(target_os = "macos"))]
+#[allow(dead_code)]
+fn assert_publish_capture_send(
+	broadcast: moq_net::broadcast::Producer,
+	catalog: moq_mux::catalog::Producer,
+	capture: capture::Config,
+	encode: Options,
+	clock: moq_mux::Clock,
+) {
+	fn is_send<T: Send>(_: &T) {}
+	is_send(&publish_capture(broadcast, catalog, capture, encode, clock));
+}
+
 /// A capture backend as the supervisor sees it. Kept separate from cpal so the
 /// retry and cancellation lifecycle can be tested without audio hardware.
 trait CaptureSource {

--- a/rs/moq-cli/src/publish.rs
+++ b/rs/moq-cli/src/publish.rs
@@ -372,8 +372,9 @@ impl Publish {
 				// broadcast + catalog. A single shared clock keeps the audio and
 				// video timelines aligned even though the devices open at
 				// different times. Video encodes on demand (camera opens only
-				// while subscribed); audio (cpal) is blocking, so it runs on a
-				// dedicated thread.
+				// while subscribed). Both run on this task rather than a spawn:
+				// on macOS the audio future holds ObjC handles across an await,
+				// so it is `!Send`.
 				let clock = moq_mux::Clock::new();
 				let video_fut = {
 					let broadcast = self.broadcast.clone();

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -153,7 +153,6 @@ pub struct DmaBufExport {
 	fd: OwnedFd,
 	// The producer's lease, held so its buffer outlives the descriptor. Only the
 	// renderer ever reads it back out, through `into_parts`.
-	#[cfg_attr(not(feature = "render"), expect(dead_code))]
 	inner: Arc<dyn DmaBufFrame>,
 }
 


### PR DESCRIPTION
Follow-up from #3356. While reviewing that PR I noticed `moq_video::encode::publish_capture` carries a compile-time `Send` assertion (`assert_publish_capture_send`) so a server can always `tokio::spawn` it, and `moq_audio::encode::publish_capture` carries nothing. The audio comments explained the difference with a claim that turns out to be false.

## Root cause

`cpal::Stream` is `Send`. cpal asserts it in every backend (`assert_stream_send!(Stream)` in coreaudio, alsa, wasapi, jack, aaudio, ...) as far back as 0.17, and this repo has been on 0.18 since moq-audio landed. Two comments in `capture.rs` said the opposite, and one of them used that premise to justify opening the device inline instead of through the crate's own `blocking` helper.

Compiling the moq-video assertion against moq-audio locally reports exactly two root causes, both macOS-gated ObjC values held across an await:

- the `RcBlock` completion handler in the TCC permission pre-check (`capture/permission.rs`)
- `SCStream` / `NSArray<SCDisplay>` in the ScreenCaptureKit system-audio backend (`capture/screencapture.rs`)

Neutralize those two and the assertion compiles, which means everything else on the path (the cpal stream, the converter, kio, the moq producers) is already `Send`. Off macOS those branches do not exist, so the audio future is `Send` there. That is the same exemption moq-video takes, so moq-audio can take it too.

## Changes

- Add `assert_publish_capture_send` to `moq-audio`, gated `#[cfg(not(target_os = "macos"))]`, mirroring moq-video. Never called; it exists to fail compilation if the future regains a `!Send` component.
- Correct the two `cpal::Stream` is `!Send` comments. The inline-open rationale keeps describing what the code does and loses the false premise. Whether that open should move onto `blocking` is a separate question this PR deliberately leaves alone.
- Correct the moq-cli comment claiming audio "runs on a dedicated thread". Both capture futures are `try_join!`ed on one task, and have been since the comment was written; the real reason they are joined rather than spawned is the `!Send` macOS path.

## Unrelated CI unblock, in the second commit

The first push went red on a moq-video lint that this branch does not touch, and the diagnosis is worth recording because it is latent on `main` right now.

`DmaBufExport::inner` carries `#[cfg_attr(not(feature = "render"), expect(dead_code))]`. Whenever that attribute is active the expectation is unfulfilled, because the field is still read by `into_parts` (dead there itself), so it fires as an error under `-D warnings`. Nothing had compiled that combination: `just check` selects the crates a branch changed, and a moq-video PR selects moq-video, whose defaults include `render`, so the attribute is never inserted. It takes a branch that selects moq-video's *dependents* without moq-video to reach it, which is exactly this one:

```
cargo clippy --all-targets --package libmoq --package moq-audio --package moq-boy --package moq-cli --package moq-ffi -- -D warnings
```

There moq-video builds with the dependents' feature union, `dmabuf` on and `render` off. Dropping the attribute from the field fixes it; `into_parts` keeps its own, which really is dead without the renderer. Any future PR scoped to moq-video's dependents would have hit the same wall.

No behavior change in either commit: the added audio code is `cfg`'d out on macOS and never called, and the moq-video change removes an attribute.

## Test plan

- `just fix` clean, no reformatting.
- `just check` clean locally (macOS, so it reaches neither the new assertion nor the dmabuf code).
- `just test`: 344 pass. `moq-audio aec::tests::survives_a_moving_echo_delay` hit the 60s nextest timeout while `just check` was saturating the same machine; re-run uncontended it passes in 26.3s. Nothing in this diff compiles on macOS, so it cannot reach that test.
- Linux CI is what validates both changes: the new assertion only compiles off macOS, and the dmabuf lint only exists on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)