### PR TITLE
docs: correct claims found during merge review

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -83,9 +83,10 @@ moq ... import capture --camera 0 --width 1280 --height 720 --fps 30 --bitrate 3
 Video goes through the platform hardware encoder (VideoToolbox, Media
 Foundation, NVENC, VAAPI, V4L2 M2M) with a built-in H.264 software fallback;
 audio is Opus. The camera is opened only while someone is watching, and
-`--bitrate` is a ceiling the encoder lowers to fit the connection's bandwidth
-estimate. `moq devices` prints every source id. Requires the `capture`
-feature; on Linux that needs libclang, V4L2, and ALSA headers.
+`--bitrate` is the opening ceiling. Backends with live bitrate control lower it
+to fit the connection's bandwidth estimate. `moq devices` prints every source
+id. Requires the `capture` feature; on Linux that needs libclang, V4L2, and
+ALSA headers.
 
 ## Transcode
 

--- a/doc/concept/use-case/ai.md
+++ b/doc/concept/use-case/ai.md
@@ -18,20 +18,21 @@ latency budget, video skippable, prompts fully reliable, all on one connection.
 ## Faster than real time
 
 A TTS model emits a whole sentence in a burst with timestamps in the future.
-WebRTC renders on arrival; MoQ delivers the burst and the player paces it. In
-the browser, set a latency ceiling on [`<moq-watch>`](/lib/js/watch#buffered-playback)
-to buffer ahead and call `reset()` on an interruption. The
+WebRTC keeps buffering and playout inside its media engine; MoQ exposes the
+timestamped burst to the application, and the player paces it. In the browser,
+set a latency ceiling on [`<moq-watch>`](/lib/js/watch#buffered-playback) to
+buffer ahead and call `reset()` on an interruption. The
 [Pipecat](https://github.com/pipecat-ai/pipecat) voice-agent framework ships
 a MoQ transport built on this.
 
 ## Inference on demand
 
-Announcements and the catalog are cheap and always flow, but media is only
-transmitted once someone subscribes to a track, and a publisher can defer
-encoding until then too. A `captions`
-track backed by Whisper runs only while a viewer has captions on. Object
-detection can consume a 360p 10 fps rendition while the full-resolution track
-stays idle until a human asks for it.
+Announcements and catalog metadata can advertise tracks before their frames
+exist. Media frames are transmitted only once someone subscribes to the track,
+and a publisher can defer encoding until then too. A `captions` track backed by
+Whisper runs only while a viewer has captions on. Object detection can consume
+a 360p 10 fps rendition while the full-resolution track stays idle until a
+human asks for it.
 
 ## Media and data together
 

--- a/doc/concept/use-case/distribution.md
+++ b/doc/concept/use-case/distribution.md
@@ -16,8 +16,9 @@ A conventional player downloads whole segments sequentially over TCP (the
 low-latency variants split them into parts, which helps but keeps the shape). When the network degrades,
 the current segment queues, the next one can't start, and the player can't
 switch renditions until the boundary. Bufferbloat sets in, playback freezes,
-and the player grows its buffer to avoid a repeat. Segments also sit on disk
-until complete, which is why smaller segments only help so much.
+and the player grows its buffer to avoid a repeat. Conventional segments are
+also published only once complete, which is why smaller segments only help so
+much.
 
 ## What MoQ does instead
 

--- a/doc/concept/use-case/index.md
+++ b/doc/concept/use-case/index.md
@@ -12,6 +12,6 @@ of scale come from.
 | Use case | Replaces | Why MoQ fits |
 | --- | --- | --- |
 | [Distribution](/concept/use-case/distribution) | HLS, DASH | Sub-second latency at CDN scale, with the viewer choosing its buffer. |
-| [Contribution](/concept/use-case/contribution) | RTMP, SRT | Pull-based, so renditions are only encoded when wanted, with redundant ingest for free. |
+| [Contribution](/concept/use-case/contribution) | RTMP, SRT | Pull-based delivery, optional on-demand encoding, and simple redundant ingest. |
 | [Conferencing](/concept/use-case/conferencing) | WebRTC | Bidirectional on one session, browser control of the pipeline, no SDP or TURN. |
 | [AI](/concept/use-case/ai) | WebRTC, WebSockets | Adjustable reliability, on-demand inference, media and prompts on one connection. |

--- a/doc/index.md
+++ b/doc/index.md
@@ -20,7 +20,7 @@ features:
   - icon:
       src: /emoji/rocket.svg
     title: Low latency
-    details: Every group of frames rides its own QUIC stream, so congestion drops old media instead of delaying new media.
+    details: Independent QUIC streams let congestion drop old media instead of delaying new media, while tiny single-frame groups can use datagrams.
 
   - icon:
       src: /emoji/stonk.svg
@@ -42,8 +42,9 @@ features:
 
 Media over QUIC (MoQ) is a live media protocol built on QUIC. A publisher
 sends a **broadcast** made of **tracks**; each track is a series of **groups**
-(a group of pictures, a second of audio, one JSON snapshot) delivered over
-independent QUIC streams. Relays forward and cache those groups without parsing
+(a group of pictures, a second of audio, one JSON snapshot). Most groups use
+independent QUIC streams; eligible single-frame groups can use unreliable
+datagrams. Relays forward and cache the stream-delivered groups without parsing
 them, so the same infrastructure carries video, audio, and arbitrary data.
 
 This project is the reference implementation: a Rust relay and toolchain, a

--- a/doc/lib/c/index.md
+++ b/doc/lib/c/index.md
@@ -9,7 +9,8 @@ description: libmoq, the stable C ABI over the Rust core
 
 `libmoq` exposes MoQ to C, C++, and any language with a C FFI through a
 stable ABI: a generated `moq.h`, a static `libmoq.a` that links the whole Rust
-runtime in, and a dynamic library. The [OBS plugin](/bin/obs) is built on it.
+runtime in, and a pkg-config file for its native link dependencies. The
+[OBS plugin](/bin/obs) is built on it.
 
 ## Install
 

--- a/doc/lib/dart/index.md
+++ b/doc/lib/dart/index.md
@@ -30,7 +30,7 @@ final broadcast = await moq.requestBroadcast('live/camera');
 ```
 
 ```dart
-// Publish
+// Publish. bytes comes from your encoder or application source.
 final mine = moq.createBroadcast('live/camera');
 final track = mine.publishTrack(name: 'video', info: null);
 track.appendGroup().writeFrame(frame: MoqFrame(payload: bytes));

--- a/doc/lib/rs/moq-video.md
+++ b/doc/lib/rs/moq-video.md
@@ -20,10 +20,10 @@ ffmpeg, no GStreamer, no system codec to install.
 
 Highlights:
 
-- **Automatic backend selection**, hardware first. Linux GPU libraries are `dlopen`ed at runtime, so one binary starts anywhere and warns when it falls back to software. openh264 is statically linked as the H.264 fallback; H.265 is hardware-only; AV1 decodes via NVDEC.
+- **Automatic backend selection**, hardware first. Linux GPU libraries are `dlopen`ed at runtime, so one binary starts anywhere and warns when it falls back to software. openh264 is statically linked as the H.264 fallback; H.265 is hardware-only; AV1 decodes via NVDEC. The VAAPI encoder is compile-verified but not yet validated on hardware.
 - **Publish on demand.** `encode::publish_capture` advertises the track up front and opens the camera only while someone subscribes.
-- **Zero-copy where the platform allows.** Frames stay as `CVPixelBuffer`, D3D11 textures, CUDA memory, Android `AHardwareBuffer`s, or DMA-BUFs through resize, transcode, and render; `Surface::into_i420()` and `into_rgba()` are the universal exits.
-- **Bitrate control** that retunes a live encoder without a keyframe, so a congestion controller can drive it.
+- **Zero-copy where the platform allows.** Matching codec backends consume their native GPU surfaces directly. The renderer imports `CVPixelBuffer` and supported DMA-BUF formats; other combinations use the universal `Surface::into_i420()` and `into_rgba()` CPU exits.
+- **Live bitrate control** where the selected backend supports it, without forcing a keyframe. An unsupported backend keeps its opening rate.
 - **Device enumeration** for cameras, displays, windows, and apps, matching `moq devices`.
 
 ```rust


### PR DESCRIPTION
## Summary

- distinguish stream-delivered groups from eligible datagrams
- correct the C artifact, WebRTC playout, GPU surface, and bitrate-control descriptions
- qualify on-demand encoding and conventional segment publication claims

## Test plan

- `nix develop --command just fix`
- final CI check and test

Follow-up to #3426, which merged while these review corrections were being prepared.

(Written by GPT-5)