### PR TITLE
docs(moq-audio): scope the local-task guidance to macOS

### DIFF
--- a/rs/moq-audio/src/encode/capture.rs
+++ b/rs/moq-audio/src/encode/capture.rs
@@ -184,9 +184,10 @@ impl Publication {
 	/// Register one stable audio track and return its control handle and driver.
 	///
 	/// The initial source is enabled, but opens only while the track has a
-	/// subscriber. Await [`Driver::run`] on a local task because native capture
-	/// streams are not `Send`; [`Publication`] itself is `Send + Sync`, so the
-	/// controls can live anywhere.
+	/// subscriber. On macOS the driver's future is `!Send`, because the permission
+	/// prompt and ScreenCaptureKit hold ObjC handles across an await, so await
+	/// [`Driver::run`] on a local task there; elsewhere it can be spawned.
+	/// [`Publication`] itself is `Send + Sync`, so the controls can live anywhere.
 	///
 	/// The track is registered here, but its catalog rendition describes the
 	/// source's PCM layout, so the driver probes for that first and registers the
@@ -1754,7 +1755,7 @@ mod tests {
 		task.await.unwrap().unwrap();
 	}
 
-	/// The controls are meant to live away from the `!Send` capture driver.
+	/// The controls are meant to live away from the capture driver.
 	#[test]
 	fn publication_controls_cross_threads() {
 		fn assert_send_sync<T: Send + Sync>() {}

--- a/rs/moq-audio/src/playback.rs
+++ b/rs/moq-audio/src/playback.rs
@@ -117,8 +117,8 @@ impl Engine {
 			shared: shared.clone(),
 		};
 
-		// cpal streams are `!Send`, so the device has to live on the thread that
-		// opens it.
+		// Everything slow or fallible about the device happens here, off the async
+		// runtime: opening it, switching it, and rebuilding it after an error.
 		std::thread::Builder::new()
 			.name("moq-audio-playback".into())
 			.spawn(move || driver::run(requests, commands, shared, config.device, opened))

--- a/rs/moq-audio/src/playback/driver.rs
+++ b/rs/moq-audio/src/playback/driver.rs
@@ -1,8 +1,7 @@
 //! The thread that owns the cpal output stream.
 //!
-//! A `cpal::Stream` is `!Send`, so it has to live on the thread that built it.
-//! That thread also owns everything slow or fallible about the device: opening
-//! it, switching it, and rebuilding it after an error. Sinks never talk to it on
+//! That thread owns everything slow or fallible about the device: opening it,
+//! switching it, and rebuilding it after an error. Sinks never talk to it on
 //! the hot path; they register themselves in [`Shared`] and hand their consumer
 //! straight to the mixer.
 


### PR DESCRIPTION
Follow-up to #3433, which merged before this correction was ready.

Codex flagged it on that PR: #3433 added a compile-time assertion that `publish_capture`'s future is `Send` off macOS, but `Publication::new`'s doc still told *every* caller to await `Driver::run` on a local task "because native capture streams are not `Send`". That steered server callers away from `tokio::spawn` on Linux and Windows for a reason that does not apply there, and the stated cause was the same false `cpal::Stream` is `!Send` claim #3433 set out to remove.

## Changes

- `Publication::new`: say where the constraint applies and why. On macOS the driver's future is `!Send` because the TCC permission prompt and ScreenCaptureKit hold ObjC handles across an await; elsewhere it can be spawned. `Publication` stays `Send + Sync` either way.
- The same false claim justified the playback thread in two more places (`playback.rs` and `playback/driver.rs`). Drop it there too. The thread still earns itself on the reason the surrounding docs already give, which is that it owns the slow and fallible device work, so nothing about that design changes.
- A test doc comment calling the capture driver `!Send` unconditionally loses the qualifier.

Comments only. No code, no behavior, no API change.

## Test plan

- `just fix` clean, no reformatting.
- Doc comments only, so nothing compiled changes; CI covers the rustdoc build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)