### PR TITLE
chore: remove redundant packaging work and plan relay ownership fixes

### DIFF
--- a/.github/workflows/release-js.yml
+++ b/.github/workflows/release-js.yml
@@ -39,9 +39,4 @@ jobs:
         run: nix develop --command bun install --frozen-lockfile
 
       - name: Release packages
-        # Web-component packages register custom elements via global type
-        # augmentations, which JSR's fast-type check rejects. Allow slow types so
-        # the JSR publish succeeds; npm still ships full .d.ts files.
-        env:
-          JSR_ALLOW_SLOW_TYPES: "true"
         run: nix develop --command bun --filter '*' release

--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ This repository provides both [Rust](rs) and [TypeScript](js) libraries with sim
 | **[@moq/demo](demo/web)** | Examples using `@moq/hang`.                                                                                  |                                                                                                       |
 | **[@moq/watch](js/watch)**         | Subscribe to and render MoQ broadcasts (Web Component + JS API).                                                        | [![npm](https://img.shields.io/npm/v/@moq/watch)](https://www.npmjs.com/package/@moq/watch)     |
 | **[@moq/publish](js/publish)**     | Publish media to MoQ broadcasts (Web Component + JS API).                                                               | [![npm](https://img.shields.io/npm/v/@moq/publish)](https://www.npmjs.com/package/@moq/publish) |
-| **[@moq/ui-core](js/ui-core)**     | Shared UI components (Button, Icon, Stats, CSS theme) used by `@moq/watch/ui` and `@moq/publish/ui`.                    | [![npm](https://img.shields.io/npm/v/@moq/ui-core)](https://www.npmjs.com/package/@moq/ui-core) |
 
 ## Protocol
 

--- a/js/common/package.ts
+++ b/js/common/package.ts
@@ -87,7 +87,6 @@ function rewriteWorkspaceDependency(dependencies?: Record<string, string>) {
 
 // Convert workspace dependencies to published versions
 rewriteWorkspaceDependency(pkg.dependencies);
-rewriteWorkspaceDependency(pkg.devDependencies);
 rewriteWorkspaceDependency(pkg.peerDependencies);
 
 pkg.devDependencies = undefined;

--- a/js/common/release.ts
+++ b/js/common/release.ts
@@ -83,10 +83,6 @@ if (publishJsr) {
 		"--no-check",
 		"--allow-dirty",
 	];
-	// Only libs publish to JSR now (web components opt out), and their built
-	// .d.ts has explicit types, so slow types shouldn't appear. Keep this as a
-	// safety valve the release workflow can toggle without a code change.
-	if (process.env.JSR_ALLOW_SLOW_TYPES === "true") args.push("--allow-slow-types");
 	if (dryRun) {
 		console.log(`🧪 Publishing ${name}@${version} to JSR (dry-run)...`);
 		args.push("--dry-run");

--- a/quest/m0/README.md
+++ b/quest/m0/README.md
@@ -27,5 +27,6 @@ regression test per Root Cause First.
 - [#3326](/quest/m0/3326-moq-audio-held-resampler-frames-keep-their-source-timestamp.md) - moq-audio: held resampler frames keep their source timestamp
 - [#2799](/quest/m0/2799-moq-video-capture-negotiates-twice-so-a-window-resize.md) - moq-transcode: the ladder follows a source resolution change instead of keeping the one it started with
 - [Group charge](/quest/m0/group-charge.md) - charge real per-group cost so MOQ_CACHE_CAPACITY bounds real memory
+- [Cache governor lifetime](/quest/m0/cache-governor-lifetime.md) - stop the headroom task after setup failure or the last owner drops
 - [uring all-features](/quest/m0/uring-all-features-build.md) - moq-uring does not compile with `--all-features`, so the nightly features gate fails on it
 - [Go smoke client](/quest/m0/smoke-go-client.md) - the interop matrix has no Go client, so nothing in CI exercises the Go wrapper

--- a/quest/m0/cache-governor-lifetime.md
+++ b/quest/m0/cache-governor-lifetime.md
@@ -1,0 +1,37 @@
+# [S] Cache governor stops with its owner
+
+## Goal
+
+A relay configured with cache headroom leaves no memory-sampling task behind
+after setup fails or its last owning handle is dropped. Repeatedly loading and
+dropping relays in one runtime does not accumulate governors. Keep the existing
+capacity and headroom behavior while the relay is alive.
+
+## Plan
+
+`rs/moq-relay/src/cache.rs` starts `governor(pool.clone(), ...)` in
+`CacheConfig::init` and discards the `JoinHandle`. The governor holds a strong
+pool clone and loops forever. Neither `Cache` nor `Cluster` owns its shutdown.
+`Relay::load` starts it before the fallible `Cluster::new` and client TLS build,
+so both a later setup error and normal relay teardown strand the task. This is
+visible in the ownership paths; add a runtime reproduction before fixing it.
+
+- Remove the detached lifetime. Prefer an owned task guard or a driver that
+  stops with its owner, using the existing cluster lifetime rather than a new
+  process-wide task registry or shutdown callback.
+- Keep the driver alive when an embedder moves `Relay::cluster` out of `Relay`
+  or clones it for sessions. Dropping the temporary `Cache` during setup must
+  not stop an otherwise live relay. Decide explicitly whether a separately
+  retained pool also retains the governor.
+- Cover setup failure after governor creation, normal last-owner drop, and
+  dropping one of several cluster handles. Use task completion or an owned
+  drop probe to prove shutdown, not just unchanged cache capacity. The
+  last-owner regression must fail with the current detached spawn restored.
+- Update `doc/bin/relay/config.md` if the ownership contract needs explanation
+  for embedders. Avoid changing public construction shapes just to attach a
+  guard; if a published API must break, target `dev`.
+
+## Related
+
+- [Construct the cluster origin once](/quest/m1/cluster-construction.md) -
+  attaching cache settings should not replace an already exposed origin

--- a/quest/m1/README.md
+++ b/quest/m1/README.md
@@ -57,6 +57,7 @@ with the current dev tree before starting.
 - [#933](/quest/m1/933-video-rotation-metadata-not-propagated-from-mobile-camera.md) - Video rotation metadata not propagated from mobile camera publish to watch renderer
 - [#3056](/quest/m1/3056-watch-video-decoder-captures-the-rewind-generation-at.md) - watch: video decoder captures the rewind generation at output time, not submit time
 - [Config provenance](/quest/m1/config-provenance.md) - the merge records which source set a value, so TOML survives CLI defaults and empty lists, and env outranks the file
+- [Cluster construction](/quest/m1/cluster-construction.md) - construct one stable origin after its cache settings are known, deleting the rebuilding builder
 - [#3046](/quest/m1/3046-fold-moq-token-into-moq-token-via-a-usage-executable-view.md) - Fold moq-token into moq token via a Usage executable view
 - [#3126](/quest/m1/3126-moq-bench-every-readme-example-fails-to-parse-and.md) - moq-bench: every README example fails to parse, and cumulative latency percentiles cannot be windowed to steady state
 - [#816](/quest/m1/816-expose-transportconfig.md) - QUIC flow-control windows on quic::Client and quic::Server, applied or refused per backend

--- a/quest/m1/cluster-construction.md
+++ b/quest/m1/cluster-construction.md
@@ -1,0 +1,36 @@
+# [M] Construct the cluster origin once
+
+## Goal
+
+A cluster exposes one stable origin from construction onward. Applying cache
+settings cannot silently detach previously derived origin handles or stats
+publishers. Callers do not need to know the order of origin-rebuilding methods.
+
+## Plan
+
+`rs/moq-relay/src/cluster.rs` constructs an origin in `Cluster::new`, exposes
+it through the public `origin` field, then constructs another in `with_cache`.
+It retains `info` alongside the live origin to support that replacement and
+rebinds `nodes` afterward. A caller can clone `cluster.origin` or attach stats
+before calling `with_cache`; those handles keep the old origin. Consuming
+`self` in the builder does not prevent this because the origin is cloneable.
+`Relay::load` orders these calls correctly, but the public API only documents
+the prerequisite that the origin must still be pristine.
+
+- Put origin-defining settings into construction, using one options struct
+  with defaults. Construct the origin and its node view once, after the cache
+  pool, retention ceiling, identity, and linger are known.
+- Delete the origin-rebuilding `with_cache` path and any stored construction
+  state that has no remaining purpose. Keep builders that only attach
+  independent services if they do not invalidate existing handles.
+- Migrate `Relay::load` and audit external embedder usage before removing the
+  published method. This is a `dev` change. Do not add a compatibility shim
+  that retains the same origin replacement hazard.
+- Verify that configured cache settings reach the same origin used by serving,
+  node discovery, and stats. Cover the API shape at compile time where possible
+  and exercise publish/consume through a retained origin handle.
+
+## Related
+
+- [Cache governor lifetime](/quest/m0/cache-governor-lifetime.md) - the
+  headroom task needs an owner that survives moving or cloning the cluster


### PR DESCRIPTION
## Summary

- Delete dev-dependency rewriting immediately before those dependencies are discarded, and remove the JSR slow-types exception now that web-component packages opt out of JSR.
- Remove the README entry for the deleted UI package.
- Add two quests for relay ownership problems: a detached cache governor that survives teardown, and a builder that replaces an already exposed cluster origin.

## Public API changes

None. The ownership changes are plans only; the cluster construction quest targets `dev`. No wire, package-version, or cross-package behavior changes.

## Test plan

- `just fix` and `git diff --check` passed.
- Local `just check` passed type checks, package builds, formatting, and validation of all 247 quest documents, then stopped at the workflow checker because Bun 1.2 parses YAML `on` as `true`. `just gh check` passed with installed Bun 1.3.13; actionlint passed for the changed workflow.
- All eight JSR libraries passed `deno publish --dry-run` without `--allow-slow-types`.
- `just test`: 1,098 passed; the RSA sign/verify test exceeded its five-second timeout. The same test passed unchanged in isolation in 1.7 seconds.
- Nix initialization stalled, so validation used the local-toolchain fallback.

(written by GPT-6)
