### PR TITLE
fix(moq-audio): give the publish-then-read tests an age budget

### DIFF
--- a/rs/moq-audio/src/decode/consumer.rs
+++ b/rs/moq-audio/src/decode/consumer.rs
@@ -743,8 +743,12 @@ mod tests {
 			&subscriber,
 			&catalog,
 			"audio",
+			// These tests publish a whole track up front and read it back afterwards,
+			// so every packet but the last is already old by the time the consumer
+			// looks. The default budget is zero, which sheds all of them.
 			Config {
 				sample_rate: Some(out_rate),
+				max_age: std::time::Duration::from_secs(1),
 				..Config::new()
 			},
 		)
@@ -860,9 +864,17 @@ mod tests {
 			.unwrap();
 		let subscriber = broadcast.consume();
 		let mut producer = moq_mux::container::Producer::new(track, moq_mux::catalog::hang::Container::Legacy);
-		let mut consumer = Consumer::new(&subscriber, &catalog, "audio", Config::new())
-			.await
-			.unwrap();
+		let mut consumer = Consumer::new(
+			&subscriber,
+			&catalog,
+			"audio",
+			Config {
+				max_age: std::time::Duration::from_secs(1),
+				..Config::new()
+			},
+		)
+		.await
+		.unwrap();
 
 		// A 20 ms packet at 0, then the next one at 22.5 ms: the 2.5 ms packet
 		// between them was lost.
@@ -947,9 +959,17 @@ mod tests {
 			.unwrap();
 		let subscriber = broadcast.consume();
 		let mut producer = moq_mux::container::Producer::new(track, moq_mux::catalog::hang::Container::Legacy);
-		let mut consumer = Consumer::new(&subscriber, &catalog, "audio", Config::new())
-			.await
-			.unwrap();
+		let mut consumer = Consumer::new(
+			&subscriber,
+			&catalog,
+			"audio",
+			Config {
+				max_age: std::time::Duration::from_secs(1),
+				..Config::new()
+			},
+		)
+		.await
+		.unwrap();
 
 		let pcm = vec![0.25f32; encoder.frame_size()];
 		for packet in 0..2 {

--- a/rs/moq-audio/src/encode/producer.rs
+++ b/rs/moq-audio/src/encode/producer.rs
@@ -862,7 +862,14 @@ mod tests {
 		};
 		let mut producer = Producer::new(&mut broadcast, catalog, input, &options).unwrap();
 
-		let track = consumer.track("audio").unwrap().subscribe(None).await.unwrap();
+		// A whole second goes out before the first read, so the default budget of zero
+		// would shed all but the last packet and the first PTS read would be the tail's.
+		let track = consumer
+			.track("audio")
+			.unwrap()
+			.subscribe(moq_net::track::Subscription::default().with_max_age(Duration::from_secs(1)))
+			.await
+			.unwrap();
 		let mut reader = moq_mux::container::Consumer::new(track, moq_mux::container::legacy::Wire);
 
 		// A second of audio, so the filter's delay is nowhere near the whole write.


### PR DESCRIPTION
## Summary

`dev` has been red since the last `main` merge (`ac69338ad`): four `moq-audio` tests fail, two by assertion and two by hanging until the nextest timeout. This blocks every `dev`-based PR, which is how I found it (while landing [#3418](https://github.com/moq-dev/moq/pull/3418)).

## Root cause

The tests arrived with [#3386](https://github.com/moq-dev/moq/pull/3386), written against `main`, where the decode budget was `latency_max: Option<Duration>` and defaulted to `None`, meaning never shed. `dev` had already replaced that with `max_age: Duration`, whose `Default` is `Duration::ZERO` and, per its own doc comment, "skips aggressively". The merge reconciled the two APIs and adapted three of #3386's tests by adding `max_age: Duration::from_secs(1)`, but four more sites kept the default.

Every one of those four publishes an entire track before it reads anything back, so by the time the consumer looks, all but the newest packet is older than a zero budget permits and gets shed:

- `a_missing_packet_leaves_a_hole` saw only the second of its two packets: 2 frames stamped from `stamps[1]` instead of the expected 4.
- `resampling_does_not_shift_the_first_pts` read a first PTS of 1_960_000 instead of 1_000_000, i.e. 0.96 s into the one second of audio it had just written.
- `a_lost_opus_packet_shorter_than_its_neighbour_is_a_gap` and `opus_pre_skip_does_not_leave_a_timestamp_hole` write each packet as its own group, so their `read()` waits forever on groups that were skipped. That is the CI timeout.

Nothing is wrong with the shedding default or with the decode logic these tests cover. The tests simply aren't playing back, so they should not be subject to a playback budget.

## Fix

Give the four sites the same one-second budget the three already-adapted tests carry:

- the `pcm_gaps` helper in `decode/consumer.rs`, covering `a_missing_packet_leaves_a_hole` and `millisecond_stamps_are_not_a_gap`
- `a_lost_opus_packet_shorter_than_its_neighbour_is_a_gap` and `opus_pre_skip_does_not_leave_a_timestamp_hole`
- the subscription in `resampling_does_not_shift_the_first_pts`

Test-only; no production code changes.

## Test plan

- `cargo test -p moq-audio`: 173 passed, 0 failed, 1 ignored (plus the doc/integration targets), against 172 passed / 1 failed / 2 hung before.
- `cargo test -p moq-audio --lib decode::consumer`: 11 passed, previously 2 failed and 2 hung past 60 s.
- Confirmed the failures reproduce on plain `origin/dev` with no changes applied, so this is the base and not any one PR.
- `just fix` clean.

## Cross-Package Sync

No row applies: this touches only `moq-audio`'s own tests. No wire, catalog, FFI, config, or CLI surface moves, so no `drafts/` or `doc/` update is due.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by claude-opus-5[1m])