### PR TITLE
perf(net): avoid redundant chunk copies and plan performance investigations

### DIFF
--- a/js/net/src/stream.test.ts
+++ b/js/net/src/stream.test.ts
@@ -306,6 +306,29 @@ test("Reader stream with partial reads", async () => {
 	expect(await reader.done()).toBe(true);
 });
 
+test("Reader owns streamed chunks and preserves returned views across fills", async () => {
+	const first = new Uint8Array([99, 1, 2, 99]);
+	const second = new Uint8Array([99, 3, 4, 5, 99]);
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			controller.enqueue(first.subarray(1, 3));
+			controller.enqueue(second.subarray(1, 4));
+			controller.close();
+		},
+	});
+	const reader = new Reader(stream);
+	const head = await reader.read(1);
+	first.fill(0);
+	expect(head).toEqual(new Uint8Array([1]));
+	const joined = await reader.read(3);
+	second.fill(0);
+	expect(joined).toEqual(new Uint8Array([2, 3, 4]));
+	joined.fill(0);
+	expect(head).toEqual(new Uint8Array([1]));
+	expect(await reader.read(1)).toEqual(new Uint8Array([5]));
+	expect(await reader.done()).toBe(true);
+});
+
 test("Reader u53 decodes two-byte stream type prefixes", async () => {
 	const { stream, written } = createTestWritableStream();
 	const writer = new Writer(stream);

--- a/js/net/src/stream.ts
+++ b/js/net/src/stream.ts
@@ -204,10 +204,10 @@ export class Reader {
 			throw new Error("unexpected empty chunk");
 		}
 
-		const buffer = new Uint8Array(result.value);
+		const buffer = result.value;
 
 		if (this.#buffer.byteLength === 0) {
-			this.#buffer = buffer;
+			this.#buffer = new Uint8Array(buffer);
 		} else {
 			const temp = new Uint8Array(this.#buffer.byteLength + buffer.byteLength);
 			temp.set(this.#buffer);

--- a/quest/m2/README.md
+++ b/quest/m2/README.md
@@ -28,6 +28,12 @@ can act on. Each still carries its own plan and regression test.
   ACK progress, reliable reset, hierarchical scheduling, and qmux
 - [Bandwidth estimate release](/quest/m2/web-transport-bandwidth-estimate.md) - web-transport-quinn reports quinn's BBR bandwidth estimate and ships a release carrying it
 - [#2847](/quest/m2/2847-the-quinn-backends-send-bandwidth-estimate-is-cwnd-rtt.md) - quinn backend: bump to the releases that report the controller bandwidth estimate instead of cwnd/rtt
+- [Benchmark comparisons](/quest/m2/performance-comparisons.md) - retained evidence, repeated paired runs, and uncertainty for performance claims
+- [Relay profiling](/quest/m2/performance-profiles.md) - reproducible CPU and allocation captures under the existing workloads
+- [Browser benchmarks](/quest/m2/browser-benchmarks.md) - measure JS transport, container, decode, and render costs in an identified browser
+- [Reader buffering](/quest/m2/stream-buffering.md) - measure and bound repeated prefix copying under fragmented input
+- [Traffic counter contention](/quest/m2/stats-contention.md) - quantify shared atomic accounting costs across fanout workers
+- [CMAF copies](/quest/m2/cmaf-copy-budget.md) - establish and reduce the browser container copy budget without changing ownership
 - [Relay memory](/quest/m2/relay-memory.md) - remeasure what an announcement costs after prefix routes
 - [Route gauge](/quest/m2/route-gauge.md) - an operator sees how many routes a relay holds for a path
 - [PoP skipping](/quest/m2/pop-skipping/README.md) - short cold paths for unpopular broadcasts without losing warm backhaul dedup

--- a/quest/m2/browser-benchmarks.md
+++ b/quest/m2/browser-benchmarks.md
@@ -1,0 +1,39 @@
+# [M] Browser transport and media performance benchmarks
+
+## Goal
+
+A reproducible browser suite measures JS transport and media costs that the Rust
+Criterion targets and native relay load generator do not exercise.
+
+## Plan
+
+`bench/run.sh::criterion_targets` discovers Cargo targets only. Existing JS unit
+tests validate behavior, and `test/wasm` validates browser interop, but neither
+provides a repeatable JS performance comparison. Reuse the existing relay/browser
+harness pieces and add a focused recipe with artifacts under the benchmark
+conventions. Microbenchmarks may run in Bun; browser conclusions must come from
+an identified browser version on a real WebTransport connection.
+
+- Cover `js/net/src/stream.ts` with buffered controls, fragmented varints, and
+  payloads from small audio through large keyframes. Sweep chunk sizes and record
+  CPU, wall time, allocation volume, GC pauses, and bytes copied where measurable.
+- Cover CMAF encode/decode with fixed audio/video fixtures and multiple samples.
+  Keep fixture generation and relay startup outside timed intervals.
+- Add publish/watch scenarios measuring delivered/decoded/presented frames,
+  dropped frames, decode queue depth, long tasks, heap trend, and tail frame delay.
+  Fix codec, resolution, framerate, device, visibility, and hardware acceleration;
+  a hidden tab or hardware decode change invalidates a comparison.
+- Run warmup and repeated alternating base/current samples. Separate network,
+  decode, and render costs; report unsupported metrics as unavailable. Include
+  payload checksums/counts so skipping work cannot look like a speedup.
+- Retain browser traces and environment metadata. Keep timing opt-in initially;
+  a bounded smoke lane should fail for crashes, missing output, or invalid samples,
+  not for an arbitrary percentage slowdown on a shared CI runner.
+- Demonstrate A/A variability and detect an injected copy-heavy variant without
+  conflating instrumentation overhead with normal playback cost.
+
+## Related
+
+- [Reader buffering](/quest/m2/stream-buffering.md) - fragmented receive workloads
+- [CMAF copies](/quest/m2/cmaf-copy-budget.md) - container workload and ownership checks
+- [Benchmark comparisons](/quest/m2/performance-comparisons.md) - reporting conventions

--- a/quest/m2/browser-benchmarks.md
+++ b/quest/m2/browser-benchmarks.md
@@ -7,7 +7,7 @@ Criterion targets and native relay load generator do not exercise.
 
 ## Plan
 
-`bench/run.sh::criterion_targets` discovers Cargo targets only. Existing JS unit
+`rs/scripts/bench.sh::criterion_targets` discovers Cargo targets only. Existing JS unit
 tests validate behavior, and `test/wasm` validates browser interop, but neither
 provides a repeatable JS performance comparison. Reuse the existing relay/browser
 harness pieces and add a focused recipe with artifacts under the benchmark

--- a/quest/m2/cmaf-copy-budget.md
+++ b/quest/m2/cmaf-copy-budget.md
@@ -1,0 +1,42 @@
+# [M] Measure and reduce JS CMAF payload copies
+
+## Goal
+
+Establish the allocation/copy budget of CMAF encode/decode and remove redundant
+work where it measurably improves media throughput without changing bytes or
+sample-buffer ownership.
+
+## Plan
+
+`js/hang/src/container/cmaf/encode.ts::encodeDataSegment` serializes the moof twice
+to resolve `trun.dataOffset`, copies the payload into a fresh mdat buffer, then
+concatenates library output into the final segment. In
+`decode.ts::decodeDataSegment`, `new Uint8Array(mdatData.slice(...))` can copy a
+sample twice when the parser returns an ordinary Uint8Array. Confirm the parser's
+actual runtime types and ownership before treating that expression as removable.
+`toArrayBuffer` also materializes parser input. These are observed operations;
+their share of end-to-end playback cost is not yet measured.
+
+- Use fixed Opus/AAC and H.264/AV1 fixtures at several sample sizes, including large
+  keyframes and multi-sample fragments. Measure encode/decode separately, recording
+  payload bytes copied, allocation count/volume, CPU, and GC time in Bun and a
+  supported browser. Keep fixture construction outside timing.
+- Inspect the locked ISO-BMFF library's accepted buffer types, write ownership,
+  and parser lifetimes. Prefer its maintained buffer/scatter facilities over a new
+  handwritten container parser. Compare eliminating duplicate copies first;
+  separately evaluate serializing headers once without assuming a fixed moof size.
+- Preserve independent writable sample results and support subarrays with nonzero
+  offsets. Returning views instead of copies may pin whole segments or allow one
+  caller's mutation to affect another, so measure retained memory as well as churn.
+- Validate decoded payload identity, sample order, timescale conversion, signed
+  composition offsets, flags, durations, and invalid-input handling. Roundtrip
+  against existing fixtures and another parser where available; verify encoded
+  wire bytes remain equivalent before calling this a pure implementation change.
+- Land only measured improvements with a regression for the removed redundant
+  work and ownership tests that retain/mutate outputs across later calls. Record
+  no-win results rather than replacing library code on intuition alone.
+
+## Related
+
+- [Browser benchmarks](/quest/m2/browser-benchmarks.md) - container and playback measurement
+- [Reader buffering](/quest/m2/stream-buffering.md) - upstream payload assembly costs

--- a/quest/m2/performance-comparisons.md
+++ b/quest/m2/performance-comparisons.md
@@ -1,0 +1,42 @@
+# [M] Retain benchmark evidence and quantify comparison noise
+
+## Goal
+
+`just bench BASE` produces repeatable, inspectable comparisons with an uncertainty
+estimate and preserved evidence, so a small reported speedup can be evaluated.
+
+## Plan
+
+`bench/run.sh` runs each relay workload once as base then current. Its runtime
+matrix already rotates order and reports medians, but the revision comparison
+does neither. `cleanup` deletes the run directory, including Criterion estimates,
+load/host JSONL, relay logs, and summaries. Preserve the existing default command
+while extending this harness rather than creating another benchmark runner.
+
+- Add configurable repeated paired rounds, alternate base/current order, and
+  perform warmup outside the measured window. Keep the current load generator,
+  workload, backend, and resolved settings identical for both revisions.
+- Save individual paired results and report median paired deltas plus a documented
+  dispersion/confidence estimate. Flag insufficient or noisy samples instead of
+  implying precision from a single ratio. Retain Criterion's own statistics.
+- Add an artifact destination retaining raw JSONL, summaries, Criterion data,
+  stdout/stderr, exact revision and dirty patch, build flags, tool versions,
+  hardware/kernel, allocator, affinity, workload, and execution order. Preserve
+  partial evidence on failure while still cleaning up owned processes/worktrees.
+- Distinguish throughput-window counters from cumulative latency/loss. Today
+  `bench/relay.sh::summarize_load` differences bytes over the last five seconds but
+  reads final lifetime latency and group-loss counters. Label that explicitly;
+  consume windowed data when the existing latency quest supplies it. Never
+  subtract percentiles or call cumulative loss a steady-state sample.
+- Compare CPU per delivered byte/frame only at comparable offered load, delivery,
+  and loss. Track load-generator CPU/saturation too: sharing a loopback host can
+  hide a relay win behind generator limits. Record io_uring worker metrics with
+  the same time bounds when available.
+- Test the reducer with synthetic stable, noisy, missing, invalid, and known-delta
+  samples. Validate an unchanged-revision A/A run and a deliberately degraded
+  fixture; keep normal machine timing informational rather than a flaky CI gate.
+
+## Related
+
+- [Windowed latency](/quest/m1/3126-moq-bench-every-readme-example-fails-to-parse-and.md) - owns histogram/window semantics
+- [Relay profiling](/quest/m2/performance-profiles.md) - shares workload and artifact conventions

--- a/quest/m2/performance-comparisons.md
+++ b/quest/m2/performance-comparisons.md
@@ -7,10 +7,10 @@ estimate and preserved evidence, so a small reported speedup can be evaluated.
 
 ## Plan
 
-`bench/run.sh` runs each relay workload once as base then current. Its runtime
-matrix already rotates order and reports medians, but the revision comparison
-does neither. `cleanup` deletes the run directory, including Criterion estimates,
-load/host JSONL, relay logs, and summaries. Preserve the existing default command
+`rs/scripts/bench.sh` runs each relay workload once as base then current,
+without repeated rounds or alternating execution order. `cleanup` deletes the run
+directory, including Criterion estimates, load/host JSONL, relay logs, and
+summaries. Preserve the existing default command
 while extending this harness rather than creating another benchmark runner.
 
 - Add configurable repeated paired rounds, alternate base/current order, and
@@ -24,8 +24,8 @@ while extending this harness rather than creating another benchmark runner.
   hardware/kernel, allocator, affinity, workload, and execution order. Preserve
   partial evidence on failure while still cleaning up owned processes/worktrees.
 - Distinguish throughput-window counters from cumulative latency/loss. Today
-  `bench/relay.sh::summarize_load` differences bytes over the last five seconds but
-  reads final lifetime latency and group-loss counters. Label that explicitly;
+  `rs/scripts/bench.sh::summarize_load` differences bytes over the last five seconds
+  but reads final lifetime latency and group-loss counters. Label that explicitly;
   consume windowed data when the existing latency quest supplies it. Never
   subtract percentiles or call cumulative loss a steady-state sample.
 - Compare CPU per delivered byte/frame only at comparable offered load, delivery,

--- a/quest/m2/performance-profiles.md
+++ b/quest/m2/performance-profiles.md
@@ -1,0 +1,45 @@
+# [M] Reproducible relay CPU and allocation profiles
+
+## Goal
+
+One local recipe captures a symbolized relay profile under an existing workload,
+with enough metadata to reproduce it and distinguish relay cost from load-generator
+cost. Profiling is opt-in and has no production overhead when disabled.
+
+## Plan
+
+`bench/run.sh` and `bench/relay.sh` already own the builds, relay PID, workload,
+and host samples, but have no profiler integration. Reuse that lifecycle instead
+of adding a second launcher. `Cargo.toml` already has a `profiling` profile and
+`rs/moq-tokio/src/jemalloc.rs` already supports on-demand heap dumps.
+
+- Add a focused `just` recipe selecting workload, duration, and capture mode through
+  one configuration. Reuse locked builds and the existing profiling Cargo profile;
+  record frame-pointer flags, features, compiler, OS/kernel, CPU, runtime, affinity,
+  allocator, exact revision, dirty diff, and resolved workload alongside the result.
+- Capture the relay process and all its workers, excluding the load generator.
+  Start sampling after readiness and mark the measurement window. Keep an
+  uninstrumented control run to quantify profiler overhead.
+- Support symbolized CPU stacks on Linux with perf and on macOS with a maintained
+  profiler such as samply. Probe tool/platform permissions and report unsupported
+  captures clearly. Do not silently substitute wall-clock timing for CPU samples.
+- Reuse jemalloc's supported build/configuration and signal listener for heap
+  snapshots before load, at steady state, and after teardown. Include allocation
+  churn as well as retained bytes; snapshots alone cannot establish allocation rate.
+  Never send a profiling signal before verifying the listener is active.
+- Retain raw captures, symbols or binary identity, commands, logs, and a locally
+  viewable report in a caller-selected artifact directory. On cancellation or a
+  failed capture, stop owned profiler/load/relay children and preserve diagnostics.
+- Validate on one supported Linux host and macOS. A smoke capture must contain
+  resolved MoQ frames, the intended PID/window, and nonempty samples. Exercise an
+  unavailable profiler and an interrupted run without leaving children behind.
+
+Tool references: [samply](https://github.com/mstange/samply) and the existing
+[jemalloc controls](https://jemalloc.net/jemalloc.3.html) are starting points;
+verify current supported versions and pin any newly installed tools.
+
+## Related
+
+- [Benchmark comparisons](/quest/m2/performance-comparisons.md) - repeatable results and artifact metadata
+- [Traffic counter contention](/quest/m2/stats-contention.md) - a concrete CPU attribution experiment
+- [Relay memory](/quest/m2/relay-memory.md) - retained route and announcement memory

--- a/quest/m2/performance-profiles.md
+++ b/quest/m2/performance-profiles.md
@@ -8,10 +8,10 @@ cost. Profiling is opt-in and has no production overhead when disabled.
 
 ## Plan
 
-`bench/run.sh` and `bench/relay.sh` already own the builds, relay PID, workload,
-and host samples, but have no profiler integration. Reuse that lifecycle instead
+`rs/scripts/bench.sh` already owns the builds, relay PID, workload, and host
+samples, but has no profiler integration. Reuse that lifecycle instead
 of adding a second launcher. `Cargo.toml` already has a `profiling` profile and
-`rs/moq-tokio/src/jemalloc.rs` already supports on-demand heap dumps.
+`rs/moq-native/src/jemalloc.rs` already supports on-demand heap dumps.
 
 - Add a focused `just` recipe selecting workload, duration, and capture mode through
   one configuration. Reuse locked builds and the existing profiling Cargo profile;

--- a/quest/m2/stats-contention.md
+++ b/quest/m2/stats-contention.md
@@ -40,5 +40,6 @@ Reference: [Linux cache-line contention analysis](https://www.kernel.org/doc/htm
 
 ## Related
 
+- [Session micro-costs](/quest/m1/perf/session-micro.md) - owns ingress stats batching; this quest measures cross-worker contention and egress fanout
 - [Cache shard](/quest/m1/perf/cache-shard.md) - separate shared recency-counter bottleneck
 - [Relay profiling](/quest/m2/performance-profiles.md) - reproducible CPU attribution

--- a/quest/m2/stats-contention.md
+++ b/quest/m2/stats-contention.md
@@ -1,0 +1,44 @@
+# [M] Measure shared traffic-counter contention during fanout
+
+## Goal
+
+Quantify the CPU cost of enabled traffic accounting across workers, and reduce it
+only if measurements justify a change while preserving exact accounting semantics.
+
+## Plan
+
+In `rs/moq-net/src/stats.rs`, `BroadcastEntry::tier` shares one `Arc<TierCounters>`
+per broadcast/tier. `Meter::bytes`, `frames`, `group`, and `datagram` update relaxed
+atomics on those shared counters. Many viewers of the same broadcast can update
+the same words from different workers. Relaxed ordering still requires cache-line
+ownership; whether this materially limits relay fanout needs measurement.
+The existing group microbenchmarks use untagged model handles and do not establish
+this cost. This is distinct from the cache pool's global recency counter.
+
+- Benchmark accounting disabled versus enabled at the same fixed delivered load.
+  Sweep 1/2/4/8 workers, same-broadcast versus distinct-broadcast traffic, realistic
+  audio/video chunk sizes, and stream versus datagram delivery. Include normal
+  and frequent metrics scrapes to expose aggregation cost.
+- Add a focused tagged-model benchmark and run the relay fanout workload. Report
+  cycles/instructions per delivered byte/frame, throughput, p99 latency, and the
+  load generator's headroom. Separate same-word contention from false sharing.
+- On supported Linux hardware, use perf c2c to locate contended cache lines;
+  ordinary CPU profiles and scaling curves remain useful where PMU support is
+  absent. Do not report unsupported counters as zero.
+- Compare worker/session-local aggregation or bounded batching before assuming
+  padding is sufficient: padding cannot remove contention on the same atomic.
+  Avoid adding a thread-local lookup or global lock to every payload operation.
+- Preserve monotonic snapshots, tier/path attribution, exact final totals, stale
+  and datagram accounting, and lifecycle gauges on abort, cancellation, handoff,
+  and last-drop. Bound delayed visibility explicitly if batching is chosen, and
+  bound shard memory when sessions or broadcasts churn.
+- Retain a change only with repeatable wins and no material single-worker or
+  disabled-accounting regression. A measured negligible cost closes this quest
+  without changing production counters.
+
+Reference: [Linux cache-line contention analysis](https://www.kernel.org/doc/html/latest/kernel-hacking/false-sharing.html).
+
+## Related
+
+- [Cache shard](/quest/m1/perf/cache-shard.md) - separate shared recency-counter bottleneck
+- [Relay profiling](/quest/m2/performance-profiles.md) - reproducible CPU attribution

--- a/quest/m2/stream-buffering.md
+++ b/quest/m2/stream-buffering.md
@@ -1,0 +1,44 @@
+# [M] Bound JS reader copy cost under fragmented input
+
+## Goal
+
+Measure and, if justified, make fragmented payload assembly linear in payload
+size without changing decoded bytes, error behavior, or returned-buffer ownership.
+
+## Plan
+
+`js/net/src/stream.ts::Reader.#fill` allocates a combined buffer and copies the
+entire unread prefix whenever another chunk arrives. `#fillTo` and `readAll`
+repeat this operation. For N equal chunks retained until one read completes,
+coalescing copies grow with N squared. Removing an intermediate incoming-chunk
+copy reduces constants but leaves that mechanism intact. This is source evidence,
+not a measured browser bottleneck yet.
+
+- Benchmark the current Reader with fixed total payloads (1 KiB, 64 KiB, 1 MiB,
+  and a bounded large keyframe), split into 1-byte, 1 KiB, 16 KiB, and whole-payload
+  chunks. Bound the pathological baseline so the experiment itself cannot exhaust
+  memory. Include streaming small reads, unread leftovers, and `readAll`.
+- Count payload allocations/copied bytes separately from elapsed time and GC.
+  Compare a chunk queue with one final copy against geometric capacity growth.
+  Account for retained backing buffers: a small returned view can pin a large
+  arena, and growing/reusing storage must not mutate earlier returned results.
+- Preserve isolation from caller-owned streamed chunks, nonzero byte offsets,
+  EOF/reset propagation, size limits, and exact cross-chunk varint behavior.
+  Test input mutation after reads and retain results across subsequent fills.
+- Evaluate BYOB only as a separately measured option. The Reader's comment claims
+  WebTransport workers cannot use it, while the current WebTransport specification
+  exposes readable byte streams. Verify actual browser/worker support and fallback
+  transports before changing that assumption; spec support is not runtime proof.
+- Keep the async API unchanged. Coordinate buffer/cursor changes with the existing
+  synchronous-decoder quest, which owns control-first ordering and queue removal.
+- Accept an implementation only with linear copy/allocation evidence on the
+  fragmented path and no material regression for already-buffered/single-chunk
+  reads. Commit a bounded regression that fails when repeated prefix copying
+  returns, plus browser before/after results or a documented no-win conclusion.
+
+Reference: [WebTransport receive streams and BYOB](https://www.w3.org/TR/webtransport/).
+
+## Related
+
+- [Synchronous decode](/quest/m2/2850-js-net-give-reader-a-synchronous-decode-so-the-publisher.md) - owns decoder and control ordering changes
+- [Browser benchmarks](/quest/m2/browser-benchmarks.md) - reusable measurement harness


### PR DESCRIPTION
## Summary

- Remove the intermediate incoming-chunk copy when the JS Reader joins buffered data. The combined buffer already owns a copy, so the extra allocation adds work without improving isolation. Add coverage for subarray offsets, input mutation, and retained output views.
- Add six scoped quests for fragmented reader buffering, shared traffic-counter contention, CMAF copies, CPU/allocation profiling, repeatable benchmark comparisons, and browser benchmarks. Each names source evidence, workloads, metrics, and acceptance criteria.

A local allocation probe assembling 1 MiB from sixteen 64 KiB chunks dropped from 31 to 16 payload allocations, removing 960 KiB of temporary copying. Wall-clock samples were too noisy to claim a speedup.

## Public API changes

None. No package versions change.

## Wire behavior changes

None. Decoded bytes, buffering ownership, errors, and delivery semantics are preserved. Rust/API/spec synchronization is unnecessary for this internal JS allocation change.

## Test plan

- `just fix origin/main`, `just check origin/main`, and `just test default origin/main` passed locally using Nix-provided Bun 1.3.13. The full Nix shell was unavailable due to stalled startup; CI covers the complete pinned toolchain.
- The targeted net suite passed 508 tests on the main-base code; subsequent changes only correct quest references and clarify overlap with existing work.
- Quest validation passed all 253 documents. `git diff --check origin/main...HEAD` passed.
- CI Check and Test passed on final head `18b1f6fa5`. The local test recipe passed 1,100 tests.

(written by GPT-6)
