### PR TITLE
docs: track the play test gap, the retirement race, and finished-track reachability

### DIFF
--- a/quest/m0/README.md
+++ b/quest/m0/README.md
@@ -20,6 +20,7 @@ regression test per Root Cause First.
 - [Adapter namespace map](/quest/m0/rs-adapter-namespace-map.md) - moq-net: a duplicate PUBLISH_NAMESPACE on draft-14/15 strands the first request, and the map never shrinks
 - [IETF error codes](/quest/m0/ietf-error-codes.md) - every code on a moq-transport wire is a registered value for the negotiated draft, requests and stream resets alike
 - [Resume info](/quest/m0/resume-info-newest.md) - moq-net: resume reports segment zero's track info, so a replaced broadcast rescales timestamps on the predecessor's timescale
+- [Track re-announce](/quest/m0/track-finish-reannounce.md) - moq-net: a finished track's name is unreachable through a relay, however often the publisher re-creates it
 - [#3080](/quest/m0/3080-fix-watch-audio-ring-truncate-can-race-the-worklet-reader.md) - watch: an audio ring truncate can race the worklet reader for one quantum
 - [#3363](/quest/m0/3363-js-watch-a-broadcast-republished-on-one-session-keeps-resuming.md) - js/watch: a broadcast republished under its name on one session keeps resuming
 - [#3361](/quest/m0/3361-js-every-moq-package-a-package-imports-is-declared.md) - js: every @moq package a package imports is a declared dependency
@@ -28,4 +29,6 @@ regression test per Root Cause First.
 - [Group charge](/quest/m0/group-charge.md) - charge real per-group cost so MOQ_CACHE_CAPACITY bounds real memory
 - [Cache governor lifetime](/quest/m0/cache-governor-lifetime.md) - stop the headroom task after setup failure or the last owner drops
 - [uring all-features](/quest/m0/uring-all-features-build.md) - moq-uring does not compile with `--all-features`, so the nightly features gate fails on it
+- [play tests](/quest/m0/play-feature-tests.md) - moq-cli: the `play` module is off by default, so nothing in the merge gate compiles its tests
 - [Go smoke client](/quest/m0/smoke-go-client.md) - the interop matrix has no Go client, so nothing in CI exercises the Go wrapper
+- [Retirement race](/quest/m0/transcode-retirement-race.md) - moq-transcode: the retirement boundary regression test only catches the bug when it loses a race

--- a/quest/m0/play-feature-tests.md
+++ b/quest/m0/play-feature-tests.md
@@ -12,8 +12,8 @@ locally without ever being compiled.
 `#[cfg(feature = "play")]` in `main.rs`, so the whole module (its `mod tests`
 included) is compiled out of every default build. `just check`, `just test`,
 and check.yml are default features only, which means the merge gate never sees
-these tests, and neither does a developer running `just test -p moq-cli` after
-editing the file.
+these tests, and neither does a developer running `just rs test -p moq-cli`
+after editing the file.
 
 The one thing that runs them is nightly's `just rs features`, whose last step
 is `nextest run --locked --workspace --all-targets --all-features`. That is

--- a/quest/m0/play-feature-tests.md
+++ b/quest/m0/play-feature-tests.md
@@ -1,0 +1,49 @@
+# [M] moq-cli: nothing in the merge gate runs the play tests
+
+## Goal
+
+A broken test in `rs/moq-cli/src/play.rs` fails the pull request that broke it.
+Today it fails nothing a reviewer sees, and the module's tests report green
+locally without ever being compiled.
+
+## Plan
+
+`play` is off by default in `rs/moq-cli/Cargo.toml`, and `mod play` is
+`#[cfg(feature = "play")]` in `main.rs`, so the whole module (its `mod tests`
+included) is compiled out of every default build. `just check`, `just test`,
+and check.yml are default features only, which means the merge gate never sees
+these tests, and neither does a developer running `just test -p moq-cli` after
+editing the file.
+
+The one thing that runs them is nightly's `just rs features`, whose last step
+is `nextest run --locked --workspace --all-targets --all-features`. That is
+post-merge, once a day, and sequential behind a `--no-default-features`
+workspace check and an `--all-features` clippy, either of which failing means
+the tests never run at all. [uring all-features](/quest/m0/uring-all-features-build.md)
+is that exact failure on dev.
+
+So a test that cannot pass reads green through review. #3381 shipped one; a
+reviewer caught it, not the gate.
+
+### Shape
+
+Most of what the tests cover does not need the device stacks. `Playback`,
+`AudioTimeline`, `fit`, and `Clock` are plain logic, and
+`subscribe_waits_for_the_announcement` needs only `moq-net`. Split the module
+so that logic compiles unconditionally and only the winit/wgpu/cpal event loop
+stays behind `play`. The default `just check` and `just test` then cover the
+tests with no new dependency, no new CI job, and no new minutes.
+
+The alternative is naming `--features moq-cli/play` in the per-PR test recipe
+the way `just rs windows` names it for its compile. That buys a wgpu + winit +
+cpal build in the test job for a handful of tests, so take it only for whatever
+genuinely cannot move.
+
+`capture` and `transcode` are gated the same way and have no tests today, so
+nothing is silently green there yet. Whatever lands here should make the
+default-compiled side the obvious place to put them.
+
+## Related
+
+- [Go smoke client](/quest/m0/smoke-go-client.md) - the other place where CI exercises none of the code
+- [uring all-features](/quest/m0/uring-all-features-build.md) - the nightly gate that is the only backstop here, failing on dev

--- a/quest/m0/track-finish-reannounce.md
+++ b/quest/m0/track-finish-reannounce.md
@@ -44,22 +44,30 @@ its `Step::Complete`, and `track_inner` keeps handing back the finished entry
 without queuing anything. So whatever lands has to re-arm serving on a later
 lookup or demand, not just splice a new route in.
 
-Then decide the shape before writing the fix. Two candidates:
+The question to settle is how a relay tells the two endings apart, and it has
+to be settled before any of this is implemented, because re-arming alone
+cannot answer it. `serve_track` calls `resume.finish()` on `Step::Complete`,
+and `takeover` refuses a finished producer with `Error::Closed`. So a relay
+that re-arms without a new signal has to pick one of two wrong things:
+not finishing, which leaves a subscriber of a genuinely ended track waiting
+forever, or replacing the map entry, which strands the subscribers holding the
+finished consumer. Both boundaries are real, and today one signal serves both.
 
-- Re-arm the spliced track: keep the finished cache readable, but let a later
-  lookup queue the name again, the way an aborted one already does, and let a
-  source (the same one or a replacement) take over the way
-  `resume::Producer::takeover` retains the live edge. No wire change, no new
-  public surface. The work is in `serve_track` returning too early as much as
-  in `track_inner`.
-- Give the producer an explicit third ending and keep `finish` terminal. That
-  is a public API addition across every binding, so it carries the Public API
-  Scrutiny cost and likely a draft update. It also makes the re-arm
-  publisher-driven rather than something the relay infers.
+Two directions, once that is settled:
 
-Prefer the first unless reproducing shows a case it cannot cover: a subscriber
-holding the finished track has to see the continuation, and a publisher that
-really is done forever must still be distinguishable.
+- Keep it inferred. The relay re-arms on a later lookup or demand, the way an
+  aborted track already does, and something else has to carry the distinction:
+  a linger, an announcement, or the route's own liveness. No wire change and no
+  new public surface, at the cost of the relay guessing what the publisher
+  meant.
+- Make it explicit. The producer gets a third ending and `finish` stays
+  terminal, so the publisher says which one it is. That is a public API
+  addition across every binding, so it carries the Public API Scrutiny cost and
+  likely a draft update, and it is the shape that makes the misuse
+  unrepresentable rather than documented.
+
+The reproduction comes first either way: it is what says whether the inferred
+version can carry both boundaries at all.
 
 Check `js/net` for the same asymmetry once the Rust behavior is settled.
 

--- a/quest/m0/track-finish-reannounce.md
+++ b/quest/m0/track-finish-reannounce.md
@@ -37,15 +37,25 @@ Reproduce first, at the model layer rather than through `moq-transcode`: the
 claim under test is that a second publication of a finished name is invisible
 to a new subscriber through a relay.
 
+Note that route replacement is only half the problem, and the smaller half.
+When the same upstream broadcast stays connected and later serves the name
+again, no replacement happens at all: `origin::serve_track` already returned on
+its `Step::Complete`, and `track_inner` keeps handing back the finished entry
+without queuing anything. So whatever lands has to re-arm serving on a later
+lookup or demand, not just splice a new route in.
+
 Then decide the shape before writing the fix. Two candidates:
 
-- Let a route replacement take over a finished spliced track the way
-  `resume::Producer::takeover` already retains the live edge for an aborted
-  one, so the cache stays readable while new groups land above it. No wire
-  change, no new public surface.
+- Re-arm the spliced track: keep the finished cache readable, but let a later
+  lookup queue the name again, the way an aborted one already does, and let a
+  source (the same one or a replacement) take over the way
+  `resume::Producer::takeover` retains the live edge. No wire change, no new
+  public surface. The work is in `serve_track` returning too early as much as
+  in `track_inner`.
 - Give the producer an explicit third ending and keep `finish` terminal. That
   is a public API addition across every binding, so it carries the Public API
-  Scrutiny cost and likely a draft update.
+  Scrutiny cost and likely a draft update. It also makes the re-arm
+  publisher-driven rather than something the relay infers.
 
 Prefer the first unless reproducing shows a case it cannot cover: a subscriber
 holding the finished track has to see the continuation, and a publisher that

--- a/quest/m0/track-finish-reannounce.md
+++ b/quest/m0/track-finish-reannounce.md
@@ -1,0 +1,54 @@
+# [M] moq-net: a finished track's name is unreachable through a relay
+
+## Goal
+
+A publisher that finishes a track and later publishes the same name on the same
+broadcast is reachable through a relay. Either a route replacement can take
+over a finished logical track, or a publisher gets a way to end a track that
+means "done for now" rather than "done forever".
+
+## Plan
+
+`broadcast::Consumer::track_inner` in `rs/moq-net/src/model/broadcast.rs` drops
+a spliced logical track that is aborted, on the grounds that an abort is a
+verdict from the sources attached at the time rather than a property of the
+name, so the next request should reach a source again. A finished one is kept,
+because its cache is still readable. There is no third state.
+
+The consequence is that behind a relay, once a track finishes, every later
+subscriber gets the finished cache. Nothing drains the pending queue, so the
+route is never asked to serve that name again however many times upstream
+re-creates it. Aborted is retryable, finished is terminal, and a publisher has
+no way to say it is done for now.
+
+This surfaced through `moq-transcode`: a resized ladder retires a rung by
+finishing its track, and reusing the rung's name for the replacement looks
+right and is unreachable, which is why #3381 gives every replacement a fresh
+name. That works around it for one publisher. The asymmetry belongs to the
+layer that owns it.
+
+### Shape
+
+Reproduce first, at the model layer rather than through `moq-transcode`: the
+claim under test is that a second publication of a finished name is invisible
+to a new subscriber through a relay.
+
+Then decide the shape before writing the fix. Two candidates:
+
+- Let a route replacement take over a finished spliced track the way
+  `resume::Producer::takeover` already retains the live edge for an aborted
+  one, so the cache stays readable while new groups land above it. No wire
+  change, no new public surface.
+- Give the producer an explicit third ending and keep `finish` terminal. That
+  is a public API addition across every binding, so it carries the Public API
+  Scrutiny cost and likely a draft update.
+
+Prefer the first unless reproducing shows a case it cannot cover: a subscriber
+holding the finished track has to see the continuation, and a publisher that
+really is done forever must still be distinguishable.
+
+Check `js/net` for the same asymmetry once the Rust behavior is settled.
+
+## Related
+
+- [#2991](/quest/m1/2991-net-coalesce-dynamic-tracks-and-preserve-sequences-across.md) - the other half of dynamic track identity across replacements

--- a/quest/m0/track-finish-reannounce.md
+++ b/quest/m0/track-finish-reannounce.md
@@ -15,11 +15,15 @@ verdict from the sources attached at the time rather than a property of the
 name, so the next request should reach a source again. A finished one is kept,
 because its cache is still readable. There is no third state.
 
-The consequence is that behind a relay, once a track finishes, every later
-subscriber gets the finished cache. Nothing drains the pending queue, so the
-route is never asked to serve that name again however many times upstream
-re-creates it. Aborted is retryable, finished is terminal, and a publisher has
-no way to say it is done for now.
+This is specific to the spliced logical tracks a route-fed broadcast mints. On
+the plain path a few lines below, the weak cache drops any closed entry,
+finished or aborted alike, and the request falls through to a source again. So
+the same publisher is reachable in process and unreachable one relay hop away:
+once the spliced track finishes, every later subscriber gets the finished
+cache, nothing drains the pending queue, and the route is never asked to serve
+that name again however many times upstream re-creates it. Aborted is
+retryable, finished is terminal, and a publisher has no way to say it is done
+for now.
 
 This surfaced through `moq-transcode`: a resized ladder retires a rung by
 finishing its track, and reusing the rung's name for the replacement looks

--- a/quest/m0/transcode-retirement-race.md
+++ b/quest/m0/transcode-retirement-race.md
@@ -3,33 +3,43 @@
 ## Goal
 
 `retirement_finishes_an_in_flight_fetch` fails against a reverted fix on every
-run and on any machine, instead of only when the scheduler happens to lose the
-accept-vs-finish race.
+run and on any machine. Getting there means first establishing why it does not
+today, because the ordering its doc comment names is not one the code can
+produce.
 
 ## Plan
 
-The test in `rs/moq-transcode/src/lib.rs` covers two ways a retiring rung can
-cut an in-flight fetch short. It catches the first every time. The second is
-finishing the track at a live edge sitting at or below the group the fetch is
-about to claim, and that one depends on timing: `Consumer::fetch_group`
+What is known: the test in `rs/moq-transcode/src/lib.rs` caught the boundary
+bug on a loaded CI runner against the un-fixed implementation, and has never
+failed on a developer machine. Two constructions for determinism were tried in
+#3381 and both passed against the reverted fix, which is a failed negative
+control, so the fix landed resting on its structural argument instead. The
+attempts are on that pull request thread.
+
+What is not known is the interleaving that actually fails, and the doc comment
+on the test asserts one the code rules out. It says `Consumer::fetch_group`
 resolves as soon as the attempt is registered, well before `GroupRequest::accept`
-creates the group, so which side of `accept` the retirement lands on is the
-scheduler's choice. A loaded CI runner lost that race; a developer machine
-never has. The test says so in its doc comment rather than pretending
-otherwise.
+creates the group. It does not: `Fetching::poll` resolves through
+`TrackState::poll_fetch_cached`, which is ready only once the sequence is in
+the track's lookup, and `accept` is what puts it there (the other exits are an
+abort, past-final, and a written rejection). So the `fetch_group(0, None).await`
+in the test has already seen the group accepted, and retirement cannot land on
+the far side of `accept`. Correct that comment whatever else this quest
+concludes.
 
-Two constructions were tried in #3381 and both failed the negative control (a
-test that passes against a reverted implementation is worth nothing), so the
-fix landed resting on the structural argument instead. The attempts are on the
-pull request thread.
+The candidate the reshape of `serve` was built around is still open: `finish`
+takes the live edge, which on a rung that only ever served fetches is sequence
+0, and a group at or above the boundary is refused, so a `finish` racing the
+accepted group's completion is what cuts it short. Establish that on a loaded
+runner against the un-fixed implementation, by instrumentation rather than by
+guessing at a third construction.
 
-What is missing is an observation point between a fetch registering and
-claiming its group, which `rung.rs` does not have. Per no internal callbacks,
-that is not a test hook parameter on `serve`. Prefer pulling the decision out
-instead: the boundary question is "what sequence can `finish` take, given the
-live edge and the fetches still in flight", and answering it in a function that
-can be called directly makes the interesting case a plain unit test. Keep the
-async test as coverage of the wiring around it.
+Once the ordering is known, prefer making the decision unit-testable over
+adding an observation point to `serve`: the question is what sequence `finish`
+may take given the live edge and the fetches still in flight, and answering it
+in a function that can be called directly makes the interesting case a plain
+test. Per no internal callbacks, a test hook parameter on `serve` is not the
+answer.
 
 ## Related
 

--- a/quest/m0/transcode-retirement-race.md
+++ b/quest/m0/transcode-retirement-race.md
@@ -1,0 +1,36 @@
+# [S] moq-transcode: the retirement boundary regression test is a coin flip
+
+## Goal
+
+`retirement_finishes_an_in_flight_fetch` fails against a reverted fix on every
+run and on any machine, instead of only when the scheduler happens to lose the
+accept-vs-finish race.
+
+## Plan
+
+The test in `rs/moq-transcode/src/lib.rs` covers two ways a retiring rung can
+cut an in-flight fetch short. It catches the first every time. The second is
+finishing the track at a live edge sitting at or below the group the fetch is
+about to claim, and that one depends on timing: `Consumer::fetch_group`
+resolves as soon as the attempt is registered, well before `GroupRequest::accept`
+creates the group, so which side of `accept` the retirement lands on is the
+scheduler's choice. A loaded CI runner lost that race; a developer machine
+never has. The test says so in its doc comment rather than pretending
+otherwise.
+
+Two constructions were tried in #3381 and both failed the negative control (a
+test that passes against a reverted implementation is worth nothing), so the
+fix landed resting on the structural argument instead. The attempts are on the
+pull request thread.
+
+What is missing is an observation point between a fetch registering and
+claiming its group, which `rung.rs` does not have. Per no internal callbacks,
+that is not a test hook parameter on `serve`. Prefer pulling the decision out
+instead: the boundary question is "what sequence can `finish` take, given the
+live edge and the fetches still in flight", and answering it in a function that
+can be called directly makes the interesting case a plain unit test. Keep the
+async test as coverage of the wiring around it.
+
+## Related
+
+- [Congestion-aware transcode ladders](/quest/m1/ladder/README.md) - the rung lifecycle this boundary belongs to

--- a/quest/m0/transcode-retirement-race.md
+++ b/quest/m0/transcode-retirement-race.md
@@ -3,9 +3,9 @@
 ## Goal
 
 `retirement_finishes_an_in_flight_fetch` fails against a reverted fix on every
-run and on any machine. Getting there means first establishing why it does not
-today, because the ordering its doc comment names is not one the code can
-produce.
+run and on any machine. Getting there means first establishing the interleaving
+that fails, because the two mechanisms written down so far are both ruled out
+by the code.
 
 ## Plan
 
@@ -16,30 +16,36 @@ in #3381 and both passed against the reverted fix, which is a failed negative
 control, so the fix landed resting on its structural argument instead. The
 attempts are on that pull request thread.
 
-What is not known is the interleaving that actually fails, and the doc comment
-on the test asserts one the code rules out. It says `Consumer::fetch_group`
-resolves as soon as the attempt is registered, well before `GroupRequest::accept`
-creates the group. It does not: `Fetching::poll` resolves through
-`TrackState::poll_fetch_cached`, which is ready only once the sequence is in
-the track's lookup, and `accept` is what puts it there (the other exits are an
-abort, past-final, and a written rejection). So the `fetch_group(0, None).await`
-in the test has already seen the group accepted, and retirement cannot land on
-the far side of `accept`. Correct that comment whatever else this quest
+What is not known is why. Two candidate mechanisms are already out:
+
+- The test's doc comment says `Consumer::fetch_group` resolves as soon as the
+  attempt is registered, well before `GroupRequest::accept` creates the group.
+  It does not. `Fetching::poll` resolves through `TrackState::poll_fetch_cached`,
+  which is ready only once the sequence is in the track's lookup, and `accept`
+  is what puts it there (the other exits are an abort, past-final, and a
+  written rejection). The awaited fetch has already seen the group accepted, so
+  retirement cannot land on the far side of `accept`.
+- `rung::serve` says a `finish` racing the accepted group can refuse it,
+  because the live edge on a rung that only ever served fetches is sequence 0.
+  It cannot. `accept` goes through `insert_group_request` into `insert_group`,
+  which advances `max_sequence` whether or not the group is visible, so
+  `Producer::finish` takes the exclusive boundary 1 and leaves group 0 alone.
+
+Both comments are wrong on main and get corrected by this quest whatever it
 concludes.
 
-The candidate the reshape of `serve` was built around is still open: `finish`
-takes the live edge, which on a rung that only ever served fetches is sequence
-0, and a group at or above the boundary is refused, so a `finish` racing the
-accepted group's completion is what cuts it short. Establish that on a loaded
-runner against the un-fixed implementation, by instrumentation rather than by
-guessing at a third construction.
+The candidate left is cancellation: before #3381, `serve` selected over `live`
+and `fetches`, so `live` returning on retirement dropped the `fetches` task,
+and with it a `group::Producer` that had been accepted but not finished. Note
+that reverting the fix reverts the retire signal itself, so state precisely
+what the baseline is before drawing conclusions from it.
 
-Once the ordering is known, prefer making the decision unit-testable over
-adding an observation point to `serve`: the question is what sequence `finish`
-may take given the live edge and the fetches still in flight, and answering it
-in a function that can be called directly makes the interesting case a plain
-test. Per no internal callbacks, a test hook parameter on `serve` is not the
-answer.
+Establish the interleaving empirically, on a loaded runner and with
+instrumentation, rather than reasoning out a third construction from the code.
+The two entries above are what that reasoning has produced so far. Only once
+the ordering is known is it worth deciding what to make directly testable; per
+no internal callbacks, whatever that is, it is not a test hook parameter on
+`serve`.
 
 ## Related
 

--- a/quest/m0/transcode-retirement-race.md
+++ b/quest/m0/transcode-retirement-race.md
@@ -11,8 +11,8 @@ produce.
 
 What is known: the test in `rs/moq-transcode/src/lib.rs` caught the boundary
 bug on a loaded CI runner against the un-fixed implementation, and has never
-failed on a developer machine. Two constructions for determinism were tried in
-#3381 and both passed against the reverted fix, which is a failed negative
+failed on a developer machine. Two constructions for determinism were tried
+in #3381 and both passed against the reverted fix, which is a failed negative
 control, so the fix landed resting on its structural argument instead. The
 attempts are on that pull request thread.
 


### PR DESCRIPTION
## Summary

Three follow-ups from #3381, all in m0.

- **[play tests](/quest/m0/play-feature-tests.md)** ([M]): `moq play` sits behind the off-by-default `play` feature and `mod play` is `#[cfg(feature = "play")]`, so `just check`, `just test`, and check.yml compile none of `play.rs`, its `mod tests` included. Nightly's `just rs features` is the only thing that runs them: post-merge, once a day, and sequential behind a `--no-default-features` workspace check and an `--all-features` clippy, either of which failing means they never run at all (`quest/m0/uring-all-features-build.md` is that exact failure on dev). A test that cannot pass reads green through review, which is how one reached #3381. Recommends splitting the module so the logic under test (`Playback`, `AudioTimeline`, `fit`, `Clock`) compiles by default and only the winit/wgpu/cpal event loop stays gated.
- **[Track re-announce](/quest/m0/track-finish-reannounce.md)** ([M]): `broadcast::Consumer::track_inner` drops a spliced logical track that aborted, so the next request reaches a source again, and keeps a finished one because its cache is still readable. The plain path's weak cache drops any closed entry, so this is specific to the spliced tracks a route-fed broadcast mints: the same publisher is reachable in process and unreachable one relay hop away. Re-arming alone cannot fix it, because `serve_track` finishes the resume producer on `Step::Complete` and `takeover` refuses a finished one, so the quest settles how a relay tells "done for now" from "done forever" before choosing between an inferred and an explicit signal. #3381 works around it by giving every replacement rung a fresh name.
- **[Retirement race](/quest/m0/transcode-retirement-race.md)** ([S]): `retirement_finishes_an_in_flight_fetch` caught the boundary bug on a loaded CI runner and has never failed locally, and two constructions for determinism failed the negative control. Both mechanisms written down for it are ruled out by the code: `Fetching::poll` cannot resolve before `GroupRequest::accept` inserts the group, and `accept` advances `max_sequence` so `finish` takes boundary 1 and cannot refuse group 0. The quest records both dead ends, leaves cancellation of the `fetches` task as the candidate, and carries the corrections to those two comments on main.

## Public API changes

None. Quest documents only.

## Test plan

- `just check` on every revision (quest: 255 documents ok)

## Review

Five rounds, all findings valid and all verified against the code before acting:

- Codex, twice on the retirement quest: `fetch_group` does not resolve at registration, and `finish` cannot refuse the accepted group. Both were inherited from comments in #3381, so the quest now carries their correction and asks for instrumentation instead of a third construction.
- Codex, twice on the re-announce quest: route replacement is the smaller half (`serve_track` returns on `Step::Complete`), and re-arming cannot preserve a real EOF while continuing the same logical track (`takeover` refuses a finished producer). The quest no longer prefers a candidate.
- Codex on the play quest: `just test` is a module, so `just rs test -p moq-cli` is the form that reaches cargo.
- CodeRabbit: scope the re-announce quest to spliced logical tracks; plus a duplicate of the first Codex finding whose suggested wording kept the wrong half, declined with a reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 5)