### PR TITLE
docs(transcode): correct the retirement comments and record what the test covers

### DIFF
--- a/quest/m0/README.md
+++ b/quest/m0/README.md
@@ -30,7 +30,7 @@ regression test per Root Cause First.
 - [uring all-features](/quest/m0/uring-all-features-build.md) - moq-uring does not compile with `--all-features`, so the nightly features gate fails on it
 - [play tests](/quest/m0/play-feature-tests.md) - moq-cli: the `play` module is off by default, so nothing in the merge gate compiles its tests
 - [Go smoke client](/quest/m0/smoke-go-client.md) - the interop matrix has no Go client, so nothing in CI exercises the Go wrapper
-- [Retirement race](/quest/m0/transcode-retirement-race.md) - moq-transcode: the retirement boundary regression test only catches the bug when it loses a race
+- [Retirement race](/quest/m0/transcode-retirement-race.md) - moq-transcode: retirement has no coverage for a fetch that is still opening its decoder
 - [PR behavioral gates](/quest/m0/pr-behavioral-gates.md) - run the applicable interop and platform gates on source PRs before merge
 - [Merge evidence](/quest/m0/merge-verification-evidence.md) - bind local, CI, and device results to the current source and merge candidate
 - [Verification preflight](/quest/m0/verification-preflight.md) - diagnose missing tools, denied access, and unusable runtimes before building

--- a/quest/m0/transcode-retirement-race.md
+++ b/quest/m0/transcode-retirement-race.md
@@ -1,51 +1,64 @@
-# [S] moq-transcode: the retirement boundary regression test is a coin flip
+# [S] moq-transcode: retirement never covers an in-flight fetch
 
 ## Goal
 
-`retirement_finishes_an_in_flight_fetch` fails against a reverted fix on every
-run and on any machine. Getting there means first establishing the interleaving
-that fails, because the two mechanisms written down so far are both ruled out
-by the code.
+A test that fails against a reverted fix on every run and on any machine for
+the case CI caught: a rung retired while the fetch handler is still opening its
+decoder for a group it has not yet claimed.
 
 ## Plan
 
-What is known: the test in `rs/moq-transcode/src/lib.rs` caught the boundary
-bug on a loaded CI runner against the un-fixed implementation, and has never
-failed on a developer machine. Two constructions for determinism were tried
-in #3381 and both passed against the reverted fix, which is a failed negative
-control, so the fix landed resting on its structural argument instead. The
-attempts are on that pull request thread.
+The mechanism is now known, and it is not the one the quest started from.
+`retirement_finishes_an_in_flight_fetch` in `rs/moq-transcode/src/lib.rs` does
+not reach the fetch handler at all on a developer machine, so it has never been
+a coin flip locally. It is a deterministic guard for a different property.
 
-What is not known is why. Two candidate mechanisms are already out:
+Established by instrumenting `rung::serve` (probe prints on the retire branch,
+on `GroupRequest::accept`, and on the live session) and running the test 40
+times:
 
-- The test's doc comment says `Consumer::fetch_group` resolves as soon as the
-  attempt is registered, well before `GroupRequest::accept` creates the group.
-  It does not. `Fetching::poll` resolves through `TrackState::poll_fetch_cached`,
-  which is ready only once the sequence is in the track's lookup, and `accept`
-  is what puts it there (the other exits are an abort, past-final, and a
-  written rejection). The awaited fetch has already seen the group accepted, so
-  retirement cannot land on the far side of `accept`.
-- `rung::serve` says a `finish` racing the accepted group can refuse it,
-  because the live edge on a rung that only ever served fetches is sequence 0.
-  It cannot. `accept` goes through `insert_group_request` into `insert_group`,
-  which advances `max_sequence` whether or not the group is visible, so
-  `Producer::finish` takes the exclusive boundary 1 and leaves group 0 alone.
+- A `track::Consumer` is demand on its own (`Demand::used` is kio's "at least
+  one consumer"), so `consumer.track("video/120p")` starts the live path
+  immediately, before the test's `rung.info().await` even resolves.
+- By the time the test calls `fetch_group(0, None)`, `rung.latest()` is already
+  `Some(0)`: the live path created output group 0. `Consumer::fetch_group`
+  resolves straight from the cache and queues no attempt, so `fetches` never
+  pops a `GroupRequest` and never spawns a fetch task. 40/40 runs.
+- What the test therefore covers is the live path riding out its open group
+  after retirement. Reverting that ride-out (retire aborts `current` and breaks
+  the session instead of continuing) fails the test 30/30. Reverting `serve` to
+  a `tokio::select!` over the two halves fails it too, with `Err(Dropped)`,
+  because the live arm is cancelled mid-group.
+- Reverting the actual historical bug (`producer.finish()` back inside `live`
+  at retirement, `serve` no longer finishing) leaves the whole `moq-transcode`
+  suite green, confirming the failed negative control recorded in #3381.
 
-Both comments are wrong on main and get corrected by this quest whatever it
-concludes.
+So the race CI lost is upstream of anything the test asserts: whether the test
+task is polled between `Request::accept` and the live path creating group 0.
+Lose it and the fetch handler serves group 0 instead, which is the ordering
+where a retirement-time `finish` computes its boundary from a group that does
+not exist yet and rejects the fetch with `Closed`.
 
-The candidate left is cancellation: before #3381, `serve` selected over `live`
-and `fetches`, so `live` returning on retirement dropped the `fetches` task,
-and with it a `group::Producer` that had been accepted but not finished. Note
-that reverting the fix reverts the retire signal itself, so state precisely
-what the baseline is before drawing conclusions from it.
+Two comments that got this wrong on main were corrected without closing the
+quest: the test's doc comment (which claimed `fetch_group` resolves before
+`accept`) and `rung::serve`'s note on what `finish` takes as its boundary. A
+third, in the retirement drain in `fetches`, claimed the track may already have
+declared its final sequence; nothing can, since `serve` finishes only after
+`tokio::join!` returns.
 
-Establish the interleaving empirically, on a loaded runner and with
-instrumentation, rather than reasoning out a third construction from the code.
-The two entries above are what that reasoning has produced so far. Only once
-the ordering is known is it worth deciding what to make directly testable; per
-no internal callbacks, whatever that is, it is not a test hook parameter on
-`serve`.
+What is left is a test that reaches the fetch handler by construction. The
+obstacle is structural: holding the consumer needed to fetch is itself the
+demand that starts the live path, and the live path serves the same group from
+the same source, so any construction has to give the fetch a group the live
+path cannot produce (a source group the shared feed does not deliver, served
+through a `Dynamic` on the source track so it stays open while the fetch runs).
+Verify any candidate against a revert that puts `finish` back in `live`, since
+that is the revert the earlier attempts passed. Per no internal callbacks,
+whatever makes this reachable is not a test hook parameter on `serve`.
+
+Also open: the test's name says "in-flight fetch" for something that usually
+exercises the live path. Renaming it was deliberately left to whoever makes the
+fetch case real, rather than churning the name twice.
 
 ## Related
 

--- a/quest/m0/transcode-retirement-race.md
+++ b/quest/m0/transcode-retirement-race.md
@@ -3,15 +3,15 @@
 ## Goal
 
 A test that fails against a reverted fix on every run and on any machine for
-the case CI caught: a rung retired while the fetch handler is still opening its
-decoder for a group it has not yet claimed.
+a rung retired while the fetch handler is still opening its decoder for a
+group it has not yet claimed.
 
 ## Plan
 
-The mechanism is now known, and it is not the one the quest started from.
+The local coverage is now measured; the historical CI failure remains unexplained.
 `retirement_finishes_an_in_flight_fetch` in `rs/moq-transcode/src/lib.rs` does
-not reach the fetch handler at all on a developer machine, so it has never been
-a coin flip locally. It is a deterministic guard for a different property.
+not reach the fetch handler in the measured local runs. Those runs exercise
+a different property.
 
 Established by instrumenting `rung::serve` (probe prints on the retire branch,
 on `GroupRequest::accept`, and on the live session) and running the test 40
@@ -33,11 +33,14 @@ times:
   at retirement, `serve` no longer finishing) leaves the whole `moq-transcode`
   suite green, confirming the failed negative control recorded in #3381.
 
-So the race CI lost is upstream of anything the test asserts: whether the test
-task is polled between `Request::accept` and the live path creating group 0.
-Lose it and the fetch handler serves group 0 instead, which is the ordering
-where a retirement-time `finish` computes its boundary from a group that does
-not exist yet and rejects the fetch with `Closed`.
+The existing test cannot retire the rung while its fetch is opening a decoder:
+it awaits `rung.fetch_group(0, None)` before changing the source catalog.
+`fetch` opens `rung.pipeline()` before `GroupRequest::accept` inserts the output
+group, and `Fetching::poll` returns that group only once it is cached. If the
+live path inserts group 0 first, the fetch handler's later acceptance instead
+returns `Duplicate`. Neither ordering establishes the previously claimed CI
+mechanism. Recover the failing revision and trace before attributing that
+failure to a specific interleaving.
 
 Two comments that got this wrong on main were corrected without closing the
 quest: the test's doc comment (which claimed `fetch_group` resolves before
@@ -46,8 +49,9 @@ third, in the retirement drain in `fetches`, claimed the track may already have
 declared its final sequence; nothing can, since `serve` finishes only after
 `tokio::join!` returns.
 
-What is left is a test that reaches the fetch handler by construction. The
-obstacle is structural: holding the consumer needed to fetch is itself the
+What is left is a test that reaches the fetch handler by construction and
+triggers retirement before acceptance, without awaiting the output group first.
+The obstacle is structural: holding the consumer needed to fetch is itself the
 demand that starts the live path, and the live path serves the same group from
 the same source, so any construction has to give the fetch a group the live
 path cannot produce (a source group the shared feed does not deliver, served

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -966,19 +966,22 @@ mod tests {
 		transcoder.abort();
 	}
 
-	/// Retiring a rung stops taking new fetches, but one already in flight has to
-	/// run to a clean end. Two things can cut it short: dropping the handler while
-	/// its request is still queued, and finishing the track at a live edge that
-	/// sits at or below the group it is about to claim (sequence 0, on a rung that
-	/// only ever served fetches).
+	/// Retiring a rung stops taking new work, but a group already being produced
+	/// has to run to a clean end: the consumer reads it out and then sees the
+	/// track finish, rather than the group going away under it.
 	///
-	/// `Consumer::fetch_group` resolves as soon as the attempt is registered, well
-	/// before `GroupRequest::accept` creates the group, so the retirement below
-	/// really does land while the fetch is still opening its decoder. Which side
-	/// of `accept` it lands on is up to the scheduler, so this catches the second
-	/// case some of the time rather than every time. It caught it on a loaded CI
-	/// runner; it has never lost that race on a developer machine, which is also
-	/// why forcing it deterministically here needs a hook the rung does not have.
+	/// Which half produces group 0 is a race. A rung consumer is demand on its
+	/// own, so `live` starts the moment the track is taken below, and it usually
+	/// wins: by the time `fetch_group` is called the group is already in the
+	/// track cache, so the fetch resolves from there and the fetch handler is
+	/// never asked. What that ordering pins down is `live` riding out the group
+	/// it is part way through after retirement, plus `serve` joining its two
+	/// halves rather than letting either cancel the other.
+	///
+	/// The other ordering, where the fetch handler serves group 0 and retirement
+	/// lands while it is still opening its decoder, is the one CI caught. It has
+	/// never come up on a developer machine, so treat that half as uncovered
+	/// here.
 	#[tokio::test]
 	async fn retirement_finishes_an_in_flight_fetch() {
 		let mut source = source_catalog(320, 240);
@@ -1017,8 +1020,8 @@ mod tests {
 		rung.info().await.unwrap();
 		let mut fetched = rung.fetch_group(0, None).await.unwrap();
 
-		// The fetch is queued against a source group that is still open, so retiring
-		// now has to leave it running until that group ends.
+		// Group 0 is still being written from a source group that is still open, so
+		// retiring now has to leave it running until that source group ends.
 		source.resize(160, 90);
 		tokio::time::timeout(
 			std::time::Duration::from_secs(5),

--- a/rs/moq-transcode/src/lib.rs
+++ b/rs/moq-transcode/src/lib.rs
@@ -978,10 +978,9 @@ mod tests {
 	/// it is part way through after retirement, plus `serve` joining its two
 	/// halves rather than letting either cancel the other.
 	///
-	/// The other ordering, where the fetch handler serves group 0 and retirement
-	/// lands while it is still opening its decoder, is the one CI caught. It has
-	/// never come up on a developer machine, so treat that half as uncovered
-	/// here.
+	/// If the fetch handler produces group 0, the awaited fetch returns only
+	/// after it has opened its decoder and accepted the group. Retirement below
+	/// therefore cannot exercise a fetch that is still opening its decoder.
 	#[tokio::test]
 	async fn retirement_finishes_an_in_flight_fetch() {
 		let mut source = source_catalog(320, 240);

--- a/rs/moq-transcode/src/rung.rs
+++ b/rs/moq-transcode/src/rung.rs
@@ -142,10 +142,11 @@ pub(crate) async fn serve(rung: Rung, request: moq_net::track::Request) -> Resul
 	let (live, fetches) = tokio::join!(live, fetches(&rung, dynamic, &mut finishing));
 
 	// Finished here rather than in `live`, because the boundary is only known once
-	// every fetch has claimed its group. `finish` takes the live edge, which on a
-	// rung that only ever served fetches is sequence 0, and a group at or above
-	// the boundary is refused: finishing while a fetch was still opening its
-	// decoder would reject the very fetch retirement drained the loop to keep.
+	// every fetch has claimed its group. `finish` sets the exclusive boundary one
+	// past the highest group produced so far (0 when none was), and a group at or
+	// above it is refused. A fetch still opening its decoder has produced nothing
+	// to count, so finishing then would reject the very fetch retirement drained
+	// the loop to keep.
 	let result = match (live, fetches) {
 		(Ok(Ended::Open), Ok(())) => producer.finish().map_err(Into::into),
 		(live, fetches) => live.map(|_| ()).and(fetches),
@@ -438,9 +439,10 @@ async fn fetches(
 			spawn_fetch(&mut tasks, rung.clone(), request, permit);
 		}
 
-		// The track may already have declared its final sequence, but groups below
-		// that boundary remain writable. Finish every one the handler accepted, or
-		// its producer stays open and the fetch stalls forever.
+		// Finish every group the handler accepted, or its producer stays open and
+		// the fetch stalls forever. Nothing has declared the track's final sequence
+		// yet: `serve` does that only once this returns, which is what leaves
+		// every one of these groups writable.
 		while let Some(result) = tasks.join_next().await {
 			if let Err(err) = result {
 				tracing::warn!(%err, "transcode fetch task panicked");


### PR DESCRIPTION
## Summary

Correct retirement comments in `moq-transcode` and update the open regression quest. `Producer::finish` uses one past the highest produced sequence, including accepted fetch groups. `serve` waits for both live and fetch work before finishing the track.

The author's instrumentation found that the existing test resolves group 0 from the live cache in 40/40 local runs. It covers the live group's completion after retirement, but does not establish coverage of decoder opening. The test awaits the output group before retirement; the fetch handler opens its decoder before accepting that group. The historical CI failure therefore remains unexplained, and the quest requires a construction that retires before acceptance plus a failing negative control.

The quest remains open. This change only corrects documentation and comments.

## Public API changes

None. No behavior or wire changes; no Cross-Package Sync row applies.

## Test plan

- Original head: GitHub Check and Test passed.
- Source inspection confirms pipeline opening precedes acceptance, and successful fetching observes an inserted group.
- Pre-rebase corrected head `61fc2a7c1`: `nix develop --command just fix`, `just check`, and `just test` passed; 66 tests passed.
- Pre-rebase corrected head `61fc2a7c1`: GitHub Check and Test passed.
- Pre-rebase quest validator: all 255 documents passed. Rust delta verified to contain comments only.
- Rebased onto current main to resolve a quest-index conflict. Reviewed Rust files and the retirement quest are byte-identical to the tested head.

- Final rebased head `4c08a9d0c0`: GitHub Check and Test passed; local quest validation passed all 263 documents.

(written by GPT-6)
