### PR TITLE
docs: track echo-delay test runtime

### DIFF
--- a/quest/m0/README.md
+++ b/quest/m0/README.md
@@ -28,6 +28,7 @@ regression test per Root Cause First.
 - [Group charge](/quest/m0/group-charge.md) - charge real per-group cost so MOQ_CACHE_CAPACITY bounds real memory
 - [Cache governor lifetime](/quest/m0/cache-governor-lifetime.md) - stop the headroom task after setup failure or the last owner drops
 - [uring all-features](/quest/m0/uring-all-features-build.md) - moq-uring does not compile with `--all-features`, so the nightly features gate fails on it
+- [Echo-delay test runtime](/quest/m0/aec-test-runtime.md) - keep the audio regression within the normal workspace test budget
 - [Go smoke client](/quest/m0/smoke-go-client.md) - the interop matrix has no Go client, so nothing in CI exercises the Go wrapper
 - [Retirement race](/quest/m0/transcode-retirement-race.md) - moq-transcode: retirement has no coverage for a fetch that is still opening its decoder
 - [PR behavioral gates](/quest/m0/pr-behavioral-gates.md) - run the applicable interop and platform gates on source PRs before merge

--- a/quest/m0/aec-test-runtime.md
+++ b/quest/m0/aec-test-runtime.md
@@ -14,7 +14,10 @@ During local macOS/Nix validation of PR #3458, the unchanged test exceeded
 `nix develop --command just rs test -p moq-audio survives_a_moving_echo_delay`
 passed in 27.241 seconds. The full-run timeout cancelled the remaining tests.
 The mechanism is not yet established; an isolated pass does not explain the
-workspace failures.
+workspace failures. A synchronous JS pattern test on the same host also
+exceeded its five-second budget: 7.02 seconds wall time versus 0.87 seconds
+user CPU and 0.18 seconds system CPU. Use that as a control when separating
+host contention from DSP cost.
 
 Reproduce with the workspace's feature graph and the isolated crate's graph,
 recording CPU time, wall time, compiler profile, and concurrent build load.

--- a/quest/m0/aec-test-runtime.md
+++ b/quest/m0/aec-test-runtime.md
@@ -1,0 +1,33 @@
+# [S] Keep the echo-delay regression within the test budget
+
+## Goal
+
+`moq-audio`'s `aec::tests::survives_a_moving_echo_delay` finishes comfortably
+within the normal nextest timeout in the workspace suite, retaining coverage
+of a filter growing, shrinking, and reconverging as the echo delay changes.
+
+## Plan
+
+During local macOS/Nix validation of PR #3458, the unchanged test exceeded
+60 seconds in the full scoped suite with both default concurrency and
+`NEXTEST_TEST_THREADS=2`. An isolated
+`nix develop --command just rs test -p moq-audio survives_a_moving_echo_delay`
+passed in 27.241 seconds. The full-run timeout cancelled the remaining tests.
+The mechanism is not yet established; an isolated pass does not explain the
+workspace failures.
+
+Reproduce with the workspace's feature graph and the isolated crate's graph,
+recording CPU time, wall time, compiler profile, and concurrent build load.
+Check whether unoptimized Sonora DSP dominates the bounded simulation. If
+so, optimize the appropriate dependency in the dev/test profile, following
+the existing bignum overrides, rather than weakening the changing-delay
+regression. Otherwise fix the measured bottleneck at its owning layer.
+
+Keep the normal timeout and full convergence assertion. Validate the fix in
+the full suite and under representative concurrent development load, and
+confirm that the upstream adaptive-filter shrink regression remains covered.
+
+## Related
+
+- [Worktree QA isolation](/quest/m0/worktree-qa-isolation.md) - make concurrent validation resources explicit
+- [PR #3458](https://github.com/moq-dev/moq/pull/3458) - validation that exposed the timeout


### PR DESCRIPTION
Record the unresolved debug-test runtime issue exposed while validating #3458. The unchanged audio echo-delay regression timed out at 60 seconds in full workspace runs with default and two-test concurrency, while an isolated crate run passed in 27 seconds.

The quest calls for measuring feature/profile and CPU-load differences, preserving the adaptive-filter regression and normal timeout. No runtime or public API changes.

Validation: `just fix`, `git diff --check`, and `nix develop --command just check` pass; quest links and index verified. The added timing observation changes prose only.

(written by GPT-6)
