### PR TITLE
test(obs): put the libmoq stubs in the merge gate

### DIFF
--- a/cpp/obs/justfile
+++ b/cpp/obs/justfile
@@ -65,7 +65,8 @@ run:
     cp -a build_macos/RelWithDebInfo/obs-moq.plugin "$dest/"
     RUST_LOG=debug RUST_BACKTRACE=1 OBS_LOG_LEVEL=debug /Applications/OBS.app/Contents/MacOS/OBS
 
-# Type-check every plugin source, without linking or an obs-deps download.
+# Type-check every plugin source and unit test, without linking or an obs-deps
+# download.
 #
 # This is the gate to run in a worktree. `just obs build` needs the
 # multi-hundred-MB obs-deps bundle (macOS/Windows) and a full cargo build, per
@@ -77,6 +78,12 @@ run:
 # It compiles the Qt sources too, which the CMake build only does when
 # ENABLE_QT and ENABLE_FRONTEND_API are on, so the definitions they gate on are
 # set here to match.
+#
+# test/ is in scope because each test file defines the libmoq entry points the
+# plugin calls, so a signature there that has drifted from the generated moq.h
+# is a conflicting C declaration. Only `just obs ci` and `just obs test` ever
+# compiled those, and neither runs on every PR, so a libmoq ABI change could
+# leave a stub stale and stay green until the next OBS build.
 compile:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -109,7 +116,7 @@ compile:
     # MOQ_VERSION_STRING only reaches a label in the dock, so any value
     # type-checks the same; CMake stamps the real libmoq version.
     status=0
-    for source in src/*.cpp; do
+    for source in src/*.cpp test/*.cpp; do
         # shellcheck disable=SC2086
         # -Wno-unused-command-line-argument: the nix compiler wrapper injects
         # link flags, which a syntax-only run reports as unused, once per file.

--- a/cpp/obs/justfile
+++ b/cpp/obs/justfile
@@ -80,10 +80,10 @@ run:
 # set here to match.
 #
 # test/ is in scope because each test file defines the libmoq entry points the
-# plugin calls, so a signature there that has drifted from the generated moq.h
-# is a conflicting C declaration. Only `just obs ci` and `just obs test` ever
-# compiled those, and neither runs on every PR, so a libmoq ABI change could
-# leave a stub stale and stay green until the next OBS build.
+# plugin calls, so a signature that drifts from the generated moq.h is a
+# conflicting C declaration. Catching that needs only headers, which is why it
+# belongs here: `just obs ci` finds the same drift, but only where obs.yml's
+# path filter reaches, and `just obs test` is manual.
 compile:
     #!/usr/bin/env bash
     set -euo pipefail

--- a/cpp/obs/test/moq-source-test.cpp
+++ b/cpp/obs/test/moq-source-test.cpp
@@ -687,6 +687,10 @@ int32_t moq_consume_video_config(uint32_t catalog, uint32_t, struct moq_video_co
 	if (g_video_config_result < 0)
 		return g_video_config_result;
 
+	// The caller hands over an uninitialized struct and libmoq writes every
+	// field, so zero it first: a field this stub doesn't know about (the label,
+	// today) would otherwise be read back as whatever the stack held.
+	*dst = {};
 	dst->name = "video";
 	dst->name_len = 5;
 	dst->codec = g_codec;
@@ -696,8 +700,6 @@ int32_t moq_consume_video_config(uint32_t catalog, uint32_t, struct moq_video_co
 	dst->coded_width = g_coded_width;
 	dst->coded_height = g_coded_height;
 	dst->container.kind = MOQ_CONTAINER_KIND_LEGACY;
-	dst->container.init = nullptr;
-	dst->container.init_len = 0;
 	return 0;
 }
 
@@ -731,6 +733,8 @@ int32_t moq_consume_frame(uint32_t frame, struct moq_frame *dst)
 		g_stub_errors++;
 		return -1;
 	}
+	// Zeroed for the reason moq_consume_video_config zeroes its own out-param.
+	*dst = {};
 	dst->payload = g_description;
 	dst->payload_size = sizeof(g_description);
 	dst->timestamp_us = 1000 * static_cast<uint64_t>(frame);

--- a/justfile
+++ b/justfile
@@ -327,12 +327,13 @@ check $BASE="":
         just swift check "$files"
         just go check "$files"
         just dart check "$files"
-    	# Type-checking the plugin needs only headers, so it runs here rather
-    	# than waiting for obs.yml to link it on Linux. libmoq is in scope
-    	# because the plugin calls through its generated C header, and flake.nix
-    	# because it owns the libobs headers this compiles against -- obs.yml
-    	# links against nixpkgs' obs-studio instead, so nothing else would notice
-    	# that package going bad.
+    	# Type-checking the plugin and its unit tests needs only headers, so it
+    	# runs here rather than waiting for obs.yml to link them on Linux. libmoq
+    	# is in scope because the plugin calls through its generated C header, and
+    	# the tests restate those entry points as stubs, so an ABI change breaks
+    	# both. flake.nix because it owns the libobs headers this compiles
+    	# against -- obs.yml links against nixpkgs' obs-studio instead, so nothing
+    	# else would notice that package going bad.
     	if echo "$files" | grep -qE '^(cpp/obs/|rs/libmoq/|flake\.nix$)'; then
     		just obs compile
     	fi


### PR DESCRIPTION
## Root cause

`cpp/obs/test/moq-source-test.cpp` defines the libmoq entry points the plugin calls, so a signature that drifts from the generated `moq.h` is a conflicting C declaration and a hard compile error. Nothing on the PR path ever compiled that file: `just check` type-checks only `cpp/obs/src/` via `just obs compile`, and obs.yml links the tests but is `pull_request`-only.

That gap is how the file landed broken, and it is not stub rot in place. The file was **added on `main`** by #3371, written against `main`'s `moq.h`, which predates two ABI changes that live only on `dev`:

- 761a883f1 (#2880) gave `moq_session_connect` a `const moq_client_config *config` parameter
- 016fc09ae1 (#2869) turned `moq_video_config`'s `coded_width` / `coded_height` from `uint32_t *` into plain `uint32_t`

`main` was green because its own header matched. `dev` went red the moment the branches met, and no gate on either side recompiles a test file when the *header* moves under it. #3420 patched the two errors after `dev` had already been broken for a day.

## The fix

Compile `test/` alongside `src/` in `just obs compile`. That recipe needs only headers (no linking, no obs-deps download), runs on every platform, and `just check` already dispatches it on `cpp/obs/` or `rs/libmoq/` in the diff. The gate now covers the file that actually restates the C ABI, not just the one that calls it.

Verified it is not vacuous: reintroducing both original changes fails `just obs compile` with the same three diagnostics CI reported.

```
test/moq-source-test.cpp:608:9: error: conflicting types for 'moq_session_connect'
test/moq-source-test.cpp:700:21: error: incompatible pointer to integer conversion assigning to 'uint32_t' ...
test/moq-source-test.cpp:701:22: error: incompatible pointer to integer conversion assigning to 'uint32_t' ...
```

## Remaining drift

I audited every stub in both test files against `moq.h` / `rs/libmoq/src/api.rs` rather than stopping at the two reported spots. No stale or dead stubs: every symbol the tests define still exists, and `moq_origin_request` is the one deliberate extra (kept link-complete so `g_request_calls` can assert the source uses the waiting API).

One drift the compiler cannot see, though. The plugin passes an **uninitialized** `struct moq_video_config`, and libmoq writes every field, but the stub never set the `label` / `label_len` pair added by #2831. Harmless today only because `moq-source.cpp` doesn't read them. Zeroing the out-params (`moq_frame` too) makes an unknown field read back as absent rather than as whatever the stack held, so the next field addition is inert instead of quietly undefined.

## Notes

- Targets `dev` because the break exists only there; both ABI commits are on `dev` alone. Test and tooling only, no published API change.
- `just obs _unit` passes locally (both binaries, all scenarios). `just obs ci`'s link step is Linux-only, so CI is the check for that half.
- Considered generating the stubs from `moq.h` instead. Not worth it: the stubs carry real bodies (a fake runtime thread, handle tables, failure injection), and the compiler already checks them against the header. The defect was *when* that check ran, not whether it existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 5)