### PR TITLE
chore(moq-net): guard the fuzz workspace lockfile

### DIFF
--- a/rs/justfile
+++ b/rs/justfile
@@ -50,9 +50,24 @@ check *args:
     {{ cargo_compile }} clippy --locked --all-targets {{ args }} -- -D warnings
     cargo fmt --all --check
     just rs _doc-names
+    just rs _fuzz-lock
     RUSTDOCFLAGS="-D warnings" {{ cargo_compile }} doc --locked --no-deps {{ args }}
     cargo shear
     cargo sort --workspace --check --no-format
+
+# The fuzz harness is its own workspace, because libFuzzer needs nightly and
+# sanitizer flags. Nothing in `check` or `test` builds it, so its lockfile drifts
+# from the path dependencies it shares with the main workspace and nobody finds out
+# until a `just rs fuzz` silently re-resolves it. Re-resolving against the committed
+# lock is metadata only, so it costs no compilation and can sit in the PR gate.
+_fuzz-lock:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if ! cargo metadata --locked --format-version 1 --manifest-path rs/moq-net/fuzz/Cargo.toml > /dev/null; then
+        echo "rs: run: cargo update --manifest-path rs/moq-net/fuzz/Cargo.toml --workspace" >&2
+        exit 1
+    fi
 
 # Two targets whose names differ only by `-` vs `_` render to the same
 # `target/doc/<name>`, and a `cargo doc` that selects both races to clean it: the

--- a/rs/moq-net/fuzz/Cargo.lock
+++ b/rs/moq-net/fuzz/Cargo.lock
@@ -245,7 +245,7 @@ dependencies = [
 
 [[package]]
 name = "kio"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "loom",
  "smallvec",
@@ -320,7 +320,7 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "moq-net"
-version = "0.2.15"
+version = "0.2.18"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -329,6 +329,7 @@ dependencies = [
  "num_enum",
  "rand",
  "serde",
+ "slab",
  "thiserror",
  "tracing",
  "web-async",

--- a/rs/moq-net/fuzz/Cargo.toml
+++ b/rs/moq-net/fuzz/Cargo.toml
@@ -1,6 +1,8 @@
 # The libFuzzer harness for moq-net's wire codecs. Its own workspace (and lockfile):
 # libFuzzer needs a nightly toolchain and sanitizer flags, so this must not be part
 # of the build `just check` and `just test` run. `just rs fuzz <target>` drives it.
+# `just rs check` still re-resolves the lockfile below (metadata only, nothing is
+# compiled) so it cannot drift from the path dependencies it shares.
 #
 # The target bodies live in `moq-net`'s hidden `fuzz` module, not here: `lite` and
 # `ietf` are private modules, so this crate cannot reach a single decoder, and sharing


### PR DESCRIPTION
## Summary

- `rs/moq-net/fuzz` is its own workspace, because libFuzzer needs a nightly toolchain and sanitizer flags. Neither `just check` nor `just test` builds it, so its lockfile drifted from the path dependencies it shares with the main workspace and nothing caught it: `moq-net 0.2.15 -> 0.2.18`, `kio 0.5.6 -> 0.5.7`, plus the `slab` dep moq-net has since picked up. A `just rs fuzz` would silently re-resolve it in place.
- Refreshed the lockfile and added `just rs _fuzz-lock` to `rs check` so it can't rot again. It is `cargo metadata --locked` against that manifest: resolution only, no compilation, ~150ms, so it fits in the PR gate next to `_doc-names`.
- On failure it prints the fix (`cargo update --manifest-path rs/moq-net/fuzz/Cargo.toml --workspace`), since cargo's own `--locked` error names the file but not how to regenerate it.

No production code changes; nothing under `rs/moq-net/src` is touched.

## Public API changes

None.

## Test plan

- `just rs check` passes on this branch (includes the new `_fuzz-lock` step).
- Verified the guard both ways: it fails against the stale lockfile and passes against the refreshed one, and the `cargo update` line it suggests reproduces the committed lockfile byte for byte.
- Ran all four fuzz targets for 180s each on nightly libFuzzer to confirm the harness still builds and runs against the refreshed lock: `lite` 29.8M runs, `ietf` 19.6M, `varint` 74.8M, `path` 5.1M. No crashes, `artifacts/` empty, so there is nothing new for `fuzz/regressions/`.
- `cargo nextest run -p moq-net fuzz::` passes (the stable replay: `regressions` + `seeds_reach_every_arm`).

Cross-Package Sync: no rows apply, this touches no wire format, public API, or CLI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015YhUdqPAxrLb9HSuneWhZt

(Written by Claude Opus 5)