### PR TITLE
docs(quest): plan the abort guard, an advisory quest gate, and what the echo-delay test already establishes

### DIFF
--- a/doc/bin/relay/http.md
+++ b/doc/bin/relay/http.md
@@ -23,10 +23,11 @@ curl http://localhost:4443/fetch/demo/bbb.hang/catalog.json
 ```
 
 A relay configured with more than one certificate has no single fingerprint to
-publish, and this endpoint answers for the first. The quinn and noq backends
-select by SNI at handshake, so which one a client is offered depends on the name
-it dials; the quiche backend serves the first pair to everyone. Either way, pin
-explicitly with `--client-tls-fingerprint`, or use `https://`.
+publish, and this endpoint answers for the first. On the quinn and noq backends
+the others are reachable over `https://`, which selects by SNI at handshake. The
+quiche backend serves the first pair to every handshake, so a name covered only
+by a later certificate needs an explicit `--client-tls-fingerprint`, which checks
+the fingerprint in place of the hostname.
 
 Tokens sent over plain HTTP are visible on the wire, so use HTTPS in
 production.

--- a/doc/bin/relay/http.md
+++ b/doc/bin/relay/http.md
@@ -22,9 +22,11 @@ curl http://localhost:4443/announced/demo
 curl http://localhost:4443/fetch/demo/bbb.hang/catalog.json
 ```
 
-Certificates are selected by SNI at handshake, so a relay configured with more
-than one has no single fingerprint to publish and this endpoint answers for the
-first. Pin those explicitly with `--client-tls-fingerprint`, or use `https://`.
+A relay configured with more than one certificate has no single fingerprint to
+publish, and this endpoint answers for the first. The quinn and noq backends
+select by SNI at handshake, so which one a client is offered depends on the name
+it dials; the quiche backend serves the first pair to everyone. Either way, pin
+explicitly with `--client-tls-fingerprint`, or use `https://`.
 
 Tokens sent over plain HTTP are visible on the wire, so use HTTPS in
 production.

--- a/doc/bin/relay/http.md
+++ b/doc/bin/relay/http.md
@@ -14,13 +14,17 @@ operational ones that must stay private.
 | --- | --- |
 | `GET /announced/<prefix>` | Broadcasts announced under the prefix. |
 | `GET /fetch/<broadcast>/<track>?group=N` | One group from the cache, the latest by default. Useful for catch-up and debugging. |
-| `GET /certificate.sha256` | The TLS fingerprint, for pinning a self-signed dev certificate. |
+| `GET /certificate.sha256` | The fingerprint of the first configured TLS certificate, for pinning a self-signed dev certificate. |
 | `GET /health` | `200 ok`, unauthenticated, for load balancers. |
 
 ```bash
 curl http://localhost:4443/announced/demo
 curl http://localhost:4443/fetch/demo/bbb.hang/catalog.json
 ```
+
+Certificates are selected by SNI at handshake, so a relay configured with more
+than one has no single fingerprint to publish and this endpoint answers for the
+first. Pin those explicitly with `--client-tls-fingerprint`, or use `https://`.
 
 Tokens sent over plain HTTP are visible on the wire, so use HTTPS in
 production.

--- a/quest/m0/README.md
+++ b/quest/m0/README.md
@@ -31,6 +31,7 @@ regression test per Root Cause First.
 - [Echo-delay test runtime](/quest/m0/aec-test-runtime.md) - keep the audio regression within the normal workspace test budget
 - [Go smoke client](/quest/m0/smoke-go-client.md) - the interop matrix has no Go client, so nothing in CI exercises the Go wrapper
 - [Retirement race](/quest/m0/transcode-retirement-race.md) - moq-transcode: retirement has no coverage for a fetch that is still opening its decoder
+- [Quest ready gate](/quest/m0/quest-ready-gate.md) - quest: nothing reports whether a quest is blocked, so the start flow reconstructs it by grepping
 - [PR behavioral gates](/quest/m0/pr-behavioral-gates.md) - run the applicable interop and platform gates on source PRs before merge
 - [Merge evidence](/quest/m0/merge-verification-evidence.md) - bind local, CI, and device results to the current source and merge candidate
 - [Verification preflight](/quest/m0/verification-preflight.md) - diagnose missing tools, denied access, and unusable runtimes before building

--- a/quest/m0/aec-test-runtime.md
+++ b/quest/m0/aec-test-runtime.md
@@ -30,6 +30,23 @@ Keep the normal timeout and full convergence assertion. Validate the fix in
 the full suite and under representative concurrent development load, and
 confirm that the upstream adaptive-filter shrink regression remains covered.
 
+Facts already established, so the measurement starts from them. The input is
+fixed run to run: `Room` is driven by the xorshift `Noise`, so whatever varies
+is the host or the profile, never the workload. That workload is 1500 calls to
+`Room::round`: 400 to grow the filter past its starting size, five 200-round
+moves that grow and shrink it again, and 100 more to measure re-convergence.
+Those counts are round numbers rather than measured minimums, so if a profile
+override does not close the gap, the next thing to measure is the shortest
+schedule that still reaches the shrink, before anything touches the assertions.
+`aec` is a default feature, so this runs on the PR path for every change to
+`moq-audio`, and it was hit again during PR #3466's session from two worktrees
+building concurrently on the same host.
+
+What the test protects is why weakening it is the last resort: the shrink path
+panicked in sonora 0.1.0, which is why the crate pins `sonora = "0.2"`, and the
+workspace's `panic = "abort"` makes that fatal in a real binary rather than a
+caught unwind.
+
 ## Related
 
 - [Worktree QA isolation](/quest/m0/worktree-qa-isolation.md) - make concurrent validation resources explicit

--- a/quest/m0/quest-ready-gate.md
+++ b/quest/m0/quest-ready-gate.md
@@ -8,10 +8,11 @@ start and spawn flows stop reconstructing that answer by grepping.
 ## Plan
 
 [quest/AGENTS.md](/quest/AGENTS.md) says only ready quests are executed and that
-a missing `Required` section is what makes one ready, but the only thing that
-reads `Required` is `quest check`, which proves the section is well-formed and
-acyclic. Those are properties of the tree; neither says whether a given quest can
-be started now.
+a missing `Required` section is what makes one ready. The only `rs/quest` command
+that reads `Required` is `quest check`, which proves the section is well-formed
+and acyclic: properties of the tree, neither of which says whether a given quest
+can be started now. The start and spawn flows answer that themselves, by grepping
+for the heading.
 
 The gap has been paid.
 [#2296](/quest/m1/2296-moq-native-bring-the-quiche-backend-to-quinn-noq-feature.md)
@@ -26,10 +27,13 @@ Add a `ready` subcommand to `rs/quest`:
   blocker, since nothing in the tree can clear it;
 - with no path, list every ready quest in tree order, which is the query the
   start flow reproduces by grepping today;
-- exit 0 either way. This is advice, not a gate: a caller under `set -e` would
-  otherwise turn a blocked quest into a hard stop, and starting a blocked quest
-  deliberately is sometimes right. Reserve a non-zero exit for the command
-  failing, the way any other tool does.
+- exit 0 either way, with the blocker list itself as the machine-readable
+  result: no output means ready, so a caller tests that rather than parsing
+  prose. Reserve a non-zero exit for the command failing, the way any other tool
+  does. Exiting non-zero on a blocked quest would hand every `set -e` caller a
+  gate it did not ask for, and starting a blocked quest deliberately, to land a
+  piece that turns out to be independent, is sometimes right. The decision stays
+  with the caller, which is the half that knows which case it is in.
 
 Liveness stays out. A quest can be ready, coherent, and already done:
 [#2979](/quest/m1/2979-moq-tokio-does-not-compile-with-no-default-features-and.md)

--- a/quest/m0/quest-ready-gate.md
+++ b/quest/m0/quest-ready-gate.md
@@ -1,0 +1,43 @@
+# [S] quest: nothing reports whether a quest is startable
+
+## Goal
+
+`quest ready` answers "is this quest blocked, and by what" from the tree, so the
+start and spawn flows stop reconstructing that answer by grepping.
+
+## Plan
+
+[quest/AGENTS.md](/quest/AGENTS.md) says only ready quests are executed and that
+a missing `Required` section is what makes one ready, but the only thing that
+reads `Required` is `quest check`, which proves the section is well-formed and
+acyclic. Those are properties of the tree; neither says whether a given quest can
+be started now.
+
+The gap has been paid.
+[#2296](/quest/m1/2296-moq-native-bring-the-quiche-backend-to-quinn-noq-feature.md)
+was started, and PR #3418 landed a large piece of it, while its `Required` bullet
+on the noq parity gate still stood. The bullet was dropped in that PR after the
+fact, which was the right call and not one anything had asked for.
+
+Add a `ready` subcommand to `rs/quest`:
+
+- with a path, print the blocker chain: each `Required` entry, and for a required
+  questline, which of its quests are still open. A plain-text bullet is always a
+  blocker, since nothing in the tree can clear it;
+- with no path, list every ready quest in tree order, which is the query the
+  start flow reproduces by grepping today;
+- exit 0 either way. This is advice, not a gate: a caller under `set -e` would
+  otherwise turn a blocked quest into a hard stop, and starting a blocked quest
+  deliberately is sometimes right. Reserve a non-zero exit for the command
+  failing, the way any other tool does.
+
+Liveness stays out. A quest can be ready, coherent, and already done:
+[#2979](/quest/m1/2979-moq-tokio-does-not-compile-with-no-default-features-and.md)
+was recommended on the strength of its plan when PR #3150 had closed the
+underlying issue in August. Checking that means asking GitHub, which is the
+calling flow's job, not a tree validator's; `quest ready` stays offline and
+deterministic.
+
+Note in the failure text that a blocked quest with an independently landable
+piece is split into its own quest, per the Creation rule, rather than started as
+it stands. Document the subcommand in `quest/AGENTS.md` beside `quest check`.

--- a/quest/m1/README.md
+++ b/quest/m1/README.md
@@ -58,6 +58,7 @@ with the current dev tree before starting.
 - [#3056](/quest/m1/3056-watch-video-decoder-captures-the-rewind-generation-at.md) - watch: video decoder captures the rewind generation at output time, not submit time
 - [Config provenance](/quest/m1/config-provenance.md) - the merge records which source set a value, so TOML survives CLI defaults and empty lists, and env outranks the file
 - [Cluster construction](/quest/m1/cluster-construction.md) - construct one stable origin after its cache settings are known, deleting the rebuilding builder
+- [Abort on drop](/quest/m1/abort-on-drop.md) - one abort-on-drop task guard per crate, replacing five copies of the same Drop
 - [#3046](/quest/m1/3046-fold-moq-token-into-moq-token-via-a-usage-executable-view.md) - Fold moq-token into moq token via a Usage executable view
 - [#3126](/quest/m1/3126-moq-bench-every-readme-example-fails-to-parse-and.md) - moq-bench: every README example fails to parse, and cumulative latency percentiles cannot be windowed to steady state
 - [#816](/quest/m1/816-expose-transportconfig.md) - QUIC flow-control windows on quic::Client and quic::Server, applied or refused per backend

--- a/quest/m1/abort-on-drop.md
+++ b/quest/m1/abort-on-drop.md
@@ -1,0 +1,30 @@
+# [XS] moq-tokio: one abort-on-drop guard instead of five
+
+## Goal
+
+One type per crate owns "abort this task when its owner drops", and every site
+that wants that behavior uses it.
+
+## Plan
+
+Dev only, which is why this sits in m1. Five copies of the same `Drop` exist
+today:
+
+- `rs/moq-tokio/src/worker.rs`: `AbortOnDrop<T>(JoinHandle<T>)`, awaited through
+  after the guard is moved, so the shared type has to keep the handle reachable.
+- `rs/moq-tokio/src/connection.rs`: `AbortOnDrop { handle: AbortHandle, closed:
+  CloseGuard }`. The `closed` field is connection policy that stays where it is;
+  only the abort half is shared.
+- `rs/moq-tokio/src/tls.rs`: `Reload(JoinHandle<()>)`, whose doc comment explains
+  what a leaked certificate watcher costs, not what the guard does. It keeps its
+  name and its comment and becomes a thin newtype.
+- `rs/moq-ffi/src/ffi.rs`: two more, one declared inside `detached` and one at
+  module scope, both over `AbortHandle`.
+
+Collapse the three `moq-tokio` sites onto one crate-private guard and the two
+`moq-ffi` ones onto another. `moq-ffi` already depends on `moq-tokio`, so a
+single shared guard is reachable, but that means a new `pub` item in a published
+crate for a five-line `Drop` with two internal callers, which Public API Scrutiny
+does not favor. Promote it if a third crate wants it.
+
+Nothing about behavior changes, so this lands on the existing tests.

--- a/rs/moq-cli/src/web.rs
+++ b/rs/moq-cli/src/web.rs
@@ -72,8 +72,8 @@ pub async fn run_web(bind: &str, certificates: moq_native::tls::Certificates) ->
 	}
 
 	let fingerprint_handler = move || async move {
-		// Get the first certificate's fingerprint.
-		// TODO serve all of them so we can support multiple signature algorithms.
+		// The first certificate in configuration order, deliberately: this exists
+		// to pin one generated self-signed certificate. See the relay's copy.
 		match certificates.fingerprints().into_iter().next() {
 			Some(fingerprint) => fingerprint.into_response(),
 			// A stream-only server has no certificate to pin.

--- a/rs/moq-relay/README.md
+++ b/rs/moq-relay/README.md
@@ -48,7 +48,7 @@ Multi-arch images (`linux/amd64` and `linux/arm64`) are published to [Docker Hub
 
 Primarily for debugging, you can also connect to the relay via HTTP.
 
-- `GET /certificate.sha256`: Returns the fingerprint of the TLS certificate.
+- `GET /certificate.sha256`: Returns the fingerprint of the first configured TLS certificate.
 - `GET /announced/*prefix`: Returns all of the announced tracks with the given (optional) prefix.
 - `GET /fetch/*path`: Returns the latest group of the given track.
 

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -575,9 +575,9 @@ async fn serve_fingerprint(State(state): State<Arc<WebState>>) -> Response {
 	// The first certificate in configuration order, deliberately. The endpoint
 	// exists so an `http://` client can pin a self-signed development
 	// certificate, where there is exactly one. With several configured there is
-	// no single answer: quinn and noq select by SNI at handshake, while quiche
-	// serves the first pair to everyone. Those clients pin explicitly or use
-	// `https://`.
+	// no single answer: quinn and noq select by SNI at handshake, so those
+	// clients use `https://`, while quiche serves the first pair to everyone and
+	// the rest need an explicit `--client-tls-fingerprint` pin.
 	match state.certificates.fingerprints().into_iter().next() {
 		Some(fingerprint) => fingerprint.into_response(),
 		// A stream-only relay has no certificate to pin.

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -574,9 +574,10 @@ async fn serve_health() -> Response {
 async fn serve_fingerprint(State(state): State<Arc<WebState>>) -> Response {
 	// The first certificate in configuration order, deliberately. The endpoint
 	// exists so an `http://` client can pin a self-signed development
-	// certificate, where there is exactly one. A deployment serving several
-	// selects by SNI at handshake, so no single hash can answer for all of them;
-	// those clients pin explicitly or use `https://`.
+	// certificate, where there is exactly one. With several configured there is
+	// no single answer: quinn and noq select by SNI at handshake, while quiche
+	// serves the first pair to everyone. Those clients pin explicitly or use
+	// `https://`.
 	match state.certificates.fingerprints().into_iter().next() {
 		Some(fingerprint) => fingerprint.into_response(),
 		// A stream-only relay has no certificate to pin.

--- a/rs/moq-relay/src/web.rs
+++ b/rs/moq-relay/src/web.rs
@@ -572,8 +572,11 @@ async fn serve_health() -> Response {
 }
 
 async fn serve_fingerprint(State(state): State<Arc<WebState>>) -> Response {
-	// Get the first certificate's fingerprint.
-	// TODO serve all of them so we can support multiple signature algorithms.
+	// The first certificate in configuration order, deliberately. The endpoint
+	// exists so an `http://` client can pin a self-signed development
+	// certificate, where there is exactly one. A deployment serving several
+	// selects by SNI at handshake, so no single hash can answer for all of them;
+	// those clients pin explicitly or use `https://`.
 	match state.certificates.fingerprints().into_iter().next() {
 		Some(fingerprint) => fingerprint.into_response(),
 		// A stream-only relay has no certificate to pin.


### PR DESCRIPTION
## Summary

Follow-ups from [#3418](https://github.com/moq-dev/moq/pull/3418) (the quiche certificate semantics) and from running the suite on a machine with several worktrees building at once. Five candidates went through the quest interview; two survive as new quests, one folds into a quest that landed while this branch was open, and two were settled outright.

## Quests added

- [`quest/m0/quest-ready-gate.md`](quest/m0/quest-ready-gate.md) `[S]` - `quest check` proves `Required` is well-formed and acyclic, which are properties of the tree; nothing says whether a given quest can be started. #2296 was started, and #3418 landed a large piece of it, while its `Required` bullet on the noq parity gate still stood. A `quest ready` subcommand prints the blocker chain for a path, lists ready quests without one, and exits 0 either way: advice that can trip `set -e` is a gate, and starting a blocked quest deliberately is sometimes the right call.
- [`quest/m1/abort-on-drop.md`](quest/m1/abort-on-drop.md) `[XS]` - five copies of the same abort-on-drop `Drop`: `worker.rs`, `connection.rs`, `tls::Reload`, and two in `moq-ffi/src/ffi.rs`. One guard per crate rather than a new `pub` item in a published crate for two internal callers.

## Quest extended

[#3462](https://github.com/moq-dev/moq/pull/3462) quested the echo-delay test runtime independently while this branch was open, at the same path. That quest keeps the path and its measurements; this adds what it did not have, since its plan asks whether unoptimized DSP dominates:

- the workload is fixed run to run (`Room` is driven by the xorshift `Noise`), so the variance is host or profile, never input;
- it is 1500 `Room::round` calls (400 grow, five 200-round moves, 100 to measure re-convergence), and those counts are round numbers rather than measured minimums, so a shorter schedule that still reaches the shrink is the next measurement if a profile override does not close the gap;
- `aec` is a default feature, so this is on the PR path for every `moq-audio` change, and it was hit again from two concurrently building worktrees on this host;
- what it protects: the shrink panicked in sonora 0.1.0, which is why the crate pins `sonora = "0.2"`, and `panic = "abort"` makes that fatal in a real binary.

## Settled instead of planned

- **`/certificate.sha256` reports the first configured certificate, deliberately.** Certificates are selected by SNI, so a relay serving several has no single fingerprint to publish; the endpoint exists to pin one self-signed development certificate. Both handlers carried `TODO serve all of them so we can support multiple signature algorithms`, which promises the opposite of the decision, so they now state why it is not coming. Same in `doc/bin/relay/http.md` and the relay README, with the workaround named: pin explicitly with `--client-tls-fingerprint`, or use `https://`.
- **`Subscription::max_age` keeps `Duration::ZERO`.** [#3441](https://github.com/moq-dev/moq/pull/3441)'s four tests publish an entire track before reading it back, which is not playback; naming a budget was the fix, and the default is not the defect. No quest.

Liveness is deliberately outside `quest ready`: #2979 was recommended on the strength of its plan after [#3150](https://github.com/moq-dev/moq/pull/3150) had already closed its issue in August, but catching that means asking GitHub, which belongs to the calling flow rather than a tree validator. The quest says so rather than leaving it to be rediscovered.

## Test plan

- `just check`: exit 0, including `quest check`.
- `just test`: 289 tests run, 289 passed, 1 skipped.
- `just fix`: clean. `quest check` re-run after the rebase: 264 documents ok.

The only non-documentation change is two comment bodies, so nothing compiles differently.

## Cross-Package Sync

`rs/moq-relay` config/behavior -> `doc/bin/relay/`: updated, along with `rs/moq-relay/README.md`. No other row applies: no wire, catalog, FFI, token, stats, or JS surface moves, so no `drafts/` change is due.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by claude-opus-5)