### PR TITLE
refactor(tokio): one abort-on-drop guard per crate instead of five

### DIFF
--- a/rs/moq-ffi/src/ffi.rs
+++ b/rs/moq-ffi/src/ffi.rs
@@ -57,6 +57,20 @@ pub(crate) fn spawn<F: Future<Output = ()> + 'static>(future: F) {
 	web_async::spawn(future);
 }
 
+/// Aborts a spawned task when the future awaiting it is dropped.
+///
+/// Aborting one that already finished is a no-op, so this is inert on the happy path.
+/// Native only: wasm32 has no runtime to spawn onto, so its callers await in place.
+#[cfg(not(target_arch = "wasm32"))]
+struct AbortOnDrop(tokio::task::AbortHandle);
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Drop for AbortOnDrop {
+	fn drop(&mut self) {
+		self.0.abort();
+	}
+}
+
 /// Run a future to completion off the caller's thread, mapping its error into [`MoqError`].
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) async fn detached<F, T, E>(future: F) -> Result<T, MoqError>
@@ -65,14 +79,6 @@ where
 	T: Send + 'static,
 	E: Into<MoqError> + Send + 'static,
 {
-	struct AbortOnDrop(tokio::task::AbortHandle);
-
-	impl Drop for AbortOnDrop {
-		fn drop(&mut self) {
-			self.0.abort();
-		}
-	}
-
 	let task = RUNTIME.spawn(future);
 	let _abort = AbortOnDrop(task.abort_handle());
 	match task.await {
@@ -236,20 +242,6 @@ impl<T: kio::MaybeSend + 'static> Task<T> {
 impl<T: kio::MaybeSend + 'static> Drop for Task<T> {
 	fn drop(&mut self) {
 		self.cancel();
-	}
-}
-
-/// Aborts a spawned task when the future awaiting it is dropped.
-///
-/// Aborting one that already finished is a no-op, so this is inert on the happy path.
-/// Native only: wasm32 has no runtime to spawn onto, so `run` awaits in place there.
-#[cfg(not(target_arch = "wasm32"))]
-struct AbortOnDrop(tokio::task::AbortHandle);
-
-#[cfg(not(target_arch = "wasm32"))]
-impl Drop for AbortOnDrop {
-	fn drop(&mut self) {
-		self.0.abort();
 	}
 }
 

--- a/rs/moq-tokio/src/abort.rs
+++ b/rs/moq-tokio/src/abort.rs
@@ -1,0 +1,36 @@
+//! Ties a spawned task's lifetime to a value the owner holds.
+
+/// Owns a spawned task, cancelling it when this guard drops.
+///
+/// A bare [`tokio::task::JoinHandle`] detaches instead, leaving the task running
+/// with nothing left able to reach it. Derefs to the handle, so an owner can still
+/// await the task's output or abort it early.
+#[derive(Debug)]
+pub(crate) struct AbortOnDrop<T = ()>(tokio::task::JoinHandle<T>);
+
+impl<T> AbortOnDrop<T> {
+	/// Take ownership of a spawned task.
+	pub(crate) fn new(handle: tokio::task::JoinHandle<T>) -> Self {
+		Self(handle)
+	}
+}
+
+impl<T> std::ops::Deref for AbortOnDrop<T> {
+	type Target = tokio::task::JoinHandle<T>;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+impl<T> std::ops::DerefMut for AbortOnDrop<T> {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		&mut self.0
+	}
+}
+
+impl<T> Drop for AbortOnDrop<T> {
+	fn drop(&mut self) {
+		self.0.abort();
+	}
+}

--- a/rs/moq-tokio/src/connection.rs
+++ b/rs/moq-tokio/src/connection.rs
@@ -9,6 +9,7 @@ use moq_net::kio;
 use rand::RngExt;
 use url::Url;
 
+use crate::abort::AbortOnDrop;
 use crate::connect::Endpoint;
 use crate::{Addrs, Client, Error};
 
@@ -515,7 +516,7 @@ impl ConnectionStatsReader {
 #[derive(Clone)]
 #[must_use = "dropping the Connection stops the dial; hold it for as long as you want the session"]
 pub struct Connection {
-	task: std::sync::Arc<AbortOnDrop>,
+	task: std::sync::Arc<Task>,
 	state: kio::Consumer<State>,
 	/// Persistent send-bitrate estimate, fed by the loop from each live session.
 	send_bandwidth: BandwidthConsumer,
@@ -526,16 +527,11 @@ pub struct Connection {
 	last_reported: Option<Status>,
 }
 
-/// Aborts the connection loop when the last [`Connection`] clone drops.
-struct AbortOnDrop {
-	handle: tokio::task::AbortHandle,
+/// The connection loop, shared by every [`Connection`] clone and aborted when the
+/// last one drops.
+struct Task {
+	handle: AbortOnDrop,
 	closed: CloseGuard,
-}
-
-impl Drop for AbortOnDrop {
-	fn drop(&mut self) {
-		self.handle.abort();
-	}
 }
 
 /// Serializes [`Connection::abort`] against the loop publishing a fresh session.
@@ -583,8 +579,8 @@ impl Connection {
 			// Dropping the producers here closes the channels, signaling consumers.
 		});
 		Self {
-			task: std::sync::Arc::new(AbortOnDrop {
-				handle: task.abort_handle(),
+			task: std::sync::Arc::new(Task {
+				handle: AbortOnDrop::new(task),
 				closed,
 			}),
 			state,

--- a/rs/moq-tokio/src/lib.rs
+++ b/rs/moq-tokio/src/lib.rs
@@ -28,6 +28,7 @@
 ))]
 compile_error!("a rustls QUIC backend requires a crypto provider: enable either the `aws-lc-rs` or `ring` feature");
 
+mod abort;
 pub mod accept;
 pub use moq_sock::bind;
 pub mod cli;

--- a/rs/moq-tokio/src/tls.rs
+++ b/rs/moq-tokio/src/tls.rs
@@ -11,6 +11,8 @@
 //! certificates it serves reload like every other backend's. [`Certificates`]
 //! reads the current served set back out.
 
+#[cfg(any(feature = "quinn", feature = "noq", feature = "quiche"))]
+use crate::abort::AbortOnDrop;
 use crate::crypto;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer, ServerName, UnixTime};
@@ -2935,10 +2937,20 @@ impl rustls::server::ResolvesServerCert for ServeCerts {
 /// repeatedly in one process would accumulate all three.
 #[cfg(any(feature = "quinn", feature = "noq", feature = "quiche"))]
 #[derive(Debug)]
-pub(crate) struct Reload(tokio::task::JoinHandle<()>);
+pub(crate) struct Reload {
+	/// Named for the drop alone: nothing reads it, and losing it stops the watcher.
+	_task: AbortOnDrop,
+}
 
 #[cfg(any(feature = "quinn", feature = "noq", feature = "quiche"))]
 impl Reload {
+	/// A guard over a task with nothing to do, for a listener with nothing to watch.
+	fn inert() -> Self {
+		Self {
+			_task: AbortOnDrop::new(tokio::spawn(std::future::ready(()))),
+		}
+	}
+
 	/// Start watching the file-backed pairs in `config`, if it has any.
 	///
 	/// The watch is registered here rather than inside the task, so it covers the
@@ -2951,14 +2963,14 @@ impl Reload {
 		let paths: Vec<PathBuf> = config.cert.iter().chain(config.key.iter()).cloned().collect();
 		if paths.is_empty() {
 			// Nothing on disk to watch, so the task has nothing to do.
-			return Self(tokio::spawn(std::future::ready(())));
+			return Self::inert();
 		}
 
 		let watcher = match crate::watch::FileWatcher::new(&paths) {
 			Ok(watcher) => watcher,
 			Err(err) => {
 				tracing::error!(%err, "failed to watch certificate files; hot reload disabled");
-				return Self(tokio::spawn(std::future::ready(())));
+				return Self::inert();
 			}
 		};
 
@@ -2971,14 +2983,9 @@ impl Reload {
 			tracing::warn!(%err, "failed to re-read server certificates after watching");
 		}
 
-		Self(tokio::spawn(reload_certs(watcher, certs, config)))
-	}
-}
-
-#[cfg(any(feature = "quinn", feature = "noq", feature = "quiche"))]
-impl Drop for Reload {
-	fn drop(&mut self) {
-		self.0.abort();
+		Self {
+			_task: AbortOnDrop::new(tokio::spawn(reload_certs(watcher, certs, config))),
+		}
 	}
 }
 

--- a/rs/moq-tokio/src/worker/group.rs
+++ b/rs/moq-tokio/src/worker/group.rs
@@ -3,7 +3,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 use super::Config;
-use crate::{Error, Result, Server, listen::Member};
+use crate::{Error, Result, Server, abort::AbortOnDrop, listen::Member};
 
 /// A bound group of QUIC workers sharing one port.
 ///
@@ -297,7 +297,7 @@ impl Spawner<'_> {
 			// The factory runs inside the task, not as the argument to the spawn:
 			// panicking while building the future is then the task's panic, not the
 			// worker thread's.
-			let task = AbortOnDrop(tokio::task::spawn_local(async move { make().await }));
+			let task = AbortOnDrop::new(tokio::task::spawn_local(async move { make().await }));
 			// The guard travels with the handle, so every way of losing it from here
 			// on (a failed send, a caller that aborts while it is still in flight,
 			// the forwarding task below being cancelled) cancels the task instead of
@@ -308,7 +308,7 @@ impl Spawner<'_> {
 
 		self.handle.spawn(async move {
 			let mut task = task_rx.await.expect("worker stopped before spawning task");
-			match (&mut task.0).await {
+			match (&mut *task).await {
 				Ok(output) => output,
 				Err(err) if err.is_panic() => std::panic::resume_unwind(err.into_panic()),
 				Err(err) => panic!("worker-local task cancelled: {err}"),
@@ -425,19 +425,6 @@ struct Ready {
 
 /// A future factory that is sent to and invoked by its worker thread.
 type Spawn = Box<dyn FnOnce() + Send + 'static>;
-
-/// Owns a worker-local task from the moment it is spawned, cancelling it if the
-/// handle standing for it is lost.
-///
-/// A bare [`tokio::task::JoinHandle`] detaches on drop, which would leave the
-/// task running unreachable on its worker until the whole group stopped.
-struct AbortOnDrop<T>(tokio::task::JoinHandle<T>);
-
-impl<T> Drop for AbortOnDrop<T> {
-	fn drop(&mut self) {
-		self.0.abort();
-	}
-}
 
 /// One worker thread: pin, bind, report, then park until it is stopped.
 ///


### PR DESCRIPTION
## Summary

- Five copies of the same abort-a-task-on-drop `Drop` impl existed; this collapses them to two, one per crate.
- `moq-tokio` gains a crate-private `abort::AbortOnDrop<T>` over a `tokio::task::JoinHandle`. It derefs to the handle, so an owner can still await the task's output (`worker::group`) or abort it early (`connection`). `tls::Reload` keeps its name and its doc comment and becomes a thin newtype over it.
- `moq-ffi` had two identical guards over an `AbortHandle`, one nested inside `detached` and one at module scope. The nested copy is gone and both call sites use the module-scope one, moved up above its first user.

## Why not one shared guard

`moq-ffi` depends on `moq-tokio`, so a single guard was reachable, but exporting it means a new `pub` item in a published crate for a five-line `Drop` with two internal callers, which Public API Scrutiny does not favor. Both guards stay crate-private. Promote it if a third crate wants it.

## Public API changes

None. `abort` is a private module and `abort::AbortOnDrop` is `pub(crate)`; `tls::Reload` was and stays `pub(crate)`; `connection`'s guard was private and is now the private `Task`.

## Incidental shape fixes

- `connection`'s guard struct is renamed `Task`, since it now holds the abort guard plus the `closed` connection policy rather than being the `Drop` itself. The `closed` half is connection policy and stays where it is.
- `Reload::spawn`'s two "nothing to watch" returns share a `Reload::inert()` constructor.
- `Reload`'s field is `_task` because nothing reads it: the drop is the whole point, and rustc's dead-code pass does not count a drop as a read.

## Quest

Executes [/quest/m1/abort-on-drop.md](https://github.com/moq-dev/moq/blob/main/quest/m1/abort-on-drop.md). That file lives on `main`'s quest tree and dev's tree is forked without it, so this PR cannot delete it: **the quest file and its `quest/m1/README.md` entry (the `Abort on drop` line) still need removing from `main` in a separate PR.**

## Cross-Package Sync

Only the `rs/moq-ffi` row is touched by path, and it does not apply: the change is a private helper inside `ffi.rs`, so the UniFFI surface is unchanged and `libmoq`, the `{py,swift,kt,dart,go}` wrappers, and `doc/lib/*` need nothing. No wire, catalog, config, or CLI surface changed, so no other row applies.

## Test plan

- `just fix`, `just check` (exit 0), `just test` (exit 0; 2488 tests passed, 12 skipped).
- `cargo check -p moq-ffi` explicitly, since `just check` does not compile that crate by default.
- `cargo check -p moq-tokio --no-default-features` clean of any new warning.
- Behavior is unchanged, so this lands on the existing tests. `tls::dropping_the_reload_guard_stops_the_watcher` is unmodified and passes; it is the direct regression test for the `Reload` rewrite.

(Written by claude-opus-5)
