### PR TITLE
docs(js): fix stale publish and watch API docs

### DIFF
--- a/doc/lib/js/publish.md
+++ b/doc/lib/js/publish.md
@@ -88,13 +88,15 @@ const broadcast = new Publish.Broadcast({
     name: Publish.Net.Path.from("alice.hang"),
 });
 
-const capture = new Publish.Video.Capture({ source });   // a Source.Camera's `out.source`
+const camera = new Publish.Source.Camera({ enabled: true });
+const microphone = new Publish.Source.Microphone({ enabled: true });
+const capture = new Publish.Video.Capture({ source: camera.out.source });
 
 // Each encoder registers a rendition on the broadcast (`broadcast.video(name)`) and
 // encodes only while someone is subscribed.
 new Publish.Video.Encoder("video/hd", { broadcast, capture, enabled: true });
 new Publish.Video.Encoder("video/sd", { broadcast, capture, enabled: true, config: { maxScale: 0.25 } });
-new Publish.Audio.Encoder("audio", { broadcast, source: audioSource, enabled: true });
+new Publish.Audio.Encoder("audio", { broadcast, source: microphone.out.source, enabled: true });
 ```
 
 Every input and output is a signal from [`@moq/signals`](/lib/js/signals).

--- a/doc/lib/js/publish.md
+++ b/doc/lib/js/publish.md
@@ -46,10 +46,36 @@ drop the element and register your own encoders on a `Publish.Broadcast`.
 
 ## Custom tracks
 
-`broadcast.publishTrack(name, serve)` serves any application track per
-subscriber, and `broadcast.catalog.mutate(c => { c.yourSection = ... })`
-advertises it without touching the media sections. Encode JSON with
-`@moq/json`.
+`broadcast.net` is the underlying `Moq.Broadcast.Producer`, so an application
+can serve its own tracks alongside the media. It is recreated on each
+(re)connection, so acquire it from an effect and reseed the track each time:
+
+```ts
+import * as Json from "@moq/json";
+
+signals.run((effect) => {
+    const net = effect.get(broadcast.net);
+    if (!net) return;
+
+    // A day-long retention so a late viewer still replays the last value.
+    const track = net.createTrack("meta.json", { latencyMax: 86_400_000 });
+    effect.cleanup(() => track.close());
+
+    const meta = new Json.Snapshot.Producer<Meta>({ track });
+    meta.update(current);
+});
+```
+
+`broadcast.catalog.mutate(c => { c.yourSection = ... })` advertises it without
+touching the media sections, which are folded in from the registered
+renditions. The catalog schema is loose, so an unknown root section passes
+through untouched; cast to name your own:
+
+```ts
+broadcast.catalog.mutate((catalog) => {
+    (catalog as Catalog.Root & { metadata?: string[] }).metadata = ["meta.json"];
+});
+```
 
 ## Without the element
 
@@ -57,12 +83,18 @@ advertises it without touching the media sections. Encode JSON with
 import * as Publish from "@moq/publish";
 
 const broadcast = new Publish.Broadcast({
-    connection,
+    connection,                                   // a Net.Connection.Established signal
     enabled: true,
-    name: "alice.hang",
-    video: { hd: { enabled: true }, sd: { enabled: true } },   // two renditions
-    audio: { enabled: true },
+    name: Publish.Net.Path.from("alice.hang"),
 });
+
+const capture = new Publish.Video.Capture({ source });   // a Source.Camera's `out.source`
+
+// Each encoder registers a rendition on the broadcast (`broadcast.video(name)`) and
+// encodes only while someone is subscribed.
+new Publish.Video.Encoder("video/hd", { broadcast, capture, enabled: true });
+new Publish.Video.Encoder("video/sd", { broadcast, capture, enabled: true, config: { maxScale: 0.25 } });
+new Publish.Audio.Encoder("audio", { broadcast, source: audioSource, enabled: true });
 ```
 
 Every input and output is a signal from [`@moq/signals`](/lib/js/signals).

--- a/js/publish/README.md
+++ b/js/publish/README.md
@@ -133,13 +133,13 @@ The `<moq-publish-ui>` element automatically discovers the nested `<moq-publish>
 
 ## Features
 
-- **Camera & microphone** — Capture from user devices
-- **Screen sharing** — Capture display or window
-- **File playback** — Publish from a media file
-- **WebCodecs encoding** — Hardware-accelerated video and audio encoding
-- **Reactive state** — All properties are signals from `@moq/signals`
-- **Simulcast** — Any number of renditions, each its own encoder and track
-- **Custom tracks** — Application tracks and catalog sections ride alongside the media
+- **Camera & microphone**: Capture from user devices
+- **Screen sharing**: Capture display or window
+- **File playback**: Publish from a media file
+- **WebCodecs encoding**: Hardware-accelerated video and audio encoding
+- **Reactive state**: All properties are signals from `@moq/signals`
+- **Simulcast**: Any number of renditions, each its own encoder and track
+- **Custom tracks**: Application tracks and catalog sections ride alongside the media
 
 ## License
 

--- a/js/publish/README.md
+++ b/js/publish/README.md
@@ -7,7 +7,7 @@
 [![npm](https://img.shields.io/npm/v/@moq/publish)](https://www.npmjs.com/package/@moq/publish)
 [![TypeScript](https://img.shields.io/badge/TypeScript-ready-blue.svg)](https://www.typescriptlang.org/)
 
-Publish media to [Media over QUIC](https://moq.dev/) (MoQ) broadcasts, built on top of [@moq/hang](../hang) and [@moq/net](../lite).
+Publish media to [Media over QUIC](https://moq.dev/) (MoQ) broadcasts, built on top of [@moq/hang](../hang) and [@moq/net](../net).
 
 ## Installation
 
@@ -54,10 +54,7 @@ The simplest way to publish a stream:
     import "@moq/publish/element";
 </script>
 
-<moq-publish
-    url="https://relay.example.com/anon"
-    path="room/alice.hang"
-    audio video controls>
+<moq-publish url="https://relay.example.com/anon" name="room/alice.hang" source="camera">
     <video muted autoplay></video>
 </moq-publish>
 ```
@@ -72,29 +69,52 @@ The simplest way to publish a stream:
 | `muted`     | boolean | false    | Mute audio capture              |
 | `invisible` | boolean | false    | Disable video capture           |
 | `preview`   | string  | `"source"` | What the preview renders: `"source"`, `"encoded"`, `"none"` |
-| `announce`  | string  | `"source"` | When to publish: `"always"`, `"never"`, `"source"` (once a source is selected) |
+| `announce`  | string  | `"source"` | When to publish: `"always"`, `"never"`, `"source"` (once media is actually captured) |
+
+A nested `<video>` shows the raw capture; a `<canvas>` is drawn by the element.
 
 ## JavaScript API
 
-For more control:
+For more control, `Broadcast` owns the network broadcast and the catalog. Renditions are
+registered by the encoders themselves, one per track name, so simulcast is just
+more encoders:
 
 ```typescript
 import * as Publish from "@moq/publish";
 
-const publish = new Publish.Broadcast(connection, {
+const connection = new Publish.Net.Connection.Reload({
+    url: new URL("https://relay.example.com/anon"),
     enabled: true,
-    name: "alice.hang",
-    video: { enabled: true },
-    audio: { enabled: true },
 });
 
-// Change source at runtime
-publish.source.camera.enabled.set(true);
+const broadcast = new Publish.Broadcast({
+    connection: connection.established,
+    enabled: true,
+    name: Publish.Net.Path.from("room/alice.hang"),
+});
+
+// Capture, then encode. Each encoder registers its rendition on the broadcast
+// and encodes only while someone is subscribed.
+const camera = new Publish.Source.Camera({ enabled: true });
+const capture = new Publish.Video.Capture({ source: camera.out.source });
+
+const hd = new Publish.Video.Encoder("video/hd", { broadcast, capture, enabled: true });
+const sd = new Publish.Video.Encoder("video/sd", { broadcast, capture, enabled: true, config: { maxScale: 0.25 } });
+
+// Tune an encoder at any time; undefined fields are auto-sized.
+hd.config.set({ codec: "vp09.00.10.08", maxBitrate: 4_000_000 });
+
+const microphone = new Publish.Source.Microphone({ enabled: true });
+const audio = new Publish.Audio.Encoder("audio", { broadcast, source: microphone.out.source, enabled: true });
+audio.volume.set(0.8);
 ```
+
+Serve application tracks alongside the media with `broadcast.net`, the
+underlying producer, and advertise them with `broadcast.catalog.mutate(...)`.
 
 ## UI Web Component
 
-`@moq/publish` includes a Web Component UI overlay (`<moq-publish-ui>`) with source selection (camera, screen, file, microphone) and status indicator. It is built on top of `@moq/signals` with no framework dependency.
+`@moq/publish` includes a Web Component UI overlay (`<moq-publish-ui>`) with source selection (camera, screen, file, microphone), audio/video toggles, a status badge, fullscreen, and a stats panel. It is built on top of `@moq/signals` with no framework dependency.
 
 ```html
 <script type="module">
@@ -103,7 +123,7 @@ publish.source.camera.enabled.set(true);
 </script>
 
 <moq-publish-ui>
-    <moq-publish url="https://relay.example.com/anon" path="room/alice.hang" audio video>
+    <moq-publish url="https://relay.example.com/anon" name="room/alice.hang" source="camera">
         <video muted autoplay></video>
     </moq-publish>
 </moq-publish-ui>
@@ -118,8 +138,8 @@ The `<moq-publish-ui>` element automatically discovers the nested `<moq-publish>
 - **File playback** — Publish from a media file
 - **WebCodecs encoding** — Hardware-accelerated video and audio encoding
 - **Reactive state** — All properties are signals from `@moq/signals`
-- **Chat** — Publish text chat messages
-- **Location** — Publish peer position and window tracking
+- **Simulcast** — Any number of renditions, each its own encoder and track
+- **Custom tracks** — Application tracks and catalog sections ride alongside the media
 
 ## License
 

--- a/js/watch/README.md
+++ b/js/watch/README.md
@@ -139,11 +139,11 @@ The `<moq-watch-ui>` element automatically discovers the nested `<moq-watch>` el
 
 ## Features
 
-- **WebCodecs decoding** — Hardware-accelerated video and audio decoding
-- **Reactive state** — All properties are signals from `@moq/signals`
-- **Latency control** — A single target, or a range that buffers future-dated frames
-- **Quality selection** — Switch between available renditions
-- **Custom tracks** — Unknown catalog sections pass through, and `broadcast.out.active` subscribes your own tracks
+- **WebCodecs decoding**: Hardware-accelerated video and audio decoding
+- **Reactive state**: All properties are signals from `@moq/signals`
+- **Latency control**: A single target, or a range that buffers future-dated frames
+- **Quality selection**: Switch between available renditions
+- **Custom tracks**: Unknown catalog sections pass through, and `broadcast.out.active` subscribes your own tracks
 
 ## License
 

--- a/js/watch/README.md
+++ b/js/watch/README.md
@@ -7,7 +7,7 @@
 [![npm](https://img.shields.io/npm/v/@moq/watch)](https://www.npmjs.com/package/@moq/watch)
 [![TypeScript](https://img.shields.io/badge/TypeScript-ready-blue.svg)](https://www.typescriptlang.org/)
 
-Subscribe to and render [Media over QUIC](https://moq.dev/) (MoQ) broadcasts, built on top of [@moq/hang](../hang) and [@moq/net](../lite).
+Subscribe to and render [Media over QUIC](https://moq.dev/) (MoQ) broadcasts, built on top of [@moq/hang](../hang) and [@moq/net](../net).
 
 ## Installation
 
@@ -54,25 +54,26 @@ The simplest way to watch a stream:
     import "@moq/watch/element";
 </script>
 
-<moq-watch
-    url="https://relay.example.com/anon"
-    name="room/alice.hang"
-    controls>
+<moq-watch url="https://relay.example.com/anon" name="room/alice.hang">
     <canvas></canvas>
 </moq-watch>
 ```
 
 ### Attributes
 
-| Attribute | Type                                | Default  | Description                              |
-|-----------|-------------------------------------|----------|------------------------------------------|
-| `url`     | string                              | required | Relay server URL                         |
-| `name`    | string                              | required | Broadcast name/path                      |
-| `paused`  | boolean                             | false    | Pause playback                           |
-| `muted`   | boolean                             | false    | Mute audio                               |
-| `visible` | never, distance, or always          | `20%`    | When to download video (see below)       |
-| `volume`  | number                              | 0.5      | Audio volume (0-1)                       |
-| `reload`  | boolean                             | true     | Wait for (re)announcement before subscribing. Ignored when the relay does not support broadcast discovery. |
+| Attribute        | Type                       | Default       | Description                              |
+|------------------|----------------------------|---------------|------------------------------------------|
+| `url`            | string                     | required      | Relay server URL                         |
+| `name`           | string                     | required      | Broadcast name/path                      |
+| `paused`         | boolean                    | false         | Pause playback                           |
+| `muted`          | boolean                    | false         | Mute audio                               |
+| `visible`        | never, distance, or always | `20%`         | When to download video (see below)       |
+| `volume`         | number                     | 0.5           | Audio volume (0-1)                       |
+| `reload`         | boolean                    | true          | Wait for (re)announcement before subscribing. Ignored when the relay does not support broadcast discovery. |
+| `latency`        | `real-time`, ms, `instant` | `real-time`   | Target latency. `instant` paints frames as they decode and disables audio. |
+| `latency-min`    | `real-time` or ms          | `real-time`   | The latency floor, opening a range instead of a single target. |
+| `latency-max`    | `real-time` or ms          | `real-time`   | The latency ceiling: buffer freely below it, skip ahead past it. |
+| `catalog-format` | hang, hangz, msf, manual   | auto-detected | The catalog format; detected from the name suffix unless set. `hangz` (compressed) is opt-in. |
 
 The `visible` attribute controls when the video track is downloaded, based on the canvas
 position relative to the viewport:
@@ -87,25 +88,35 @@ Only the distance mode suspends video while the tab is hidden; `always` keeps do
 
 ## JavaScript API
 
-For more control:
+For more control, `Broadcast` fetches the catalog and follows the broadcast across reconnects.
+The rest of the pipeline is assembled around it: a `Source` picks a rendition,
+a `Decoder` decodes it, `Sync` paces both media clocks, and a `Renderer` /
+`Emitter` paints to a canvas and plays through WebAudio.
 
 ```typescript
 import * as Watch from "@moq/watch";
 
-const watch = new Watch.Broadcast(connection, {
+const connection = new Watch.Net.Connection.Reload({
+    url: new URL("https://relay.example.com/anon"),
     enabled: true,
-    name: "alice.hang",
-    video: { enabled: true },
-    audio: { enabled: true },
 });
 
-// Access the video stream
-watch.video.media.subscribe((stream) => {
-    if (stream) {
-        videoElement.srcObject = stream;
-    }
+const broadcast = new Watch.Broadcast({
+    connection: connection.established,
+    enabled: true,
+    name: Watch.Net.Path.from("room/alice.hang"),
 });
+
+const source = new Watch.Video.Source({ broadcast, supported: Watch.Video.Decoder.supported });
+const sync = new Watch.Sync({ connection: connection.established, video: source.out.jitter });
+const decoder = new Watch.Video.Decoder(source, sync, { enabled: true });
+
+// Video renders to a <canvas>; there is no MediaStream to assign.
+const renderer = new Watch.Video.Renderer(decoder, { canvas });
 ```
+
+Audio is the same shape: `Audio.Source` into `Audio.Decoder` into
+`Audio.Emitter`, sharing the one `Sync`.
 
 ## UI Web Component
 
@@ -130,9 +141,9 @@ The `<moq-watch-ui>` element automatically discovers the nested `<moq-watch>` el
 
 - **WebCodecs decoding** — Hardware-accelerated video and audio decoding
 - **Reactive state** — All properties are signals from `@moq/signals`
-- **Chat** — Subscribe to text chat channels
-- **Location** — Peer location and window tracking
+- **Latency control** — A single target, or a range that buffers future-dated frames
 - **Quality selection** — Switch between available renditions
+- **Custom tracks** — Unknown catalog sections pass through, and `broadcast.out.active` subscribes your own tracks
 
 ## License
 


### PR DESCRIPTION
## Summary

- `doc/lib/js/publish.md` documented `broadcast.publishTrack(name, serve)`, which does not exist. Custom tracks are served through `broadcast.net` (the underlying `Moq.Broadcast.Producer`, recreated on each reconnection), as `demo/web/src/publish.ts` does for its `meta.json` track. `broadcast.catalog.mutate(...)` is real and stays, now with the cast an unknown root section needs.
- The same page's "Without the element" example passed `video`/`audio` props to `Publish.Broadcast`, which takes neither. Renditions are registered by the encoders (`new Video.Encoder("video/hd", { broadcast, capture })`).
- `js/watch/README.md`: `new Watch.Broadcast(connection, {...})` takes a single props object; `watch.video.media` / `srcObject` is gone with MSE, so the example now runs the real Source -> Sync -> Decoder -> Renderer pipeline onto a canvas. Dropped the Chat and Location features (neither exists), the non-existent `controls` attribute, and added the `latency*` and `catalog-format` attributes.
- `js/publish/README.md` had the same class of problems: `path=` instead of `name=`, non-existent `audio`/`video`/`controls` attributes, the wrong `Broadcast` constructor, `publish.source.camera.enabled`, and the Chat/Location features.
- Both READMEs linked `@moq/net` at `../lite`.

## Public API

None. Documentation only.

## Wire

None.

(written by Claude Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)