### PR TITLE
fix(mux): refuse an fMP4 fragment whose decode time doesn't advance

### DIFF
--- a/demo/pub/justfile
+++ b/demo/pub/justfile
@@ -38,12 +38,12 @@ list:
 # Publish Big Buck Bunny to a relay server.
 bbb url='http://localhost:4443' *args:
     just download bbb
-    just cmaf bbb "{{ url }}" {{ args }}
+    just ts bbb "{{ url }}" {{ args }}
 
 # Publish Tears of Steel to a relay server.
 tos url='http://localhost:4443' *args:
     just download tos
-    just cmaf tos "{{ url }}" {{ args }}
+    just ts tos "{{ url }}" {{ args }}
 
 # Publish a video using ffmpeg (CMAF / fMP4) to a relay server.
 cmaf name url='http://localhost:4443' *args:
@@ -59,7 +59,7 @@ ts name url='http://localhost:4443' *args:
 iroh name url prefix="":
     just download "{{ name }}"
     cargo build --bin moq
-    just ffmpeg-cmaf "media/{{ name }}.mp4" | cargo run --bin moq -- --iroh-enabled --client-connect "{{ url }}" --broadcast "{{ prefix }}{{ name }}.hang" import fmp4
+    just ffmpeg-ts "media/{{ name }}.mp4" | cargo run --bin moq -- --iroh-enabled --client-connect "{{ url }}" --broadcast "{{ prefix }}{{ name }}.hang" import ts
 
 # Generate and ingest an HLS stream from a video file.
 hls name relay="http://localhost:4443":
@@ -154,7 +154,7 @@ h264 name url="http://localhost:4443" *args:
 serve name *args:
     just download "{{ name }}"
     cargo build --bin moq
-    just ffmpeg-cmaf "media/{{ name }}.mp4" | cargo run --bin moq -- {{ args }} --server-bind "[::]:4443" --tls-generate "localhost" --broadcast "{{ name }}.hang" import fmp4
+    just ffmpeg-ts "media/{{ name }}.mp4" | cargo run --bin moq -- {{ args }} --server-bind "[::]:4443" --tls-generate "localhost" --broadcast "{{ name }}.hang" import ts
 
 # Generate and serve an HLS stream from a video for testing.
 serve-hls name port="8000":

--- a/demo/pub/justfile
+++ b/demo/pub/justfile
@@ -12,7 +12,7 @@ deploy:
     bun install
     bun wrangler deploy
 
-# Upload a single file to R2. Fragment videos first, e.g. `ffmpeg -i input.mp4 -c copy -f mp4 -movflags cmaf+separate_moof+delay_moov+skip_trailer+frag_every_frame output.mp4`.
+# Upload a single file to R2. Fragment videos first, e.g. `ffmpeg -i input.mp4 -c copy -f mp4 -movflags cmaf+separate_moof+delay_moov+skip_trailer -frag_duration 1000 output.mp4`.
 upload file:
     bun install
     bun wrangler r2 object put "video-moq-dev/{{ file }}" --file "media/{{ file }}" --remote
@@ -230,14 +230,16 @@ download name:
     	curl -fsSL "https://vid.moq.dev/{{ name }}.mp4" -o "media/{{ name }}.mp4"; \
     fi
 
-# Convert an h264 input file to CMAF (fmp4) format to stdout.
+# Convert an h264 input file to CMAF (fmp4) format to stdout, with one fragment per sample.
+# -frag_duration rather than frag_every_frame: the latter repeats a fragment's tfdt when it
+# interleaves audio and video, landing two samples on one timestamp.
 [private]
 ffmpeg-cmaf input output='-' *args:
     ffmpeg -hide_banner -v quiet \
     	-stream_loop -1 -re \
     	-i "{{ input }}" \
     	-c copy \
-    	-f mp4 -movflags cmaf+separate_moof+delay_moov+skip_trailer+frag_every_frame {{ args }} {{ output }}
+    	-f mp4 -movflags cmaf+separate_moof+delay_moov+skip_trailer -frag_duration 1000 {{ args }} {{ output }}
 
 # Convert an h264 input file to MPEG-TS format to stdout, with one PES per audio frame.
 [private]

--- a/rs/moq-cli/README.md
+++ b/rs/moq-cli/README.md
@@ -32,14 +32,14 @@ moq --client-connect https://relay.example.com/anon \
 ### Publish to a remote relay
 
 ```bash
-ffmpeg -i input.mp4 -f mp4 -movflags cmaf - | \
-    moq --client-connect https://relay.example.com --broadcast my-stream.hang import fmp4
+ffmpeg -i input.mp4 -c copy -f mpegts -pes_payload_size 0 - | \
+    moq --client-connect https://relay.example.com --broadcast my-stream.hang import ts
 ```
 
 ### Subscribe from a remote relay
 
 ```bash
-moq --client-connect https://relay.example.com --broadcast my-stream.hang export fmp4 | \
+moq --client-connect https://relay.example.com --broadcast my-stream.hang export ts | \
     ffplay -
 ```
 
@@ -54,8 +54,8 @@ moq --client-connect https://relay.example.com --broadcast my-stream.hang play
 Hosts a MoQ server and publishes a single broadcast read from stdin into it. Useful for local testing without a separate relay process.
 
 ```bash
-ffmpeg -i input.mp4 -f mp4 -movflags cmaf - | \
-    moq --server-bind '[::]:4443' --tls-generate localhost --broadcast my-stream.hang import fmp4
+ffmpeg -i input.mp4 -c copy -f mpegts -pes_payload_size 0 - | \
+    moq --server-bind '[::]:4443' --tls-generate localhost --broadcast my-stream.hang import ts
 ```
 
 ### Self-host: subscribe to an inbound broadcast
@@ -63,7 +63,7 @@ ffmpeg -i input.mp4 -f mp4 -movflags cmaf - | \
 Hosts a MoQ server and writes an incoming broadcast's media to stdout. The inverse of the above.
 
 ```bash
-moq --server-bind '[::]:4443' --tls-generate localhost --broadcast my-stream.hang export fmp4 | ffplay -
+moq --server-bind '[::]:4443' --tls-generate localhost --broadcast my-stream.hang export ts | ffplay -
 ```
 
 ### Import formats

--- a/rs/moq-mux/CLAUDE.md
+++ b/rs/moq-mux/CLAUDE.md
@@ -6,6 +6,7 @@ The transmuxer: file/stream containers (`container/`) and codec parsers (`codec/
 - Frame durations are backfilled from the next frame in decode order, never across a discontinuity; a backwards gap (B-frame reordering) stays unset. Frames that arrive with a duration keep it.
 - hang frames carry a timestamp normalized to microseconds (`hang::container::TIMESCALE`). `moq_net::track::Info::default()` is milliseconds, so pin the track with `with_timescale` when creating it.
 - Reject an unsupported codec or container with a typed `Error` rather than warn and drop.
+- An fMP4 fragment's `tfdt` must advance past the previous fragment on that track. ffmpeg's `frag_every_frame` repeats one when it interleaves audio and video, so the demo recipes use `-frag_duration`.
 - Catalog fields that decide decoder configuration (codec, dimensions, description) are effectively immutable for a rendition; bitrate and similar hints are maximums.
 
 # Cross-language

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -563,7 +563,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 
 			// Every fragment restates its decode time, so a stale one puts two different samples
 			// on the same timestamp, which reads downstream as an undeclared hole.
-			if let Some(previous) = track.last_decode_time.replace(dts)
+			if let Some(previous) = track.last_decode_time
 				&& dts <= previous
 			{
 				return Err(Error::NonMonotonicDecodeTime {
@@ -573,6 +573,8 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 				}
 				.into());
 			}
+
+			track.last_decode_time = Some(dts);
 
 			let timescale = moq_net::Timescale::new(trak.mdia.mdhd.timescale as u64)?;
 
@@ -905,6 +907,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 				g.finish()?;
 			}
 			track.pending_sequence = Some(sequence);
+			track.last_decode_time = None;
 		}
 		Ok(())
 	}

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -560,6 +560,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 
 			let tfdt = traf.tfdt.as_ref().ok_or(Error::MissingTfdt)?;
 			let mut dts = tfdt.base_media_decode_time;
+			let timescale = moq_net::Timescale::new(trak.mdia.mdhd.timescale as u64)?;
 
 			// Every fragment restates its decode time, so a stale one puts two different samples
 			// on the same timestamp, which reads downstream as an undeclared hole.
@@ -568,15 +569,13 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 			{
 				return Err(Error::NonMonotonicDecodeTime {
 					track: track_id,
-					decode_time: dts,
-					previous,
+					decode_time: Timestamp::new(dts, timescale)?,
+					previous: Timestamp::new(previous, timescale)?,
 				}
 				.into());
 			}
 
 			track.last_decode_time = Some(dts);
-
-			let timescale = moq_net::Timescale::new(trak.mdia.mdhd.timescale as u64)?;
 
 			let mut offset = traf.tfhd.base_data_offset.unwrap_or_default() as usize;
 			let mut track_data_start: Option<usize> = None;

--- a/rs/moq-mux/src/container/fmp4/import.rs
+++ b/rs/moq-mux/src/container/fmp4/import.rs
@@ -85,6 +85,9 @@ struct Fmp4Track {
 	// The last timestamp seen for this track.
 	last_timestamp: Option<Timestamp>,
 
+	// The decode time of the last fragment, which the next one has to advance past.
+	last_decode_time: Option<u64>,
+
 	// The minimum duration between frames for this track.
 	min_duration: Option<Timestamp>,
 
@@ -269,6 +272,7 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 					recorder: Some(timeline.recorder()),
 					jitter: None,
 					last_timestamp: None,
+					last_decode_time: None,
 					min_duration: None,
 					pending_sequence: None,
 					estimator: Estimator::new(),
@@ -556,6 +560,20 @@ impl<E: crate::catalog::hang::CatalogExt> Import<E> {
 
 			let tfdt = traf.tfdt.as_ref().ok_or(Error::MissingTfdt)?;
 			let mut dts = tfdt.base_media_decode_time;
+
+			// Every fragment restates its decode time, so a stale one puts two different samples
+			// on the same timestamp, which reads downstream as an undeclared hole.
+			if let Some(previous) = track.last_decode_time.replace(dts)
+				&& dts <= previous
+			{
+				return Err(Error::NonMonotonicDecodeTime {
+					track: track_id,
+					decode_time: dts,
+					previous,
+				}
+				.into());
+			}
+
 			let timescale = moq_net::Timescale::new(trak.mdia.mdhd.timescale as u64)?;
 
 			let mut offset = traf.tfhd.base_data_offset.unwrap_or_default() as usize;

--- a/rs/moq-mux/src/container/fmp4/import_test.rs
+++ b/rs/moq-mux/src/container/fmp4/import_test.rs
@@ -587,3 +587,73 @@ fn test_flac_catalog() {
 	let desc = a.description.as_ref().expect("flac description");
 	assert_eq!(&desc[..4], b"fLaC");
 }
+
+/// One audio fragment for bbb's track 2, carrying a single sample at the track's 44100 timescale.
+///
+/// `trun.data_offset` is left unset so the samples start at the front of the mdat, which is all
+/// the importer needs to slice them back out.
+fn audio_fragment(base_media_decode_time: u64, duration: u32, size: u32) -> Vec<u8> {
+	let moof = mp4_atom::Moof {
+		mfhd: mp4_atom::Mfhd { sequence_number: 0 },
+		traf: vec![mp4_atom::Traf {
+			tfhd: mp4_atom::Tfhd {
+				track_id: 2,
+				default_sample_duration: Some(duration),
+				default_sample_size: Some(size),
+				..Default::default()
+			},
+			tfdt: Some(mp4_atom::Tfdt { base_media_decode_time }),
+			trun: vec![mp4_atom::Trun {
+				data_offset: None,
+				entries: vec![mp4_atom::TrunEntry::default()],
+			}],
+			..Default::default()
+		}],
+	};
+
+	let mut buf = Vec::new();
+	moof.encode(&mut buf).unwrap();
+	mp4_atom::Mdat {
+		data: vec![0xAA; size as usize],
+	}
+	.encode(&mut buf)
+	.unwrap();
+	buf
+}
+
+/// Every fragment restates its decode time, so a stale one puts two different samples on the same
+/// timestamp, which a decoder reads as an undeclared hole and resets on. ffmpeg writes exactly that
+/// when `frag_every_frame` interleaves audio and video, so refuse the fragment rather than publish
+/// the collision.
+#[test]
+fn non_advancing_fragment_decode_time_is_rejected() {
+	let data = include_bytes!("test_data/bbb.mp4");
+	let (ftyp, moov) = decode_init(data);
+	let mut init = Vec::new();
+	ftyp.encode(&mut init).unwrap();
+	moov.encode(&mut init).unwrap();
+
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.reserve());
+	fmp4.decode(&init).unwrap();
+
+	// An advancing pair imports, one AAC frame apart.
+	fmp4.decode(&audio_fragment(3072, 1024, 327)).unwrap();
+	fmp4.decode(&audio_fragment(4096, 1024, 361)).unwrap();
+
+	// A third fragment repeating the previous decode time is a different sample landing on the
+	// same timestamp.
+	let err = fmp4.decode(&audio_fragment(4096, 1024, 339)).unwrap_err();
+	assert!(
+		matches!(
+			err,
+			crate::Error::Cmaf(crate::container::fmp4::Error::NonMonotonicDecodeTime {
+				track: 2,
+				decode_time: 4096,
+				previous: 4096,
+			})
+		),
+		"expected a non-monotonic decode time, got {err:?}"
+	);
+}

--- a/rs/moq-mux/src/container/fmp4/import_test.rs
+++ b/rs/moq-mux/src/container/fmp4/import_test.rs
@@ -650,9 +650,10 @@ fn non_advancing_fragment_decode_time_is_rejected() {
 			err,
 			crate::Error::Cmaf(crate::container::fmp4::Error::NonMonotonicDecodeTime {
 				track: 2,
-				decode_time: 4096,
-				previous: 4096,
-			})
+				decode_time,
+				previous,
+			}) if decode_time == moq_net::Timestamp::from_scale(4096, 44100).unwrap()
+				&& previous == decode_time
 		),
 		"expected a non-monotonic decode time, got {err:?}"
 	);
@@ -689,7 +690,8 @@ fn rejected_fragment_preserves_decode_time() {
 	assert!(matches!(
 		fmp4.decode(&audio_fragment(3500, 1024, 327)),
 		Err(crate::Error::Cmaf(
-			crate::container::fmp4::Error::NonMonotonicDecodeTime { previous: 4096, .. }
-		))
+			crate::container::fmp4::Error::NonMonotonicDecodeTime { decode_time, previous, .. }
+		)) if previous == moq_net::Timestamp::from_scale(4096, 44100).unwrap()
+			&& decode_time == moq_net::Timestamp::from_scale(3500, 44100).unwrap()
 	));
 }

--- a/rs/moq-mux/src/container/fmp4/import_test.rs
+++ b/rs/moq-mux/src/container/fmp4/import_test.rs
@@ -657,3 +657,39 @@ fn non_advancing_fragment_decode_time_is_rejected() {
 		"expected a non-monotonic decode time, got {err:?}"
 	);
 }
+
+#[test]
+fn seek_resets_fragment_decode_time() {
+	let (ftyp, moov) = decode_init(include_bytes!("test_data/bbb.mp4"));
+	let mut init = Vec::new();
+	ftyp.encode(&mut init).unwrap();
+	moov.encode(&mut init).unwrap();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.reserve());
+	fmp4.decode(&init).unwrap();
+	fmp4.decode(&audio_fragment(4096, 1024, 327)).unwrap();
+	fmp4.seek(1).unwrap();
+	fmp4.decode(&audio_fragment(0, 1024, 327)).unwrap();
+	fmp4.decode(&audio_fragment(1024, 1024, 327)).unwrap();
+}
+
+#[test]
+fn rejected_fragment_preserves_decode_time() {
+	let (ftyp, moov) = decode_init(include_bytes!("test_data/bbb.mp4"));
+	let mut init = Vec::new();
+	ftyp.encode(&mut init).unwrap();
+	moov.encode(&mut init).unwrap();
+	let mut broadcast = moq_net::broadcast::Info::new().produce();
+	let catalog = crate::catalog::Producer::new(&mut broadcast).unwrap();
+	let mut fmp4 = crate::container::fmp4::Import::new(broadcast, catalog.reserve());
+	fmp4.decode(&init).unwrap();
+	fmp4.decode(&audio_fragment(4096, 1024, 327)).unwrap();
+	assert!(fmp4.decode(&audio_fragment(3000, 1024, 327)).is_err());
+	assert!(matches!(
+		fmp4.decode(&audio_fragment(3500, 1024, 327)),
+		Err(crate::Error::Cmaf(
+			crate::container::fmp4::Error::NonMonotonicDecodeTime { previous: 4096, .. }
+		))
+	));
+}

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -177,6 +177,19 @@ pub enum Error {
 	/// Presentation timestamps do not reveal decode duration for reordered video.
 	#[error("duration-less video needs stated durations or presentation-ordered inference")]
 	MissingVideoDuration,
+
+	/// Each fragment restates its decode time, so a stale one lands two different samples on
+	/// the same timestamp. ffmpeg writes one when `frag_every_frame` interleaves audio and
+	/// video; `-frag_duration` cuts just as finely and stamps the fragments correctly.
+	#[error(
+		"track {track}: fragment decode time {decode_time} does not advance past {previous}; \
+		 ffmpeg repeats a tfdt when frag_every_frame interleaves audio and video, use -frag_duration instead"
+	)]
+	NonMonotonicDecodeTime {
+		track: u32,
+		decode_time: u64,
+		previous: u64,
+	},
 }
 
 impl From<mp4_atom::Error> for Error {

--- a/rs/moq-mux/src/container/fmp4/mod.rs
+++ b/rs/moq-mux/src/container/fmp4/mod.rs
@@ -182,13 +182,16 @@ pub enum Error {
 	/// the same timestamp. ffmpeg writes one when `frag_every_frame` interleaves audio and
 	/// video; `-frag_duration` cuts just as finely and stamps the fragments correctly.
 	#[error(
-		"track {track}: fragment decode time {decode_time} does not advance past {previous}; \
+		"track {track}: fragment decode time {decode_time:?} does not advance past {previous:?}; \
 		 ffmpeg repeats a tfdt when frag_every_frame interleaves audio and video, use -frag_duration instead"
 	)]
 	NonMonotonicDecodeTime {
+		/// The track containing the rejected fragment.
 		track: u32,
-		decode_time: u64,
-		previous: u64,
+		/// The rejected fragment's decode time in the track's timescale.
+		decode_time: moq_net::Timestamp,
+		/// The preceding fragment's decode time in the track's timescale.
+		previous: moq_net::Timestamp,
 	},
 }
 


### PR DESCRIPTION
## Summary

- Reject fMP4 fragments whose per-track decode time fails to advance. FFmpeg's interleaved `frag_every_frame` output can stamp distinct audio samples with the same decode time; the explicit CMAF recipe uses `-frag_duration 1000` instead.
- Reset decode-time history on seek so an HLS discontinuity can restart the timeline, and preserve the accepted history when rejecting a non-advancing fragment.
- Use MPEG-TS for the default BBB/TOS demos, direct localhost serving, Iroh publishing, and CLI publishing/playback examples. FFmpeg uses `-pes_payload_size 0` to avoid audio PES batching. Explicit CMAF and HLS test recipes remain available.

## Public API

Adds `moq_mux::container::fmp4::Error::NonMonotonicDecodeTime` to the existing non-exhaustive error enum. Its `decode_time` and `previous` fields are `moq_net::Timestamp` values carrying the track's timescale. Invalid non-advancing fragments now fail. No breaking changes to a released API.

## Wire

No wire or catalog format changes.

## Validation

Regressions cover repeated decode times, seeking to a restarted timeline, and preserving the accepted decode time after rejection. Error assertions also verify the track's 44,100 Hz timescale. On `9b7eb80bba`, all 580 local mux tests passed, `just fix` passed for native and WebAssembly, and GitHub Check and Test passed. The refreshed Codex review reported no major issues.

(written by GPT-6)
