### PR TITLE
ci: auto-merge Dependabot pull requests

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,56 @@
+name: Dependabot
+
+# Enables auto-merge on Dependabot pull requests, so a bump lands on its own
+# once Check and Test pass. The main ruleset requires both, and dependabot.yml
+# holds every new version for 7 days, so nothing merges unreviewed by CI or the
+# moment it is published.
+#
+# `pull_request_target` rather than `pull_request`: Dependabot runs with a
+# read-only token and no access to secrets, so a `pull_request` run could
+# neither read APP_PRIVATE_KEY nor enable auto-merge. That trigger is only safe
+# because this job never checks out or executes the pull request's code; it
+# calls one `gh` command against the pull request number.
+#
+# The moq-bot token rather than GITHUB_TOKEN: a merge enabled by GITHUB_TOKEN
+# does not trigger further workflow runs, which would silently skip Cache
+# (the Rust cache warm keyed on Cargo.lock, exactly what the cargo group
+# changes), release-rs and release-js on every auto-merged bump.
+
+permissions: {}
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  auto-merge:
+    name: Auto-merge
+    # head.repo guards the `pull_request_target` trigger: Dependabot pushes its
+    # branches to this repository, so a pull request from a fork claiming to be
+    # Dependabot is not one.
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate moq-bot token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        id: token
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: moq-dev
+          repositories: moq
+          # Narrow the minted token to only what `gh pr merge --auto` needs.
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Enable auto-merge
+        env:
+          # Token is minted fresh per run, expires in 1 hour, never at rest.
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        # Squash to match the rest of the history; the ruleset requires a
+        # linear one. Re-running on a later push is a no-op.
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
Dependabot PRs now enable auto-merge on themselves, so a bump lands once `Check` and `Test` pass rather than waiting on a manual merge.

The gates are unchanged: the `main` ruleset requires both checks, and `dependabot.yml` already holds every new version for 7 days before proposing it.

## Notes

**`pull_request_target`, not `pull_request`.** Dependabot runs with a read-only token and no secret access, so a `pull_request` run could neither read `APP_PRIVATE_KEY` nor enable auto-merge. That trigger is only safe here because the job never checks out or executes the PR's code, and it is gated on `head.repo` being this repository so a fork cannot pose as Dependabot.

**moq-bot token, not `GITHUB_TOKEN`.** A merge enabled by `GITHUB_TOKEN` triggers no further workflow runs. That would silently skip `Cache`, `release-rs` and `release-js` on every auto-merged bump, and `Cache` warms the Rust cache keyed on `Cargo.lock` which is exactly what the cargo group changes. The app is already installed org-wide with `contents:write` and `pull_requests:write`, so no new secret or setup is needed.

**Alerting.** PR-only workflow, so it is correctly absent from `alert.yml`; `just gh check` passes.

## Public API and wire impact

None. CI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by claude-opus-5)