### PR TITLE
refactor(obs): receive PCM through moq-audio

### DIFF
--- a/cpp/obs/src/moq-source.cpp
+++ b/cpp/obs/src/moq-source.cpp
@@ -19,8 +19,6 @@ extern "C" {
 #include <libavutil/imgutils.h>
 #include <libavutil/pixdesc.h>
 #include <libswscale/swscale.h>
-#include <libavutil/channel_layout.h>
-#include <libavutil/samplefmt.h>
 #include "moq.h"
 }
 
@@ -64,66 +62,8 @@ static AVCodecID codec_string_to_id(const char *codec, size_t len)
 	return AV_CODEC_ID_NONE;
 }
 
-// Map an audio codec string from moq_audio_config to an FFmpeg codec ID. Catalog codec strings follow the
-// WebCodecs registry: "mp4a.40.2" (AAC-LC), "mp4a.40.5"/"mp4a.40.29" (HE-AAC v1/v2), "opus".
-static AVCodecID audio_codec_string_to_id(const char *codec, size_t len)
-{
-	if (!codec || len == 0)
-		return AV_CODEC_ID_NONE;
-	if ((len >= 4 && strncasecmp(codec, "mp4a", 4) == 0) || (len >= 3 && strncasecmp(codec, "aac", 3) == 0))
-		return AV_CODEC_ID_AAC;
-	if (len >= 4 && strncasecmp(codec, "opus", 4) == 0)
-		return AV_CODEC_ID_OPUS;
-	return AV_CODEC_ID_NONE;
-}
-
-// Map an FFmpeg sample format to the OBS audio format OBS ingests directly (obs_source_output_audio
-// converts to the mixer format itself).
-static enum audio_format av_sample_fmt_to_obs(enum AVSampleFormat fmt)
-{
-	switch (fmt) {
-	case AV_SAMPLE_FMT_U8:
-		return AUDIO_FORMAT_U8BIT;
-	case AV_SAMPLE_FMT_S16:
-		return AUDIO_FORMAT_16BIT;
-	case AV_SAMPLE_FMT_S32:
-		return AUDIO_FORMAT_32BIT;
-	case AV_SAMPLE_FMT_FLT:
-		return AUDIO_FORMAT_FLOAT;
-	case AV_SAMPLE_FMT_U8P:
-		return AUDIO_FORMAT_U8BIT_PLANAR;
-	case AV_SAMPLE_FMT_S16P:
-		return AUDIO_FORMAT_16BIT_PLANAR;
-	case AV_SAMPLE_FMT_S32P:
-		return AUDIO_FORMAT_32BIT_PLANAR;
-	case AV_SAMPLE_FMT_FLTP:
-		return AUDIO_FORMAT_FLOAT_PLANAR;
-	default:
-		return AUDIO_FORMAT_UNKNOWN;
-	}
-}
-
-static enum speaker_layout channels_to_speakers(int channels)
-{
-	switch (channels) {
-	case 1:
-		return SPEAKERS_MONO;
-	case 2:
-		return SPEAKERS_STEREO;
-	case 3:
-		return SPEAKERS_2POINT1;
-	case 4:
-		return SPEAKERS_4POINT0;
-	case 5:
-		return SPEAKERS_4POINT1;
-	case 6:
-		return SPEAKERS_5POINT1;
-	case 8:
-		return SPEAKERS_7POINT1;
-	default:
-		return SPEAKERS_UNKNOWN;
-	}
-}
+// Fix the PCM layout at subscription time because raw frame metadata carries only bytes and a timestamp.
+static constexpr moq_audio_decoder_output audio_output = {MOQ_AUDIO_FORMAT_F32, 48000, 2, 0};
 
 struct moq_source {
 	obs_source_t *source;
@@ -159,15 +99,6 @@ struct moq_source {
 	uint64_t video_attempt;
 	int32_t audio_track;
 	uint64_t audio_attempt;
-
-	// Audio decoder state (audio rendition 0, when the catalog carries one). Frames arrive encoded
-	// (AAC/Opus) with the broadcast's presentation timestamps; decoded to PCM and handed to OBS as async
-	// audio carrying those timestamps, so OBS aligns them with the async video.
-	AVCodecContext *audio_codec_ctx;
-	uint32_t audio_sample_rate;
-	uint32_t audio_channels;
-	uint32_t audio_decode_errors;
-	uint64_t audio_frames_output;
 
 	// Decoder state
 	AVCodecContext *codec_ctx;
@@ -281,9 +212,6 @@ static void moq_source_blank_video(struct moq_source *ctx);
 static std::unique_ptr<prepared_decoder> moq_source_prepare_decoder(const struct moq_video_config *config);
 static void moq_source_install_decoder_locked(struct moq_source *ctx, std::unique_ptr<prepared_decoder> decoder);
 static void moq_source_destroy_decoder_locked(struct moq_source *ctx);
-static bool moq_source_init_audio_decoder_locked(struct moq_source *ctx, const struct moq_audio_config *config);
-static void moq_source_destroy_audio_decoder_locked(struct moq_source *ctx);
-static void moq_source_decode_audio_frame(struct moq_source *ctx, int32_t frame_id);
 static void moq_source_subscribe_audio(struct moq_source *ctx, int32_t catalog, uint32_t current_gen);
 static void moq_source_decode_frame(struct moq_source *ctx, int32_t frame_id);
 
@@ -311,11 +239,6 @@ static void *moq_source_create(obs_data_t *settings, obs_source_t *source)
 	ctx->video_track = -1;
 	ctx->audio_track = -1;
 	ctx->audio_attempt = 0;
-	ctx->audio_codec_ctx = NULL;
-	ctx->audio_sample_rate = 0;
-	ctx->audio_channels = 0;
-	ctx->audio_decode_errors = 0;
-	ctx->audio_frames_output = 0;
 	ctx->catalog_attempt = 0;
 	ctx->video_attempt = 0;
 
@@ -697,21 +620,12 @@ static void on_video_frame(void *user_data, int32_t frame_id)
 	moq_source_decode_frame(ctx, frame_id);
 }
 
-// Subscribe to audio rendition `index` of a catalog snapshot (the caller still owns the snapshot) and
-// install the matching decoder. Mirrors the video path: pre-account the subscription's lifetime reference
-// and reserve the next attempt, subscribe with a callback_state carrying (generation, attempt), then make it
-// current under the mutex only on success. A broadcast with no audio rendition stays video-only (not an error).
+// Each raw consumer owns its decoder; immediate subscription failures leave the active consumer intact.
 static void moq_source_subscribe_audio(struct moq_source *ctx, int32_t catalog, uint32_t current_gen)
 {
-	struct moq_audio_config audio_config;
-	if (moq_consume_audio_config(catalog, 0, &audio_config) < 0) {
-		LOG_INFO("Catalog has no audio rendition; video only");
-		return;
-	}
 	pthread_mutex_lock(&ctx->mutex);
-	if (!moq_source_init_audio_decoder_locked(ctx, &audio_config)) {
+	if (ctx->generation != current_gen || ctx->shutting_down.load() || ctx->consume < 0) {
 		pthread_mutex_unlock(&ctx->mutex);
-		LOG_ERROR("Failed to initialize audio decoder; continuing video only");
 		return;
 	}
 	uint64_t audio_attempt = ctx->audio_attempt + 1;
@@ -720,15 +634,25 @@ static void moq_source_subscribe_audio(struct moq_source *ctx, int32_t catalog, 
 	auto audio_state = std::make_shared<callback_state>(ctx, current_gen, audio_attempt);
 	auto *audio_data = new callback_data{audio_state};
 
-	int32_t track = moq_consume_audio(catalog, 0, 0, on_audio_frame, audio_data);
+	int32_t track = moq_consume_audio_raw(catalog, 0, &audio_output, on_audio_frame, audio_data);
 	if (track < 0) {
-		LOG_ERROR("Failed to subscribe to audio track: %d", track);
 		delete audio_data;
 		pthread_mutex_lock(&ctx->mutex);
-		moq_source_destroy_audio_decoder_locked(ctx);
+		int32_t old_track = -1;
+		// NoIndex means a valid catalog has no audio rendition. Other failures preserve the active track.
+		if (track == -19 && ctx->generation == current_gen && ctx->audio_attempt + 1 == audio_attempt &&
+		    !ctx->shutting_down.load()) {
+			old_track = ctx->audio_track;
+			ctx->audio_track = -1;
+			ctx->audio_attempt = audio_attempt;
+		}
 		if (--ctx->refs == 0)
 			pthread_cond_broadcast(&ctx->refs_zero);
 		pthread_mutex_unlock(&ctx->mutex);
+		if (old_track >= 0)
+			moq_consume_audio_raw_close(old_track);
+		if (track != -19)
+			LOG_ERROR("Failed to subscribe to audio track: %d", track);
 		return;
 	}
 	pthread_mutex_lock(&ctx->mutex);
@@ -739,13 +663,12 @@ static void moq_source_subscribe_audio(struct moq_source *ctx, int32_t catalog, 
 		ctx->audio_track = track;
 		pthread_mutex_unlock(&ctx->mutex);
 		if (old_track >= 0)
-			moq_consume_audio_close(old_track);
-		LOG_INFO("Subscribed to audio track successfully (%u Hz, %u ch)", ctx->audio_sample_rate,
-			 ctx->audio_channels);
+			moq_consume_audio_raw_close(old_track);
+		LOG_INFO("Subscribed to raw audio track");
 	} else {
 		pthread_mutex_unlock(&ctx->mutex);
 		if (!audio_state->terminal.load())
-			moq_consume_audio_close(track);
+			moq_consume_audio_raw_close(track);
 	}
 }
 
@@ -776,16 +699,39 @@ static void on_audio_frame(void *user_data, int32_t frame_id)
 		return;
 	}
 
+	struct moq_audio_frame frame = {};
+	int32_t result = moq_consume_audio_raw_frame(frame_id, &frame);
 	pthread_mutex_lock(&ctx->mutex);
 	if (ctx->shutting_down.load() || ctx->generation != state->gen || ctx->audio_attempt != state->attempt ||
 	    ctx->consume < 0) {
 		pthread_mutex_unlock(&ctx->mutex);
-		moq_consume_frame_free(frame_id);
+		moq_consume_audio_raw_frame_free(frame_id);
 		return;
 	}
+	constexpr size_t stride = sizeof(float) * audio_output.channels;
+	if (result < 0 || !frame.data || frame.data_size == 0 || frame.data_size % stride != 0 ||
+	    frame.data_size / stride > UINT32_MAX || frame.timestamp_us > UINT64_MAX / 1000) {
+		LOG_ERROR("Invalid raw audio frame: %d", result);
+		int32_t track = ctx->audio_track;
+		ctx->audio_track = -1;
+		ctx->audio_attempt++;
+		pthread_mutex_unlock(&ctx->mutex);
+		moq_consume_audio_raw_frame_free(frame_id);
+		if (track >= 0)
+			moq_consume_audio_raw_close(track);
+		return;
+	}
+	struct obs_source_audio audio = {};
+	audio.data[0] = frame.data;
+	audio.frames = static_cast<uint32_t>(frame.data_size / stride);
+	audio.speakers = SPEAKERS_STEREO;
+	audio.format = AUDIO_FORMAT_FLOAT;
+	audio.samples_per_sec = audio_output.sample_rate;
+	audio.timestamp = frame.timestamp_us * 1000;
+	// Keep the generation check and output under one lock so reconnect cannot admit a stale frame.
+	obs_source_output_audio(ctx->source, &audio);
 	pthread_mutex_unlock(&ctx->mutex);
-
-	moq_source_decode_audio_frame(ctx, frame_id);
+	moq_consume_audio_raw_frame_free(frame_id);
 }
 
 // Helper function implementations
@@ -1107,7 +1053,7 @@ static void moq_source_disconnect_locked(struct moq_source *ctx)
 	}
 
 	if (ctx->audio_track >= 0) {
-		moq_consume_audio_close(ctx->audio_track);
+		moq_consume_audio_raw_close(ctx->audio_track);
 		ctx->audio_track = -1;
 	}
 
@@ -1140,7 +1086,6 @@ static void moq_source_disconnect_locked(struct moq_source *ctx)
 	}
 
 	moq_source_destroy_decoder_locked(ctx);
-	moq_source_destroy_audio_decoder_locked(ctx);
 	ctx->got_keyframe = false;
 	ctx->frames_waiting_for_keyframe = 0;
 	ctx->consecutive_decode_errors = 0;
@@ -1509,143 +1454,6 @@ static void moq_source_decode_frame(struct moq_source *ctx, int32_t frame_id)
 	ctx->frame.timestamp = frame_data.timestamp_us * 1000;
 	obs_source_output_video(ctx->source, &ctx->frame);
 
-	av_frame_free(&frame);
-	pthread_mutex_unlock(&ctx->mutex);
-	moq_consume_frame_free(frame_id);
-}
-
-// ---- Audio -------------------------------------------------------------------
-// NOTE: caller holds ctx->mutex.
-static bool moq_source_init_audio_decoder_locked(struct moq_source *ctx, const struct moq_audio_config *config)
-{
-	AVCodecID codec_id = audio_codec_string_to_id(config->codec, config->codec_len);
-	if (codec_id == AV_CODEC_ID_NONE) {
-		char codec_str[64] = {0};
-		size_t n = config->codec_len < sizeof(codec_str) - 1 ? config->codec_len : sizeof(codec_str) - 1;
-		if (config->codec && n > 0)
-			memcpy(codec_str, config->codec, n);
-		LOG_ERROR("Unknown or unsupported audio codec: '%s'", codec_str);
-		return false;
-	}
-	const AVCodec *codec = avcodec_find_decoder(codec_id);
-	if (!codec) {
-		LOG_ERROR("Audio decoder not found for codec ID: %d", codec_id);
-		return false;
-	}
-	AVCodecContext *cctx = avcodec_alloc_context3(codec);
-	if (!cctx) {
-		LOG_ERROR("Failed to allocate audio codec context");
-		return false;
-	}
-	cctx->sample_rate = static_cast<int>(config->sample_rate);
-	av_channel_layout_default(&cctx->ch_layout, static_cast<int>(config->channel_count));
-	cctx->pkt_timebase = AVRational{1, 1000000}; // libmoq frame timestamps are microseconds
-	if (config->description && config->description_len > 0) {
-		cctx->extradata = (uint8_t *)av_mallocz(config->description_len + AV_INPUT_BUFFER_PADDING_SIZE);
-		if (cctx->extradata) {
-			memcpy(cctx->extradata, config->description, config->description_len);
-			cctx->extradata_size = static_cast<int>(config->description_len);
-		}
-	}
-	if (avcodec_open2(cctx, codec, NULL) < 0) {
-		LOG_ERROR("Failed to open audio codec");
-		avcodec_free_context(&cctx);
-		return false;
-	}
-	moq_source_destroy_audio_decoder_locked(ctx);
-	ctx->audio_codec_ctx = cctx;
-	ctx->audio_sample_rate = config->sample_rate;
-	ctx->audio_channels = config->channel_count;
-	ctx->audio_decode_errors = 0;
-	ctx->audio_frames_output = 0;
-	return true;
-}
-
-// NOTE: caller holds ctx->mutex.
-static void moq_source_destroy_audio_decoder_locked(struct moq_source *ctx)
-{
-	if (ctx->audio_codec_ctx)
-		avcodec_free_context(&ctx->audio_codec_ctx);
-	ctx->audio_sample_rate = 0;
-	ctx->audio_channels = 0;
-}
-
-static void moq_source_decode_audio_frame(struct moq_source *ctx, int32_t frame_id)
-{
-	if (ctx->shutting_down.load()) {
-		moq_consume_frame_free(frame_id);
-		return;
-	}
-	pthread_mutex_lock(&ctx->mutex);
-	if (ctx->shutting_down.load() || !ctx->audio_codec_ctx) {
-		pthread_mutex_unlock(&ctx->mutex);
-		moq_consume_frame_free(frame_id);
-		return;
-	}
-	struct moq_frame frame_data;
-	if (moq_consume_frame(frame_id, &frame_data) < 0) {
-		LOG_ERROR("Failed to get audio frame data");
-		pthread_mutex_unlock(&ctx->mutex);
-		moq_consume_frame_free(frame_id);
-		return;
-	}
-	AVPacket *packet = av_packet_alloc();
-	if (!packet) {
-		pthread_mutex_unlock(&ctx->mutex);
-		moq_consume_frame_free(frame_id);
-		return;
-	}
-	packet->data = (uint8_t *)frame_data.payload;
-	packet->size = static_cast<int>(frame_data.payload_size);
-	packet->pts = static_cast<int64_t>(frame_data.timestamp_us);
-	packet->dts = packet->pts;
-	int ret = avcodec_send_packet(ctx->audio_codec_ctx, packet);
-	av_packet_free(&packet);
-	if (ret < 0) {
-		ctx->audio_decode_errors++;
-		if (ctx->audio_decode_errors == 1 || (ctx->audio_decode_errors % 100) == 0)
-			LOG_WARNING("Audio decode error %d (count %u)", ret, ctx->audio_decode_errors);
-		pthread_mutex_unlock(&ctx->mutex);
-		moq_consume_frame_free(frame_id);
-		return;
-	}
-	AVFrame *frame = av_frame_alloc();
-	if (!frame) {
-		pthread_mutex_unlock(&ctx->mutex);
-		moq_consume_frame_free(frame_id);
-		return;
-	}
-	while (avcodec_receive_frame(ctx->audio_codec_ctx, frame) == 0) {
-		enum audio_format fmt = av_sample_fmt_to_obs(static_cast<enum AVSampleFormat>(frame->format));
-		int channels = frame->ch_layout.nb_channels;
-		enum speaker_layout speakers = channels_to_speakers(channels);
-		if (fmt == AUDIO_FORMAT_UNKNOWN || speakers == SPEAKERS_UNKNOWN || frame->sample_rate <= 0 ||
-		    frame->nb_samples <= 0) {
-			ctx->audio_decode_errors++;
-			if (ctx->audio_decode_errors == 1)
-				LOG_WARNING("Unsupported decoded audio layout: fmt=%d channels=%d rate=%d",
-					    frame->format, channels, frame->sample_rate);
-			av_frame_unref(frame);
-			continue;
-		}
-		struct obs_source_audio audio = {};
-		int planes = av_sample_fmt_is_planar(static_cast<enum AVSampleFormat>(frame->format)) ? channels : 1;
-		for (int i = 0; i < planes && i < MAX_AV_PLANES; i++)
-			audio.data[i] = frame->data[i];
-		audio.frames = static_cast<uint32_t>(frame->nb_samples);
-		audio.speakers = speakers;
-		audio.format = fmt;
-		audio.samples_per_sec = static_cast<uint32_t>(frame->sample_rate);
-		int64_t pts_us = frame->pts != AV_NOPTS_VALUE ? frame->pts
-							      : static_cast<int64_t>(frame_data.timestamp_us);
-		audio.timestamp = static_cast<uint64_t>(pts_us) * 1000ULL; // OBS expects nanoseconds
-		obs_source_output_audio(ctx->source, &audio);
-		ctx->audio_frames_output++;
-		if (ctx->audio_frames_output == 1)
-			LOG_INFO("First audio frame output: %d samples, %d Hz, %d ch, fmt=%d", frame->nb_samples,
-				 frame->sample_rate, channels, frame->format);
-		av_frame_unref(frame);
-	}
 	av_frame_free(&frame);
 	pthread_mutex_unlock(&ctx->mutex);
 	moq_consume_frame_free(frame_id);

--- a/cpp/obs/test/moq-source-test.cpp
+++ b/cpp/obs/test/moq-source-test.cpp
@@ -38,8 +38,6 @@ extern "C" {
 #include <libavcodec/avcodec.h>
 #include <libavutil/imgutils.h>
 #include <libavutil/pixdesc.h>
-#include <libavutil/channel_layout.h>
-#include <libavutil/samplefmt.h>
 #include <libswscale/swscale.h>
 #include "moq.h"
 }
@@ -165,6 +163,8 @@ std::atomic<uint64_t> g_last_timestamp{0};
 // PCM buffers the audio decode path handed to OBS.
 std::atomic<int> g_output_audio{0};
 std::atomic<uint64_t> g_last_audio_timestamp{0};
+std::atomic<uint32_t> g_last_audio_frames{0};
+const float g_pcm[] = {0.25f, -0.5f, 0.75f, -1.0f};
 
 // The bmalloc/bfree balance. The source's whole teardown contract reduces to
 // this: ctx is freed only once every subscription has delivered its terminal, so
@@ -254,6 +254,11 @@ void obs_source_output_audio(obs_source_t *, const struct obs_source_audio *audi
 {
 	if (!audio)
 		return;
+	if (audio->format != AUDIO_FORMAT_FLOAT || audio->speakers != SPEAKERS_STEREO ||
+	    audio->samples_per_sec != 48000 || audio->frames != 2 || !audio->data[0] || audio->data[1] ||
+	    memcmp(audio->data[0], g_pcm, sizeof(g_pcm)) != 0)
+		g_stub_errors++;
+	g_last_audio_frames = audio->frames;
 	g_last_audio_timestamp = audio->timestamp;
 	g_output_audio++;
 }
@@ -374,26 +379,6 @@ void av_frame_free(AVFrame **frame)
 	*frame = nullptr;
 }
 
-void av_frame_unref(AVFrame *) {}
-
-void av_channel_layout_default(AVChannelLayout *ch_layout, int nb_channels)
-{
-	if (!ch_layout)
-		return;
-	*ch_layout = AVChannelLayout{};
-	ch_layout->order = AV_CHANNEL_ORDER_NATIVE;
-	ch_layout->nb_channels = nb_channels;
-}
-
-int av_sample_fmt_is_planar(enum AVSampleFormat sample_fmt)
-{
-	return sample_fmt == AV_SAMPLE_FMT_U8P || sample_fmt == AV_SAMPLE_FMT_S16P ||
-			       sample_fmt == AV_SAMPLE_FMT_S32P || sample_fmt == AV_SAMPLE_FMT_FLTP ||
-			       sample_fmt == AV_SAMPLE_FMT_DBLP
-		       ? 1
-		       : 0;
-}
-
 void *av_mallocz(size_t size)
 {
 	g_av_allocs++;
@@ -459,7 +444,8 @@ struct Sub {
 std::mutex g_subs_mutex;
 std::map<int32_t, Sub> g_subs;
 std::map<int32_t, bool> g_snapshots; // live catalog snapshot ids
-std::map<int32_t, bool> g_frames;    // live frame ids -> keyframe
+std::map<int32_t, bool> g_raw_frames;
+std::map<int32_t, bool> g_frames; // live frame ids -> keyframe
 
 // Disjoint ranges, so a handle misread as a snapshot or a frame id fails loudly
 // instead of resolving to something plausible.
@@ -496,6 +482,7 @@ std::atomic<int> g_catalog_calls{0};
 std::atomic<int> g_video_calls{0};
 std::atomic<int> g_audio_calls{0};
 std::atomic<int> g_audio_closes{0};
+std::atomic<int> g_raw_frame_frees{0};
 std::atomic<int> g_snapshot_frees{0};
 std::atomic<int> g_frame_frees{0};
 std::atomic<int> g_consume_closes{0};
@@ -516,14 +503,12 @@ int g_catalog_result = 0;
 int g_video_result = 0;
 int g_video_config_result = 0;
 
-// Audio rendition knobs. Default: no audio rendition (config returns < 0), so
-// every existing scenario stays video-only and its counts are unchanged. A test
-// that wants the audio path sets g_audio_config_result = 0.
+// Raw subscription failure injection. NoIndex means the catalog has no audio rendition.
 int g_audio_result = 0;
-int g_audio_config_result = -1;
-const char g_audio_codec[] = "mp4a.40.2";
-uint32_t g_audio_sample_rate = 48000;
-uint32_t g_audio_channels = 2;
+int g_audio_config_result = -19;
+size_t g_raw_size = sizeof(g_pcm);
+uint64_t g_raw_timestamp = 1234567;
+int g_raw_frame_result = 0;
 
 // What moq_consume_video_config hands back.
 uint32_t g_coded_width = 320;
@@ -768,7 +753,8 @@ int32_t moq_consume_video_close(uint32_t track)
 	return closeSub(static_cast<int32_t>(track));
 }
 
-int32_t moq_consume_audio_config(uint32_t catalog, uint32_t, struct moq_audio_config *dst)
+int32_t moq_consume_audio_raw(uint32_t catalog, uint32_t index, const struct moq_audio_decoder_output *output,
+			      void (*on_frame)(void *, int32_t), void *user_data)
 {
 	{
 		std::lock_guard<std::mutex> lock(g_subs_mutex);
@@ -777,34 +763,11 @@ int32_t moq_consume_audio_config(uint32_t catalog, uint32_t, struct moq_audio_co
 			return -1;
 		}
 	}
-	// Absent by default: the broadcast carries no audio rendition, which the
-	// plugin must treat as video-only rather than as an error.
+	if (index != 0 || !output || output->format != MOQ_AUDIO_FORMAT_F32 || output->sample_rate != 48000 ||
+	    output->channels != 2 || output->latency_max_ms != 0)
+		g_stub_errors++;
 	if (g_audio_config_result < 0)
 		return g_audio_config_result;
-
-	dst->name = "audio";
-	dst->name_len = 5;
-	dst->codec = g_audio_codec;
-	dst->codec_len = sizeof(g_audio_codec) - 1;
-	dst->description = g_describe ? g_description : nullptr;
-	dst->description_len = g_describe ? sizeof(g_description) : 0;
-	dst->sample_rate = g_audio_sample_rate;
-	dst->channel_count = g_audio_channels;
-	dst->container.kind = MOQ_CONTAINER_KIND_LEGACY;
-	dst->container.init = nullptr;
-	dst->container.init_len = 0;
-	return 0;
-}
-
-int32_t moq_consume_audio(uint32_t catalog, uint32_t, uint64_t, void (*on_frame)(void *, int32_t), void *user_data)
-{
-	{
-		std::lock_guard<std::mutex> lock(g_subs_mutex);
-		if (g_snapshots.find(static_cast<int32_t>(catalog)) == g_snapshots.end()) {
-			g_stub_errors++;
-			return -1;
-		}
-	}
 	if (g_audio_result < 0)
 		return g_audio_result;
 	g_audio_calls++;
@@ -813,10 +776,36 @@ int32_t moq_consume_audio(uint32_t catalog, uint32_t, uint64_t, void (*on_frame)
 	return handle;
 }
 
-int32_t moq_consume_audio_close(uint32_t track)
+int32_t moq_consume_audio_raw_close(uint32_t track)
 {
 	g_audio_closes++;
 	return closeSub(static_cast<int32_t>(track));
+}
+
+int32_t moq_consume_audio_raw_frame(uint32_t frame, struct moq_audio_frame *dst)
+{
+	std::lock_guard<std::mutex> lock(g_subs_mutex);
+	if (!g_raw_frames.count(static_cast<int32_t>(frame))) {
+		g_stub_errors++;
+		return -1;
+	}
+	if (g_raw_frame_result < 0)
+		return g_raw_frame_result;
+	dst->data = reinterpret_cast<const uint8_t *>(g_pcm);
+	dst->data_size = g_raw_size;
+	dst->timestamp_us = g_raw_timestamp;
+	return 0;
+}
+
+int32_t moq_consume_audio_raw_frame_free(uint32_t frame)
+{
+	std::lock_guard<std::mutex> lock(g_subs_mutex);
+	if (!g_raw_frames.erase(static_cast<int32_t>(frame))) {
+		g_stub_errors++;
+		return -1;
+	}
+	g_raw_frame_frees++;
+	return 0;
 }
 
 int32_t moq_consume_frame(uint32_t frame, struct moq_frame *dst)
@@ -886,6 +875,14 @@ int32_t newSnapshot()
 	return id;
 }
 
+int32_t newRawFrame()
+{
+	std::lock_guard<std::mutex> lock(g_subs_mutex);
+	int32_t id = g_next_frame++;
+	g_raw_frames[id] = true;
+	return id;
+}
+
 int32_t newFrame(bool keyframe)
 {
 	std::lock_guard<std::mutex> lock(g_subs_mutex);
@@ -925,6 +922,7 @@ void reset()
 		g_subs.clear();
 		g_snapshots.clear();
 		g_frames.clear();
+		g_raw_frames.clear();
 		g_deferred.clear();
 	}
 	g_settings.url = "https://relay.example/anon";
@@ -947,6 +945,7 @@ void reset()
 	g_video_calls = 0;
 	g_audio_calls = 0;
 	g_audio_closes = 0;
+	g_raw_frame_frees = 0;
 	g_snapshot_frees = 0;
 	g_frame_frees = 0;
 	g_consume_closes = 0;
@@ -969,7 +968,11 @@ void reset()
 	g_video_result = 0;
 	g_video_config_result = 0;
 	g_audio_result = 0;
-	g_audio_config_result = -1;
+	g_audio_config_result = -19;
+	g_raw_size = sizeof(g_pcm);
+	g_raw_timestamp = 1234567;
+	g_raw_frame_result = 0;
+	g_last_audio_frames = 0;
 	g_find_decoder_ok = true;
 	g_send_result = 0;
 	g_receive_result = 0;
@@ -1004,6 +1007,7 @@ void destroySource(void *source)
 	CHECK(g_av_allocs == 0);
 	CHECK(g_double_close == 0);
 	CHECK(g_stub_errors == 0);
+	CHECK(g_raw_frames.empty());
 }
 
 // Close out a scenario, naming it and saying whether any of its assertions
@@ -1197,11 +1201,11 @@ int main()
 	}
 	report("audio rendition subscribed alongside video");
 
-	// The default: no audio rendition in the catalog. moq_consume_audio_config
+	// The default: no audio rendition in the catalog. moq_consume_audio_raw
 	// returns absent, and the source stays video-only with nothing subscribed or
 	// torn down for audio. This is the shape every other scenario runs under.
 	{
-		reset(); // g_audio_config_result stays -1
+		reset(); // g_audio_config_result stays -19
 		void *source = createSource();
 		subscribeVideo(newBroadcast());
 		CHECK(g_video_calls == 1);
@@ -1210,6 +1214,131 @@ int main()
 		CHECK(g_audio_closes == 0);
 	}
 	report("no audio rendition stays video-only");
+
+	// Removing audio from a catalog must retire the previously advertised track.
+	{
+		reset();
+		g_audio_config_result = 0;
+		void *source = createSource();
+		subscribeVideo(newBroadcast());
+		g_audio_config_result = -19; // libmoq NoIndex
+		int32_t snapshot = newSnapshot();
+		g_runtime->Run([snapshot] { deliverStatus(g_last_catalog, snapshot); });
+		CHECK(g_audio_closes == 1);
+		destroySource(source);
+	}
+	report("catalog removal retires audio");
+
+	// PCM output preserves samples and presentation time, and frees the raw frame slab entry.
+	{
+		reset();
+		g_audio_config_result = 0;
+		void *source = createSource();
+		subscribeVideo(newBroadcast());
+		int32_t frame = newRawFrame();
+		g_runtime->Run([frame] { deliverStatus(g_last_audio, frame); });
+		CHECK(g_output_audio == 1);
+		CHECK(g_last_audio_frames == 2);
+		CHECK(g_last_audio_timestamp == 1234567000);
+		CHECK(g_raw_frame_frees == 1);
+		CHECK(g_frame_frees == 0);
+		destroySource(source);
+	}
+	report("raw PCM output and timestamp conversion");
+
+	// Immediate rejection preserves the old consumer; a successful replacement rejects its late frames.
+	{
+		reset();
+		g_audio_config_result = 0;
+		void *source = createSource();
+		subscribeVideo(newBroadcast());
+		int32_t first = g_last_audio;
+		g_audio_result = -77;
+		int32_t snapshot = newSnapshot();
+		g_runtime->Run([snapshot] { deliverStatus(g_last_catalog, snapshot); });
+		CHECK(g_audio_closes == 0);
+		int32_t frame = newRawFrame();
+		g_runtime->Run([first, frame] { deliverStatus(first, frame); });
+		CHECK(g_output_audio == 1);
+		g_audio_result = 0;
+		g_defer_terminals = true;
+		snapshot = newSnapshot();
+		g_runtime->Run([snapshot] { deliverStatus(g_last_catalog, snapshot); });
+		CHECK(g_audio_closes == 1);
+		CHECK(g_last_audio != first);
+		frame = newRawFrame();
+		g_runtime->Run([first, frame] { deliverStatus(first, frame); });
+		CHECK(g_output_audio == 1);
+		g_defer_terminals = false;
+		flushDeferred();
+		frame = newRawFrame();
+		g_runtime->Run([frame] { deliverStatus(g_last_audio, frame); });
+		CHECK(g_output_audio == 2);
+		CHECK(g_raw_frame_frees == 3);
+		destroySource(source);
+	}
+	report("raw consumer replacement preserves ownership");
+
+	// A removed rendition and a reconnect both invalidate queued raw frames before output.
+	for (bool reconnect : {false, true}) {
+		reset();
+		g_audio_config_result = 0;
+		void *source = createSource();
+		subscribeVideo(newBroadcast());
+		int32_t first = g_last_audio;
+		g_defer_terminals = true;
+		if (reconnect) {
+			g_settings.broadcast = "obs/other";
+			g_info.update(source, settingsData());
+		} else {
+			g_audio_config_result = -19;
+			int32_t snapshot = newSnapshot();
+			g_runtime->Run([snapshot] { deliverStatus(g_last_catalog, snapshot); });
+		}
+		int32_t frame = newRawFrame();
+		g_runtime->Run([first, frame] { deliverStatus(first, frame); });
+		CHECK(g_output_audio == 0);
+		CHECK(g_raw_frame_frees == 1);
+		g_defer_terminals = false;
+		flushDeferred();
+		destroySource(source);
+	}
+	report("removed and disconnected audio cannot output stale PCM");
+
+	// A decoder failure is terminal and does not make destroy close an already retired handle.
+	{
+		reset();
+		g_audio_config_result = 0;
+		void *source = createSource();
+		subscribeVideo(newBroadcast());
+		g_runtime->Run([] { deliverStatus(g_last_audio, -77); });
+		destroySource(source);
+		CHECK(g_audio_closes == 0);
+	}
+	report("raw decoder failure releases subscription");
+
+	// Invalid frame metadata must not reach OBS or leave the consumer running.
+	for (int failure = 0; failure < 4; failure++) {
+		reset();
+		g_audio_config_result = 0;
+		void *source = createSource();
+		subscribeVideo(newBroadcast());
+		if (failure == 0)
+			g_raw_size = sizeof(g_pcm) - 1;
+		else if (failure == 1)
+			g_raw_frame_result = -77;
+		else if (failure == 2)
+			g_raw_timestamp = UINT64_MAX;
+		else
+			g_raw_size = 0;
+		int32_t frame = newRawFrame();
+		g_runtime->Run([frame] { deliverStatus(g_last_audio, frame); });
+		CHECK(g_output_audio == 0);
+		CHECK(g_audio_closes == 1);
+		CHECK(g_raw_frame_frees == 1);
+		destroySource(source);
+	}
+	report("invalid raw frames stop the consumer and are freed");
 
 	// Frames that arrive before the first keyframe, and frames the decoder
 	// rejects, take early returns out of the decode path. Each one still owns the

--- a/cpp/obs/test/moq-source-test.cpp
+++ b/cpp/obs/test/moq-source-test.cpp
@@ -917,6 +917,8 @@ bool allTerminated()
 
 void reset()
 {
+	// The source can release its last reference before the stub finishes terminal bookkeeping.
+	g_runtime->Run([] {});
 	{
 		std::lock_guard<std::mutex> lock(g_subs_mutex);
 		g_subs.clear();

--- a/doc/bin/obs.md
+++ b/doc/bin/obs.md
@@ -33,6 +33,16 @@ OBS Studio install.
   **About** lists plugin and libmoq versions, documentation links, and available
   video encoders.
 
+## Source audio
+
+MoQ Source receives the first audio rendition alongside video. Audio decoding uses
+`moq-audio` through libmoq and supports Opus and AAC-LC in mono or stereo.
+HE-AAC and multichannel audio are unsupported. Broadcasts without an audio
+rendition remain video-only.
+
+Audio reaches OBS as 48 kHz stereo float PCM with the broadcast presentation
+timestamps. OBS mixes it with the scene's other audio sources.
+
 ## Source quality and moq-transcode
 
 OBS publishes **one** hang mezzanine. It does not encode a viewer ladder inside


### PR DESCRIPTION
## Summary

- Stack on #3490 at `0c4588a3a61be2ac3bf70b2b59242d664b343d63`. The base branch mirrors that exact commit because #3490 is hosted in a contributor's fork. Rebase this follow-up onto `main` and retarget it after #3490 lands.
- Receive audio through libmoq's existing `moq_consume_audio_raw` API, backed by `moq-audio`, instead of maintaining another FFmpeg audio decoder in OBS. Request 48 kHz stereo float PCM and preserve presentation timestamps at the OBS boundary.
- Limit supported encoded input to Opus and AAC-LC mono/stereo; document that HE-AAC and multichannel input are unsupported.
- Retire audio removed from the catalog, preserve the current consumer on immediate subscription rejection, and reject stale callbacks under the same mutex as OBS output. Add PCM, timestamp, frame ownership, replacement, removal, reconnect, and terminal-failure regressions.

## Public API

No exported API changes. Uses the existing raw PCM C API. OBS source codec coverage is narrowed as described above.

## Wire

No changes.

## Validation

- `nix develop --command just obs _unit`: passed, including the new adapter and lifecycle regressions.
- `nix develop --command just fix`, `just check`, and `just test`: passed against the stacked base.
- Native Apple Clang ThreadSanitizer: the complete source test suite passed after fixing a harness reset race. Reset now drains queued callback bookkeeping before clearing the subscription map.
- Parent negative control: the same catalog-removal regression fails on #3490 with exactly one assertion (`g_audio_closes == 1`); it passes with this refactor.
- The adapter tests stub libmoq; no new end-to-end playback or Windows runtime validation is claimed.

(written by GPT-6)
