### PR TITLE
docs: use MPEG-TS in low-latency examples

### DIFF
--- a/doc/bin/cli.md
+++ b/doc/bin/cli.md
@@ -41,11 +41,11 @@ instead host sessions with `--server-bind`, or both at once. `moq import --help`
 
 ```bash
 # Publish a file (remux to MPEG-TS without re-encoding)
-ffmpeg -re -i video.mp4 -c copy -f mpegts - | \
+ffmpeg -re -i video.mp4 -c copy -f mpegts -pes_payload_size 0 - | \
     moq --client-connect https://relay.example.com/anon --broadcast my-stream.hang import ts
 
 # Pull it back out
-moq --client-connect https://relay.example.com/anon --broadcast my-stream.hang export fmp4 | ffplay -
+moq --client-connect https://relay.example.com/anon --broadcast my-stream.hang export ts | ffplay -
 
 # With a token
 moq --client-connect "https://relay.example.com/rooms/1?jwt=$TOKEN" --broadcast alice.hang import ts

--- a/doc/concept/standard.md
+++ b/doc/concept/standard.md
@@ -54,10 +54,10 @@ supports, and prints it in the logs. Publish a test pattern and play it back:
 ```bash
 ffmpeg -re -f lavfi -i testsrc=size=1280x720:rate=30 -f lavfi -i sine=frequency=440 \
     -c:v libx264 -preset ultrafast -tune zerolatency -g 60 -c:a aac \
-    -f mp4 -movflags cmaf+frag_keyframe+empty_moov+default_base_moof - \
-| moq --client-connect https://relay.example.com --broadcast test.hang import fmp4
+    -f mpegts -pes_payload_size 0 - \
+| moq --client-connect https://relay.example.com --broadcast test.hang import ts
 
-moq --client-connect https://relay.example.com --broadcast test.hang export fmp4 | ffplay -
+moq --client-connect https://relay.example.com --broadcast test.hang export ts | ffplay -
 ```
 
 Add `--client-tls-disable-verify` for a self-signed relay on your own test

--- a/doc/setup/dev.md
+++ b/doc/setup/dev.md
@@ -23,7 +23,9 @@ match CI.
 | `just boy` | Run the [MoQ Boy](/bin/demo) demo. |
 
 Recipes default to the local relay at `http://localhost:4443`. Pass
-`https://cdn.moq.dev/anon` to use the public relay instead.
+`https://cdn.moq.dev/anon` to use the public relay instead. The default BBB/TOS
+publishers and `just pub serve` use MPEG-TS, with one audio frame per PES to
+avoid batching latency. Use `just pub cmaf` only when testing fMP4/CMAF.
 
 ## Debugging
 


### PR DESCRIPTION
## Summary

- Use MPEG-TS for the generic CLI and interop publishing/playback examples, with `-pes_payload_size 0` to avoid audio PES batching.
- Document that localhost BBB/TOS and direct-serving recipes default to TS; retain explicit CMAF/HLS format examples.

## Public API

None. Documentation only.

## Wire

None.

## Validation

`nix develop --command just fix` and `nix develop --command just check` passed. Audited localhost recipes and the CLI README, which already use TS.

(written by GPT-6)
