### PR TITLE
ci: trust the cachix substituter in the Smoke workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -53,6 +53,15 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
         with:
           determinate: false
+          # Trust the flake's cachix substituter. `nixConfig` in flake.nix is
+          # untrusted by default, so nix logs "ignoring untrusted flake
+          # configuration setting 'extra-substituters'" and rebuilds from
+          # source anything missing from the public nixpkgs cache. That was
+          # costing 678s per job for uniffi-bindgen-go alone, in every job that
+          # enters the dev shell.
+          extra-conf: |
+            extra-substituters = https://kixelated.cachix.org
+            extra-trusted-public-keys = kixelated.cachix.org-1:CmFcV0lyM6KuVM2m9mih0q4SrAa0XyCsiM7GHrz3KKk=
 
       # Reuse ~/.cargo + ./target across nightly runs so only changed crates
       # recompile (the relay, cli, moq-ffi, and libmoq all build from source).


### PR DESCRIPTION
The `nix-installer-action` step in `.github/workflows/smoke.yml` never got the `extra-conf` block that `check.yml` and `cache.yml` use, so nix ignored the flake's `nixConfig` substituter (untrusted by default) and compiled `uniffi-bindgen-go` from source on every Smoke run.

Copies the same block over, keeping `determinate: false` and the comment explaining why it is needed.

## Verification

Dispatched Smoke on this branch ([run 34171020975](https://github.com/moq-dev/moq/actions/runs/34171020975)) and compared the `Playwright Chromium` step, which is the first `nix develop` and therefore realizes the dev shell:

| Run | Step duration |
|---|---|
| [34169855705](https://github.com/moq-dev/moq/actions/runs/34169855705) (before) | 12m 28s |
| [34171020975](https://github.com/moq-dev/moq/actions/runs/34171020975) (after) | 1m 24s |

Confirmed in the log: ```copying path '/nix/store/...-uniffi-bindgen-go-0.8.0+v0.32.0' from 'https://kixelated.cachix.org'```. The run finished green through the full matrix, negative control, and TS compliance.

The `ignoring untrusted flake configuration setting` warnings still appear, as they do in Check. That is expected: the substituter now comes from `nix.conf`, so the flake's own copy of the setting is redundant.

## Public API and wire impact

None. CI configuration only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by claude-opus-5)
