### PR TITLE
chore: load Nix environment in Codex

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[shell_environment_policy.set]
+BASH_ENV = '$HOME/.codex/bash-env.sh'

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -2,10 +2,12 @@
 	"hooks": {
 		"SessionStart": [
 			{
+				"matcher": "startup|resume",
 				"hooks": [
 					{
 						"type": "command",
-						"command": "bash -lc 'project_dir=\"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\"; exec bash \"$project_dir/.codex/hooks/direnv.sh\"'"
+						"command": "bash -lc 'project_dir=\"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\"; exec bash \"$project_dir/.codex/hooks/direnv.sh\"'",
+						"statusMessage": "Loading Nix development shell"
 					}
 				]
 			}

--- a/.codex/hooks/direnv.sh
+++ b/.codex/hooks/direnv.sh
@@ -1,24 +1,15 @@
 #!/usr/bin/env bash
-# Load the project's direnv/Nix dev shell into the agent session so shell tool
-# commands resolve flake-pinned tools (just, bun, nixfmt, ...) instead of system
-# ones. No-op for anyone without direnv or an .envrc, so non-Nix setups are
-# unaffected.
-#
-# direnv only approves the .envrc; the actual env is exported into the session
-# env file, which the agent sources for later shell commands.
+# Capture the project's direnv/Nix dev shell for Codex shell commands. Codex
+# runs each command in a fresh Bash process, which sources this snapshot through
+# BASH_ENV as configured in .codex/config.toml.
 
-set -u
-
-env_file="${CODEX_ENV_FILE:-${CLAUDE_ENV_FILE:-}}"
-
-# Nothing to export into without this; older agent versions won't set it.
-[ -n "$env_file" ] || exit 0
+set -eu
 
 command -v direnv >/dev/null 2>&1 || exit 0
 
 # Require an explicit project dir so we never approve/export a stray .envrc from
 # some unrelated working directory.
-project_dir="${CODEX_PROJECT_DIR:-${CLAUDE_PROJECT_DIR:-${PWD:-}}}"
+project_dir="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 [ -n "$project_dir" ] || exit 0
 cd "$project_dir" || exit 0
 [ -f .envrc ] || exit 0
@@ -31,16 +22,19 @@ export XDG_DATA_HOME="$PWD/.direnv/share"
 export DIRENV_CONFIG="$XDG_CONFIG_HOME/direnv"
 mkdir -p "$XDG_CACHE_HOME" "$XDG_CONFIG_HOME" "$XDG_DATA_HOME"
 
+env_file="$PWD/.direnv/codex-env.sh"
+env_tmp="$env_file.tmp"
+trap 'rm -f "$env_tmp"' EXIT
+
 # Codex only needs the flake dev shell environment, so avoid depending on
 # nix-direnv's remote bootstrap when Nix can emit the shell exports directly.
 if command -v nix >/dev/null 2>&1 && [ -f flake.nix ]; then
-    nix_env="$(mktemp)"
-    if nix print-dev-env --profile "$PWD/.direnv/codex-profile" .#default >"$nix_env" 2>"$PWD/.direnv/codex-hook.log"; then
-        cat "$nix_env" >>"$env_file"
-        rm -f "$nix_env"
+    if nix --extra-experimental-features 'nix-command flakes' --accept-flake-config \
+        print-dev-env --profile "$PWD/.direnv/codex-profile" .#default \
+        >"$env_tmp" 2>"$PWD/.direnv/codex-hook.log"; then
+        mv "$env_tmp" "$env_file"
         exit 0
     fi
-    rm -f "$nix_env"
 fi
 
 # Clear any inherited direnv state so `export` recomputes the full diff. Without
@@ -49,6 +43,7 @@ fi
 unset DIRENV_DIR DIRENV_DIFF DIRENV_WATCHES DIRENV_FILE DIRENV_LAYOUT
 
 direnv allow . 2>>"$PWD/.direnv/codex-hook.log"
-direnv export bash >>"$env_file" 2>>"$PWD/.direnv/codex-hook.log"
+direnv export bash >"$env_tmp" 2>>"$PWD/.direnv/codex-hook.log"
+mv "$env_tmp" "$env_file"
 
 exit 0


### PR DESCRIPTION
## Summary

- capture the flake development environment when a Codex session starts
- inject the cached environment into each non-interactive Bash command
- replace the ineffective parent-environment export with an atomic, worktree-local snapshot
- depends on https://github.com/kixelated/dotfiles/pull/10 for the reusable loader

## Public API

- none

## Wire

- none

## Validation

- `just fix`
- `just check`
- `just test`
- verified `cargo 1.95.0`, `just`, and `bun` resolve from the pinned Nix environment

(written by gpt-5.6-sol)