### PR TITLE
quest: plan the audio codecs line

### DIFF
--- a/quest/m2/README.md
+++ b/quest/m2/README.md
@@ -22,6 +22,7 @@ can act on. Each still carries its own plan and regression test.
 - [Wildcard](/quest/m2/wildcard/README.md) - a service advertises a path pattern it could serve instead of enumerating broadcasts
 - [Path patterns](/quest/m2/path-patterns/README.md) - one versioned matcher for every predicate over broadcast paths: tokens, origins, interest
 - [OBS native codecs](/quest/m2/obs-moq-video/README.md) - remove FFmpeg decoding dependencies, deliver GPU frames, and use native audio/video encoders
+- [Audio codecs](/quest/m2/audio-codecs/README.md) - a broadcast that plays in the browser plays natively: platform decoders and encoders behind a backend seam, HE-AAC, and channel layouts up to 7.1
 - [Keyframe trigger](/quest/m2/keyframe-trigger.md) - an application can ask the built-in capture encoder for a keyframe
 - [QoS](/quest/m2/qos/README.md) - broadcast health from the relay: viewer starvation and publisher timeliness histograms, publisher stats, viewer feedback
 - [Drain](/quest/m2/drain/README.md) - relay restarts drain sessions over GOAWAY instead of hard-dropping them

--- a/quest/m2/audio-codecs/README.md
+++ b/quest/m2/audio-codecs/README.md
@@ -1,0 +1,59 @@
+# Audio codecs
+
+## Goal
+
+A broadcast that plays in the browser plays natively. Today the browser
+decodes whatever the platform offers (HE-AAC, 5.1 AAC, AC-3, surround Opus)
+while `moq-audio` decodes Opus and AAC-LC in mono or stereo, so the same
+stream plays on moq.dev and fails in OBS, `moq play`, and every binding. The
+native side grows the backend seam `moq-video` already has, uses the OS codec
+where one exists, keeps symphonia as the pure-Rust fallback, and carries more
+than two channels end to end. Encoding follows the same seam so a native
+publisher can produce AAC.
+
+## Plan
+
+Platform first, exactly like video: AudioToolbox on macOS and iOS, Media
+Foundation on Windows, MediaCodec on Android, and symphonia (AAC-LC
+mono/stereo) as the software fallback that openh264 is for H.264. Linux has no
+OS audio decoder, so HE-AAC and multichannel AAC stay refused there, stated in
+the docs and rejected at construction. A platform backend claims every catalog
+codec its framework opens, so AC-3, E-AC-3, MP3, and FLAC ride along on the
+hosts that have them; each still needs a fixture before the backend advertises
+it.
+
+Channels are a `Layout`, not a count: a closed set of well-known layouts in one
+canonical order, derived from the codec description (AAC channelConfiguration,
+OpusHead mapping) so the catalog and wire do not change. Every decoder reorders
+from its codec's native order into that one, so the mixer, the FFI, and OBS
+never guess where the LFE is. Playback downmixes to whatever the output device
+opened. Counts with no standard layout are refused.
+
+Encode mirrors decode: an `encode::backend` seam, `Codec::Aac` meaning AAC-LC
+at the input's layout, and platform encoders behind it. Opus encode stays
+mono/stereo.
+
+The layout and seam quests are independent and come first; each platform then
+lands as its own decode and encode quest so verification stays per host. The
+HE-AAC refusal is a defect in what ships today and is ready now.
+
+## Quests
+
+- [HE-AAC refusal](/quest/m2/audio-codecs/he-aac-refusal.md) - implicit-SBR HE-AAC over TS is refused instead of half-decoded as the LC core
+- [Layout](/quest/m2/audio-codecs/layout.md) - a `Layout` type in one canonical order carries up to 7.1 through decode, resample, playback, and the FFI
+- [Decode seam](/quest/m2/audio-codecs/decode-backend.md) - `decode::backend` selects a platform decoder before symphonia, mirroring moq-video
+- [AudioToolbox decode](/quest/m2/audio-codecs/decode-audiotoolbox.md) - macOS and iOS decode HE-AAC, multichannel AAC, and what else the framework offers
+- [Opus surround](/quest/m2/audio-codecs/opus-surround.md) - mapping family 1 decodes on every host through the multistream decoder
+- [Encode seam](/quest/m2/audio-codecs/encode-backend.md) - `encode::backend` and `Codec::Aac`, so a native publisher can produce AAC-LC
+- [AudioToolbox encode](/quest/m2/audio-codecs/encode-audiotoolbox.md) - macOS and iOS encode AAC-LC
+- [Media Foundation decode](/quest/m2/audio-codecs/decode-mediafoundation.md) - Windows decodes HE-AAC, multichannel AAC, and what else the MFTs offer
+- [Media Foundation encode](/quest/m2/audio-codecs/encode-mediafoundation.md) - Windows encodes AAC-LC
+- [MediaCodec decode](/quest/m2/audio-codecs/decode-mediacodec.md) - Android decodes HE-AAC, multichannel AAC, and what else the device offers
+- [MediaCodec encode](/quest/m2/audio-codecs/encode-mediacodec.md) - Android encodes AAC-LC
+
+## Related
+
+- [OBS native codecs](/quest/m2/obs-moq-video/README.md) - the OBS source and encoder adapters consume this through libmoq; #3498 narrowed OBS to what moq-audio decodes today
+- [Mobile](/quest/m2/mobile/README.md) - the iOS and Android slices ship these backends through moq-ffi
+- [Runtime QA hosts](/quest/m2/runtime-qa-hosts.md) - Windows and Android verification needs a host; the Windows and macOS CI gates run nightly, not per PR
+- [Dart codec parity](/quest/m2/dart-codecs.md) - Dart gains these once it builds with the `audio` feature

--- a/quest/m2/audio-codecs/decode-audiotoolbox.md
+++ b/quest/m2/audio-codecs/decode-audiotoolbox.md
@@ -1,0 +1,40 @@
+# [M] AudioToolbox decode on macOS and iOS
+
+## Goal
+
+On macOS and iOS, `moq-audio` decodes AAC-LC, HE-AAC v1 and v2, and
+multichannel AAC through AudioToolbox, and whichever of AC-3, E-AC-3, MP3, and
+FLAC the framework opens. The OBS source and `moq play` play the streams #3498
+documents as unsupported.
+
+## Plan
+
+An `AudioConverter` from the packetized format to interleaved `f32` at the
+codec's native rate and layout, behind the decode seam as the first platform
+candidate on `target_os = "macos"` and `"ios"`. `objc2-audio-toolbox` is the
+binding, alongside the `objc2-core-audio-types` the crate already carries.
+
+- Build the `AudioStreamBasicDescription` and magic cookie from the catalog
+  description; the converter reports the output layout, which maps to
+  `Layout` from the AudioChannelLayout tag rather than a count.
+- HE-AAC: the converter reads SBR in band and reports the doubled rate; the
+  seam passes it through. No config-level guessing.
+- Priming and remainder: AudioToolbox reports `kAudioConverterPrimeInfo`;
+  trim it so timestamps line up with symphonia's output on the same stream.
+- Every codec the backend advertises has a fixture and a decode test, and the
+  test asserts the layout order matches the canonical one (the LFE and centre
+  end up where `Layout` says).
+- iOS: the binding compiles into the moq-ffi iOS slice; runtime proof waits
+  on a device like the rest of the mobile line.
+- Docs: `doc/bin/obs.md` drops the HE-AAC and multichannel caveat on macOS,
+  and the backend table names what this host decodes.
+
+## Required
+
+- [Decode seam](/quest/m2/audio-codecs/decode-backend.md) - the candidate order this backend joins
+- [Layout](/quest/m2/audio-codecs/layout.md) - what a multichannel frame is delivered as
+
+## Related
+
+- [Media Foundation decode](/quest/m2/audio-codecs/decode-mediafoundation.md) - the same shape on Windows
+- [MediaCodec decode](/quest/m2/audio-codecs/decode-mediacodec.md) - the same shape on Android

--- a/quest/m2/audio-codecs/decode-backend.md
+++ b/quest/m2/audio-codecs/decode-backend.md
@@ -1,0 +1,41 @@
+# [M] A decode backend seam that prefers the platform codec
+
+## Goal
+
+`moq_audio::decode` selects a backend per codec the way `moq_video::decode`
+does: platform first, software fallback, and a `Kind` to force one. Opus,
+PCM, and symphonia AAC-LC become the software backends, and the crate
+documents which codecs each host decodes.
+
+## Plan
+
+Mirror `rs/moq-video/src/decode/backend` in name and shape: a crate-private
+`Backend` trait (`decode`, `flush`, `name`), an `open(codec, config)` that
+walks the platform candidates before the software ones and refuses when none
+takes the track, and `decode::Kind { Auto, Platform, Software, Named }` on
+`decode::Config`. `Decoder::name()` reports what was opened, which the OBS
+stats and `moq play` surface.
+
+- The seam is generic over `hang::catalog::AudioCodec`, so a backend advertises
+  the set it opens and the selector asks each in order. Symphonia advertises
+  AAC-LC mono/stereo only; the platform backends that follow advertise what
+  their framework opens and has a fixture for.
+- Move today's Opus, PCM, and symphonia code behind the trait without changing
+  behavior; the HE-AAC sniff from [HE-AAC refusal](/quest/m2/audio-codecs/he-aac-refusal.md)
+  lands in the symphonia backend.
+- A backend's output rate and layout are what it produced, not what the
+  catalog said (HE-AAC doubles the rate); `Consumer` already resamples and
+  remixes to the requested output, so that stays the seam's contract.
+- The `aac` feature keeps gating symphonia. Platform backends are
+  `cfg(target_os)` like their video counterparts, with `mediacodec` behind the
+  existing feature.
+- Docs: `doc/lib/rs/moq-audio.md` gains the backend table `moq-video.md` has,
+  and states the Linux gap. `doc/bin/cli.md` and `doc/bin/obs.md` follow.
+- Regression: the selection order and `Named` refusal, tested with a stub
+  backend like the video seam's `probe`.
+
+The FFI does not expose `Kind` until a consumer asks.
+
+## Related
+
+- [Layout](/quest/m2/audio-codecs/layout.md) - independent; the platform backends need both

--- a/quest/m2/audio-codecs/decode-mediacodec.md
+++ b/quest/m2/audio-codecs/decode-mediacodec.md
@@ -1,0 +1,32 @@
+# [M] MediaCodec decode on Android
+
+## Goal
+
+On Android, `moq-audio` decodes AAC-LC, HE-AAC v1 and v2, and multichannel
+AAC through `AMediaCodec`, and whichever of MP3, FLAC, AC-3, and E-AC-3 the
+device's codec list opens.
+
+## Plan
+
+The audio counterpart of `rs/moq-video/src/decode/backend/mediacodec.rs`,
+behind the existing `mediacodec` feature and the decode seam, on `target_os
+= "android"`.
+
+- `audio/mp4a-latm` with the catalog description as `csd-0`; the output format
+  reports the channel count and, on API 23 and later, the channel mask that
+  maps to `Layout`.
+- Optional codecs are probed through `AMediaCodecList` at open and advertised
+  only where present.
+- Fixtures and layout-order tests as in the AudioToolbox quest; runtime proof
+  on a device or emulator, since no CI runs Android.
+- The binding ships in the moq-ffi Android slice, which is how Kotlin and Dart
+  reach it.
+
+## Required
+
+- [Decode seam](/quest/m2/audio-codecs/decode-backend.md) - the candidate order this backend joins
+- [Layout](/quest/m2/audio-codecs/layout.md) - what a multichannel frame is delivered as
+
+## Related
+
+- [Android capture](/quest/m2/mobile/video-android.md) - the video MediaCodec family this sits beside

--- a/quest/m2/audio-codecs/decode-mediafoundation.md
+++ b/quest/m2/audio-codecs/decode-mediafoundation.md
@@ -1,0 +1,33 @@
+# [M] Media Foundation decode on Windows
+
+## Goal
+
+On Windows, `moq-audio` decodes AAC-LC, HE-AAC v1 and v2, and multichannel
+AAC through the Media Foundation AAC decoder MFT, and whichever of MP3, FLAC,
+AC-3, and E-AC-3 the installed MFTs open.
+
+## Plan
+
+The audio counterpart of `rs/moq-video/src/decode/backend/mediafoundation.rs`,
+using the `windows` crate features moq-video already enables plus the audio
+ones. Behind the decode seam as the first candidate on `target_os =
+"windows"`.
+
+- The AAC decoder MFT takes an `MF_MT_USER_DATA` blob built from the catalog
+  AudioSpecificConfig and reports the output `WAVEFORMATEXTENSIBLE`, whose
+  channel mask maps to `Layout`.
+- Optional MFTs (Dolby, FLAC) are probed at open: absent means the codec is
+  not advertised on that host, not an error at decode time.
+- Fixtures and layout-order tests as in the AudioToolbox quest.
+- Verification runs on a Windows host; the per-PR CI only compiles the
+  platform code, and `just rs windows` runs nightly.
+
+## Required
+
+- [Decode seam](/quest/m2/audio-codecs/decode-backend.md) - the candidate order this backend joins
+- [Layout](/quest/m2/audio-codecs/layout.md) - what a multichannel frame is delivered as
+
+## Related
+
+- [Runtime QA hosts](/quest/m2/runtime-qa-hosts.md) - where the Windows run happens
+- [Windows decoded frames](/quest/m2/obs-moq-video/decode-windows.md) - the OBS Windows line this feeds

--- a/quest/m2/audio-codecs/encode-audiotoolbox.md
+++ b/quest/m2/audio-codecs/encode-audiotoolbox.md
@@ -10,8 +10,9 @@ layout, up to 7.1, and the result plays in the browser, `moq play`, and OBS.
 An `AudioConverter` from interleaved `f32` to `kAudioFormatMPEG4AAC`, behind
 the encode seam as the platform candidate on macOS and iOS.
 
-- Read the magic cookie after the first packet for the catalog description,
-  and `kAudioConverterPrimeInfo` for the delay the timestamps fold in.
+- The catalog ASC is synthesized at construction per the encode seam; read
+  `kAudioConverterCompressionMagicCookie` at open and assert it matches.
+  `kAudioConverterPrimeInfo` gives the delay the timestamps fold in.
 - Bitrate through `kAudioConverterEncodeBitRate`, updated live where the
   converter allows.
 - Regression: a stereo and a 5.1 encode round-trip through the AudioToolbox
@@ -22,3 +23,4 @@ the encode seam as the platform candidate on macOS and iOS.
 
 - [Encode seam](/quest/m2/audio-codecs/encode-backend.md) - the candidate order this backend joins
 - [Layout](/quest/m2/audio-codecs/layout.md) - the input layout the encoder accepts
+- [AudioToolbox decode](/quest/m2/audio-codecs/decode-audiotoolbox.md) - the round-trip regression decodes through it

--- a/quest/m2/audio-codecs/encode-audiotoolbox.md
+++ b/quest/m2/audio-codecs/encode-audiotoolbox.md
@@ -1,0 +1,24 @@
+# [M] AudioToolbox AAC encode on macOS and iOS
+
+## Goal
+
+On macOS and iOS, `Codec::Aac` encodes through AudioToolbox at the input's
+layout, up to 7.1, and the result plays in the browser, `moq play`, and OBS.
+
+## Plan
+
+An `AudioConverter` from interleaved `f32` to `kAudioFormatMPEG4AAC`, behind
+the encode seam as the platform candidate on macOS and iOS.
+
+- Read the magic cookie after the first packet for the catalog description,
+  and `kAudioConverterPrimeInfo` for the delay the timestamps fold in.
+- Bitrate through `kAudioConverterEncodeBitRate`, updated live where the
+  converter allows.
+- Regression: a stereo and a 5.1 encode round-trip through the AudioToolbox
+  decoder and through symphonia (stereo only), with timestamps continuous
+  across the priming.
+
+## Required
+
+- [Encode seam](/quest/m2/audio-codecs/encode-backend.md) - the candidate order this backend joins
+- [Layout](/quest/m2/audio-codecs/layout.md) - the input layout the encoder accepts

--- a/quest/m2/audio-codecs/encode-backend.md
+++ b/quest/m2/audio-codecs/encode-backend.md
@@ -16,12 +16,19 @@ that walks platform candidates before software ones, and `encode::Kind` on
 only software backends: no Rust AAC encoder exists, which is why the platform
 quests follow.
 
-- `encode::Codec` gains `Aac`, meaning `mp4a.40.2`. `as_str` and `FromStr`
-  accept `"aac"`, which is what the FFI and libmoq codec strings carry, so
-  moq-ffi and every binding gain AAC by string with no signature change.
-- Catalog emission: `AudioCodec::AAC` with profile 2, the ASC as
-  `description`, `Container::Legacy`, and the encoder's reported delay folded
-  into timestamps like Opus pre-skip is today.
+- `encode::Codec` gains `Aac`, meaning `mp4a.40.2`, and `as_str` / `FromStr`
+  accept `"aac"`, which is what libmoq's codec string carries. moq-ffi's
+  `MoqAudioCodec` is a closed UniFFI enum, so it gains an `Aac` variant and
+  conversion, and the generated bindings, hand-written wrappers, and docs
+  follow the Cross-Package Sync table.
+- Catalog emission: `AudioCodec::AAC` with profile 2, `Container::Legacy`,
+  and the encoder's reported delay folded into timestamps like Opus pre-skip
+  is today. `Producer` registers the rendition before the first frame is
+  written, so the ASC `description` is synthesized at construction from the
+  config with `moq_mux::codec::aac::Config::encode`, never read back from the
+  backend's first packet. A backend that reports its own header (a magic
+  cookie, `csd-0`, `MF_MT_USER_DATA`) must produce one equal to the synthesized
+  ASC, asserted in its tests.
 - Frame size is the codec's (1024 samples for AAC), so `frame_duration` is
   validated per codec rather than against the Opus table.
 - Bitrate updates go through the backend; one that cannot change rate

--- a/quest/m2/audio-codecs/encode-backend.md
+++ b/quest/m2/audio-codecs/encode-backend.md
@@ -1,0 +1,38 @@
+# [M] An encode backend seam and an AAC output codec
+
+## Goal
+
+`moq_audio::encode` selects a backend the way `moq_video::encode` does, and
+`Codec::Aac` is a valid output: AAC-LC at the input's sample rate and layout,
+published with the AudioSpecificConfig description every player expects. A
+host with no AAC encoder refuses it at construction.
+
+## Plan
+
+Mirror the decode seam: `encode::backend` with a crate-private `Backend`
+trait (`encode`, `flush`, `set_bitrate`, `name`), an `open(codec, config)`
+that walks platform candidates before software ones, and `encode::Kind` on
+`encode::Config`. Opus and PCM move behind the trait unchanged and remain the
+only software backends: no Rust AAC encoder exists, which is why the platform
+quests follow.
+
+- `encode::Codec` gains `Aac`, meaning `mp4a.40.2`. `as_str` and `FromStr`
+  accept `"aac"`, which is what the FFI and libmoq codec strings carry, so
+  moq-ffi and every binding gain AAC by string with no signature change.
+- Catalog emission: `AudioCodec::AAC` with profile 2, the ASC as
+  `description`, `Container::Legacy`, and the encoder's reported delay folded
+  into timestamps like Opus pre-skip is today.
+- Frame size is the codec's (1024 samples for AAC), so `frame_duration` is
+  validated per codec rather than against the Opus table.
+- Bitrate updates go through the backend; one that cannot change rate
+  mid-stream keeps its opening rate, as the video seam documents.
+- Regression: the selection order with a stub backend; `Codec::Aac` refused on
+  a host with no backend; the Opus and PCM paths unchanged.
+
+## Required
+
+- [Decode seam](/quest/m2/audio-codecs/decode-backend.md) - the naming and shape this mirrors
+
+## Related
+
+- [OBS audio publishing](/quest/m2/obs-moq-video/audio-publish.md) - the OBS encoder adapter can offer AAC once this lands

--- a/quest/m2/audio-codecs/encode-mediacodec.md
+++ b/quest/m2/audio-codecs/encode-mediacodec.md
@@ -10,8 +10,9 @@ where the device's encoder supports it.
 The audio counterpart of `rs/moq-video/src/encode/backend/mediacodec.rs`,
 behind the `mediacodec` feature and the encode seam.
 
-- `audio/mp4a-latm` with `KEY_AAC_PROFILE` = LC; the `csd-0` output buffer is
-  the catalog description.
+- `audio/mp4a-latm` with `KEY_AAC_PROFILE` = LC. The catalog ASC is
+  synthesized at construction per the encode seam, since `csd-0` only arrives
+  with the first output buffer; assert the two match.
 - Multichannel is device-dependent; probe the encoder's capabilities at open
   and refuse a layout it does not list.
 - Round-trip regression through the MediaCodec decoder; runtime proof on a
@@ -21,3 +22,4 @@ behind the `mediacodec` feature and the encode seam.
 
 - [Encode seam](/quest/m2/audio-codecs/encode-backend.md) - the candidate order this backend joins
 - [Layout](/quest/m2/audio-codecs/layout.md) - the input layout the encoder accepts
+- [MediaCodec decode](/quest/m2/audio-codecs/decode-mediacodec.md) - the round-trip regression decodes through it

--- a/quest/m2/audio-codecs/encode-mediacodec.md
+++ b/quest/m2/audio-codecs/encode-mediacodec.md
@@ -1,0 +1,23 @@
+# [M] MediaCodec AAC encode on Android
+
+## Goal
+
+On Android, `Codec::Aac` encodes through `AMediaCodec` at the input's layout
+where the device's encoder supports it.
+
+## Plan
+
+The audio counterpart of `rs/moq-video/src/encode/backend/mediacodec.rs`,
+behind the `mediacodec` feature and the encode seam.
+
+- `audio/mp4a-latm` with `KEY_AAC_PROFILE` = LC; the `csd-0` output buffer is
+  the catalog description.
+- Multichannel is device-dependent; probe the encoder's capabilities at open
+  and refuse a layout it does not list.
+- Round-trip regression through the MediaCodec decoder; runtime proof on a
+  device or emulator.
+
+## Required
+
+- [Encode seam](/quest/m2/audio-codecs/encode-backend.md) - the candidate order this backend joins
+- [Layout](/quest/m2/audio-codecs/layout.md) - the input layout the encoder accepts

--- a/quest/m2/audio-codecs/encode-mediafoundation.md
+++ b/quest/m2/audio-codecs/encode-mediafoundation.md
@@ -13,7 +13,8 @@ behind the encode seam on Windows.
 - The encoder MFT fixes its output rates and bitrates per channel count;
   refuse configurations outside that table at construction rather than
   letting the MFT pick silently.
-- The output type's `MF_MT_USER_DATA` carries the ASC for the catalog.
+- The catalog ASC is synthesized at construction per the encode seam; the
+  output type's `MF_MT_USER_DATA` must match it, asserted in tests.
 - Round-trip regression through the Media Foundation decoder; verification on
   a Windows host, since the per-PR CI compiles only.
 
@@ -21,6 +22,7 @@ behind the encode seam on Windows.
 
 - [Encode seam](/quest/m2/audio-codecs/encode-backend.md) - the candidate order this backend joins
 - [Layout](/quest/m2/audio-codecs/layout.md) - the input layout the encoder accepts
+- [Media Foundation decode](/quest/m2/audio-codecs/decode-mediafoundation.md) - the round-trip regression decodes through it
 
 ## Related
 

--- a/quest/m2/audio-codecs/encode-mediafoundation.md
+++ b/quest/m2/audio-codecs/encode-mediafoundation.md
@@ -1,0 +1,27 @@
+# [M] Media Foundation AAC encode on Windows
+
+## Goal
+
+On Windows, `Codec::Aac` encodes through the Media Foundation AAC encoder
+MFT, mono, stereo, and up to 5.1.
+
+## Plan
+
+The audio counterpart of `rs/moq-video/src/encode/backend/mediafoundation.rs`,
+behind the encode seam on Windows.
+
+- The encoder MFT fixes its output rates and bitrates per channel count;
+  refuse configurations outside that table at construction rather than
+  letting the MFT pick silently.
+- The output type's `MF_MT_USER_DATA` carries the ASC for the catalog.
+- Round-trip regression through the Media Foundation decoder; verification on
+  a Windows host, since the per-PR CI compiles only.
+
+## Required
+
+- [Encode seam](/quest/m2/audio-codecs/encode-backend.md) - the candidate order this backend joins
+- [Layout](/quest/m2/audio-codecs/layout.md) - the input layout the encoder accepts
+
+## Related
+
+- [Runtime QA hosts](/quest/m2/runtime-qa-hosts.md) - where the Windows run happens

--- a/quest/m2/audio-codecs/he-aac-refusal.md
+++ b/quest/m2/audio-codecs/he-aac-refusal.md
@@ -1,0 +1,38 @@
+# [S] Refuse implicit-SBR HE-AAC instead of half-decoding it
+
+## Goal
+
+An HE-AAC stream that signals AAC-LC and carries SBR only in band is refused
+with a clear error, the same way explicitly signaled and backward-compatible
+HE-AAC already are. Today it decodes as the LC core at half the sample rate
+with no indication anything is wrong.
+
+## Plan
+
+ADTS carries a 2-bit profile, so HE-AAC over MPEG-TS (SRT, `moq import ts`)
+always arrives as `mp4a.40.2` with a synthesized LC AudioSpecificConfig. The
+config-level checks in `rs/moq-audio/src/aac.rs` cannot see it, and the code
+says so. The stream itself can: the first raw data block carries an `ID_FIL`
+element with `EXT_SBR_DATA` (or `EXT_SBR_DATA_CRC`), and every later frame
+does too.
+
+- Sniff the fill elements of the first packet before handing it to symphonia.
+  An SBR extension makes the track `Error::Unsupported` with the same wording
+  as the config-level refusal, naming the host's decoder as the reason.
+- Symphonia already walks the element tree, so the sniff is a small parser
+  over the same syntax, not a decode. It runs once per track.
+- Regression: an ADTS fixture with implicit SBR is refused; the existing
+  explicit and backward-compatible fixtures keep their errors; an LC fixture
+  with an unrelated fill element still decodes.
+- When a platform decoder handles the track ([Decode seam](/quest/m2/audio-codecs/decode-backend.md)),
+  the sniff belongs to the symphonia backend only; the OS decoders read SBR in
+  band themselves.
+
+Also fix the two places the catalog invents a channel count: the ADTS and
+ASC importers in `rs/moq-mux/src/codec/aac` map `channel_config == 0` (a
+program config element) and reserved values to stereo with a warning.
+Warn-then-continue is banned: parse the PCE or refuse the track.
+
+## Related
+
+- [Decode seam](/quest/m2/audio-codecs/decode-backend.md) - the sniff becomes the software backend's contract

--- a/quest/m2/audio-codecs/layout.md
+++ b/quest/m2/audio-codecs/layout.md
@@ -1,0 +1,47 @@
+# [M] Channel layouts through decode, playback, and the FFI
+
+## Goal
+
+`moq-audio` carries up to 7.1 end to end. A decoded frame says which layout
+it is in, the playback mixer downmixes it to whatever the device opened, a raw
+PCM consumer can ask for a layout, and the FFI and libmoq expose the same.
+Proven with multichannel PCM, the one codec that needs no new decoder.
+
+## Plan
+
+A closed `Layout` enum (mono, stereo, 2.1, quad, 5.0, 5.1, 6.1, 7.1, and the
+other AAC channelConfiguration and Opus mapping family 1 entries) in one
+canonical order, the SMPTE/WAVE order. Each codec module maps its native
+order into it: AAC's `C L R Ls Rs LFE` and Opus's Vorbis `L C R Ls Rs LFE`
+both become `L R C LFE Ls Rs`. A count with no standard layout is refused at
+construction, so a `Layout` always downmixes.
+
+- `decode::Config` and the encoder input take a `Layout` where they take a
+  channel count today; `Frame` stays layout-free since the consumer fixed it
+  at construction. `Layout::channels()` gives the count.
+- `resample::remix` becomes a generic remix over layouts: ITU-R BS.775
+  coefficients for downmix, silence in the extra speakers for upmix, and the
+  existing mono/stereo paths as the two-channel special cases. The resampler is
+  already channel-generic.
+- Playback: the mix bus takes the device's layout instead of fixed stereo, the
+  device chooser prefers the widest well-known layout the device offers (a
+  5.1 HDMI sink opens at six channels, a headset at two), and each `Sink`
+  remixes into the bus. Today's "silence past the front pair" fan-out goes.
+- moq-ffi and libmoq: `channels` on the decoder output, encoder input, and
+  encoder output become a layout, additive with a default so every binding and
+  the C ABI keep compiling. Bindings (Python, Swift, Kotlin, Go, Dart wrappers
+  and docs) follow the Cross-Package Sync table.
+- The catalog does not change: `channel_count` already carries what the
+  description implies, and `js/hang`'s `aac.ts` stops falling back to stereo
+  for a count it cannot map.
+- Regressions: a 5.1 PCM broadcast published through `encode::Producer` and
+  read back through `decode::Consumer` at 5.1, at stereo, and at mono; the
+  mixer fed a 5.1 sink into a stereo bus and a stereo sink into a 5.1 bus; the
+  device chooser picking six channels when offered.
+
+Capture stays mono/stereo, and Opus encode stays mapping family 0.
+
+## Related
+
+- [Opus surround](/quest/m2/audio-codecs/opus-surround.md) - the first coded multichannel consumer of the layout
+- [AudioToolbox decode](/quest/m2/audio-codecs/decode-audiotoolbox.md) - the first platform decoder producing more than stereo

--- a/quest/m2/audio-codecs/layout.md
+++ b/quest/m2/audio-codecs/layout.md
@@ -27,10 +27,12 @@ construction, so a `Layout` always downmixes.
   device chooser prefers the widest well-known layout the device offers (a
   5.1 HDMI sink opens at six channels, a headset at two), and each `Sink`
   remixes into the bus. Today's "silence past the front pair" fan-out goes.
-- moq-ffi and libmoq: `channels` on the decoder output, encoder input, and
-  encoder output become a layout, additive with a default so every binding and
-  the C ABI keep compiling. Bindings (Python, Swift, Kotlin, Go, Dart wrappers
-  and docs) follow the Cross-Package Sync table.
+- moq-ffi and libmoq keep `channels` as a count, and the count means the
+  default layout for that count (the WAVE convention: 3 is 2.1, 4 is quad, 6
+  is 5.1, 8 is 7.1), delivered or accepted in the canonical order. No record,
+  `repr(C)` struct, or binding changes, so this stays on `main`; only the
+  Rust API names the layout, and a binding that needs 5.0 rather than 5.1 is
+  a later additive field. Document the mapping in every binding's audio doc.
 - The catalog does not change: `channel_count` already carries what the
   description implies, and `js/hang`'s `aac.ts` stops falling back to stereo
   for a count it cannot map.

--- a/quest/m2/audio-codecs/opus-surround.md
+++ b/quest/m2/audio-codecs/opus-surround.md
@@ -1,0 +1,26 @@
+# [S] Opus surround through the multistream decoder
+
+## Goal
+
+An Opus track with channel mapping family 1 (up to 7.1, RFC 7845 §5.1.1)
+decodes on every host, delivered in the canonical `Layout` order. Pure Rust,
+so this is the one multichannel path Linux gets.
+
+## Plan
+
+- `moq_mux::codec::opus::Config` parses the channel mapping (family, stream
+  count, coupled count, and the mapping table) instead of skipping it. Family
+  0 stays mono/stereo; family 1 maps to a `Layout` by channel count; family
+  255 and unknown families are refused, since they carry no speaker
+  assignment.
+- The Opus decode backend opens `opus_multistream_decoder_create` from
+  `unsafe-libopus` when the family is 1, and reorders Vorbis order into the
+  canonical one on the way out.
+- Encode stays family 0; `Config::encode` keeps refusing more than two
+  channels.
+- Regression: a family-1 5.1 fixture decodes to six channels in canonical
+  order; family 255 is refused at construction.
+
+## Required
+
+- [Layout](/quest/m2/audio-codecs/layout.md) - the type the mapping resolves to

--- a/quest/m2/obs-moq-video/README.md
+++ b/quest/m2/obs-moq-video/README.md
@@ -34,3 +34,4 @@ The quests separate portable decoding, platform GPU delivery, audio, and publish
 
 - [VAAPI encode and decode](/quest/m2/video-vaapi.md) - owns Linux backend decode/import capabilities; reconcile its older dependency assumptions against current code
 - [Video hardware validation](/quest/m3/video-hardware.md) - physical hardware evidence is required for each claimed GPU path
+- [Audio codecs](/quest/m2/audio-codecs/README.md) - HE-AAC, multichannel, and native AAC encode reach the OBS source and encoder adapters through libmoq

--- a/quest/m2/obs-moq-video/audio-publish.md
+++ b/quest/m2/obs-moq-video/audio-publish.md
@@ -15,3 +15,7 @@ MoQ publishing can encode OBS's mixed audio with moq-audio Opus while preserving
 ## Required
 
 - [Encoder presets](/quest/m2/obs-moq-video/presets.md) - shared policy and truthful reporting
+
+## Related
+
+- [Encode seam](/quest/m2/audio-codecs/encode-backend.md) - `Codec::Aac` lets the adapter offer AAC instead of leaving it to the OBS encoder mode


### PR DESCRIPTION
## Summary

Plans `quest/m2/audio-codecs/`, a questline that closes the native-vs-browser audio gap #3498 documents: a broadcast that plays in the browser plays in OBS, `moq play`, and the bindings.

Settled in the planning interview:

- **Platform first, symphonia as the software fallback**, mirroring `moq_video::decode::backend`: AudioToolbox (macOS/iOS), Media Foundation (Windows), MediaCodec (Android). Linux keeps AAC-LC mono/stereo and refuses the rest at construction; the docs say so.
- **A platform backend claims every codec its framework opens** (HE-AAC v1/v2, multichannel AAC, AC-3, E-AC-3, MP3, FLAC), each behind a fixture.
- **Channels are a closed `Layout` in one canonical order**, derived from the codec description. No catalog or wire change. Playback downmixes to what the device opened; counts with no standard layout are refused.
- **Opus surround (mapping family 1)** decodes everywhere via the multistream decoder already in `unsafe-libopus`. Encode stays mono/stereo.
- **Encode mirrors decode**: an `encode::backend` seam and `Codec::Aac` (AAC-LC only) with platform encoders behind it.

Eleven quests: the HE-AAC refusal, layout, and decode seam are ready now and independent; each platform lands as its own decode and encode quest so verification stays per host.

One of them is a defect in what ships today: implicit-SBR HE-AAC over MPEG-TS (SRT) passes every config check and symphonia plays the LC core at half rate, silently. It sits in this line because it shares the symphonia backend, but it could move to m0.

The interview also surfaced that `moq-mux` maps AAC `channel_config == 0` (PCE) and reserved values to stereo with a warning; that fix rides with the HE-AAC refusal quest.

## Public API

None. Planning only. The quests describe the intended `moq-audio` surface: `decode::Kind`, `encode::Kind`, `Layout`, `encode::Codec::Aac`, and an `Aac` variant on the FFI codec enum. The FFI keeps `channels` as a count meaning the default layout for that count, so no record or C struct changes.

## Wire

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Claude Fable 5.1)