### PR TITLE
fix(publish)!: restore Firefox hardware encoding and scale screen sources

### DIFF
--- a/js/publish/README.md
+++ b/js/publish/README.md
@@ -95,6 +95,14 @@ const publish = new Publish.Broadcast(connection, {
 publish.source.camera.enabled.set(true);
 ```
 
+Video encoders prefer hardware encoding, including on Firefox. AV1 is only
+considered with hardware acceleration; software selection starts with H.264.
+Screen tracks default to logical resolution when the browser supplies
+`screenPixelRatio` and native dimensions: a 5120×2880 surface at 2× encodes at
+2560×1440. Browsers without that metadata keep the captured resolution.
+Explicit `maxPixels`, `maxScale`, or source width/height limits override this
+default; `maxScale: 1` preserves the captured resolution.
+
 ## UI Web Component
 
 `@moq/publish` includes a Web Component UI overlay (`<moq-publish-ui>`) with source selection (camera, screen, file, microphone) and status indicator. It is built on top of `@moq/signals` with no framework dependency.

--- a/js/publish/README.md
+++ b/js/publish/README.md
@@ -95,9 +95,10 @@ const publish = new Publish.Broadcast(connection, {
 publish.source.camera.enabled.set(true);
 ```
 
-Video encoders prefer hardware encoding, including on Firefox. AV1 is only
+Video encoders prefer hardware encoding, including on Firefox 143 and newer. AV1 is only
 considered with hardware acceleration; software selection starts with H.264.
-Screen tracks default to logical resolution when the browser supplies
+Screen capture passes `{ track, scale: screenPixelRatio }` as its video source.
+Encoders default to logical resolution when the browser supplies
 `screenPixelRatio` and native dimensions: a 5120×2880 surface at 2× encodes at
 2560×1440. Browsers without that metadata keep the captured resolution.
 Explicit `maxPixels`, `maxScale`, or source width/height limits override this

--- a/js/publish/README.md
+++ b/js/publish/README.md
@@ -97,7 +97,9 @@ publish.source.camera.enabled.set(true);
 
 Video encoders prefer hardware encoding, including on Firefox 143 and newer. AV1 is only
 considered with hardware acceleration; software selection starts with H.264.
-Screen capture passes `{ track, scale: screenPixelRatio }` as its video source.
+Screen capture passes `{ track, get scale() { ... } }` as its video source, reading
+the current `screenPixelRatio` for each captured frame. Custom sources can use a
+fixed `scale: 2` or a live property getter.
 Encoders default to logical resolution when the browser supplies
 `screenPixelRatio` and native dimensions: a 5120×2880 surface at 2× encodes at
 2560×1440. Browsers without that metadata keep the captured resolution.

--- a/js/publish/src/element.ts
+++ b/js/publish/src/element.ts
@@ -284,13 +284,13 @@ export default class MoqPublish extends HTMLElement {
 
 			// srcObject only takes a MediaStream, so a source that hands us frames directly (a
 			// decoded file, an image) has nothing to show here. A <canvas> renders those.
-			if (!Video.isStreamTrack(source)) {
+			if ("frames" in source) {
 				preview.style.display = "none";
 				console.warn("moq-publish: this source needs a <canvas> preview; a <video> can't show it.");
 				return;
 			}
 
-			preview.srcObject = new MediaStream([source]);
+			preview.srcObject = new MediaStream([Video.normalizeSource(source).track]);
 			preview.style.display = "block";
 
 			effect.cleanup(() => {

--- a/js/publish/src/source/retry.test.ts
+++ b/js/publish/src/source/retry.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { expect, spyOn, test } from "bun:test";
 import { Signal } from "@moq/signals";
 import type * as Audio from "../audio";
 import type * as Video from "../video";
@@ -435,3 +435,21 @@ test("screen capture prompts again after being switched off and on", async () =>
 
 	screen.close();
 });
+
+for (const screenPixelRatio of [undefined, 2]) {
+	test(`screen capture maps pixel ratio ${screenPixelRatio} into source scale`, async () => {
+		using media = install(new FakeScreenDevices());
+		const settings = spyOn(media.video, "getSettings").mockReturnValue({
+			deviceId: "default",
+			screenPixelRatio,
+		} as MediaTrackSettings);
+		const screen = new Screen({ enabled: true });
+		try {
+			await settle();
+			expect(screen.out.source.peek()?.video).toMatchObject({ track: media.video, scale: screenPixelRatio });
+		} finally {
+			screen.close();
+			settings.mockRestore();
+		}
+	});
+}

--- a/js/publish/src/source/retry.test.ts
+++ b/js/publish/src/source/retry.test.ts
@@ -446,7 +446,11 @@ for (const screenPixelRatio of [undefined, 2]) {
 		const screen = new Screen({ enabled: true });
 		try {
 			await settle();
-			expect(screen.out.source.peek()?.video).toMatchObject({ track: media.video, scale: screenPixelRatio });
+			const source = screen.out.source.peek()?.video;
+			expect(source).toMatchObject({ track: media.video, scale: screenPixelRatio });
+			settings.mockReturnValue({ deviceId: "default", screenPixelRatio: 1 } as MediaTrackSettings);
+			expect(source).toMatchObject({ track: media.video, scale: 1 });
+			expect(screen.out.source.peek()?.video).toBe(source);
 		} finally {
 			screen.close();
 			settings.mockRestore();

--- a/js/publish/src/source/screen.ts
+++ b/js/publish/src/source/screen.ts
@@ -120,7 +120,13 @@ export class Screen {
 			}
 
 			effect.set(this.#out.source, {
-				video: v,
+				video: v
+					? {
+							track: v,
+							scale: (v.getSettings() as MediaTrackSettings & { screenPixelRatio?: number })
+								.screenPixelRatio,
+						}
+					: undefined,
 				audio: a ? { track: a, kind: "music" } : undefined,
 			});
 		});

--- a/js/publish/src/source/screen.ts
+++ b/js/publish/src/source/screen.ts
@@ -123,8 +123,10 @@ export class Screen {
 				video: v
 					? {
 							track: v,
-							scale: (v.getSettings() as MediaTrackSettings & { screenPixelRatio?: number })
-								.screenPixelRatio,
+							get scale() {
+								return (v.getSettings() as MediaTrackSettings & { screenPixelRatio?: number })
+									.screenPixelRatio;
+							},
 						}
 					: undefined,
 				audio: a ? { track: a, kind: "music" } : undefined,

--- a/js/publish/src/support/element.ts
+++ b/js/publish/src/support/element.ts
@@ -9,9 +9,6 @@ import { Effect, Signal } from "@moq/signals";
 import * as DOM from "@moq/signals/dom";
 import { type Codec, type Full, isSupported, type Level } from "./";
 
-// https://bugzilla.mozilla.org/show_bug.cgi?id=1967793
-const isFirefox = navigator.userAgent.toLowerCase().includes("firefox");
-
 const OBSERVED = ["show", "details"] as const;
 type Observed = (typeof OBSERVED)[number];
 
@@ -209,7 +206,7 @@ export default class MoqPublishSupport extends HTMLElement {
 
 		const binary = (value: boolean | undefined) => (value ? "🟢 Yes" : "🔴 No");
 		const hardware = (codec: Codec | undefined) =>
-			codec?.hardware ? "🟢 Hardware" : codec?.software ? `🟡 Software${isFirefox ? "*" : ""}` : "🔴 No";
+			codec?.hardware ? "🟢 Hardware" : codec?.software ? "🟡 Software" : "🔴 No";
 		const partial = (value: Level | undefined) =>
 			value === "full" ? "🟢 Full" : value === "partial" ? "🟡 Polyfill" : "🔴 None";
 
@@ -260,31 +257,6 @@ export default class MoqPublishSupport extends HTMLElement {
 		addRow("", "H.264", hardware(support.video.encoding?.h264));
 		addRow("", "VP9", hardware(support.video.encoding?.vp9));
 		addRow("", "VP8", hardware(support.video.encoding?.vp8));
-
-		if (isFirefox) {
-			const noteDiv = DOM.create(
-				"div",
-				{
-					style: {
-						gridColumnStart: "1",
-						gridColumnEnd: "4",
-						textAlign: "center",
-						fontSize: "0.875rem",
-						fontStyle: "italic",
-					},
-				},
-				"Hardware acceleration is ",
-				DOM.create(
-					"a",
-					{
-						href: "https://github.com/w3c/webcodecs/issues/896",
-					},
-					"undetectable",
-				),
-				" on Firefox.",
-			);
-			container.appendChild(noteDiv);
-		}
 
 		parent.appendChild(container);
 		effect.cleanup(() => parent.removeChild(container));

--- a/js/publish/src/support/index.ts
+++ b/js/publish/src/support/index.ts
@@ -72,7 +72,6 @@ async function videoEncoderSupported(codec: keyof typeof CODECS): Promise<Codec>
 		hardwareAcceleration: "prefer-software",
 	});
 
-	// We can't reliably detect hardware encoding on Firefox: https://github.com/w3c/webcodecs/issues/896
 	const hardware = await VideoEncoder.isConfigSupported({
 		codec: CODECS[codec],
 		width: 1280,
@@ -80,11 +79,8 @@ async function videoEncoderSupported(codec: keyof typeof CODECS): Promise<Codec>
 		hardwareAcceleration: "prefer-hardware",
 	});
 
-	// Safari always echoes "prefer-hardware" back, so the hint tells us nothing. Treat it like
-	// Firefox and report hardware support as unknown rather than advertising hardware VP9/AV1 it
-	// doesn't have.
-	const unknown =
-		Util.Hacks.isFirefox || Util.Hacks.isSafari || hardware.config?.hardwareAcceleration !== "prefer-hardware";
+	// Safari accepts software codecs under "prefer-hardware", so report hardware support as unknown.
+	const unknown = Util.Hacks.isSafari || hardware.config?.hardwareAcceleration !== "prefer-hardware";
 
 	return {
 		hardware: unknown ? undefined : hardware.supported === true,

--- a/js/publish/src/support/index.ts
+++ b/js/publish/src/support/index.ts
@@ -4,9 +4,9 @@
  *
  * @module
  */
-import * as Util from "@moq/hang/util";
 import { Connection } from "@moq/net";
 import { workerSupported } from "../video/processor";
+import { probe } from "./video";
 
 export type Level = "full" | "partial" | "none";
 
@@ -64,30 +64,6 @@ async function audioEncoderSupported(codec: keyof typeof CODECS): Promise<boolea
 	return res.supported === true;
 }
 
-async function videoEncoderSupported(codec: keyof typeof CODECS): Promise<Codec> {
-	const software = await VideoEncoder.isConfigSupported({
-		codec: CODECS[codec],
-		width: 1280,
-		height: 720,
-		hardwareAcceleration: "prefer-software",
-	});
-
-	const hardware = await VideoEncoder.isConfigSupported({
-		codec: CODECS[codec],
-		width: 1280,
-		height: 720,
-		hardwareAcceleration: "prefer-hardware",
-	});
-
-	// Safari accepts software codecs under "prefer-hardware", so report hardware support as unknown.
-	const unknown = Util.Hacks.isSafari || hardware.config?.hardwareAcceleration !== "prefer-hardware";
-
-	return {
-		hardware: unknown ? undefined : hardware.supported === true,
-		software: software.supported === true,
-	};
-}
-
 export async function isSupported(): Promise<Full> {
 	return {
 		// Report "partial" when @moq/net forces the WebSocket fallback.
@@ -113,11 +89,11 @@ export async function isSupported(): Promise<Full> {
 			encoding:
 				typeof VideoEncoder !== "undefined"
 					? {
-							h264: await videoEncoderSupported("h264"),
-							h265: await videoEncoderSupported("h265"),
-							vp8: await videoEncoderSupported("vp8"),
-							vp9: await videoEncoderSupported("vp9"),
-							av1: await videoEncoderSupported("av1"),
+							h264: await probe(CODECS.h264),
+							h265: await probe(CODECS.h265),
+							vp8: await probe(CODECS.vp8),
+							vp9: await probe(CODECS.vp9),
+							av1: await probe(CODECS.av1),
 						}
 					: undefined,
 		},

--- a/js/publish/src/support/video.test.ts
+++ b/js/publish/src/support/video.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test";
+import { probe } from "./video";
+
+for (const version of [140, 142, 143, 152]) {
+	test(`Firefox ${version} reports hardware support only when its probe is trustworthy`, async () => {
+		const userAgent = Object.getOwnPropertyDescriptor(navigator, "userAgent");
+		const encoder = Object.getOwnPropertyDescriptor(globalThis, "VideoEncoder");
+		Object.defineProperty(navigator, "userAgent", {
+			configurable: true,
+			value: `Mozilla/5.0 Firefox/${version}.0`,
+		});
+		Object.defineProperty(globalThis, "VideoEncoder", {
+			configurable: true,
+			value: { isConfigSupported: async (config: VideoEncoderConfig) => ({ supported: true, config }) },
+		});
+		try {
+			expect(await probe("vp09.00.10.08")).toEqual({
+				software: true,
+				hardware: version < 143 ? undefined : true,
+			});
+		} finally {
+			if (userAgent) Object.defineProperty(navigator, "userAgent", userAgent);
+			else Reflect.deleteProperty(navigator, "userAgent");
+			if (encoder) Object.defineProperty(globalThis, "VideoEncoder", encoder);
+			else Reflect.deleteProperty(globalThis, "VideoEncoder");
+		}
+	});
+}

--- a/js/publish/src/support/video.test.ts
+++ b/js/publish/src/support/video.test.ts
@@ -26,3 +26,22 @@ for (const version of [140, 142, 143, 152]) {
 		}
 	});
 }
+
+test("software-only AV1 is not advertised as usable encoding", async () => {
+	const encoder = Object.getOwnPropertyDescriptor(globalThis, "VideoEncoder");
+	Object.defineProperty(globalThis, "VideoEncoder", {
+		configurable: true,
+		value: {
+			isConfigSupported: async (config: VideoEncoderConfig) => ({
+				supported: config.hardwareAcceleration === "prefer-software",
+				config,
+			}),
+		},
+	});
+	try {
+		expect(await probe("av01.0.08M.08")).toEqual({ software: false, hardware: false });
+	} finally {
+		if (encoder) Object.defineProperty(globalThis, "VideoEncoder", encoder);
+		else Reflect.deleteProperty(globalThis, "VideoEncoder");
+	}
+});

--- a/js/publish/src/support/video.ts
+++ b/js/publish/src/support/video.ts
@@ -1,0 +1,34 @@
+import * as Util from "@moq/hang/util";
+import type { Codec } from "./index";
+
+/** Whether the browser reliably distinguishes hardware from software encoding. */
+export function hardwareReliable(): boolean {
+	// Firefox before 143 reports software codecs as hardware-capable (Mozilla bug 1967793).
+	const firefoxVersion = navigator.userAgent.match(/Firefox\/(\d+)/i)?.[1];
+	return !Util.Hacks.isSafari && (firefoxVersion === undefined || Number(firefoxVersion) >= 143);
+}
+
+/** Probe the browser's software and hardware support for a video codec. */
+export async function probe(codec: string): Promise<Codec> {
+	const software = await VideoEncoder.isConfigSupported({
+		codec,
+		width: 1280,
+		height: 720,
+		hardwareAcceleration: "prefer-software",
+	});
+
+	const hardware = await VideoEncoder.isConfigSupported({
+		codec,
+		width: 1280,
+		height: 720,
+		hardwareAcceleration: "prefer-hardware",
+	});
+
+	// Some browsers accept software codecs under "prefer-hardware".
+	const unknown = !hardwareReliable() || hardware.config?.hardwareAcceleration !== "prefer-hardware";
+
+	return {
+		hardware: unknown ? undefined : hardware.supported === true,
+		software: software.supported === true,
+	};
+}

--- a/js/publish/src/support/video.ts
+++ b/js/publish/src/support/video.ts
@@ -10,12 +10,14 @@ export function hardwareReliable(): boolean {
 
 /** Probe the browser's software and hardware support for a video codec. */
 export async function probe(codec: string): Promise<Codec> {
-	const software = await VideoEncoder.isConfigSupported({
-		codec,
-		width: 1280,
-		height: 720,
-		hardwareAcceleration: "prefer-software",
-	});
+	const software = codec.startsWith("av01")
+		? { supported: false }
+		: await VideoEncoder.isConfigSupported({
+				codec,
+				width: 1280,
+				height: 720,
+				hardwareAcceleration: "prefer-software",
+			});
 
 	const hardware = await VideoEncoder.isConfigSupported({
 		codec,

--- a/js/publish/src/video/capture.test.ts
+++ b/js/publish/src/video/capture.test.ts
@@ -1,0 +1,66 @@
+import { expect, mock, test } from "bun:test";
+import type { StreamTrack } from "./types";
+
+mock.module("./capture-worker.ts?worker&inline", () => ({ default: class {} }));
+const { Capture } = await import("./capture");
+
+class Frame {
+	codedWidth = 1920;
+	codedHeight = 1080;
+	timestamp: number;
+	closed = false;
+
+	constructor(source?: Frame, init?: { timestamp: number }) {
+		this.timestamp = init?.timestamp ?? source?.timestamp ?? 0;
+	}
+
+	clone(): Frame {
+		return new Frame(this);
+	}
+
+	close(): void {
+		this.closed = true;
+	}
+}
+
+test("capture resamples live scale when frame dimensions stay unchanged", async () => {
+	const processor = Object.getOwnPropertyDescriptor(globalThis, "MediaStreamTrackProcessor");
+	const videoFrame = Object.getOwnPropertyDescriptor(globalThis, "VideoFrame");
+	let controller!: ReadableStreamDefaultController<VideoFrame>;
+	const readable = new ReadableStream<VideoFrame>({
+		start: (value) => {
+			controller = value;
+		},
+	});
+	Object.defineProperty(globalThis, "MediaStreamTrackProcessor", {
+		configurable: true,
+		value: class {
+			readonly readable = readable;
+		},
+	});
+	Object.defineProperty(globalThis, "VideoFrame", { configurable: true, value: Frame });
+	let scale = 2;
+	const capture = new Capture({
+		source: {
+			track: {} as StreamTrack,
+			get scale() {
+				return scale;
+			},
+		},
+	});
+	try {
+		let changed = capture.out.display.changed();
+		controller.enqueue(new Frame() as unknown as VideoFrame);
+		expect(await changed).toMatchObject({ width: 1920, height: 1080, scale: 2 });
+		scale = 1;
+		changed = capture.out.display.changed();
+		controller.enqueue(new Frame() as unknown as VideoFrame);
+		expect(await changed).toMatchObject({ width: 1920, height: 1080, scale: 1 });
+	} finally {
+		capture.close();
+		if (processor) Object.defineProperty(globalThis, "MediaStreamTrackProcessor", processor);
+		else Reflect.deleteProperty(globalThis, "MediaStreamTrackProcessor");
+		if (videoFrame) Object.defineProperty(globalThis, "VideoFrame", videoFrame);
+		else Reflect.deleteProperty(globalThis, "VideoFrame");
+	}
+});

--- a/js/publish/src/video/capture.ts
+++ b/js/publish/src/video/capture.ts
@@ -1,7 +1,7 @@
 import { Effect, type Getter, getter, type Inputs, type Readonlys, readonlys, Signal } from "@moq/signals";
 import { Fanout } from "../fanout";
 import { TrackProcessor } from "./processor";
-import { isStreamTrack, type Source } from "./types";
+import { normalizeSource, type Source } from "./types";
 
 // The raw capture source to pump frames from.
 export type CaptureInput = {
@@ -49,7 +49,7 @@ export class Capture {
 		// A capture track goes through MediaStreamTrackProcessor, which rewrites timestamps onto our
 		// wall clock so they stay consistent when the source changes or the encoder reloads. A
 		// FrameSource already stamps against that clock, so take its frames as they are.
-		const stream = isStreamTrack(source) ? TrackProcessor(source) : source.frames;
+		const stream = "frames" in source ? source.frames : TrackProcessor(normalizeSource(source).track);
 
 		const fanout = new Fanout(stream.pipeThrough(this.#measure()), {
 			// A frame is a resource with an explicit lifetime, so every reader needs its own handle

--- a/js/publish/src/video/capture.ts
+++ b/js/publish/src/video/capture.ts
@@ -12,8 +12,8 @@ type CaptureOutput = {
 	// The captured frames, replaced whenever the source changes. Subscribe for a stream of your own;
 	// each reader owns the frames it receives and must close them.
 	frames: Signal<Fanout<VideoFrame> | undefined>;
-	// The captured (coded) dimensions, tracked from each frame.
-	display: Signal<{ width: number; height: number } | undefined>;
+	// The captured dimensions and source scale, sampled together for each frame.
+	display: Signal<{ width: number; height: number; scale?: number } | undefined>;
 };
 
 /**
@@ -28,7 +28,7 @@ export class Capture {
 
 	readonly #out: CaptureOutput = {
 		frames: new Signal<Fanout<VideoFrame> | undefined>(undefined),
-		display: new Signal<{ width: number; height: number } | undefined>(undefined),
+		display: new Signal<{ width: number; height: number; scale?: number } | undefined>(undefined),
 	};
 	readonly out = readonlys(this.#out);
 
@@ -51,7 +51,7 @@ export class Capture {
 		// FrameSource already stamps against that clock, so take its frames as they are.
 		const stream = "frames" in source ? source.frames : TrackProcessor(normalizeSource(source).track);
 
-		const fanout = new Fanout(stream.pipeThrough(this.#measure()), {
+		const fanout = new Fanout(stream.pipeThrough(this.#measure(source)), {
 			// A frame is a resource with an explicit lifetime, so every reader needs its own handle
 			// and closes it. Sharing one would let the first reader close it under the others.
 			clone: (frame) => frame.clone(),
@@ -65,13 +65,18 @@ export class Capture {
 		});
 	}
 
-	// Read the coded size off each frame on its way past. The signal only notifies when the size
-	// actually changes, so this costs nothing per frame beyond the comparison.
-	#measure(): TransformStream<VideoFrame, VideoFrame> {
+	// Sample live source metadata even when the coded dimensions stay unchanged.
+	#measure(source: Source): TransformStream<VideoFrame, VideoFrame> {
 		return new TransformStream<VideoFrame, VideoFrame>({
 			transform: (frame, controller) => {
-				this.#out.display.set({ width: frame.codedWidth, height: frame.codedHeight });
-				controller.enqueue(frame);
+				try {
+					const scale = "frames" in source ? undefined : normalizeSource(source).scale;
+					this.#out.display.set({ width: frame.codedWidth, height: frame.codedHeight, scale });
+					controller.enqueue(frame);
+				} catch (error) {
+					frame.close();
+					throw error;
+				}
 			},
 		});
 	}

--- a/js/publish/src/video/encoder.test.ts
+++ b/js/publish/src/video/encoder.test.ts
@@ -243,7 +243,7 @@ test("hardware encoding takes priority over software H.264", async () => {
 	}));
 	const capture = {
 		in: { source: new Signal({ getSettings: () => ({ frameRate: 30 }), getConstraints: () => ({}) }) },
-		out: { frame: new Signal({ codedWidth: 1920, codedHeight: 1080 }) },
+		out: { display: new Signal({ width: 1920, height: 1080 }) },
 	};
 	const encoder = new Encoder("video", { enabled: true, capture: capture as never });
 	try {
@@ -264,7 +264,7 @@ test("software-only AV1 is refused even when explicitly requested", async () => 
 	const error = spyOn(console, "error").mockImplementation(() => {});
 	const capture = {
 		in: { source: new Signal({ getSettings: () => ({ frameRate: 30 }), getConstraints: () => ({}) }) },
-		out: { frame: new Signal({ codedWidth: 1920, codedHeight: 1080 }) },
+		out: { display: new Signal({ width: 1920, height: 1080 }) },
 	};
 	const encoder = new Encoder("video", { enabled: true, capture: capture as never, config: { codec: "av01" } });
 	try {
@@ -285,22 +285,25 @@ test("screen encoders default to logical pixels without scaling an already reduc
 	const capture = {
 		in: {
 			source: new Signal({
-				getSettings: () => ({ frameRate: 30, screenPixelRatio: 2 }),
-				getConstraints: () => ({}),
-				getCapabilities: () => ({ width: { max: 5120 }, height: { max: 2880 } }),
+				scale: 2,
+				track: {
+					getSettings: () => ({ frameRate: 30 }),
+					getConstraints: () => ({}),
+					getCapabilities: () => ({ width: { max: 5120 }, height: { max: 2880 } }),
+				},
 			}),
 		},
-		out: { frame: new Signal({ codedWidth: 5120, codedHeight: 2880 }) },
+		out: { display: new Signal({ width: 5120, height: 2880 }) },
 	};
 	const encoder = new Encoder("video", { enabled: true, capture: capture as never });
 	try {
 		await settle();
 		expect(encoder.out.resolved.peek()).toMatchObject({ width: 2560, height: 1440 });
-		capture.out.frame.set({ codedWidth: 2560, codedHeight: 1440 });
+		capture.out.display.set({ width: 2560, height: 1440 });
 		await settle();
 		expect(encoder.out.resolved.peek()).toMatchObject({ width: 2560, height: 1440 });
 
-		capture.out.frame.set({ codedWidth: 5120, codedHeight: 2880 });
+		capture.out.display.set({ width: 5120, height: 2880 });
 		encoder.config.set({ maxScale: 1 });
 		await settle();
 		expect(encoder.out.resolved.peek()).toMatchObject({ width: 5120, height: 2880 });
@@ -309,5 +312,53 @@ test("screen encoders default to logical pixels without scaling an already reduc
 		expect(encoder.out.resolved.peek()).toMatchObject({ width: 1920, height: 1072 });
 	} finally {
 		encoder.close();
+	}
+});
+
+for (const version of [140, 142, 143, 152]) {
+	test(`Firefox ${version} uses trustworthy hardware probes only`, async () => {
+		using _videoEncoder = installFakeVideoEncoder();
+		const userAgent = Object.getOwnPropertyDescriptor(navigator, "userAgent");
+		Object.defineProperty(navigator, "userAgent", {
+			configurable: true,
+			value: `Mozilla/5.0 Firefox/${version}.0`,
+		});
+		const probe = spyOn(FakeVideoEncoder, "isConfigSupported").mockImplementation(async () => ({
+			supported: true,
+		}));
+		const capture = {
+			in: { source: new Signal({ getSettings: () => ({ frameRate: 30 }), getConstraints: () => ({}) }) },
+			out: { display: new Signal({ width: 1920, height: 1080 }) },
+		};
+		const encoder = new Encoder("video", { enabled: true, capture: capture as never });
+		try {
+			await settle();
+			expect(encoder.out.resolved.peek()?.hardwareAcceleration).toBe(
+				version < 143 ? "prefer-software" : "prefer-hardware",
+			);
+			if (version < 143) expect(encoder.out.resolved.peek()?.codec.startsWith("avc1")).toBe(true);
+		} finally {
+			encoder.close();
+			probe.mockRestore();
+			if (userAgent) Object.defineProperty(navigator, "userAgent", userAgent);
+			else Reflect.deleteProperty(navigator, "userAgent");
+		}
+	});
+}
+
+test("frame sources retain their dimensions and nominal frame rate", async () => {
+	using _videoEncoder = installFakeVideoEncoder();
+	const frames = new ReadableStream<VideoFrame>();
+	const capture = {
+		in: { source: new Signal({ frames, frameRate: 24 }) },
+		out: { display: new Signal({ width: 1920, height: 1080 }) },
+	};
+	const encoder = new Encoder("video", { enabled: true, capture: capture as never });
+	try {
+		await settle();
+		expect(encoder.out.resolved.peek()).toMatchObject({ width: 1920, height: 1072, framerate: 24 });
+	} finally {
+		encoder.close();
+		await frames.cancel();
 	}
 });

--- a/js/publish/src/video/encoder.test.ts
+++ b/js/publish/src/video/encoder.test.ts
@@ -293,17 +293,22 @@ test("screen encoders default to logical pixels without scaling an already reduc
 				},
 			}),
 		},
-		out: { display: new Signal({ width: 5120, height: 2880 }) },
+		out: { display: new Signal({ width: 5120, height: 2880, scale: 2 }) },
 	};
 	const encoder = new Encoder("video", { enabled: true, capture: capture as never });
 	try {
 		await settle();
 		expect(encoder.out.resolved.peek()).toMatchObject({ width: 2560, height: 1440 });
-		capture.out.display.set({ width: 2560, height: 1440 });
+		capture.out.display.set({ width: 2560, height: 1440, scale: 2 });
 		await settle();
 		expect(encoder.out.resolved.peek()).toMatchObject({ width: 2560, height: 1440 });
 
-		capture.out.display.set({ width: 5120, height: 2880 });
+		capture.out.display.set({ width: 5120, height: 2880, scale: 2 });
+		await settle();
+		capture.out.display.set({ width: 5120, height: 2880, scale: 1 });
+		await settle();
+		expect(encoder.out.resolved.peek()).toMatchObject({ width: 5120, height: 2880 });
+		capture.out.display.set({ width: 5120, height: 2880, scale: 2 });
 		encoder.config.set({ maxScale: 1 });
 		await settle();
 		expect(encoder.out.resolved.peek()).toMatchObject({ width: 5120, height: 2880 });

--- a/js/publish/src/video/encoder.test.ts
+++ b/js/publish/src/video/encoder.test.ts
@@ -235,3 +235,79 @@ test("every published config was probed for its own codec and dimensions", async
 function probeKey(config: { codec: string; width: number; height: number }): string {
 	return `${config.codec}@${config.width}x${config.height}`;
 }
+
+test("hardware encoding takes priority over software H.264", async () => {
+	using _videoEncoder = installFakeVideoEncoder();
+	const probe = spyOn(FakeVideoEncoder, "isConfigSupported").mockImplementation(async (config) => ({
+		supported: config.codec.startsWith("avc1"),
+	}));
+	const capture = {
+		in: { source: new Signal({ getSettings: () => ({ frameRate: 30 }), getConstraints: () => ({}) }) },
+		out: { frame: new Signal({ codedWidth: 1920, codedHeight: 1080 }) },
+	};
+	const encoder = new Encoder("video", { enabled: true, capture: capture as never });
+	try {
+		await settle();
+		expect(encoder.out.resolved.peek()?.hardwareAcceleration).toBe("prefer-hardware");
+		expect(probe.mock.calls.every(([config]) => config.hardwareAcceleration === "prefer-hardware")).toBe(true);
+	} finally {
+		encoder.close();
+		probe.mockRestore();
+	}
+});
+
+test("software-only AV1 is refused even when explicitly requested", async () => {
+	using _videoEncoder = installFakeVideoEncoder();
+	const probe = spyOn(FakeVideoEncoder, "isConfigSupported").mockImplementation(async (config) => ({
+		supported: config.codec.startsWith("av01") && config.hardwareAcceleration === "prefer-software",
+	}));
+	const error = spyOn(console, "error").mockImplementation(() => {});
+	const capture = {
+		in: { source: new Signal({ getSettings: () => ({ frameRate: 30 }), getConstraints: () => ({}) }) },
+		out: { frame: new Signal({ codedWidth: 1920, codedHeight: 1080 }) },
+	};
+	const encoder = new Encoder("video", { enabled: true, capture: capture as never, config: { codec: "av01" } });
+	try {
+		await settle();
+		expect(probe).toHaveBeenCalled();
+		expect(probe.mock.calls.some(([config]) => config.hardwareAcceleration === "prefer-software")).toBe(false);
+		expect(encoder.out.resolved.peek()).toBeUndefined();
+		expect(error).toHaveBeenCalled();
+	} finally {
+		encoder.close();
+		probe.mockRestore();
+		error.mockRestore();
+	}
+});
+
+test("screen encoders default to logical pixels without scaling an already reduced capture twice", async () => {
+	using _videoEncoder = installFakeVideoEncoder();
+	const capture = {
+		in: {
+			source: new Signal({
+				getSettings: () => ({ frameRate: 30, screenPixelRatio: 2 }),
+				getConstraints: () => ({}),
+				getCapabilities: () => ({ width: { max: 5120 }, height: { max: 2880 } }),
+			}),
+		},
+		out: { frame: new Signal({ codedWidth: 5120, codedHeight: 2880 }) },
+	};
+	const encoder = new Encoder("video", { enabled: true, capture: capture as never });
+	try {
+		await settle();
+		expect(encoder.out.resolved.peek()).toMatchObject({ width: 2560, height: 1440 });
+		capture.out.frame.set({ codedWidth: 2560, codedHeight: 1440 });
+		await settle();
+		expect(encoder.out.resolved.peek()).toMatchObject({ width: 2560, height: 1440 });
+
+		capture.out.frame.set({ codedWidth: 5120, codedHeight: 2880 });
+		encoder.config.set({ maxScale: 1 });
+		await settle();
+		expect(encoder.out.resolved.peek()).toMatchObject({ width: 5120, height: 2880 });
+		encoder.config.set({ maxPixels: 1920 * 1080 });
+		await settle();
+		expect(encoder.out.resolved.peek()).toMatchObject({ width: 1920, height: 1072 });
+	} finally {
+		encoder.close();
+	}
+});

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -36,7 +36,7 @@ export interface Config {
 	codec?: string;
 
 	// Constrain the encoded width/height in pixels. If unset, source width.max and height.max
-	// constraints provide the cap when both are present.
+	// constraints provide the cap when both are present; otherwise screens default to logical pixels.
 	maxPixels?: number;
 
 	// Cap the encoded resolution to this fraction of the source pixel count.
@@ -425,7 +425,11 @@ export class Encoder {
 		const sourcePixels = display.width * display.height;
 
 		// maxPixels caps absolutely; maxScale caps relative to the source. The smaller cap wins.
-		let maxPixels = user?.maxPixels ?? sourceConstraintPixels(source) ?? sourcePixels;
+		let maxPixels =
+			user?.maxPixels ??
+			sourceConstraintPixels(source) ??
+			(user?.maxScale === undefined ? screenPixels(source) : undefined) ??
+			sourcePixels;
 		if (user?.maxScale !== undefined) {
 			if (!Number.isFinite(user.maxScale) || user.maxScale <= 0) {
 				throw new Error(`maxScale must be a finite number greater than 0: ${user.maxScale}`);
@@ -504,20 +508,14 @@ export class Encoder {
 			// This likely won't work because of licensing issues.
 			"hev1.1.6.L93.B0",
 			"hev1", // Browser's choice
-
-			// AV1
-			// Super expensive to encode so it's our last choice.
-			"av01.0.08M.08",
-			"av01",
 		];
 
 		// Try hardware encoding first.
-		// We can't reliably detect hardware encoding on Firefox: https://github.com/w3c/webcodecs/issues/896
 		// Safari accepts every codec under `prefer-hardware` and echoes the hint straight back, but
 		// VideoToolbox only hardware-encodes H.264 and HEVC. Skip the hardware pass and let it fall
 		// through to the software pass, which is H.264 first, since Safari routes that through
 		// VideoToolbox anyway regardless of the hint.
-		if (!Util.Hacks.isFirefox && !Util.Hacks.isSafari) {
+		if (!Util.Hacks.isSafari) {
 			for (const codec of HARDWARE_CODECS) {
 				if (!codec.startsWith(required)) continue;
 
@@ -607,6 +605,18 @@ function sourceConstraintPixels(source: Source): number | undefined {
 	const height = constraintMax(constraints.height);
 
 	return width !== undefined && height !== undefined ? width * height : undefined;
+}
+
+function screenPixels(source: Source): number | undefined {
+	const ratio = source.getSettings().screenPixelRatio;
+	if (ratio === undefined || !Number.isFinite(ratio) || ratio <= 1) return;
+
+	// Cap against the native surface, not the current frame, which may already be downscaled.
+	const capabilities = source.getCapabilities();
+	const width = capabilities.width?.max;
+	const height = capabilities.height?.max;
+	if (!width || !height) return;
+	return (width * height) / ratio ** 2;
 }
 
 function constraintMax(value: MediaTrackConstraints["width"]): number | undefined {

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -428,7 +428,7 @@ export class Encoder {
 		let maxPixels =
 			user?.maxPixels ??
 			sourceConstraintPixels(source) ??
-			(user?.maxScale === undefined ? scaledPixels(source) : undefined) ??
+			(user?.maxScale === undefined ? scaledPixels(source, display.scale) : undefined) ??
 			sourcePixels;
 		if (user?.maxScale !== undefined) {
 			if (!Number.isFinite(user.maxScale) || user.maxScale <= 0) {
@@ -607,9 +607,9 @@ function sourceConstraintPixels(source: Source): number | undefined {
 	return width !== undefined && height !== undefined ? width * height : undefined;
 }
 
-function scaledPixels(source: Source): number | undefined {
+function scaledPixels(source: Source, scale: number | undefined): number | undefined {
 	if ("frames" in source) return;
-	const { track, scale } = normalizeSource(source);
+	const { track } = normalizeSource(source);
 	if (scale === undefined) return;
 	if (!Number.isFinite(scale) || scale <= 0)
 		throw new Error(`scale must be a finite number greater than 0: ${scale}`);

--- a/js/publish/src/video/encoder.ts
+++ b/js/publish/src/video/encoder.ts
@@ -1,6 +1,5 @@
 import * as Catalog from "@moq/hang/catalog";
 import * as Container from "@moq/hang/container";
-import * as Util from "@moq/hang/util";
 import type * as Moq from "@moq/net";
 import { Time } from "@moq/net";
 import {
@@ -14,8 +13,9 @@ import {
 	Signal,
 } from "@moq/signals";
 import type { Broadcast } from "../broadcast";
+import { hardwareReliable } from "../support/video";
 import type { Capture } from "./capture";
-import { isStreamTrack, type Source } from "./types";
+import { normalizeSource, type Source } from "./types";
 
 /** Cumulative encoder output totals, measured from the chunks the encoder produces. */
 export interface Stats {
@@ -428,7 +428,7 @@ export class Encoder {
 		let maxPixels =
 			user?.maxPixels ??
 			sourceConstraintPixels(source) ??
-			(user?.maxScale === undefined ? screenPixels(source) : undefined) ??
+			(user?.maxScale === undefined ? scaledPixels(source) : undefined) ??
 			sourcePixels;
 		if (user?.maxScale !== undefined) {
 			if (!Number.isFinite(user.maxScale) || user.maxScale <= 0) {
@@ -515,7 +515,7 @@ export class Encoder {
 		// VideoToolbox only hardware-encodes H.264 and HEVC. Skip the hardware pass and let it fall
 		// through to the software pass, which is H.264 first, since Safari routes that through
 		// VideoToolbox anyway regardless of the hint.
-		if (!Util.Hacks.isSafari) {
+		if (hardwareReliable()) {
 			for (const codec of HARDWARE_CODECS) {
 				if (!codec.startsWith(required)) continue;
 
@@ -569,7 +569,7 @@ export class Encoder {
 // The source's nominal frame rate: what the capture device settled on, or what a frame stream
 // declared. Undefined when nothing reports one.
 function sourceFrameRate(source: Source): number | undefined {
-	return isStreamTrack(source) ? source.getSettings().frameRate : source.frameRate;
+	return "frames" in source ? source.frameRate : normalizeSource(source).track.getSettings().frameRate;
 }
 
 // A hardware probe result, carrying the inputs it ran against so a consumer can tell whether it
@@ -598,25 +598,28 @@ function codecBitrateScale(codec: string): number {
 
 function sourceConstraintPixels(source: Source): number | undefined {
 	// Only a capture track has constraints; a frame stream is whatever size it produces.
-	if (!isStreamTrack(source)) return undefined;
+	if ("frames" in source) return undefined;
 
-	const constraints = source.getConstraints();
+	const constraints = normalizeSource(source).track.getConstraints();
 	const width = constraintMax(constraints.width);
 	const height = constraintMax(constraints.height);
 
 	return width !== undefined && height !== undefined ? width * height : undefined;
 }
 
-function screenPixels(source: Source): number | undefined {
-	const ratio = source.getSettings().screenPixelRatio;
-	if (ratio === undefined || !Number.isFinite(ratio) || ratio <= 1) return;
+function scaledPixels(source: Source): number | undefined {
+	if ("frames" in source) return;
+	const { track, scale } = normalizeSource(source);
+	if (scale === undefined) return;
+	if (!Number.isFinite(scale) || scale <= 0)
+		throw new Error(`scale must be a finite number greater than 0: ${scale}`);
 
 	// Cap against the native surface, not the current frame, which may already be downscaled.
-	const capabilities = source.getCapabilities();
+	const capabilities = track.getCapabilities();
 	const width = capabilities.width?.max;
 	const height = capabilities.height?.max;
 	if (!width || !height) return;
-	return (width * height) / ratio ** 2;
+	return (width * height) / scale ** 2;
 }
 
 function constraintMax(value: MediaTrackConstraints["width"]): number | undefined {

--- a/js/publish/src/video/types.test.ts
+++ b/js/publish/src/video/types.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { type FrameSource, isStreamTrack, type StreamTrack } from "./types";
+import { type FrameSource, isStreamTrack, normalizeSource, type StreamTrack } from "./types";
 
 // A MediaStreamTrack stand-in: the check is structural, never a prototype check, so it stays
 // correct for a track that came from another realm (an iframe, a worker).
@@ -20,4 +20,11 @@ describe("isStreamTrack", () => {
 	test("recognizes a frame stream with no declared rate", () => {
 		expect(isStreamTrack({ frames: new ReadableStream<VideoFrame>() })).toBe(false);
 	});
+});
+
+test("capture options preserve the track and scale without masquerading as a bare track", () => {
+	const source = { track, scale: 2 };
+	expect(isStreamTrack(source)).toBe(false);
+	expect(normalizeSource(source)).toBe(source);
+	expect(normalizeSource(track).track).toBe(track);
 });

--- a/js/publish/src/video/types.ts
+++ b/js/publish/src/video/types.ts
@@ -43,6 +43,8 @@ export interface TrackSettings {
 	height: number;
 	resizeMode: "none" | "crop-and-scale";
 	width: number;
+	/** Physical pixels per logical pixel on the captured screen. */
+	screenPixelRatio?: number;
 }
 
 export type Constraints = Omit<

--- a/js/publish/src/video/types.ts
+++ b/js/publish/src/video/types.ts
@@ -8,7 +8,7 @@ export type Source = StreamTrack | SourceConfig | FrameSource;
 export interface SourceConfig {
 	/** The track to capture. */
 	track: StreamTrack;
-	/** Native pixels per logical pixel; defaults to 1. */
+	/** Native pixels per logical pixel; sampled per frame, so a property getter can provide live values. */
 	scale?: number;
 }
 

--- a/js/publish/src/video/types.ts
+++ b/js/publish/src/video/types.ts
@@ -2,7 +2,20 @@
  * Where video comes from: a live capture track, or a stream of frames we produce ourselves (a
  * decoded file, an image, a canvas you drive yourself).
  */
-export type Source = StreamTrack | FrameSource;
+export type Source = StreamTrack | SourceConfig | FrameSource;
+
+/** A video track and its native pixels per logical pixel. */
+export interface SourceConfig {
+	/** The track to capture. */
+	track: StreamTrack;
+	/** Native pixels per logical pixel; defaults to 1. */
+	scale?: number;
+}
+
+/** Return the track and sizing options for either capture source form. */
+export function normalizeSource(source: StreamTrack | SourceConfig): SourceConfig {
+	return "track" in source ? source : { track: source };
+}
 
 /**
  * A stream of frames from something that isn't a capture device.
@@ -19,10 +32,10 @@ export interface FrameSource {
 	frameRate?: number;
 }
 
-/** Whether this source is a live capture track rather than a {@link FrameSource}. */
+/** Whether this source is a bare live capture track. */
 export function isStreamTrack(source: Source): source is StreamTrack {
 	// Structural check rather than `instanceof MediaStreamTrack` so this stays correct across realms.
-	return !("frames" in source);
+	return !("frames" in source) && !("track" in source);
 }
 
 // Stronger typing for the MediaStreamTrack interface.
@@ -43,8 +56,6 @@ export interface TrackSettings {
 	height: number;
 	resizeMode: "none" | "crop-and-scale";
 	width: number;
-	/** Physical pixels per logical pixel on the captured screen. */
-	screenPixelRatio?: number;
 }
 
 export type Constraints = Omit<


### PR DESCRIPTION
## Summary

- Probe hardware encoders on Firefox 143 and newer, while preserving H.264-first software selection and unknown hardware-support reporting on older Firefox versions whose probes are unreliable.
- Refuse software-only AV1 encoding.
- Pass screen capture as `{ track, get scale() { ... } }`, reading the current screen pixel ratio for every frame. Encoders use native dimensions and scale to default to logical resolution without downscaling an already reduced capture twice. Explicit sizing overrides remain available.

## Public API

- Add `Video.SourceConfig` with `track` and optional `scale` (native pixels per logical pixel, accepting a live property getter), and `Video.normalizeSource`.
- Extend `Video.Source` to accept source options alongside existing bare tracks. **Breaking:** screen capture now returns a source-options object instead of a bare track; consumers must unwrap `track`. Targets `dev`.
- Add optional `Video.Capture.out.display.scale`, sampled with frame dimensions so scale changes also reconfigure the encoder.
- Update `Video.isStreamTrack` to recognize only bare tracks; frame-stream sources remain supported.
- Keep browser-specific `screenPixelRatio` out of `Video.TrackSettings`.

## Wire

No wire-format changes.

## Validation

- Pinned Nix `just fix` and `just check` passed; all 115 publish tests passed. The full `just test` run hit a 5-second timeout in the unrelated token RSA test; all 94 token tests passed on a separate pinned Nix rerun.
- Regression coverage for Firefox versions 140/142/143/152, source metadata mapping, hardware preference, software-only AV1 refusal, logical sizing, already reduced captures, and explicit overrides.
- Chromium runtime on the rebased dev implementation: a real 5120×2880 canvas track passed through `Video.Capture` with `scale: 2`, resolved 2560×1440 with hardware preference, and produced an encoded HEVC frame without errors. A second browser test kept capture at 1920×1088 while changing scale from 2 to 1: encoding changed from 960×544 to 1920×1088 and produced an encoded frame. These tests do not exercise a real screen picker.

(written by GPT-6)
