### PR TITLE
fix(native): default noq and iroh to BBRv3 now that noq 1.2.0 lands the loss fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4906,6 +4906,7 @@ dependencies = [
  "jni 0.22.4",
  "libc",
  "moq-net",
+ "noq",
  "noq-proto",
  "notify",
  "qmux",

--- a/doc/bin/relay/config.md
+++ b/doc/bin/relay/config.md
@@ -22,7 +22,7 @@ generate = ["localhost"]             # Or: a self-signed cert for development.
 root = ["peer-ca.pem"]               # Optional: CAs whose client certs get full access (mTLS).
 
 [server.quic]
-congestion_control = "delay"         # "delay" (BBR, default on quinn/quiche) or "loss" (CUBIC).
+congestion_control = "delay"         # "delay" (BBR, the default) or "loss" (CUBIC).
 
 [server.tcp]                         # Plaintext qmux over TCP for trusted local workers.
 bind = "127.0.0.1:4444"
@@ -33,8 +33,8 @@ allow.uid = [1001]
 ```
 
 The `quinn` (default), `quiche`, and `noq` QUIC backends are compile-time
-features selected with `backend`. Don't pick `"delay"` on `noq` or iroh: their
-BBRv3 can panic on loss.
+features selected with `backend`. `"delay"` is BBR on all of them, but the
+generation differs: BBRv1 on quinn, BBRv2 on quiche, BBRv3 on noq and iroh.
 
 ## \[web]
 

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -1098,7 +1098,7 @@ pub extern "C" fn moq_client_set_quic_mtu_discovery(client: u32, enabled: bool) 
 ///
 /// Either `"loss"` (CUBIC, throughput-oriented) or `"delay"` (BBR, which keeps queues
 /// short and the send rate steady enough for an encoder to track). A NULL or empty value
-/// puts it back to the backend's own default. QUIC only.
+/// puts it back to the default, `"delay"` on every backend. QUIC only.
 ///
 /// Returns zero on success, or a negative code if the handle is unknown or the family is
 /// unrecognized.

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["multimedia", "network-programming", "web-programming"]
 [features]
 default = ["quinn", "aws-lc-rs", "websocket", "tcp", "uds"]
 quinn = ["dep:quinn", "dep:web-transport-quinn", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "watch", "dep:dns-lookup"]
-noq = ["dep:web-transport-noq", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "watch", "dep:dns-lookup"]
+noq = ["dep:web-transport-noq", "dep:noq", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "watch", "dep:dns-lookup"]
 quiche = ["dep:web-transport-quiche", "dep:rcgen", "dep:reqwest", "dep:rustls-webpki", "dep:rustls-native-certs", "dep:dns-lookup", "watch"]
 # Filesystem watcher for hot-reloading on-disk TLS certs, keys, and root CAs.
 watch = ["dep:notify"]
@@ -51,8 +51,14 @@ humantime-serde = { workspace = true }
 
 moq-net = { workspace = true }
 # iroh runs on noq but re-exports only the ControllerFactory trait, not the concrete
-# congestion configs. Version matched to the copy iroh pulls in.
-noq-proto = { version = "1", default-features = false, optional = true }
+# congestion configs. Version matched to the copy iroh pulls in. The floor is 1.2
+# because that is where BBRInflightAtLoss stopped underflowing, and this backend
+# installs BBRv3 by default.
+noq-proto = { version = "1.2", default-features = false, optional = true }
+# Depended on directly rather than through web-transport-noq's re-export so the
+# version floor is ours: web-transport-noq only asks for `noq = "1"`, and this
+# backend installs BBRv3 by default, which underflows on loss before 1.2.
+noq = { version = "1.2", default-features = false, optional = true }
 notify = { version = "8", optional = true }
 qmux = { workspace = true, features = ["wss", "tls", "tcp"], optional = true }
 quinn = { version = "0.11", default-features = false, features = ["platform-verifier", "runtime-tokio", "bloom"], optional = true }

--- a/rs/moq-native/Cargo.toml
+++ b/rs/moq-native/Cargo.toml
@@ -50,15 +50,15 @@ humantime = { workspace = true }
 humantime-serde = { workspace = true }
 
 moq-net = { workspace = true }
+# Depended on directly rather than through web-transport-noq's re-export so the
+# version floor is ours: web-transport-noq only asks for `noq = "1"`, and this
+# backend installs BBRv3 by default, which underflows on loss before 1.2.
+noq = { version = "1.2", default-features = false, optional = true }
 # iroh runs on noq but re-exports only the ControllerFactory trait, not the concrete
 # congestion configs. Version matched to the copy iroh pulls in. The floor is 1.2
 # because that is where BBRInflightAtLoss stopped underflowing, and this backend
 # installs BBRv3 by default.
 noq-proto = { version = "1.2", default-features = false, optional = true }
-# Depended on directly rather than through web-transport-noq's re-export so the
-# version floor is ours: web-transport-noq only asks for `noq = "1"`, and this
-# backend installs BBRv3 by default, which underflows on loss before 1.2.
-noq = { version = "1.2", default-features = false, optional = true }
 notify = { version = "8", optional = true }
 qmux = { workspace = true, features = ["wss", "tls", "tcp"], optional = true }
 quinn = { version = "0.11", default-features = false, features = ["platform-verifier", "runtime-tokio", "bloom"], optional = true }

--- a/rs/moq-native/src/iroh.rs
+++ b/rs/moq-native/src/iroh.rs
@@ -15,16 +15,6 @@ use web_transport_proto::{ConnectRequest, ConnectResponse};
 pub use iroh::Endpoint;
 pub use web_transport_iroh;
 
-/// The congestion control family to install, defaulting to loss-based.
-///
-/// Unlike the other backends we don't default to BBR here: noq's BBRv3 subtracts
-/// without a floor when computing the inflight bytes at the loss event, so a single
-/// packet loss can underflow and panic, taking the whole process with it. Delay-based
-/// stays reachable, but only when an operator asks for it by name.
-fn congestion_control(quic: &crate::quic::Resolved) -> CongestionControl {
-	quic.congestion_control.unwrap_or(CongestionControl::Loss)
-}
-
 /// The iroh controller factory for a congestion control family.
 ///
 /// iroh is built on noq, so its BBR is v3. It re-exports the `ControllerFactory`
@@ -212,7 +202,7 @@ impl EndpointConfig {
 		if !quic.mtu_discovery {
 			transport = transport.mtu_discovery_config(None);
 		}
-		transport = transport.congestion_controller_factory(congestion_factory(congestion_control(&quic)));
+		transport = transport.congestion_controller_factory(congestion_factory(quic.congestion()));
 
 		let mut builder = if self.disable_relay.unwrap_or(false) {
 			Endpoint::builder(iroh::endpoint::presets::N0DisableRelay)
@@ -372,17 +362,5 @@ mod tests {
 
 		let delay = congestion_factory(CongestionControl::Delay).build(now, mtu);
 		assert!(delay.into_any().downcast::<noq_proto::congestion::Bbr3>().is_ok());
-	}
-
-	/// noq's BBRv3 panics on loss, so an unset knob must land on CUBIC here even
-	/// though every other backend defaults to BBR.
-	#[test]
-	fn congestion_control_defaults_to_loss() {
-		let mut quic = crate::quic::Client::default();
-		assert_eq!(congestion_control(&quic.resolve()), CongestionControl::Loss);
-
-		// An explicit request still gets through.
-		quic.congestion_control = Some(CongestionControl::Delay);
-		assert_eq!(congestion_control(&quic.resolve()), CongestionControl::Delay);
 	}
 }

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -57,17 +57,7 @@ fn apply_transport(transport: &mut noq::TransportConfig, quic: &Resolved) {
 		transport.enable_segmentation_offload(gso);
 	}
 
-	transport.congestion_controller_factory(congestion_factory(congestion_control(quic)));
-}
-
-/// The congestion control family to install, defaulting to loss-based.
-///
-/// Unlike the other backends we don't default to BBR here: noq's BBRv3 subtracts
-/// without a floor when computing the inflight bytes at the loss event, so a single
-/// packet loss can underflow and panic, taking the whole process with it. Delay-based
-/// stays reachable, but only when an operator asks for it by name.
-fn congestion_control(quic: &Resolved) -> CongestionControl {
-	quic.congestion_control.unwrap_or(CongestionControl::Loss)
+	transport.congestion_controller_factory(congestion_factory(quic.congestion()));
 }
 
 /// The noq controller factory for a congestion control family. noq's BBR is v3.
@@ -705,15 +695,76 @@ mod tests {
 		assert!(delay.into_any().downcast::<noq::congestion::Bbr3>().is_ok());
 	}
 
-	/// noq's BBRv3 panics on loss, so an unset knob must land on CUBIC here even
-	/// though every other backend defaults to BBR.
-	#[test]
-	fn congestion_control_defaults_to_loss() {
-		let mut quic = crate::quic::Client::default();
-		assert_eq!(congestion_control(&quic.resolve()), CongestionControl::Loss);
+	/// Loopback regression test: with the knob unset, live noq connections must run
+	/// BBRv3 on both ends.
+	///
+	/// This backend defaulted to CUBIC while noq's BBRv3 underflowed computing the
+	/// inflight bytes at a loss event. noq 1.2.0 rewrote `BBRInflightAtLoss` in
+	/// signed arithmetic and covers the loss path with its own packet-level
+	/// simulator, so the exception is gone and the default is asserted here.
+	#[tokio::test]
+	async fn default_reaches_the_live_connection() {
+		let server_config = ServerConfig {
+			bind: Some("127.0.0.1:0".to_string()),
+			tls: crate::tls::Server {
+				generate: vec!["localhost".into()],
+				..Default::default()
+			},
+			..Default::default()
+		};
 
-		// An explicit request still gets through.
-		quic.congestion_control = Some(CongestionControl::Delay);
-		assert_eq!(congestion_control(&quic.resolve()), CongestionControl::Delay);
+		let server = NoqServer::new(server_config).expect("server init");
+		let addr = server.local_addr().expect("local addr");
+
+		let accepted = tokio::spawn(async move {
+			let incoming = server.accept().await.expect("no incoming connection");
+			let conn = incoming.accept().expect("accept").await.expect("handshake");
+			is_bbr3(&conn)
+		});
+
+		// tls::Client has a private field, so it can't be built with a struct literal.
+		let mut tls_config = crate::tls::Client::default();
+		tls_config.disable_verify = Some(true);
+
+		let client_config = ClientConfig {
+			bind: "127.0.0.1:0".parse().unwrap(),
+			tls: tls_config,
+			..Default::default()
+		};
+
+		let tls = client_config.tls.build().expect("tls config");
+		let client = NoqClient::new(&client_config).expect("client init");
+		// Dial the loopback IP directly so the system resolver is never involved.
+		let url: Url = format!("moqt://127.0.0.1:{}", addr.port()).parse().unwrap();
+
+		// Bound the whole connect + accept + assert flow so a handshake
+		// regression fails fast instead of stalling CI.
+		tokio::time::timeout(Duration::from_secs(5), async move {
+			let session = client
+				.connect(&tls, url, &moq_net::Versions::default())
+				.await
+				.expect("connect failed");
+
+			// web_transport_noq::Session derefs to the noq connection.
+			assert!(is_bbr3(&session), "client connection is not running BBRv3");
+			assert!(
+				accepted.await.expect("server task panicked"),
+				"server connection is not running BBRv3"
+			);
+		})
+		.await
+		.expect("test timed out");
+	}
+
+	/// Whether a live connection's initial path is running BBRv3.
+	///
+	/// noq is multipath, so the controller is per path rather than per connection;
+	/// `PathId::ZERO` is the path the handshake came up on.
+	fn is_bbr3(conn: &noq::Connection) -> bool {
+		conn.congestion_state(noq::PathId::ZERO)
+			.expect("no controller on the initial path")
+			.into_any()
+			.downcast::<noq::congestion::Bbr3>()
+			.is_ok()
 	}
 }

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -12,8 +12,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use url::Url;
 
-use web_transport_noq::noq;
-
 pub use web_transport_noq;
 
 /// Attach a qlog factory writing into the configured directory, if any.
@@ -699,9 +697,10 @@ mod tests {
 	/// BBRv3 on both ends.
 	///
 	/// This backend defaulted to CUBIC while noq's BBRv3 underflowed computing the
-	/// inflight bytes at a loss event. noq 1.2.0 rewrote `BBRInflightAtLoss` in
-	/// signed arithmetic and covers the loss path with its own packet-level
-	/// simulator, so the exception is gone and the default is asserted here.
+	/// inflight bytes at a loss event. noq 1.2.0 rewrote `BBRInflightAtLoss` to compute
+	/// the loss prefix in floating point, so the subtraction can go negative instead of
+	/// wrapping, and covers the loss path with its own packet-level simulator. The
+	/// exception is gone, so the default is asserted here.
 	#[tokio::test]
 	async fn default_reaches_the_live_connection() {
 		let server_config = ServerConfig {

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -695,12 +695,6 @@ mod tests {
 
 	/// Loopback regression test: with the knob unset, live noq connections must run
 	/// BBRv3 on both ends.
-	///
-	/// This backend defaulted to CUBIC while noq's BBRv3 underflowed computing the
-	/// inflight bytes at a loss event. noq 1.2.0 rewrote `BBRInflightAtLoss` to compute
-	/// the loss prefix in floating point, so the subtraction can go negative instead of
-	/// wrapping, and covers the loss path with its own packet-level simulator. The
-	/// exception is gone, so the default is asserted here.
 	#[tokio::test]
 	async fn default_reaches_the_live_connection() {
 		let server_config = ServerConfig {

--- a/rs/moq-native/src/quic.rs
+++ b/rs/moq-native/src/quic.rs
@@ -145,9 +145,8 @@ pub struct Client {
 	)]
 	pub mtu_discovery: Option<bool>,
 
-	/// Congestion control family. Defaults to `delay` on quinn and quiche, and to
-	/// `loss` on noq and iroh, whose shared BBRv3 can panic on packet loss and take
-	/// the process with it. Selecting `delay` there is for deliberate testing only.
+	/// Congestion control family, defaulting to `delay` on every backend. Which BBR
+	/// generation that is depends on the backend (see [`CongestionControl`]).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[arg(
 		id = "client-quic-congestion-control",
@@ -283,9 +282,8 @@ pub struct Server {
 	)]
 	pub mtu_discovery: Option<bool>,
 
-	/// Congestion control family. Defaults to `delay` on quinn and quiche, and to
-	/// `loss` on noq, whose BBRv3 can panic on packet loss and take the process with
-	/// it. Selecting `delay` there is for deliberate testing only.
+	/// Congestion control family, defaulting to `delay` on every backend. Which BBR
+	/// generation that is depends on the backend (see [`CongestionControl`]).
 	#[serde(skip_serializing_if = "Option::is_none")]
 	#[arg(
 		id = "server-quic-congestion-control",
@@ -392,8 +390,8 @@ pub struct Resolved {
 	pub keep_alive: Option<Duration>,
 	/// Whether to run path MTU discovery.
 	pub mtu_discovery: bool,
-	/// Congestion control override, or `None` for the backend's own default. Each
-	/// backend picks that default itself, since they don't all agree.
+	/// Congestion control override, or `None` for the default. Read it through
+	/// [`Resolved::congestion`], which applies that default once for every backend.
 	pub congestion_control: Option<CongestionControl>,
 	/// Directory to write qlog traces into, or `None` to not capture them.
 	pub qlog: Option<PathBuf>,
@@ -426,6 +424,20 @@ impl Resolved {
 			congestion_control,
 			qlog,
 		}
+	}
+
+	/// The congestion control family to install.
+	///
+	/// Delay-based unless the operator says otherwise: BBR keeps queues short and the
+	/// send rate steady enough for a live encoder to track, which is what this stack
+	/// carries. Every backend resolves the default here rather than each picking its
+	/// own, so the answer can't drift between them.
+	#[cfg_attr(
+		not(any(feature = "quinn", feature = "noq", feature = "quiche", feature = "iroh")),
+		allow(dead_code)
+	)]
+	pub fn congestion(&self) -> CongestionControl {
+		self.congestion_control.unwrap_or(CongestionControl::Delay)
 	}
 
 	/// The directory to write qlog traces into, if any.
@@ -616,7 +628,19 @@ mod tests {
 		assert_eq!(both.client.congestion_control, Some(CongestionControl::Delay));
 		assert_eq!(both.server.congestion_control, Some(CongestionControl::Loss));
 
-		// Unset stays None; each backend then picks its own default.
+		// Unset stays None on the wire; `Resolved::congestion` applies the default.
 		assert_eq!(Client::default().resolve().congestion_control, None);
+	}
+
+	/// One default for every backend, so a knob left unset can't mean CUBIC on one
+	/// and BBR on another.
+	#[test]
+	fn congestion_defaults_to_delay() {
+		let mut quic = Client::default();
+		assert_eq!(quic.resolve().congestion(), CongestionControl::Delay);
+
+		// An explicit request still gets through.
+		quic.congestion_control = Some(CongestionControl::Loss);
+		assert_eq!(quic.resolve().congestion(), CongestionControl::Loss);
 	}
 }

--- a/rs/moq-native/src/quic.rs
+++ b/rs/moq-native/src/quic.rs
@@ -390,8 +390,8 @@ pub struct Resolved {
 	pub keep_alive: Option<Duration>,
 	/// Whether to run path MTU discovery.
 	pub mtu_discovery: bool,
-	/// Congestion control override, or `None` for the default. Read it through
-	/// [`Resolved::congestion`], which applies that default once for every backend.
+	/// Congestion control override, or `None` for the default. The backends read it
+	/// through `Resolved::congestion`, which applies that default once for all of them.
 	pub congestion_control: Option<CongestionControl>,
 	/// Directory to write qlog traces into, or `None` to not capture them.
 	pub qlog: Option<PathBuf>,
@@ -436,7 +436,7 @@ impl Resolved {
 		not(any(feature = "quinn", feature = "noq", feature = "quiche", feature = "iroh")),
 		allow(dead_code)
 	)]
-	pub fn congestion(&self) -> CongestionControl {
+	pub(crate) fn congestion(&self) -> CongestionControl {
 		self.congestion_control.unwrap_or(CongestionControl::Delay)
 	}
 

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -179,10 +179,7 @@ fn apply_settings(settings: &mut web_transport_quiche::Settings, quic: &Resolved
 	settings.max_idle_timeout = Some(quic.idle_timeout);
 	settings.discover_path_mtu = quic.mtu_discovery;
 
-	// Live media wants a steady send rate an encoder can track, not CUBIC's sawtooth,
-	// so default to BBR rather than quiche's own CUBIC.
-	let family = quic.congestion_control.unwrap_or(CongestionControl::Delay);
-	settings.cc_algorithm = cc_algorithm(family).to_owned();
+	settings.cc_algorithm = cc_algorithm(quic.congestion()).to_owned();
 
 	// quiche writes one file per connection itself, named after the connection ID.
 	if let Some(dir) = quic.qlog_dir() {

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -68,15 +68,7 @@ fn apply_transport(transport: &mut quinn::TransportConfig, quic: &Resolved) {
 		transport.enable_segmentation_offload(gso);
 	}
 
-	transport.congestion_controller_factory(congestion_factory(congestion_control(quic)));
-}
-
-/// The congestion control family to install, defaulting to delay-based.
-///
-/// Live media wants a steady send rate an encoder can track, not CUBIC's sawtooth,
-/// so override quinn's own CUBIC default.
-fn congestion_control(quic: &Resolved) -> CongestionControl {
-	quic.congestion_control.unwrap_or(CongestionControl::Delay)
+	transport.congestion_controller_factory(congestion_factory(quic.congestion()));
 }
 
 /// The quinn controller factory for a congestion control family. quinn's BBR is v1.
@@ -752,17 +744,6 @@ mod tests {
 
 		let delay = congestion_factory(CongestionControl::Delay).build(now, mtu);
 		assert!(delay.into_any().downcast::<quinn::congestion::Bbr>().is_ok());
-	}
-
-	/// An unset knob must land on BBR rather than quinn's own CUBIC default.
-	#[test]
-	fn congestion_control_defaults_to_delay() {
-		let mut quic = crate::quic::Client::default();
-		assert_eq!(congestion_control(&quic.resolve()), CongestionControl::Delay);
-
-		// An explicit request still gets through.
-		quic.congestion_control = Some(CongestionControl::Loss);
-		assert_eq!(congestion_control(&quic.resolve()), CongestionControl::Loss);
 	}
 
 	/// Loopback regression test: a config selecting BBR must produce live


### PR DESCRIPTION
## Summary

- **Root cause.** noq's BBRv3 computed `BBRInflightAtLoss` with an unchecked `u64` subtraction:

  ```rust
  let compared_loss = (inflight_prev_threshold.round() as u64) - lost_prev;
  ```

  That line is only reached once `is_inflight_too_high()` is true, i.e. exactly when `lost_prev` has already outgrown `LOSS_THRESH * inflight_prev`, so it underflowed on the *common* loss path rather than a rare one. `moq-native` worked around it by defaulting the `noq` and `iroh` backends to CUBIC while every other backend defaulted to BBR.
- **The workaround is void.** noq 1.2.0 (n0-computer/noq#785) recomputes the loss prefix in floating point, so the subtraction goes negative instead of wrapping and the `as u64` cast saturates at 0. `Cargo.lock` already carries noq/noq-proto 1.2.0. `iroh` is included because it builds on the same `noq-proto` congestion module, not a separate BBRv3.
- **Floored the dependency.** `web-transport-noq` only asks for `noq = "1"`, so a downstream consumer of a published `moq-native` could resolve 1.0/1.1 and get the underflowing BBRv3 now that it is the default. `moq-native` depends on `noq` directly at `1.2` and reaches it that way rather than through the re-export, so the floor is load-bearing rather than an unused pin. `noq-proto` (the iroh path) gets the same floor.
- **One default, not four.** `noq`, `quinn` and `iroh` each had a private `congestion_control()` helper and `quiche` inlined a fourth copy; they had already drifted (two said CUBIC, two said BBR). They now all read `Resolved::congestion`, so an unset knob cannot mean different things on different backends.
- Docs updated where the exception was written down: the two flag doc comments, `doc/bin/relay/config.md`, and the `libmoq` FFI setter.

## Testing

`noq::tests::default_reaches_the_live_connection` is a new loopback test: it brings up a real noq server and client with the knob unset and asserts both live connections run `Bbr3`, mirroring the existing `quinn::tests::delay_reaches_the_live_connection`. Verified it is a real guard, not a tautology: flipping `Resolved::congestion` back to `Loss` fails it with `client connection is not running BBRv3`.

The loss event itself is **not** re-driven here. Reaching `inflight_at_loss` requires BBR to be in `PROBE_UP` with `bw_probe_samples` set, which needs the full `STARTUP -> DRAIN -> PROBE_BW -> PROBE_UP` cycle plus a sustained above-threshold loss rate, and the state it asserts on (`Bbr3::new`, `bbr.state`, `SpaceKind`) is not reachable through `noq::congestion`. noq 1.2.0 added exactly that simulator alongside the fix -- `probe_bw_exits_probe_up_to_probe_down_on_loss_when_app_limited`, absent in 1.1.1 -- so re-implementing it here would fork a dependency's test against APIs this crate cannot reach. The 4% loss coverage lives upstream; this crate's job is that the default lands on BBRv3, which is what the new test pins.

`cargo test -p moq-native --lib --features noq,quiche,iroh`: 153 passed. Clippy clean on `--all-targets`. Builds checked for `--all-features` and `--no-default-features --features noq,aws-lc-rs`.

Not covered here: WAN behavior. BBRv3 under real loss on a relay fleet is the consumer-side verification, tracked separately.

## Public API

No new, renamed, or removed public items, and no breaking changes.

- **Behavior:** with `congestion_control` unset, the `noq` and `iroh` backends now install BBRv3 instead of CUBIC. `quinn` and `quiche` are unchanged (already BBR). Setting the flag explicitly still selects either family on every backend.
- **Manifest:** `moq-native` gains a direct optional `noq` dependency (enabled by the existing `noq` feature) purely to raise the version floor. `noq-proto` floors from `1` to `1.2`.
- `Resolved::congestion` is `pub(crate)`; the four private per-backend helpers it replaces were not exported either.

## Wire

No change.