### PR TITLE
docs: trim the agent guides and add PROMPTING.md

### DIFF
--- a/.claude/rules/prompting.md
+++ b/.claude/rules/prompting.md
@@ -1,0 +1,10 @@
+---
+paths:
+  - "**/CLAUDE.md"
+  - "**/AGENTS.md"
+  - "CONTRIBUTING.md"
+  - "PROMPTING.md"
+  - ".claude/skills/**"
+---
+
+Before editing this file, read `PROMPTING.md` at the repository root and apply it.

--- a/.claude/skills/plan-quests/SKILL.md
+++ b/.claude/skills/plan-quests/SKILL.md
@@ -37,9 +37,7 @@ Once complete, create, update, or delete the relevant quests and questlines.
 
 Commit and make a PR then:
 
-- Monitor it for CI failures and reviews.
-- Address any automated review findings (Codex/CodeRabbit) you agree with. Turn down any you disagree with with a comment.
-- Push any changes you made to the PR, updating the summary if needed.
-- Repeat at most once, avoiding a loop of back-and-forth review/feedback cycles.
+- Monitor it for CI failures and the automatic reviews. Never request a review.
+- Address any findings you agree with, turn down the rest with a comment, and push once. If the next review still has findings, stop and report.
 
 Merge the PR when ready.

--- a/.claude/skills/spawn-quests/SKILL.md
+++ b/.claude/skills/spawn-quests/SKILL.md
@@ -9,9 +9,14 @@ The scope consists of all unblocked quests that are not claimed and have no bloc
 Use the argument (if provided) to filter to specific quests/questlines.
 Report which quests are not ready to be worked on and why.
 
-For each quest, spawn a sub-agent to /start-quest.
+For each quest, interactively prompt the user if we should work on the quest, scope it further with /plan-quest, lower the priority, or skip it.
+
+For each quest to work on, spawn a background sub-agent to /start-quest.
 Determine the base branch for the quest and create a fresh worktree.
 Limit the concurrency to at most N agents in parallel, where N is half the number of CPU cores.
+Keep prompting the user if needed while these agents work in the background.
 
-Monitor the sub-agents and report their final status.
-Don't monitor or merge any PRs.
+Monitor the sub-agents and report their final status, but do not monitor their PRs.
+Prompt the user if they want to /plan-quest for any suggested follow-ups.
+
+Finally, create a PR if there are any created/updated quests.

--- a/.claude/skills/spawn-quests/SKILL.md
+++ b/.claude/skills/spawn-quests/SKILL.md
@@ -5,18 +5,28 @@ description: Spawn background agents work on quests in parallel.
 
 Before you begin, read `quest/CLAUDE.md` completely.
 
+Your goal is to execute and/or plan quests in parallel.
+
 The scope consists of all unblocked quests that are not claimed and have no blockers.
 Use the argument (if provided) to filter to specific quests/questlines.
 Report which quests are not ready to be worked on and why.
 
-For each quest, interactively prompt the user if we should work on the quest, scope it further with /plan-quest, lower the priority, or skip it.
+For each quest, interactively prompt the user if:
+1. we should work on the quest.
+2. plan it further with /plan-quest.
+3. deprioritize it.
+4. delete it.
+
+Include a recommended option.
 
 For each quest to work on, spawn a background sub-agent to /start-quest.
 Determine the base branch for the quest and create a fresh worktree.
 Limit the concurrency to at most N agents in parallel, where N is half the number of CPU cores.
-Keep prompting the user if needed while these agents work in the background.
 
 Monitor the sub-agents and report their final status, but do not monitor their PRs.
 Prompt the user if they want to /plan-quest for any suggested follow-ups.
+
+Run /plan-quest for any selected quests in the foreground.
+Perform any research and monitoring in the background.
 
 Finally, create a PR if there are any created/updated quests.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,21 +20,9 @@ Key architectural rule: The CDN/relay does not know anything about media. Anythi
 
 WebSocket, TLS, UDS, etc are fallback transports via qmux. Reliable transports can't shed load during congestion.
 
-# Structure
+# Guides
 
-Top-level only. Read the area-specific `CLAUDE.md` where one exists before working there.
-
-- `/rs/` - Rust crates, published as `moq-*`. See `rs/CLAUDE.md`.
-- `/js/` - TypeScript packages for the browser, published as `@moq/*`. See `js/CLAUDE.md`.
-- `/py/`, `/swift/`, `/kt/`, `/go/`, `/dart/` - language wrappers over `rs/moq-ffi`. See `rs/moq-ffi/CLAUDE.md` and `py/CLAUDE.md`.
-- `/cpp/` - C/C++ consumers of `libmoq`, including the OBS plugin.
-- `/demo/` - demos and test media. `just dev` runs a local relay, publisher, and web UI.
-- `/test/` - harnesses that span languages or need a server (`just test smoke`).
-- `/doc/` - documentation site. Keep it current; surface what is possible rather than every detail.
-- `/drafts/` - our IETF drafts. See `drafts/CLAUDE.md`. Upstream: `https://datatracker.ietf.org/wg/moq/documents/`
-- `/quest/` - versioned plans for work needing durable scope. See `quest/CLAUDE.md`. Prefer a quest over an issue.
-
-Changes ripple across languages. Follow the Cross-Package Sync checklist below.
+Area guides live beside the code as nested `CLAUDE.md` files (the root `AGENTS.md` is a symlink). Read the one for the area you touch. Changes ripple across languages; follow the Cross-Package Sync checklist below. Prefer a quest under `quest/` over a GitHub issue for work needing durable scope.
 
 # Libraries
 
@@ -56,32 +44,39 @@ The API is the most important thing to get right. A bad shape costs a breaking c
 - Never add `foo_with_x`, `foo_checked`, or a compatibility shim. Make the breaking change to `foo` on `dev` instead. Additive changes stay on `main`.
 - Let the type system make misuse unrepresentable: enums over strings, `Duration` over seconds, terminal operations consume `self`, cleanup in `Drop` rather than a `close()` the caller can forget.
 - Avoid callback parameters. Return a handle, an event, or a Producer/Consumer split.
-- Take slices in, return owned values. Avoid 4+ args; use a struct.
-- Name by role, not today's implementation. Short names under a module namespace (`encode::Config`, not `EncoderConfig`). Mirror names across Rust, JS, and the bindings.
+- Avoid 4+ args; use a struct or object.
+- Name by role, not today's implementation.
 - When a name or shape feels awkward, propose alternatives with a recommendation instead of shipping it.
+- Short names under a module namespace (`encode::Config`, not `EncoderConfig`). Mirror names across Rust, JS, and the bindings.
+- Document every exported symbol in one plain line, the way you'd say it out loud.
 
 # Required
 
-- Dig into the root cause and fix it at the source. Never work around it in the caller.
-- Never add retries, sleeps, lingers, or arbitrary timeouts to paper over a race. Fail fast with the real error.
-- Error on unsupported or malformed input rather than warn and continue. Warn-then-ignore is banned: supported or refused.
-- Reproduce bugs before fixing them. Add a regression test when one is easy.
+- Dig into the root cause and fix it at the source. Never work around a fixable bug with a retry, sleep, or timeout.
+- Fail loud and early. Error on unsupported or malformed input rather than warn and continue: supported or refused.
+- Reproduce bugs before fixing them. Land each fix with a regression test that fails without it, when one is easy.
 - Keep the PR focused. No unrelated refactors, formatting churn, or drive-by changes; split when in doubt.
-- Refactor aggressively for long-term maintainability, but re-evaluate the direction as you learn. Propose a course change, or abandon the PR, rather than finish a half-solution.
-- When taking over someone's PR, build on their commits so they keep credit.
+- Refactor aggressively for long-term maintainability, but re-evaluate the direction as you learn.
+- Propose a course change, even suggest abandoning a PR, rather than finish a half-solution.
 - When a decision is the maintainer's (API shape, naming, scope), ask with 2-3 options and a recommendation.
+- All tests need to be wired into CI, at least a nightly.
+- Never edit a `CLAUDE.md`, `CONTRIBUTING.md`, or skill without being prompted, and read `PROMPTING.md` first.
+- No em dashes.
+- Match the existing conventions, patterns, and naming when possible.
+- Fix any outdated docs and comments inline; don't add a separate PR for it.
 
 # Guidelines
 
-- New dependencies use the newest stable version. Prefer a maintained crate over hand-rolling non-core functionality.
+- Prefer a maintained crate over hand-rolling non-core functionality.
+- New dependencies use the newest stable version.
 - Do not bump package versions unless asked. Releases are cut separately.
-- No em dashes.
-- Document every exported symbol in one plain line, the way you'd say it out loud. Comments inside code only explain the non-obvious why, and describe the current state, never history.
-- Inline simple helpers. Question whether functionality is needed at all before adding it.
-- Match the existing conventions, patterns, and naming.
-- These `CLAUDE.md` files (the root `AGENTS.md` is a symlink) are stateless instructions: minimal, situational, no history, no file links. If a missing line here would have saved you cycles, suggest it.
+- Comments should explain the non-obvious why, and never the history.
+- Inline simple helpers.
+- Question whether functionality is needed at all before adding it.
 - Deleting code is better than adding code.
-- Suggest follow up sessions and quests.
+- Suggest follow up sessions and quests when finished, interactively prompting the user.
+- Prefer the simple solution.
+- Say it once, in the fewest words that hold up.
 
 # Development
 
@@ -99,7 +94,7 @@ just fix          # Auto-fix lint/formatting, same scope
 
 These diff the branch against its base and only run the affected packages. Run `just fix` before committing. CI runs the same `check` and `test`.
 
-See `CONTRIBUTING.md` before making or merging a PR .
+See `CONTRIBUTING.md` before making or merging a PR.
 
 # Cross-Package Sync
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,10 +61,9 @@ Add the AI marker `(Written by <model>)` to any posts on GitHub, excluding commi
 
 # Reviews
 
-Codex and CodeRabbit automatically review PRs.
+Codex and CodeRabbit review every push on their own. Never request a review; an @codex or @coderabbitai mention is banned.
 CodeRabbit may be rate-limited, treat it as optional.
 
-Address review comments or leave a comment if you disagree with a suggestion.
-Repeat at most once without user intervention, avoiding a loop of back-and-forth review/feedback cycles.
-Never manually request a review.
-If a review comment is out of scope or not relevant to the PR, make or update a follow-up quest.
+Fix the findings you agree with, reply to the ones you do not, and push once.
+If the next automatic review still has findings, stop and report to the user.
+If a finding is out of scope, make or update a follow-up quest.

--- a/PROMPTING.md
+++ b/PROMPTING.md
@@ -1,0 +1,64 @@
+# Prompting agents
+
+Read this before editing any `CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`, or `SKILL.md`. These files are prompts. Agents are not trained to write prompts for themselves, so the rules below come from the vendors' own guidance (sources at the end) and from what has failed here.
+
+# What belongs
+
+A guide holds what an agent cannot derive from the tree and would otherwise get wrong twice: commands it can't guess, conventions that differ from the language default, invariants no type check enforces, footguns that fail silently, and repository etiquette. Everything else buries the rules that matter.
+
+- Add a line when the same mistake happens a second time, a review catches something the guide should have said, or the same correction gets typed into chat twice.
+- Cut a line if removing it would not cause a mistake. Ask that of every line, including the ones already there.
+- Never add directory trees, file-by-file descriptions, dependency lists, architecture overviews, how a feature works, or the history of a change. A PR that explains its own change in a guide is adding history.
+- Never add a rule an agent already follows. "Write clean code" and restated language conventions cost tokens and adherence.
+- A multi-step procedure is a skill. A rule that must hold every time is a hook; guides are advisory.
+- Deferred work is a quest, never a note in a guide.
+
+# Where it goes
+
+- The root guide: rules that apply to every change in the repository.
+- A nested guide: rules for one area, loaded only when an agent works there. Put a rule in the narrowest directory it applies to.
+- `CONTRIBUTING.md`: how a change lands, from commit to merge, including how automated reviews are handled.
+- A skill: a procedure someone runs on demand.
+- Auto memory: one person's preferences and corrections. Never a repository fact.
+
+# How to write it
+
+- Short. Under 200 lines per file; Codex truncates the whole concatenated chain at 32 KiB, nearest file last.
+- Concrete enough to verify. "Run `just fix` before committing" beats "keep the code formatted". Name the exact command, flag, or type.
+- Say what to do and why, in one sentence. The why lets the model generalize; a bare "never X" is followed literally or not at all.
+- A limit is a number, not a judgment. "One fix round, then stop" holds. "Avoid loops" and "abort if not making progress" do not, because an agent always believes it is making progress.
+- No emphasis. Capitals and "IMPORTANT" work on one line per file; on ten, none stand out.
+- No contradictions. Between two rules that disagree, the model picks at random. Grep the other guides for the topic before adding a rule.
+- Facts, not narration. State the invariant and the failure it prevents. Skip the story of how it was found.
+- Prefer the positive form. "Bind `[::]`" over "don't bind v4-only".
+- Show a short example when the rule is about shape (a name, a message format). Three lines of example beat a paragraph.
+- Plain markdown: headers and bullets, one topic per section, no em dashes. Claude and Codex read the same file, so nothing tool-specific.
+
+# Skills
+
+A skill loads once and stays in context for the rest of the session.
+
+- The `description` decides when it triggers. Lead with the use case and the phrases a user would say; two sentences at most.
+- Under 50 lines. Reference material goes in a sibling file, linked from the skill.
+- Standing instructions, not one-time steps: the skill is not re-read later in the session.
+- What to do, not why. The why belongs in a guide, if anywhere.
+- Every loop has a numeric cap and a stop condition that hands control back to the user.
+- A skill with side effects (deploy, post, merge) sets `disable-model-invocation: true` so only a person starts it.
+- One job per skill. "Review, fix, document, and plan" is four skills.
+
+# Prompting a subagent or Codex
+
+- One task per run. Say what done looks like and the output shape you need.
+- Say what to verify before finishing, never "think harder".
+- Name what to read, and that unknowns are reported rather than guessed.
+- Keep going on low-risk ambiguity; stop only when a missing detail changes correctness, safety, or an irreversible action.
+- For a run that writes, bound the scope: no unrelated refactors, no new abstractions, no defensive code for cases that can't happen.
+
+# Sources
+
+- Claude Code, CLAUDE.md: <https://code.claude.com/docs/en/memory>
+- Claude Code best practices: <https://code.claude.com/docs/en/best-practices>
+- Claude Code skills: <https://code.claude.com/docs/en/skills>
+- Prompting Claude: <https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices>
+- Codex AGENTS.md: <https://developers.openai.com/codex/guides/agents-md>
+- AGENTS.md format: <https://agents.md>

--- a/PROMPTING.md
+++ b/PROMPTING.md
@@ -12,9 +12,17 @@ More specific context (ex. per language or project) should exist in respective f
 
 These base prompts are meant to keep agents from constantly drifting in the wrong direction.
 There needs to be a history of misuse to justify a change to `CLAUDE.md` and friends.
-If you think a slight tweak to the base prompt would help, make it.
+If you think a slight tweak to the base prompt would help, propose it.
+A limit is a number, not a judgment call: "one fix round, then stop" holds, "abort if not making progress" does not.
 
-Check the official Claude/Codex guidance when making any changes.
+Check the official Claude/Codex guidance when making any changes:
+
+- <https://code.claude.com/docs/en/memory>
+- <https://code.claude.com/docs/en/best-practices>
+- <https://code.claude.com/docs/en/skills>
+- <https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices>
+- <https://developers.openai.com/codex/guides/agents-md>
+- <https://agents.md>
 
 # Skills
 Skills are meant to avoid repeated duplicate prompts.

--- a/PROMPTING.md
+++ b/PROMPTING.md
@@ -1,64 +1,21 @@
-# Prompting agents
+Read this before editing any `CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`, or `SKILL.md`. These files are prompts.
 
-Read this before editing any `CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`, or `SKILL.md`. These files are prompts. Agents are not trained to write prompts for themselves, so the rules below come from the vendors' own guidance (sources at the end) and from what has failed here.
+Agents are not trained to write prompts for themselves.
+They're (currently) trained on the outputs, not the inputs.
 
-# What belongs
+# Context
+Focus on best practices and conventions.
+Don't document the repository; the code and documentation can handle that.
 
-A guide holds what an agent cannot derive from the tree and would otherwise get wrong twice: commands it can't guess, conventions that differ from the language default, invariants no type check enforces, footguns that fail silently, and repository etiquette. Everything else buries the rules that matter.
+These files need to be light because they're loaded into every prompt.
+More specific context (ex. per language or project) should exist in respective folders.
 
-- Add a line when the same mistake happens a second time, a review catches something the guide should have said, or the same correction gets typed into chat twice.
-- Cut a line if removing it would not cause a mistake. Ask that of every line, including the ones already there.
-- Never add directory trees, file-by-file descriptions, dependency lists, architecture overviews, how a feature works, or the history of a change. A PR that explains its own change in a guide is adding history.
-- Never add a rule an agent already follows. "Write clean code" and restated language conventions cost tokens and adherence.
-- A multi-step procedure is a skill. A rule that must hold every time is a hook; guides are advisory.
-- Deferred work is a quest, never a note in a guide.
+These base prompts are meant to keep agents from constantly drifting in the wrong direction.
+There needs to be a history of misuse to justify a change to `CLAUDE.md` and friends.
+If you think a slight tweak to the base prompt would help, make it.
 
-# Where it goes
-
-- The root guide: rules that apply to every change in the repository.
-- A nested guide: rules for one area, loaded only when an agent works there. Put a rule in the narrowest directory it applies to.
-- `CONTRIBUTING.md`: how a change lands, from commit to merge, including how automated reviews are handled.
-- A skill: a procedure someone runs on demand.
-- Auto memory: one person's preferences and corrections. Never a repository fact.
-
-# How to write it
-
-- Short. Under 200 lines per file; Codex truncates the whole concatenated chain at 32 KiB, nearest file last.
-- Concrete enough to verify. "Run `just fix` before committing" beats "keep the code formatted". Name the exact command, flag, or type.
-- Say what to do and why, in one sentence. The why lets the model generalize; a bare "never X" is followed literally or not at all.
-- A limit is a number, not a judgment. "One fix round, then stop" holds. "Avoid loops" and "abort if not making progress" do not, because an agent always believes it is making progress.
-- No emphasis. Capitals and "IMPORTANT" work on one line per file; on ten, none stand out.
-- No contradictions. Between two rules that disagree, the model picks at random. Grep the other guides for the topic before adding a rule.
-- Facts, not narration. State the invariant and the failure it prevents. Skip the story of how it was found.
-- Prefer the positive form. "Bind `[::]`" over "don't bind v4-only".
-- Show a short example when the rule is about shape (a name, a message format). Three lines of example beat a paragraph.
-- Plain markdown: headers and bullets, one topic per section, no em dashes. Claude and Codex read the same file, so nothing tool-specific.
+Check the official Claude/Codex guidance when making any changes.
 
 # Skills
-
-A skill loads once and stays in context for the rest of the session.
-
-- The `description` decides when it triggers. Lead with the use case and the phrases a user would say; two sentences at most.
-- Under 50 lines. Reference material goes in a sibling file, linked from the skill.
-- Standing instructions, not one-time steps: the skill is not re-read later in the session.
-- What to do, not why. The why belongs in a guide, if anywhere.
-- Every loop has a numeric cap and a stop condition that hands control back to the user.
-- A skill with side effects (deploy, post, merge) sets `disable-model-invocation: true` so only a person starts it.
-- One job per skill. "Review, fix, document, and plan" is four skills.
-
-# Prompting a subagent or Codex
-
-- One task per run. Say what done looks like and the output shape you need.
-- Say what to verify before finishing, never "think harder".
-- Name what to read, and that unknowns are reported rather than guessed.
-- Keep going on low-risk ambiguity; stop only when a missing detail changes correctness, safety, or an irreversible action.
-- For a run that writes, bound the scope: no unrelated refactors, no new abstractions, no defensive code for cases that can't happen.
-
-# Sources
-
-- Claude Code, CLAUDE.md: <https://code.claude.com/docs/en/memory>
-- Claude Code best practices: <https://code.claude.com/docs/en/best-practices>
-- Claude Code skills: <https://code.claude.com/docs/en/skills>
-- Prompting Claude: <https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/claude-prompting-best-practices>
-- Codex AGENTS.md: <https://developers.openai.com/codex/guides/agents-md>
-- AGENTS.md format: <https://agents.md>
+Skills are meant to avoid repeated duplicate prompts.
+Read transcripts to determine the user's repeated intent.


### PR DESCRIPTION
## Summary

- The root guide keeps durable practice and warts only. Duplicated bullets are folded into one home each, the directory tree is gone (nested guides load for the area an agent touches), and a typo in the "never edit a guide unprompted" rule is fixed.
- `PROMPTING.md` is new: what belongs in a guide or skill and how to phrase it, drawn from the Claude Code and Codex documentation. Both root guides require reading it before editing a guide or skill, and a path-scoped rule in `.claude/rules/` loads it for Claude automatically.
- The Reviews section of `CONTRIBUTING.md` now states a numeric rule: automated reviewers run on every push, requesting one is banned, one fix round, then stop and report. The old "repeat at most once, avoid loops" wording did not hold; PR #3506 re-requested reviews about 45 times.
- The plan-quests skill defers to that rule instead of restating its own.

## Public API

None.

## Wire

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Claude Fable 5.1)
