### PR TITLE
fix(docs): format PROMPTING.md and the spawn-quests skill

### DIFF
--- a/.claude/skills/spawn-quests/SKILL.md
+++ b/.claude/skills/spawn-quests/SKILL.md
@@ -12,6 +12,7 @@ Use the argument (if provided) to filter to specific quests/questlines.
 Report which quests are not ready to be worked on and why.
 
 For each quest, interactively prompt the user if:
+
 1. we should work on the quest.
 2. plan it further with /plan-quest.
 3. deprioritize it.

--- a/PROMPTING.md
+++ b/PROMPTING.md
@@ -4,6 +4,7 @@ Agents are not trained to write prompts for themselves.
 They're (currently) trained on the outputs, not the inputs.
 
 # Context
+
 Focus on best practices and conventions.
 Don't document the repository; the code and documentation can handle that.
 
@@ -25,5 +26,6 @@ Check the official Claude/Codex guidance when making any changes:
 - <https://agents.md>
 
 # Skills
+
 Skills are meant to avoid repeated duplicate prompts.
 Read transcripts to determine the user's repeated intent.


### PR DESCRIPTION
## Summary

- remark wants a blank line after three list items in `PROMPTING.md` and `.claude/skills/spawn-quests/SKILL.md`. #3542 merged with its Check job failing on exactly this, so every open pull request now fails `just check` at the Markdown lint.
- Whitespace only; no guide content changes.

## Public API

None.

## Wire

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Claude Fable 5.1)