### PR TITLE
quest: plan the just and CI tooling cleanup

### DIFF
--- a/.claude/skills/spawn-quests/SKILL.md
+++ b/.claude/skills/spawn-quests/SKILL.md
@@ -12,6 +12,7 @@ Use the argument (if provided) to filter to specific quests/questlines.
 Report which quests are not ready to be worked on and why.
 
 For each quest, interactively prompt the user if:
+
 1. we should work on the quest.
 2. plan it further with /plan-quest.
 3. deprioritize it.

--- a/PROMPTING.md
+++ b/PROMPTING.md
@@ -4,6 +4,7 @@ Agents are not trained to write prompts for themselves.
 They're (currently) trained on the outputs, not the inputs.
 
 # Context
+
 Focus on best practices and conventions.
 Don't document the repository; the code and documentation can handle that.
 
@@ -25,5 +26,6 @@ Check the official Claude/Codex guidance when making any changes:
 - <https://agents.md>
 
 # Skills
+
 Skills are meant to avoid repeated duplicate prompts.
 Read transcripts to determine the user's repeated intent.

--- a/quest/m0/README.md
+++ b/quest/m0/README.md
@@ -28,7 +28,8 @@ regression test per Root Cause First.
 - [Group charge](/quest/m0/group-charge.md) - charge real per-group cost so MOQ_CACHE_CAPACITY bounds real memory
 - [uring all-features](/quest/m0/uring-all-features-build.md) - moq-uring does not compile with `--all-features`, so the nightly features gate fails on it
 - [Failure artifacts](/quest/m0/qa-failure-artifacts.md) - a failing harness run keeps its run directory and a Playwright trace, and CI uploads them
-- [Harness drive-bys](/quest/m0/harness-drive-bys.md) - drop the just worktree recipe and decide the relay listening kind field that came with #3509
+- [Harness drive-bys](/quest/m0/harness-drive-bys.md) - decide whether the relay listening kind field that came with #3509 stays
 - [Capture denial](/quest/m0/browser-permission-qa.md) - moq-publish swallows a refused camera or microphone and retries forever; it surfaces the denial and recovers on grant
 - [Publisher audio unlock](/quest/m0/publish-audio-unlock.md) - the publisher's capture AudioContext stays suspended when the page had no gesture, so no audio is ever encoded
 - [Impaired path](/quest/m0/transport-impairment-profile.md) - the transport drills run over a seeded, impaired UDP path on any host
+- [Tooling](/quest/m0/tooling/README.md) - justfiles become a one-line menu over `sh/`, one impact map scopes CI, and every workflow step runs a recipe

--- a/quest/m0/harness-drive-bys.md
+++ b/quest/m0/harness-drive-bys.md
@@ -1,26 +1,23 @@
-# [S] Trim what rode in with the harness isolation
+# [XS] Decide the relay listening kind field
 
 ## Goal
 
 The test harness isolation from #3509 keeps its point (private run
-directories, reserved ports, process-group teardown) and sheds the two
-things that came along without a reason to live in this repository: the
-`just worktree` recipe and, if nobody reads it, the `kind` field on the
-relay's `listening` log line.
+directories, reserved ports, process-group teardown) and sheds the one thing
+that came along without a reason to live here if nobody reads it: the `kind`
+field on the relay's `listening` log line.
 
 ## Plan
 
-- Delete the `worktree` recipe and its helpers from the root `justfile`
-  (about 265 lines: metadata-access probing, base recording, staleness
-  reports) and the section of `test/README.md` that documents it. Keep the
-  `_base` split that `_changed` shares, since `just check` scopes with it.
 - Decide whether the relay's `kind = "quic" | "http" | "https"` on the
   `listening` line and the two new web-listener lines stay. They are
   operator-visible and documented in `doc/bin/relay/config.md`; keep them
   only if the harness actually reads the bound address from them, otherwise
   revert to the single line and drop the doc.
-- `just clean` staying this-checkout-only is fine; leave it.
+- The `just worktree` recipe that rode in with the same PR is deleted by
+  [Thin justfiles](/quest/m0/tooling/justfiles.md), not here.
 
 ## Related
 
 - [Failure artifacts](/quest/m0/qa-failure-artifacts.md) - the harness run directory this trims around
+- [Thin justfiles](/quest/m0/tooling/justfiles.md) - removes the `worktree` recipe

--- a/quest/m0/tooling/README.md
+++ b/quest/m0/tooling/README.md
@@ -1,0 +1,25 @@
+# Tooling: thin justfiles and CI that calls them
+
+## Goal
+
+A month of merges left the command surface bloated: 865 lines of root
+`justfile`, seven self-tests of the tooling itself on every pull request,
+three metadata guards, recipes nothing calls, and release workflows that are
+the same file with a binary name swapped. The result is a `just` tree that is
+a menu, not a language: every recipe is one line, every script lives under
+`sh/`, the diff is resolved once by one impact map, and every workflow step
+runs a recipe rather than a script path.
+
+## Plan
+
+`just` stays as the entry point because the vocabulary (`just check`, `just
+test`, `just fix`) is in every doc, skill, and workflow. Its cost was
+self-inflicted: logic inside recipes. The quests below are ordered and each
+requires the one before it, so they land as one line of pull requests.
+
+## Quests
+
+- [Thin justfiles](/quest/m0/tooling/justfiles.md) - recipe bodies move to `sh/`, one impact map scopes check/fix/test, self-tests and guards are deleted
+- [Workflows call just](/quest/m0/tooling/workflows-call-just.md) - no workflow `run:` step names a `.sh`; every script a workflow needs has a recipe
+- [Binary release workflow](/quest/m0/tooling/release-binary.md) - moq-cli, moq-relay, and moq-token-cli share one reusable workflow behind three thin callers
+- [FFI release workflow](/quest/m0/tooling/release-ffi.md) - the five `release-*-ffi.yml` share the moq-ffi target matrix and artifact staging

--- a/quest/m0/tooling/justfiles.md
+++ b/quest/m0/tooling/justfiles.md
@@ -56,11 +56,16 @@ Delete:
   `_doc-names-test`, `_publish-test`, `sh/rs/package-nfpm.test.sh`,
   `sh/gh/package-binary.test.sh`.
 - Guards: `_doc-names` and `doc-names.jq`, `_fuzz-lock`, and the publish
-  lower-bound check. Where each incident surfaces instead: a doc-directory
-  collision fails the `cargo doc` step of the pull request that selects both
-  crates (resolve with `doc = false` as before); fuzz lockfile drift fails the
-  nightly fuzz job; a stale internal lower bound fails release-plz's publish.
-  `alert.sh check-coverage` stays: it is a lint of alert.yml, not of a recipe.
+  lower-bound check. This is a deliberate trade: the guards were three
+  incidents' worth of bash plus their self-tests on every pull request. Where
+  each surfaces instead: a doc-directory collision shows up as an intermittent
+  `failed to remove directory` in the `cargo doc` step of whichever pull
+  request selects both crates, not deterministically (resolve with `doc =
+  false` as before); a stale internal lower bound fails release-plz's publish.
+  `_fuzz-lock` is already deleted by #3543, which folds the fuzz harness into
+  the workspace so the root lockfile and `--locked` cover it; if that lands
+  first there is nothing left to remove here. `alert.sh check-coverage`
+  stays: it is a lint of alert.yml, not of a recipe.
 - The `worktree` recipe and its 170 lines, plus the Worktrees section of
   `test/README.md`. This absorbs the justfile half of
   [Harness drive-bys](/quest/m0/harness-drive-bys.md); keep `_base` folded
@@ -77,7 +82,8 @@ Rename:
 
 - Root `wasm` becomes `js wasm`: it emits `js/wasm/dist`, so it is a JS
   package build. `rs wasm` stays the compile gate and `test wasm` the browser
-  run. Update wasm.yml, root `build`, and the four doc references.
+  run. Update wasm.yml, root `build`, `test/wasm/run.sh` (which runs `just
+  wasm` to build the package under test), and the four doc references.
 
 Keep, moved into scripts unchanged in behavior: the remark mirror-and-diff in
 `sh/markdown.sh` (remark-cli has no check mode and the lint presets are

--- a/quest/m0/tooling/justfiles.md
+++ b/quest/m0/tooling/justfiles.md
@@ -1,0 +1,96 @@
+# [L] Thin justfiles with one impact map
+
+## Goal
+
+Every justfile is a menu: each recipe is a single line that runs a tool or a
+script under `sh/`, `just --list` shows each recipe once, and no recipe body
+is bash. The scoped `check`, `fix`, and `test` resolve the branch diff once,
+in one impact map, instead of a scope regex per language justfile plus a
+mirror of them in the strict-tools preflight. Nothing that tests the tooling
+itself runs on a pull request. A recipe that no workflow, doc, skill, or other
+recipe invokes is gone, except the hand-run demo and infra ops recipes, which
+stay as they are.
+
+## Plan
+
+Layout:
+
+- New root `sh/`. Root helpers sit at the top (`sh/dispatch.sh`,
+  `sh/markdown.sh`, `sh/shell.sh`, `sh/clean.sh`); per-area tooling moves
+  under `sh/<area>/`: `rs/scripts` to `sh/rs`, `.github/scripts` to `sh/gh`,
+  `go/scripts` to `sh/go`, `kt/scripts` to `sh/kt`, `swift/scripts` to
+  `sh/swift`, `dart/scripts` to `sh/dart`, and the OBS recipe bodies to
+  `sh/obs`. Workflow references to moved paths are updated mechanically here;
+  the next quest replaces them with recipes.
+- Package build scripts that nix, CMake, gradle, and the dart build hook
+  point at stay put: `rs/*/build.sh`, `rs/moq-gst/{package,scrub,smoke}.sh`,
+  `cpp/obs/build.sh`, `infra/*/publish.sh`. The harness under `test/` is
+  harness code, not tooling; it stays too.
+- `shfmt -f .` already enumerates `sh/`, so the shell lint covers everything
+  the justfiles stop containing.
+
+Dispatch:
+
+- `just check [BASE]`, `just fix [BASE]`, and `just test [BASE]` are one line
+  each: `sh/dispatch.sh check|fix|test "$BASE"`. The script resolves BASE
+  (arg, `GITHUB_BASE_REF`, upstream, `origin/main`), lists changed files into
+  a temp file, and applies one impact map: which language modules run, which
+  tools `MOQ_STRICT` demands, and whether the root orchestration changed and
+  everything runs. The map lives in one place; the `scope` variables in the
+  js, py, kt, swift, go, and dart justfiles and the regex table in `_tools`
+  are deleted with it.
+- Per-language `check`, `fix`, and `test` lose their `$FILES` parameter and
+  skip logic. Only rs still receives the list: `just rs check-changed
+  <listfile>` (and `fix-changed`, `test-changed`) hand the path to
+  `sh/rs/select.sh`, which does the crate selection today spread over
+  `_select`, `_names`, and `_wants-wasm`.
+- Passing a path instead of the list kills the argv budget:
+  `changed_max`, `_changed-cap`, `_changed-test`, `_echo`, and the E2BIG
+  commentary go.
+- `check-all`, `fix-all`, and `test all` keep their names; cache.yml,
+  nightly.yml, and the docs call them.
+
+Delete:
+
+- Self-tests: `_changed-test`, `_markdown-test`, `_select-test`,
+  `_doc-names-test`, `_publish-test`, `sh/rs/package-nfpm.test.sh`,
+  `sh/gh/package-binary.test.sh`.
+- Guards: `_doc-names` and `doc-names.jq`, `_fuzz-lock`, and the publish
+  lower-bound check. Where each incident surfaces instead: a doc-directory
+  collision fails the `cargo doc` step of the pull request that selects both
+  crates (resolve with `doc = false` as before); fuzz lockfile drift fails the
+  nightly fuzz job; a stale internal lower bound fails release-plz's publish.
+  `alert.sh check-coverage` stays: it is a lint of alert.yml, not of a recipe.
+- The `worktree` recipe and its 170 lines, plus the Worktrees section of
+  `test/README.md`. This absorbs the justfile half of
+  [Harness drive-bys](/quest/m0/harness-drive-bys.md); keep `_base` folded
+  into `sh/dispatch.sh`.
+- `rs bump` and `rs semver`. `rs release` stays for release-rs.yml.
+- The `mod` lines in `demo/justfile`: `just pub`, `just relay`, `just boy`,
+  `just sub`, `just web` are the only spelling, and `--list` stops showing
+  each twice. `just demo` remains the default recipe and `just dev` its
+  documented alias.
+- `_rust_cargo`/`cargo_compile`, declared three times. Recipe lines read
+  `${RUST_CARGO:-cargo}` directly.
+
+Rename:
+
+- Root `wasm` becomes `js wasm`: it emits `js/wasm/dist`, so it is a JS
+  package build. `rs wasm` stays the compile gate and `test wasm` the browser
+  run. Update wasm.yml, root `build`, and the four doc references.
+
+Keep, moved into scripts unchanged in behavior: the remark mirror-and-diff in
+`sh/markdown.sh` (remark-cli has no check mode and the lint presets are
+wanted), `_shell`, `_flake` as its one-liner, `clean`, the rs `package` and
+`fuzz` bodies, and the OBS `compile`, `_includes`, `_unit`, `test`, `check`,
+and `preset` bodies.
+
+Docs: `doc/setup/dev.md`, `CONTRIBUTING.md`, `test/README.md`, and the
+`CLAUDE.md` mentions of `just wasm` follow the survivors. Verify with `just
+check`, `just test`, and `just check-all`, and confirm every recipe name
+check.yml, cache.yml, nightly.yml, smoke.yml, wasm.yml, obs.yml, swift.yml,
+and release-*.yml invoke still resolves.
+
+## Related
+
+- [Harness drive-bys](/quest/m0/harness-drive-bys.md) - the relay `kind` field decision that stays behind once the `worktree` recipe is deleted here

--- a/quest/m0/tooling/release-binary.md
+++ b/quest/m0/tooling/release-binary.md
@@ -1,0 +1,32 @@
+# [M] One reusable workflow for the binary releases
+
+## Goal
+
+`moq-cli.yml`, `moq-relay.yml`, and `moq-token-cli.yml` are three copies of
+the same 224-line workflow with the binary name swapped. They become one
+reusable `release-binary.yml` taking `crate` and `bin` inputs, and three
+callers of a dozen lines each that keep their tag trigger and workflow name,
+so `alert.yml`, `release-brew.yml`, and `release-winget.yml` keep matching on
+the names they match today.
+
+## Plan
+
+- `release-binary.yml` on `workflow_call` with inputs `crate` (the cargo
+  package) and `bin` (the executable name; `moq-cli` ships `moq`,
+  `moq-token-cli` ships `moq-token`). It holds the Linux native-runner matrix,
+  the macOS tarball job, the Windows job, the `.deb` and `.rpm` packaging, the
+  release creation, and the repo-publish trigger, all as `just` recipes per
+  the preceding quest.
+- Each caller keeps `name:` and `on.push.tags` exactly as they are and does
+  nothing but `uses: ./.github/workflows/release-binary.yml` with the two
+  inputs and the secrets it forwards. `workflow_run` consumers trigger off
+  the caller's name, so nothing downstream changes.
+- The one text difference between the three today (a comment and a step name
+  about the glibc floor) belongs in the reusable file.
+- Verify with `just gh check` and by diffing the rendered job list of each
+  caller against its predecessor with `gh workflow view`. The next tagged
+  release is the end-to-end check; say so in the PR.
+
+## Required
+
+- [Workflows call just](/quest/m0/tooling/workflows-call-just.md) - the reusable workflow is written in the recipe style from the start

--- a/quest/m0/tooling/release-ffi.md
+++ b/quest/m0/tooling/release-ffi.md
@@ -1,0 +1,30 @@
+# [M] One reusable workflow for the moq-ffi releases
+
+## Goal
+
+`release-dart-ffi.yml`, `release-go-ffi.yml`, `release-kt-ffi.yml`,
+`release-swift-ffi.yml`, and `release-py-ffi.yml` share half to two thirds of
+their lines: the moq-ffi cross-target build matrix and the artifact staging.
+That shared half becomes one reusable `release-ffi.yml`; each language keeps
+only its packaging and publish steps.
+
+## Plan
+
+- Measure the shared lines first (`comm` over the sorted files shows 74 to
+  176 common lines per pair) and confirm the matrix targets agree. Where a
+  language needs a different target set (iOS simulator for swift, Android
+  ABIs for kt and dart), make the target list an input rather than forcing
+  one matrix.
+- `release-ffi.yml` on `workflow_call`: builds `rs/moq-ffi` for the requested
+  targets, uploads one artifact per target, and outputs the version parsed
+  from the tag. Callers download the artifacts and run their `just <lang>
+  package` and publish recipes.
+- Callers keep their `name:` and triggers, as the binary quest did, so
+  `alert.yml` and the `workflow_run` chains (`release-go.yml`,
+  `release-py.yml`, `release-swift-lib.yml`) are untouched.
+- Verify with `just gh check`; the next tagged `moq-ffi-v*` release is the
+  end-to-end check.
+
+## Required
+
+- [Binary release workflow](/quest/m0/tooling/release-binary.md) - proves the reusable-plus-callers pattern before it is applied to five files

--- a/quest/m0/tooling/release-ffi.md
+++ b/quest/m0/tooling/release-ffi.md
@@ -19,6 +19,11 @@ only its packaging and publish steps.
   targets, uploads one artifact per target, and outputs the version parsed
   from the tag. Callers download the artifacts and run their `just <lang>
   package` and publish recipes.
+- `release-dart-ffi.yml` and `release-go-ffi.yml` also run on `pull_request`,
+  where `GITHUB_REF` is not a `moq-ffi-v*` tag and `parse-version` fails; they
+  read the version from `rs/moq-ffi/Cargo.toml` instead. The reusable
+  workflow keeps that fallback (an input or a ref check), or those PR runs die
+  before building.
 - Callers keep their `name:` and triggers, as the binary quest did, so
   `alert.yml` and the `workflow_run` chains (`release-go.yml`,
   `release-py.yml`, `release-swift-lib.yml`) are untouched.

--- a/quest/m0/tooling/workflows-call-just.md
+++ b/quest/m0/tooling/workflows-call-just.md
@@ -1,0 +1,45 @@
+# [M] Every workflow step runs a recipe
+
+## Goal
+
+No `run:` line in `.github/workflows` names a `.sh` file. Every script a
+workflow needs has a `just` recipe, so the menu is the whole command surface
+and a script can move or change its arguments without touching twenty
+workflows. The same recipes work locally for a dry run.
+
+## Plan
+
+Today the workflows call scripts directly at roughly ninety sites:
+`sh/gh/release.sh` (54 calls as a helper library: `parse-version`,
+`prev-tag`, `create`, registry existence checks), `sh/rs/package-nfpm.sh`,
+`sh/rs/package-binary.sh`, `sh/rs/package-windows.sh`,
+`sh/gh/trigger-repo-publish.sh`, `sh/gh/render-formula.sh`, `sh/gh/alert.sh`,
+the swift `package`, `package-ffi`, `publish`, `publish-ffi`, `verify`,
+`verify-ffi`, and `check` scripts, the go `package-ffi`, `package-wrapper`,
+`publish-ffi`, `publish-wrapper` scripts, `sh/dart/package.sh`,
+`sh/kt/package.sh`, and `infra/*/publish.sh`.
+
+- Add pass-through recipes where none exist, named by role under the area
+  module: `just gh release <subcommand> ...`, `just gh alert ...`,
+  `just gh formula ...`, `just gh trigger-repo-publish ...`,
+  `just rs package-binary ...`, `just rs package-nfpm ...`,
+  `just rs package-windows ...`, `just swift publish|verify|package-ffi|...`,
+  `just go publish-ffi|publish-wrapper`, `just dart package`,
+  `just infra apt publish` and `just infra rpm publish` (the recipes exist).
+  Existing wrappers (`kt package`, `swift package`, `go package-ffi`,
+  `go package-wrapper`, `py package`) are used as they are.
+- Rewrite every `run:` step to the recipe. Where a workflow runs outside the
+  nix dev shell (Windows and macOS runners, AlmaLinux containers), `just` is
+  already installed or installable the way nightly.yml does it; keep that
+  pattern rather than falling back to a path.
+- Record the rule in the CI section of `CONTRIBUTING.md` in one line, and
+  have `just gh check` enforce it: fail on any workflow `run:` line matching
+  `\.sh\b`.
+- Verify with `actionlint` via `just gh check`, and with a manual
+  `workflow_dispatch` of apt-repo.yml, rpm-repo.yml, and release-winget.yml
+  where the inputs allow a dry run. The tag-triggered release workflows are
+  verified by the next release; say so in the PR.
+
+## Required
+
+- [Thin justfiles](/quest/m0/tooling/justfiles.md) - establishes `sh/` and the module recipes the workflows will call


### PR DESCRIPTION
## Summary

Plans the cleanup of the `just` recipes and CI scripts that accreted over the last month, as a `quest/m0/tooling/` questline of four ordered quests. Decisions came out of a `/plan-quests` interview:

- **`just` stays, as a menu only.** Every recipe becomes one line calling a tool or a script under a new root `sh/` (`sh/rs`, `sh/gh`, `sh/kt`, ...), so no bash lives in a justfile and no recipe tests another recipe. Package build scripts wired into nix, CMake, gradle, and the dart hook stay where they are.
- **One impact map.** `check`, `fix`, and `test` resolve the diff once in `sh/dispatch.sh`; the per-language `scope` regexes, the `MOQ_STRICT` tool table, and the argv-size guard (`_changed-cap`, `_changed-test`, `_echo`) go. Only `rs` still receives a file list, as a path.
- **Deleted:** the 7 tooling self-tests, the 3 metadata guards (`_doc-names`, `_fuzz-lock`, `_publish-test`; their incidents surface in `cargo doc`, the nightly fuzz job, and release-plz instead), `worktree`, `rs bump`, `rs semver`, the duplicated `cargo_compile`, and the `demo::` re-declaration of the demo mods. Root `wasm` is renamed `js wasm`. Hand-run demo and infra ops recipes stay.
- **Workflows call recipes.** No `run:` step names a `.sh`; `just gh check` enforces it. Then `moq-cli`/`moq-relay`/`moq-token-cli.yml` collapse into one reusable workflow with three thin callers, and the five `release-*-ffi.yml` follow.
- `harness-drive-bys.md` shrinks to the relay `kind` decision; its `worktree` deletion moves into the justfiles quest.

Depends on #3544 for a green `just check` (main's Markdown lint is red since #3542); this branch is based on that commit.

## Public API

None.

## Wire

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Claude Fable 5.1)
