### PR TITLE
chore(quest): add frame slot charge

### DIFF
--- a/quest/m0/README.md
+++ b/quest/m0/README.md
@@ -24,6 +24,7 @@ regression test per Root Cause First.
 - [Connect auth race](/quest/m0/3532-connect-auth-race.md) - moq-native: a 403 on the WebSocket arm no longer fails a connect whose QUIC arm is still in flight; moq-ffi can disable the fallback
 - [Resume info](/quest/m0/resume-info-newest.md) - moq-net: resume reports segment zero's track info, so a replaced broadcast rescales timestamps on the predecessor's timescale
 - [TS restart stall](/quest/m0/3533-ts-export-restart-stall.md) - moq export ts: a content restart on a continuous timeline no longer fences video and primary audio for good
+- [Frame slot charge](/quest/m0/frame-slot-charge.md) - moq-net: a group's frame slots count against the cache budget, including the capacity it keeps after eviction
 - [uring all-features](/quest/m0/uring-all-features-build.md) - moq-uring does not compile with `--all-features`, so the nightly features gate fails on it
 - [Failure artifacts](/quest/m0/qa-failure-artifacts.md) - a failing harness run keeps its run directory and a Playwright trace, and CI uploads them
 - [Harness drive-bys](/quest/m0/harness-drive-bys.md) - decide whether the relay listening kind field that came with #3509 stays

--- a/quest/m0/frame-slot-charge.md
+++ b/quest/m0/frame-slot-charge.md
@@ -1,0 +1,53 @@
+# [S] Frame slots are cached for free
+
+## Goal
+
+A group's frame slots are charged against `MOQ_CACHE_CAPACITY`, so a track
+producing many small frames per group is billed for what it holds. The fixed
+per-group overhead already covers the first few slots; this is the growth past
+them, and the capacity a group keeps after eviction.
+
+## Plan
+
+`GroupState::cache` counts frame payload bytes and nothing else. The frames
+themselves live in a `VecDeque<Frame>` whose slots are 48 B each, and two
+things follow:
+
+- The deque grows geometrically as frames are appended. Every slot past the
+  fixed per-group allowance is 48 B the pool never sees.
+- `evict` pops from the front and subtracts only `frame.payload.len()`. A
+  `VecDeque` never shrinks its capacity, so a group that once held 64 frames
+  keeps 3 KB of slots after every payload is gone, charged as zero.
+
+It only bites where many small frames share one group: 50 frames of 200 B
+undercharges by about 30%. Video is unaffected, since a group carrying
+kilobyte frames is dominated by payload.
+
+The fix is not a bigger constant. `cache` has to start counting the deque's
+capacity, which means charging the delta at each of the four `charge.add`
+sites in `rs/moq-net/src/model/group.rs` (`write_frame`, the `write_frames`
+loop, the partial commit, and `frame_commit`), and keeping `evict` and
+`release` consistent with capacity rather than payload.
+
+Decide what `MAX_CACHE_BYTES` compares against before touching any of it.
+Today it is a payload limit and the tests read it that way, so folding slots
+into `cache` silently changes the per-group ceiling and the point at which a
+group starts evicting itself. Either keep a separate payload counter for that
+comparison or restate the limit; do not let one field mean both.
+
+`rs/moq-net/tests/group_charge.rs` weighs the process with a counting
+allocator and is the place to prove it: add a many-small-frames shape beside
+the existing one-frame-per-group case, and a unit test that crosses a deque
+growth boundary and asserts the pool charge moved.
+
+### How it was found
+
+CodeRabbit raised it on
+[#3523](https://github.com/moq-dev/moq/pull/3523), which fixed the
+one-frame-per-group undercount that was OOM-killing relays serving chat. The
+finding was correct and deliberately left out of that PR: it is a different
+shape, and it changes what `cache` means.
+
+## Related
+
+- [Relay memory](/quest/m2/relay-memory.md) - the per-announcement half of the same question, whose figures also predate the current accounting

--- a/quest/m2/relay-memory.md
+++ b/quest/m2/relay-memory.md
@@ -36,4 +36,5 @@ degree and adds a second, more specific route per carried broadcast.
 ## Related
 
 - [Routes per broadcast gauge](/quest/m2/route-gauge.md) - the operator-facing count, shippable on its own
+- [Frame slot charge](/quest/m0/frame-slot-charge.md) - the group-cache half: frame slots are held but not billed
 - [Perf](/quest/m1/perf/README.md) - the hot-path work that owns the remaining per-cell cost


### PR DESCRIPTION
## Summary

Adds `quest/m0/frame-slot-charge.md`, the follow-up CodeRabbit raised on [#3523](https://github.com/moq-dev/moq/pull/3523).

`GroupState::cache` counts frame payload bytes only. The frames live in a `VecDeque<Frame>` with 48 B slots, so two costs go unbilled:

- the deque grows geometrically, and every slot past the fixed per-group allowance is invisible to the pool
- `evict` pops from the front subtracting only the payload, and a `VecDeque` never shrinks, so a group that once held 64 frames keeps 3 KB of slots charged as zero

Only bites where many small frames share one group: 50 frames of 200 B undercharges by about 30%. Video is unaffected.

It was left out of #3523 on purpose. That PR fixed the one-frame-per-group shape that was OOM-killing relays; this one is a different shape and, more importantly, folding slots into `cache` changes what `MAX_CACHE_BYTES` compares against. The quest calls that out as the decision to make first rather than a detail to discover mid-change.

Filed at m0 below the uring build break. Also linked from `quest/m2/relay-memory.md`, which owns the per-announcement half of the same accounting question.

## Public API

None.

## Wire

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)