### PR TITLE
ci: cut the Release RS job from ~55 minutes

### DIFF
--- a/.github/workflows/release-rs.yml
+++ b/.github/workflows/release-rs.yml
@@ -18,6 +18,7 @@ on:
     # or its API shouldn't queue one.
     paths:
       - "rs/**"
+      - "justfile"
       - "Cargo.toml"
       - "Cargo.lock"
       - "rust-toolchain.toml"

--- a/.github/workflows/release-rs.yml
+++ b/.github/workflows/release-rs.yml
@@ -13,6 +13,20 @@ on:
   push:
     branches:
       - main
+    # A run costs the better part of an hour and they serialize on the
+    # concurrency group above, so a push that can't change a crate's version
+    # or its API shouldn't queue one.
+    paths:
+      - "rs/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - "flake.nix"
+      - "flake.lock"
+      - ".release-plz.toml"
+      - ".github/workflows/release-rs.yml"
+  # Releasing by hand, e.g. after a skipped push or a cold cache.
+  workflow_dispatch:
 
 jobs:
   release:
@@ -20,6 +34,14 @@ jobs:
 
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'moq-dev' }}
+
+    env:
+      # release-plz copies each crate into its own temp directory to compare it
+      # against the registry, so cargo-semver-checks would otherwise build
+      # rustdoc for every crate, baseline and current, into a throwaway target
+      # directory. Pin one absolute path instead so the ~30 crates share their
+      # dependency builds and the cache below can carry them between runs.
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target
 
     steps:
       - name: Free disk space
@@ -46,6 +68,27 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
         with:
           determinate: false
+          # Trust the flake's cachix substituter. `nixConfig` in flake.nix is
+          # untrusted by default, so nix logs "ignoring untrusted flake
+          # configuration setting 'extra-substituters'" and rebuilds from
+          # source anything missing from the public nixpkgs cache. Entering
+          # the dev shell costs ~12 minutes of uniffi-bindgen-go without it.
+          extra-conf: |
+            extra-substituters = https://kixelated.cachix.org
+            extra-trusted-public-keys = kixelated.cachix.org-1:CmFcV0lyM6KuVM2m9mih0q4SrAa0XyCsiM7GHrz3KKk=
+
+      # Its own key rather than the shared one from .github/actions/rust-cache:
+      # this holds cargo-semver-checks rustdoc, not the check and test artifacts
+      # cache.yml warms, and this workflow only runs on `main` so it is the sole
+      # writer of the key.
+      - name: Rust cache
+        uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        with:
+          # Build scripts link against Nix store paths from the dev shell. Roll
+          # the cache when that shell changes so Cargo never restores executables
+          # whose dynamic linker has disappeared.
+          shared-key: release-rs-${{ hashFiles('flake.nix', 'flake.lock') }}
+          cache-on-failure: true
 
       - name: Release
         run: nix develop --command just rs release


### PR DESCRIPTION
## Problem

[Run 34285318378](https://github.com/moq-dev/moq/actions/runs/34285318378) is typical: the `Plz` job took 56 minutes, and runs serialize on the `release-rs` concurrency group, so pushes to `main` stack up behind each other. Log timings for the `Release` step:

| Phase | Time |
|---|---|
| nix builds `uniffi-bindgen-go` from source | ~12 min |
| release-plz packaging/diff for 30 crates | ~2 min |
| `cargo semver-checks` | **~40 min** |
| `release-plz release` (the actual publish) | 2 sec |

All of the cost is in `release-plz release-pr`. Everything was already published.

## Changes

**Trust the cachix substituter.** [cache.yml](.github/workflows/cache.yml) and [smoke.yml](.github/workflows/smoke.yml) already pass `extra-conf` for this, with a comment noting `uniffi-bindgen-go` alone was costing 678s in every job that enters the dev shell. `release-rs.yml` never got the fix. Saves ~12 min.

**Pin `CARGO_TARGET_DIR`.** release-plz copies each crate into its own temp directory to diff it against the registry, so cargo-semver-checks builds rustdoc for ~30 crates, baseline and current, into a throwaway target directory every time. One absolute path lets those builds share dependencies, and a `Swatinem/rust-cache` entry carries them between runs. This gets its own `shared-key` rather than reusing `.github/actions/rust-cache`: the contents are semver-checks rustdoc, not the check/test artifacts cache.yml warms, and cache.yml is documented as the single writer of that key. This workflow only runs on `main`, so it is the sole writer of its own.

**Add a `paths` filter**, mirroring cache.yml. A push that can't change a crate's version or API no longer queues an hour-long job ahead of one that can. `workflow_dispatch` is there as the manual escape hatch. A release-PR merge touches `rs/**` and `Cargo.lock`, so the follow-up publish still fires.

`semver_check` stays on: release-plz uses it to pick patch vs minor, and nothing else in CI runs `cargo semver-checks`.

## Public API and wire impact

None. CI configuration only.

## Verification

`just check` passes, including `actionlint`. The caching win can't be measured before merge, since the workflow only runs on push to `main`; the first run after this lands will be cold and should show the shape of it on the second.

Two notes for review:
- The new cache is a third entry against the repository's 10 GB budget, alongside cache.yml's arm and x64 entries. If it crowds them out, `cache-targets: false` would keep the registry half and drop the expensive half.
- If the semver-checks win turns out smaller than hoped, the remaining lever is `semver_check = false` in `.release-plz.toml`, which trades the breaking-change detection for the whole 40 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by claude-opus-5)