### PR TITLE
chore: bump the JavaScript package versions

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -101,7 +101,7 @@
     },
     "js/hang": {
       "name": "@moq/hang",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@kixelated/libavjs-webcodecs-polyfill": "^0.5.5",
         "@libav.js/variant-opus-af": "^6.10.9",
@@ -155,7 +155,7 @@
     },
     "js/moq-boy": {
       "name": "@moq/boy",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@moq/json": "workspace:^",
         "@moq/net": "workspace:^",
@@ -176,7 +176,7 @@
     },
     "js/msf": {
       "name": "@moq/msf",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@moq/net": "workspace:^",
         "@zod/mini": "^4.5.4",
@@ -189,7 +189,7 @@
     },
     "js/net": {
       "name": "@moq/net",
-      "version": "0.3.4",
+      "version": "0.3.5",
       "dependencies": {
         "@moq/qmux": "^0.3.3",
         "@moq/signals": "workspace:*",
@@ -211,7 +211,7 @@
     },
     "js/publish": {
       "name": "@moq/publish",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/json": "workspace:^",
@@ -252,7 +252,7 @@
     },
     "js/token": {
       "name": "@moq/token",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "bin": {
         "moq-token": "./src/cli.ts",
       },
@@ -276,7 +276,7 @@
     },
     "js/watch": {
       "name": "@moq/watch",
-      "version": "0.5.3",
+      "version": "0.5.4",
       "dependencies": {
         "@moq/hang": "workspace:^",
         "@moq/json": "workspace:^",

--- a/js/hang/package.json
+++ b/js/hang/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/hang",
 	"type": "module",
-	"version": "0.4.2",
+	"version": "0.4.3",
 	"description": "WebCodecs-based media format for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/moq-boy/package.json
+++ b/js/moq-boy/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/boy",
 	"type": "module",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"jsr": false,
 	"description": "MoQ Boy - Crowd-controlled Game Boy streaming via MoQ",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/msf/package.json
+++ b/js/msf/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/msf",
 	"type": "module",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"description": "MSF (MOQT Streaming Format) catalog types for MoQ",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/net/package.json
+++ b/js/net/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/net",
 	"type": "module",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"description": "The networking layer for Media over QUIC: real-time pub/sub with built-in caching, fan-out, and prioritization.",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/publish/package.json
+++ b/js/publish/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/publish",
 	"type": "module",
-	"version": "0.4.6",
+	"version": "0.4.7",
 	"jsr": false,
 	"description": "Publish Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",

--- a/js/token/package.json
+++ b/js/token/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/token",
 	"type": "module",
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"description": "Media over QUIC - Token Generation and Validation",
 	"license": "(MIT OR Apache-2.0)",
 	"repository": "github:moq-dev/moq",

--- a/js/watch/package.json
+++ b/js/watch/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "@moq/watch",
 	"type": "module",
-	"version": "0.5.3",
+	"version": "0.5.4",
 	"jsr": false,
 	"description": "Watch Media over QUIC broadcasts",
 	"license": "(MIT OR Apache-2.0)",


### PR DESCRIPTION
## Summary

Seven `@moq/*` packages have shipped changes since their last npm release. Every published version on `main` matched npm exactly beforehand, so the last bump commit was also the last release for each; these are the patch bumps that release them.

- `@moq/net` 0.3.4 → 0.3.5
- `@moq/hang` 0.4.2 → 0.4.3
- `@moq/watch` 0.5.3 → 0.5.4
- `@moq/publish` 0.4.6 → 0.4.7
- `@moq/token` 0.3.2 → 0.3.3
- `@moq/msf` 0.2.1 → 0.2.2
- `@moq/boy` 0.3.0 → 0.3.1

All patch: pre-1.0, and every change is a fix, a behavioural improvement, or additive.

Left alone, with the reason:

- **Rust crates** — `.release-plz.toml` owns crate versions and their dependency requirements.
- **`@moq/flate`, `@moq/json`, `@moq/signals`** — zero diff since their last release.
- **`@moq/loc`** — a `@types/bun` devDependency bump only, nothing shipped.
- **`swift/VERSION` (0.4.6), `kt/gradle.properties` (0.4.5), `py/moq-rs` (0.4.7)** — no changes in those trees since their version files last moved. Maven is at 0.4.5 and PyPI at 0.4.6, so `moq-rs` 0.4.7 is a release already pending rather than a bump owed.
- **`go/wrapper/VERSION` (0.5)** — the wrapper did change, but a diff of every exported Go symbol against the last release is purely additive (`VideoProducer`, `MediaGroupConsumer`, `PublishVideo`, the encoder constructors, new error values) with no removals or renames. CI derives the patch, so the hand-owned `MAJOR.MINOR` stays put.
- **`@moq/clock`, `@moq/wasm`** — private, no `release` script.

## What each bump releases

| Package | Change requiring it |
|---|---|
| `@moq/net` | `latencyMax` is ceil'd and refuses a negative or non-finite value; console output gated behind `dev()` with URLs redacted; pending track requests tracked so a close rejects them; `accept()` after close no longer resurrects a closed producer; `Reader` drops a redundant copy |
| `@moq/hang` | Container consumer rewind/reset fixes: a retained `group.start`, the live edge rather than the cursor as the rewind bound, and a cursor advance when the active group is dropped as stale |
| `@moq/watch` | New `audio/config` module (playback identity, codec jitter defaults), plus decoder and shared-ring-buffer changes; adds a `@moq/json` dependency |
| `@moq/publish` | The audio encoder survives track swaps, a fatal encoder error propagates to the current and every later subscriber, and a demand gate skips chunks with no subscriber; adds a `@moq/json` dependency |
| `@moq/token` | Adds a `@zod/mini` dependency and moves to `jose` ^6.2.10 |
| `@moq/msf` | Moves off the `zod/mini` subpath to the `@zod/mini` package, a newly declared dependency |
| `@moq/boy` | `tsconfig.build.json` keeps tests out of `dist/`; same `@zod/mini` dependency |

## Public API

No exported item is added, renamed, or removed by this PR: it only edits `version` fields in seven manifests and their matching `bun.lock` workspace entries.

One behaviour change worth noting, in the code being released rather than in this diff: `@moq/net`'s `infoDefaults` and `subscriptionDefaults` now throw `RangeError` on a negative or non-finite `latencyMax` where they previously passed the value through. That is tightening validation on input which was already invalid, so it stays a patch.

## Wire

None.

## Verification

`just js check` passes. The build's `workspace:^` rewriting resolves to the new numbers (`@moq/net → ^0.3.5`, `@moq/watch → ^0.5.4`), and `bun install` leaves the lockfile unchanged afterwards. No documented version coordinates exist under `doc/`, `demo/`, or the READMEs, so nothing else needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(Written by Claude Opus 5)

