### PR TITLE
ci: route the Rust cache through mr boxington

### DIFF
--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -9,32 +9,35 @@ inputs:
 runs:
   using: composite
   steps:
-    # The toolchain keys the cache, so reading rust-toolchain.toml keeps it tied
-    # to the one thing that decides which rustc actually runs. The action's own
-    # probe reads `rustc` off PATH, which at this point in the job is whatever
-    # the runner image ships, not the dev shell's pinned compiler.
-    - name: Read toolchain
-      id: toolchain
-      shell: bash
-      run: |
-        channel=$(grep -m1 '^channel' rust-toolchain.toml | sed 's/.*"\(.*\)".*/\1/')
-        if [ -z "$channel" ]; then
-          echo "could not read channel from rust-toolchain.toml" >&2
-          exit 1
-        fi
-        echo "channel=$channel" >> "$GITHUB_OUTPUT"
-
     - uses: jdx/mr-boxington-action@7234d3dd1a6ca8f6c381eea8e4dfb03f18fcf777 # v1.3.0
       with:
         version: 1.10.0
-        toolchain: ${{ steps.toolchain.outputs.channel }}
-        # Build scripts link against Nix store paths from the dev shell. Roll the
-        # cache when that shell changes so Cargo never restores executables whose
-        # dynamic linker has disappeared.
-        cache-generation: nix-${{ hashFiles('flake.nix', 'flake.lock') }}
-        save-on-workflow-dispatch: ${{ inputs.save-on-dispatch }}
         # `github-cache-mode` is left at its `target` default. That transports
         # Cargo's pruned target tree, the same payload Swatinem carried, with
         # mbx's per-compilation store on top. The `objects` closure is portable
         # across differing target directories, which nothing here needs, and
         # measured slower.
+        #
+        # The key is spelled out because the generated one cannot name this
+        # repository's compiler. It keys on `rustc -vV` from PATH, which here is
+        # whatever the runner image ships: the compiler these jobs build with
+        # exists only inside `nix develop`. The `toolchain` input is no help
+        # either, since it names a rustup toolchain and probes
+        # `rustc +<name> -vV`, and nothing installs 1.95.0 through rustup.
+        #
+        # flake.lock pins that compiler, so hashing the flake identifies it more
+        # precisely than `rustc -vV` would, and rolls the cache when the dev
+        # shell changes. Build scripts link against Nix store paths, so a
+        # restored executable whose dynamic linker moved is worse than a cold
+        # cache. rust-toolchain.toml is in the hash because it picks the channel,
+        # even though it is kept in sync with the flake.
+        #
+        # Every segment the generated layout carries has to be carried here too:
+        # the runner pair, so the two architectures cache.yml warms cannot read
+        # each other, and `target`, so changing `github-cache-mode` cannot
+        # restore the other payload. The trailing run id rolls the key on every
+        # run, which is what lets a repeated `workflow_dispatch` seed a cold
+        # cache against GitHub's immutable entries.
+        cache-key: ${{ runner.os }}-${{ runner.arch }}-mbx-target-${{ hashFiles('flake.nix', 'flake.lock', 'rust-toolchain.toml') }}-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: ${{ runner.os }}-${{ runner.arch }}-mbx-target-${{ hashFiles('flake.nix', 'flake.lock', 'rust-toolchain.toml') }}-
+        save-on-workflow-dispatch: ${{ inputs.save-on-dispatch }}

--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -1,5 +1,5 @@
 name: Rust cache
-description: Restore the Cargo build cache cache.yml warms on the default branch.
+description: Install mbx and restore the Rust build cache cache.yml warms on the default branch.
 
 inputs:
   save-on-dispatch:
@@ -9,14 +9,32 @@ inputs:
 runs:
   using: composite
   steps:
-    # One shared key lets differently named jobs restore the cache warmed by
-    # cache.yml. Pull requests stay read-only, while a trusted manual run can
-    # explicitly seed a cold cache.
-    - uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+    # The toolchain keys the cache, so reading rust-toolchain.toml keeps it tied
+    # to the one thing that decides which rustc actually runs. The action's own
+    # probe reads `rustc` off PATH, which at this point in the job is whatever
+    # the runner image ships, not the dev shell's pinned compiler.
+    - name: Read toolchain
+      id: toolchain
+      shell: bash
+      run: |
+        channel=$(grep -m1 '^channel' rust-toolchain.toml | sed 's/.*"\(.*\)".*/\1/')
+        if [ -z "$channel" ]; then
+          echo "could not read channel from rust-toolchain.toml" >&2
+          exit 1
+        fi
+        echo "channel=$channel" >> "$GITHUB_OUTPUT"
+
+    - uses: jdx/mr-boxington-action@7234d3dd1a6ca8f6c381eea8e4dfb03f18fcf777 # v1.3.0
       with:
-        # Build scripts link against Nix store paths from the dev shell. Roll
-        # the cache when that shell changes so Cargo never restores executables
-        # whose dynamic linker has disappeared.
-        shared-key: rust-${{ hashFiles('flake.nix', 'flake.lock') }}
-        cache-on-failure: true
-        save-if: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.save-on-dispatch == 'true') }}
+        version: 1.10.0
+        toolchain: ${{ steps.toolchain.outputs.channel }}
+        # Build scripts link against Nix store paths from the dev shell. Roll the
+        # cache when that shell changes so Cargo never restores executables whose
+        # dynamic linker has disappeared.
+        cache-generation: nix-${{ hashFiles('flake.nix', 'flake.lock') }}
+        save-on-workflow-dispatch: ${{ inputs.save-on-dispatch }}
+        # `github-cache-mode` is left at its `target` default. That transports
+        # Cargo's pruned target tree, the same payload Swatinem carried, with
+        # mbx's per-compilation store on top. The `objects` closure is portable
+        # across differing target directories, which nothing here needs, and
+        # measured slower.

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -5,9 +5,8 @@ name: Cache
 #
 # Actions scopes cache reads to the current branch plus the default branch, so
 # only caches written here on `main` are reachable from a pull request. This
-# workflow is therefore the single trusted writer, with one cache per runner
-# architecture. Pull requests restore it without publishing private entries
-# that fill the repository's 10 GB budget.
+# workflow is therefore the single trusted writer. The action keys the store by
+# runner architecture and toolchain, and refuses to publish from a pull request.
 #
 # This runs the unscoped suite rather than the diff-scoped one: the point is to
 # leave artifacts for whatever a future PR happens to touch, not to check `main`
@@ -28,8 +27,9 @@ on:
       - "flake.nix"
       - "flake.lock"
       - ".github/workflows/cache.yml"
-      # The shared cache implementation lives here. Re-warm immediately when it
-      # changes instead of waiting for the next Rust change to land.
+      # The action pin and the toolchain read both live here, and either can
+      # roll the cache key. Without this the sole writer would not re-run after
+      # such a change, leaving every PR reader cold until something else landed.
       - ".github/actions/rust-cache/**"
   # Priming a cold cache by hand, e.g. after a toolchain bump rolls the key.
   workflow_dispatch:
@@ -92,8 +92,9 @@ jobs:
           nix develop --profile /tmp/devshell --command true
           cachix push kixelated /tmp/devshell
 
-      # The single writer. `save-on-dispatch` lets the `workflow_dispatch` above
-      # prime a cold cache; pull request jobs are restore-only.
+      # The single writer. `save-on-dispatch` is what lets the
+      # `workflow_dispatch` above prime a cold store; the action otherwise saves
+      # only on pushes to the default branch.
       - name: Rust cache
         uses: ./.github/actions/rust-cache
         with:
@@ -105,11 +106,13 @@ jobs:
       - name: Check
         run: nix develop --command just check-all
         env:
+          RUST_CARGO: mbx
           MOQ_STRICT: 1
 
       - name: Test
         if: ${{ !cancelled() }}
         run: nix develop --command just test all
         env:
+          RUST_CARGO: mbx
           MOQ_STRICT: 1
           NEXTEST_PROFILE: ci

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -5,8 +5,8 @@ name: Cache
 #
 # Actions scopes cache reads to the current branch plus the default branch, so
 # only caches written here on `main` are reachable from a pull request. This
-# workflow is therefore the single trusted writer. The action keys the store by
-# runner architecture and toolchain, and refuses to publish from a pull request.
+# workflow is therefore the single trusted writer, with one store per runner
+# architecture. The action refuses to publish from a pull request regardless.
 #
 # This runs the unscoped suite rather than the diff-scoped one: the point is to
 # leave artifacts for whatever a future PR happens to touch, not to check `main`
@@ -27,9 +27,9 @@ on:
       - "flake.nix"
       - "flake.lock"
       - ".github/workflows/cache.yml"
-      # The action pin and the toolchain read both live here, and either can
-      # roll the cache key. Without this the sole writer would not re-run after
-      # such a change, leaving every PR reader cold until something else landed.
+      # The action pin and the cache key both live here, and either can roll
+      # the store. Without this the sole writer would not re-run after such a
+      # change, leaving every PR reader cold until something else landed.
       - ".github/actions/rust-cache/**"
   # Priming a cold cache by hand, e.g. after a toolchain bump rolls the key.
   workflow_dispatch:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -58,8 +58,10 @@ jobs:
             extra-trusted-public-keys = kixelated.cachix.org-1:CmFcV0lyM6KuVM2m9mih0q4SrAa0XyCsiM7GHrz3KKk=
       - uses: DeterminateSystems/flake-checker-action@de924abd783455e8429c858962b9e43062d19da1 # main
 
-      # Restore only. cache.yml is the single writer, on `main`; see the comment
-      # there for why.
+      # cache.yml warms the default-branch store on `main`. Pull requests restore
+      # it; the action refuses to publish from a pull request, and Actions would
+      # scope such an entry to the PR's own branch anyway, where no later PR
+      # could read it while it ate the repository's 10 GB budget.
       - name: Rust cache
         uses: ./.github/actions/rust-cache
 
@@ -74,6 +76,7 @@ jobs:
       - name: Check
         run: nix develop --command just check
         env:
+          RUST_CARGO: mbx
           MOQ_STRICT: 1
 
   test:
@@ -117,5 +120,6 @@ jobs:
       - name: Test
         run: nix develop --command just test
         env:
+          RUST_CARGO: mbx
           MOQ_STRICT: 1
           NEXTEST_PROFILE: ci

--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -84,9 +84,10 @@ jobs:
             extra-substituters = https://kixelated.cachix.org
             extra-trusted-public-keys = kixelated.cachix.org-1:CmFcV0lyM6KuVM2m9mih0q4SrAa0XyCsiM7GHrz3KKk=
 
-      # Restore only. cache.yml is the single writer, on `main`; see the comment
-      # there for why. It holds dev-profile artifacts, which is why `just obs ci`
-      # builds libmoq in debug rather than the preset's release.
+      # cache.yml warms the default-branch store on `main`. Pull requests restore
+      # it; the action refuses to publish from a pull request. It holds
+      # dev-profile artifacts, which is why `just obs ci` builds libmoq in debug
+      # rather than the preset's release.
       - name: Rust cache
         uses: ./.github/actions/rust-cache
 
@@ -94,3 +95,5 @@ jobs:
       # the platform's CI preset.
       - name: Build
         run: nix develop --command just obs ci
+        env:
+          RUST_CARGO: mbx

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -86,8 +86,8 @@ jobs:
             extra-substituters = https://kixelated.cachix.org
             extra-trusted-public-keys = kixelated.cachix.org-1:CmFcV0lyM6KuVM2m9mih0q4SrAa0XyCsiM7GHrz3KKk=
 
-      # Restore only. cache.yml is the single writer, on `main`; see the comment
-      # there for why.
+      # cache.yml warms the default-branch store on `main`. Pull requests restore
+      # it; the action refuses to publish from a pull request.
       - name: Rust cache
         uses: ./.github/actions/rust-cache
 
@@ -101,3 +101,5 @@ jobs:
       - name: WASM
         run: nix develop --command just test wasm
         shell: bash -leo pipefail {0}
+        env:
+          RUST_CARGO: mbx

--- a/cpp/obs/justfile
+++ b/cpp/obs/justfile
@@ -15,7 +15,7 @@
 
 set quiet
 
-# Plain `cargo` unless set. See rs/justfile for the local wrapper option.
+# Plain `cargo` unless set; CI sets it to `mbx`. See rs/justfile for the rule.
 _rust_cargo := env_var_or_default("RUST_CARGO", "cargo")
 cargo_compile := if _rust_cargo == "" { "cargo" } else { _rust_cargo }
 

--- a/flake.nix
+++ b/flake.nix
@@ -478,10 +478,10 @@
           # that shim lives; it exits non-zero when the host has none, which is
           # every machine that made a different caching choice.
           #
-          # Never in CI, where check.yml enters this shell and the `target/`
-          # the workflow restored is the one the job has to build in. A shim
-          # would silently move it into a machine-wide managed target instead,
-          # on whichever runner happens to have been set up that way.
+          # Never in CI, which selects mbx explicitly with RUST_CARGO and
+          # configures it through `.github/actions/rust-cache`. A host shim
+          # would be a second, unconfigured way in, on whichever runner happened
+          # to have been set up that way.
           shellHook = ''
             if [ -z "''${CI:-}" ] && status=$(mbx setup --status 2>/dev/null); then
               shim=$(printf '%s\n' "$status" | sed -n '1s/.*: //p')
@@ -510,9 +510,8 @@
         formatter = pkgs.nixfmt-tree;
 
         # Heavy Rust CI (clippy / doc / test) runs via `just check` and `just
-        # test` (see rs/justfile). CI and local commands default to plain Cargo;
-        # local development can select a compatible wrapper with RUST_CARGO.
-        # Neither path goes through crane.
+        # test` (see rs/justfile). CI selects mbx with RUST_CARGO; local commands
+        # default to plain cargo. Neither path goes through crane.
         # `nix flake check` is kept -- it still validates flake eval + builds the
         # dev shell -- but no longer compiles the workspace, so it's cheap
         # enough that `just check` runs it on any Nix/Rust input change. Release

--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@
 
 set unstable
 
-# Plain `cargo` unless set. See rs/justfile for the local wrapper option.
+# Plain `cargo` unless set; CI sets it to `mbx`. See rs/justfile for the rule.
 _rust_cargo := env_var_or_default("RUST_CARGO", "cargo")
 cargo_compile := if _rust_cargo == "" { "cargo" } else { _rust_cargo }
 

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -258,10 +258,9 @@ let
   };
 
   # CI checks run via `just check` (clippy / doc) and `just test` (nextest), not
-  # through crane/`nix flake check`. CI and local commands default to plain
-  # Cargo; local development can select a compatible wrapper with RUST_CARGO.
-  # Which compiler cache backs CI is a workflow concern
-  # (`.github/actions/rust-cache`), not configured here.
+  # through crane/`nix flake check`. CI selects mbx with RUST_CARGO, while local
+  # commands default to plain Cargo. Which compiler cache backs those runs is a
+  # workflow concern (`.github/actions/rust-cache`), not configured here.
   # ./target stays per-job -- the persistent CARGO_TARGET_DIR growth that the old
   # crane checks were introduced to fix doesn't recur.
   # Release artifacts still build via crane `buildPackage` below.

--- a/rs/justfile
+++ b/rs/justfile
@@ -9,9 +9,8 @@
 
 set working-directory := '..'
 
-# Plain `cargo` unless set. A developer can select a compatible wrapper such as
-# mbx to share build artifacts across worktrees instead of using one target/
-# per worktree.
+# Plain `cargo` unless set. CI sets it to `mbx`, and so can a developer who
+# wants mbx's shared build store instead of a target/ per worktree.
 #
 # Every recipe that compiles reads it, with three exceptions. `package` hands
 # nfpm a literal target/release path, and a managed target/ is a symlink.

--- a/rs/libmoq/CMakeLists.txt
+++ b/rs/libmoq/CMakeLists.txt
@@ -41,8 +41,9 @@ if(BUILD_RUST_LIB)
     set(RUST_LIB "${RUST_DIR}/${LIB_PREFIX}moq${LIB_SUFFIX}")
     set(RUST_HEADER "${RUST_TARGET_DIR}/include/moq.h")
 
-    # Same RUST_CARGO knob the justfiles read, so a local Cargo wrapper reaches
-    # the one Rust compile this plugin actually pays for.
+    # Same RUST_CARGO knob the justfiles read, so CI's cache wrapper reaches the
+    # one Rust compile this plugin actually pays for. Without it the env var is
+    # set on the job and silently ignored here.
     if(DEFINED ENV{RUST_CARGO} AND NOT "$ENV{RUST_CARGO}" STREQUAL "")
         set(CARGO_COMMAND "$ENV{RUST_CARGO}")
     else()


### PR DESCRIPTION
## Summary

Re-applies the [mr boxington](https://mr-boxington.jdx.dev/) integration that #3175 landed and #3273 reverted, across `check.yml`, `cache.yml`, `obs.yml`, and `wasm.yml`.

The revert's reasoning was that mbx didn't beat Swatinem on GitHub-hosted runners. That was true of the payload mbx shipped then: `jdx/mr-boxington-action` cached a portable object closure *instead of* the target directory, and the action's own README said as much.

`v1.3.0` (Sep 5, after the revert) changed the default. `github-cache-mode: target` transports Cargo's pruned target tree and registry, which is the payload Swatinem carried, and layers mbx's per-compilation store on top. Against the current baseline that is additive rather than a swap, which is why it's worth measuring again.

## Changes

- `.github/actions/rust-cache` installs `jdx/mr-boxington-action` pinned to v1.3.0 with mbx 1.10.0, and spells the cache key out rather than taking the generated one.
- **Why the key is hand-written.** The generated key carries the identity of `rustc -vV` from `PATH`, which in these jobs is whatever the runner image ships; the compiler they actually build with exists only inside `nix develop`. The `toolchain` input doesn't reach it either, because it names a *rustup* toolchain and probes `rustc +<name> -vV`, and nothing installs 1.95.0 through rustup here. `flake.lock` pins the compiler, so the key hashes `flake.nix`, `flake.lock`, and `rust-toolchain.toml` instead: more precise than `rustc -vV`, and already the thing that has to roll the cache, since build scripts link against Nix store paths and a restored executable whose dynamic linker moved is worse than a cold cache. The runner pair, the `target` payload marker, and a per-run suffix are carried explicitly so the two architectures can't read each other, a `github-cache-mode` change can't restore the wrong payload, and a repeated `workflow_dispatch` can still seed against GitHub's immutable entries.
- The four workflows set `RUST_CARGO=mbx`. That seam survived the revert, so the compiling recipes, `rs/libmoq/CMakeLists.txt`, and the `go`/`kt`/`test/wasm` scripts already route through it; only the workflows and the action needed changing.
- `main` stays the single writer, via the action's `save-on-workflow-dispatch`. Pull requests are restore-only, and the action refuses to publish from one regardless.

## Public API and wire impact

None. CI configuration and comments only.

## Verification

`nix develop --command just check` passes, including `actionlint`, `just gh check`, and the nix/justfile lints.

As in #3175, the win can't be measured before this merges: only `main` writes the store, so this PR's own runs are cold and mbx will report near-zero hits. The signal is the first PR after `cache.yml` runs on `main`. Warm baseline to beat is roughly 4 minutes scoped and 7 minutes unscoped.

## Notes

- Seven other workflows still use Swatinem on their own per-job keys, including the `release-rs.yml` entry #3547 just added. They're independent of this store; `release-rs.yml` can't use `RUST_CARGO` because release-plz spawns Cargo itself, so routing it through mbx would need the Cargo shim on `PATH` inside the dev shell, which `flake.nix` deliberately disables in CI. Left for a follow-up.
- If the warm numbers don't come back at or under the Swatinem baseline, revert this the same way #3273 did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by claude-opus-5)
