### PR TITLE
fix(packaging): name system packages after their executables

### DIFF
--- a/.github/homebrew/Formula/moq-cli.rb.tmpl
+++ b/.github/homebrew/Formula/moq-cli.rb.tmpl
@@ -1,4 +1,4 @@
-class MoqCli < Formula
+class Moq < Formula
   desc "CLI for publishing and subscribing to Media over QUIC broadcasts"
   homepage "https://moq.dev"
   version "__VERSION__"

--- a/.github/homebrew/Formula/moq-token-cli.rb.tmpl
+++ b/.github/homebrew/Formula/moq-token-cli.rb.tmpl
@@ -1,4 +1,4 @@
-class MoqTokenCli < Formula
+class MoqToken < Formula
   desc "JWT token generator and validator for moq-relay"
   homepage "https://moq.dev"
   version "__VERSION__"

--- a/.github/justfile
+++ b/.github/justfile
@@ -5,6 +5,8 @@ set fallback
 
 # Lint GitHub Actions workflows.
 check:
+    python3 {{ source_directory() }}/scripts/install-formula.test.py
+    python3 rs/scripts/package-rename.test.py
     @if command -v actionlint >/dev/null 2>&1; then actionlint; fi
     {{ source_directory() }}/scripts/alert.sh check-coverage
     @if command -v rustc >/dev/null 2>&1; then {{ source_directory() }}/scripts/package-binary.test.sh; fi

--- a/.github/scripts/install-formula.py
+++ b/.github/scripts/install-formula.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Install a rendered formula and migrate its former crate-based name."""
+
+import json
+from pathlib import Path
+import shutil
+import sys
+
+
+def install(crate: str, rendered: Path, tap: Path) -> None:
+    names = {"moq-cli": "moq", "moq-token-cli": "moq-token"}
+    name = names.get(crate, crate)
+    formulas = tap / "Formula"
+    formulas.mkdir(exist_ok=True)
+    shutil.copyfile(rendered, formulas / f"{name}.rb")
+
+    renames_path = tap / "formula_renames.json"
+    renames = json.loads(renames_path.read_text()) if renames_path.exists() else {}
+    if name != crate:
+        # Publish the mapping only once its destination exists in this tap.
+        (formulas / f"{crate}.rb").unlink(missing_ok=True)
+        renames[crate] = name
+        readme = tap / "README.md"
+        if readme.exists():
+            readme.write_text(readme.read_text().replace(f"moq-dev/tap/{crate}", f"moq-dev/tap/{name}"))
+    renames_path.write_text(json.dumps(renames, indent=2, sort_keys=True) + "\n")
+
+
+if __name__ == "__main__":
+    crate, rendered, tap = sys.argv[1:]
+    install(crate, Path(rendered), Path(tap))

--- a/.github/scripts/install-formula.test.py
+++ b/.github/scripts/install-formula.test.py
@@ -1,0 +1,42 @@
+"""Exercise successive releases into an existing tap without losing migrations."""
+
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+spec = importlib.util.spec_from_file_location("install_formula", Path(__file__).with_name("install-formula.py"))
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+class InstallFormulaTest(unittest.TestCase):
+    def test_successive_releases(self):
+        with tempfile.TemporaryDirectory() as directory:
+            tap = Path(directory)
+            formulas = tap / "Formula"
+            formulas.mkdir()
+            for crate in ("moq-cli", "moq-token-cli", "moq-relay"):
+                (formulas / f"{crate}.rb").write_text("old")
+            (tap / "formula_renames.json").write_text('{"prior": "unrelated"}')
+            (tap / "README.md").write_text("brew install moq-dev/tap/moq-cli moq-dev/tap/moq-token-cli\n")
+            rendered = tap / "rendered.rb"
+            rendered.write_text("new")
+            module.install("moq-cli", rendered, tap)
+            self.assertFalse((formulas / "moq-cli.rb").exists())
+            self.assertEqual((formulas / "moq.rb").read_text(), "new")
+            self.assertTrue((formulas / "moq-token-cli.rb").exists())
+            self.assertNotIn("moq-token-cli", json.loads((tap / "formula_renames.json").read_text()))
+            module.install("moq-token-cli", rendered, tap)
+            module.install("moq-relay", rendered, tap)
+            module.install("moq-cli", rendered, tap)
+            self.assertEqual(json.loads((tap / "formula_renames.json").read_text()), {
+                "prior": "unrelated", "moq-cli": "moq", "moq-token-cli": "moq-token",
+            })
+            self.assertEqual((tap / "README.md").read_text(), "brew install moq-dev/tap/moq moq-dev/tap/moq-token\n")
+            self.assertEqual((formulas / "moq-relay.rb").read_text(), "new")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/moq-cli.yml
+++ b/.github/workflows/moq-cli.yml
@@ -75,7 +75,9 @@ jobs:
           VERSION: ${{ steps.parse.outputs.version }}
           ARCH: ${{ matrix.deb-arch }}
           BINARY_PATH: target/${{ matrix.target }}/release/moq
-        run: rs/scripts/package-nfpm.sh packaging/moq-cli/nfpm.yaml deb dist/
+        run: |
+          rs/scripts/package-nfpm.sh packaging/moq-cli/nfpm.yaml deb dist/
+          rs/scripts/package-nfpm.sh packaging/moq-cli/transition.yaml deb dist/
 
       - name: Package .rpm
         shell: bash

--- a/.github/workflows/moq-token-cli.yml
+++ b/.github/workflows/moq-token-cli.yml
@@ -75,7 +75,9 @@ jobs:
           VERSION: ${{ steps.parse.outputs.version }}
           ARCH: ${{ matrix.deb-arch }}
           BINARY_PATH: target/${{ matrix.target }}/release/moq-token
-        run: rs/scripts/package-nfpm.sh packaging/moq-token-cli/nfpm.yaml deb dist/
+        run: |
+          rs/scripts/package-nfpm.sh packaging/moq-token-cli/nfpm.yaml deb dist/
+          rs/scripts/package-nfpm.sh packaging/moq-token-cli/transition.yaml deb dist/
 
       - name: Package .rpm
         shell: bash

--- a/.github/workflows/release-brew.yml
+++ b/.github/workflows/release-brew.yml
@@ -135,10 +135,8 @@ jobs:
           GIT_COMMITTER_EMAIL: moq-bot[bot]@users.noreply.github.com
         run: |
           cd homebrew-tap
-          mkdir -p Formula
-          cp "../rendered/${CRATE}.rb" "Formula/${CRATE}.rb"
 
-          # Seed a README the first time the tap repo receives a push.
+          # Seed the tap README; install-formula updates each name as it ships.
           if [[ ! -f README.md ]]; then
             cat > README.md <<'EOF'
           # moq Homebrew tap
@@ -160,11 +158,13 @@ jobs:
           EOF
           fi
 
+          python3 ../.github/scripts/install-formula.py "$CRATE" "../rendered/${CRATE}.rb" .
+
           if git diff --quiet && [[ -z "$(git status --porcelain)" ]]; then
             echo "No changes to commit (formula already up to date)."
             exit 0
           fi
 
-          git add Formula/ README.md
+          git add -A Formula/ README.md formula_renames.json
           git commit -m "${CRATE}: bump to v${VERSION}"
           git push

--- a/doc/setup/install.md
+++ b/doc/setup/install.md
@@ -1,6 +1,6 @@
 ---
 title: Install
-description: Install moq-relay, moq-cli, moq-token, and the plugins on Linux, macOS, and Windows
+description: Install moq-relay, moq, moq-token, and the plugins on Linux, macOS, and Windows
 ---
 
 # Install
@@ -10,10 +10,15 @@ Three binaries and two plugins ship prebuilt:
 | Package | Binary | What it does |
 | --- | --- | --- |
 | `moq-relay` | `moq-relay` | The [relay server](/bin/relay/) |
-| `moq-cli` | `moq` | The [media router](/bin/cli): publish, play, convert, gateways, and `moq token` |
-| `moq-token-cli` | `moq-token` | Standalone JWT tool; the same commands as `moq token` |
+| `moq` | `moq` | The [media router](/bin/cli): publish, play, convert, gateways, and `moq token` |
+| `moq-token` | `moq-token` | Standalone JWT tool; the same commands as `moq token` |
 | GStreamer plugin | `moqsink`, `moqsrc` | [GStreamer](/bin/gstreamer) elements |
 | OBS plugin | | [OBS Studio](/bin/obs) output and source |
+
+Homebrew and Linux package names match the executables. Cargo crates and
+Windows package IDs retain `moq-cli` and `moq-token-cli`. Existing Homebrew
+installs migrate through formula renames; apt upgrades use transitional
+packages, and dnf replaces the old packages.
 
 ## Any platform
 
@@ -22,7 +27,7 @@ Three binaries and two plugins ship prebuilt:
 cargo install moq-relay moq-cli moq-token-cli
 
 # Homebrew (macOS and Linux)
-brew install moq-dev/tap/moq-relay moq-dev/tap/moq-cli
+brew install moq-dev/tap/moq-relay moq-dev/tap/moq moq-dev/tap/moq-token
 
 # Nix (pin a release tag to use the binary cache)
 nix run github:moq-dev/moq#moq-relay -- relay.toml
@@ -48,7 +53,7 @@ is available on Debian 12+ and Ubuntu 24.04+.
 curl -fsSL https://apt.moq.dev/moq-keyring.gpg | sudo tee /usr/share/keyrings/moq-keyring.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/moq-keyring.gpg] https://apt.moq.dev stable main" | sudo tee /etc/apt/sources.list.d/moq.list
 sudo apt update
-sudo apt install moq-relay moq-cli moq-token-cli gstreamer1.0-moq
+sudo apt install moq-relay moq moq-token gstreamer1.0-moq
 ```
 
 ## Fedora, RHEL, and openSUSE
@@ -57,7 +62,7 @@ Fedora 39+, RHEL 9, Rocky 9, AlmaLinux 9. On openSUSE use `zypper addrepo`.
 
 ```bash
 sudo dnf config-manager --add-repo https://rpm.moq.dev/moq.repo
-sudo dnf install moq-relay moq-cli moq-token-cli gstreamer1-moq
+sudo dnf install moq-relay moq moq-token gstreamer1-moq
 ```
 
 Both repositories are signed with the project key, served at

--- a/justfile
+++ b/justfile
@@ -437,7 +437,7 @@ _tools $FILES="":
     scoped() { [[ "$FILES" == ALL ]] || grep -qE "$1" <<< "$FILES"; }
 
     # `_check-common` runs on every invocation, so its tools are unconditional.
-    tools=(actionlint bun jq nix nixfmt shellcheck shfmt taplo)
+    tools=(actionlint bun jq nix nixfmt shellcheck shfmt taplo python3 nfpm dpkg-deb envsubst)
     scoped '^(quest/|rs/|Cargo\.(toml|lock)$|rust-toolchain\.toml$)' && tools+=(cargo envsubst)
     scoped '^(py/|pyproject\.toml$|uv\.lock$|rs/moq-ffi/)'     && tools+=(uv)
     scoped '^(kt/|rs/moq-ffi/)'                                && tools+=(gradle java)

--- a/packaging/moq-cli/nfpm.yaml
+++ b/packaging/moq-cli/nfpm.yaml
@@ -1,8 +1,8 @@
-# nfpm config for the moq-cli package.
+# The moq-cli crate ships as the moq system package.
 # Produces both .deb and .rpm from one definition.
 # Driven by env vars set in CI: VERSION, ARCH, BINARY_PATH.
 
-name: moq-cli
+name: moq
 arch: ${ARCH}
 platform: linux
 version: ${VERSION}
@@ -25,13 +25,21 @@ contents:
 
 overrides:
   deb:
+    replaces:
+      - moq-cli (<< ${VERSION})
     depends:
       - libc6 (>= 2.34)
   rpm:
+    provides:
+      - moq-cli = ${VERSION}
+    replaces:
+      - moq-cli < ${VERSION}
     depends:
       - glibc >= 2.34
 
 deb:
+  breaks:
+    - moq-cli (<< ${VERSION})
   fields:
     Bugs: https://github.com/moq-dev/moq/issues
 

--- a/packaging/moq-cli/transition.yaml
+++ b/packaging/moq-cli/transition.yaml
@@ -1,0 +1,12 @@
+# Keep apt upgrades following the renamed package.
+name: moq-cli
+arch: ${ARCH}
+platform: linux
+version: ${VERSION}
+section: oldlibs
+priority: optional
+maintainer: MoQ Project <admin@moq.dev>
+description: Transitional package for moq.
+license: MIT OR Apache-2.0
+depends:
+  - moq (>= ${VERSION})

--- a/packaging/moq-token-cli/nfpm.yaml
+++ b/packaging/moq-token-cli/nfpm.yaml
@@ -1,8 +1,8 @@
-# nfpm config for the moq-token-cli package.
+# The moq-token-cli crate ships as the moq-token system package.
 # Produces both .deb and .rpm from one definition.
 # Driven by env vars set in CI: VERSION, ARCH, BINARY_PATH.
 
-name: moq-token-cli
+name: moq-token
 arch: ${ARCH}
 platform: linux
 version: ${VERSION}
@@ -25,13 +25,21 @@ contents:
 
 overrides:
   deb:
+    replaces:
+      - moq-token-cli (<< ${VERSION})
     depends:
       - libc6 (>= 2.34)
   rpm:
+    provides:
+      - moq-token-cli = ${VERSION}
+    replaces:
+      - moq-token-cli < ${VERSION}
     depends:
       - glibc >= 2.34
 
 deb:
+  breaks:
+    - moq-token-cli (<< ${VERSION})
   fields:
     Bugs: https://github.com/moq-dev/moq/issues
 

--- a/packaging/moq-token-cli/transition.yaml
+++ b/packaging/moq-token-cli/transition.yaml
@@ -1,0 +1,12 @@
+# Keep apt upgrades following the renamed package.
+name: moq-token-cli
+arch: ${ARCH}
+platform: linux
+version: ${VERSION}
+section: oldlibs
+priority: optional
+maintainer: MoQ Project <admin@moq.dev>
+description: Transitional package for moq-token.
+license: MIT OR Apache-2.0
+depends:
+  - moq-token (>= ${VERSION})

--- a/rs/justfile
+++ b/rs/justfile
@@ -706,4 +706,8 @@ package crate packager:
     mkdir -p dist
     VERSION="$version" ARCH="$arch" BINARY_PATH="target/release/$bin" \
         rs/scripts/package-nfpm.sh packaging/{{ crate }}/nfpm.yaml {{ packager }} dist/
+    if [[ "{{ packager }}" == deb && -f "packaging/{{ crate }}/transition.yaml" ]]; then
+        VERSION="$version" ARCH="$arch" \
+            rs/scripts/package-nfpm.sh packaging/{{ crate }}/transition.yaml deb dist/
+    fi
     ls -1 dist/

--- a/rs/scripts/package-rename.test.py
+++ b/rs/scripts/package-rename.test.py
@@ -1,0 +1,54 @@
+"""Verify renamed package artifacts and apt transition dependencies."""
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+class PackageRenameTest(unittest.TestCase):
+    def test_packages(self):
+        with tempfile.TemporaryDirectory() as directory:
+            scratch = Path(directory)
+            binary = scratch / "binary"
+            binary.write_text("#!/bin/sh\necho packaged\n")
+            binary.chmod(0o755)
+            for name in ("moq", "moq-token"):
+                with self.subTest(name=name):
+                    old = f"{name}-cli"
+                    env = dict(os.environ, VERSION="99.0.0", ARCH="amd64", BINARY_PATH=str(binary))
+                    outputs = {}
+                    for config, packager in (("nfpm", "deb"), ("transition", "deb"), ("nfpm", "rpm")):
+                        output = scratch / f"{name}-{config}.{packager}"
+                        subprocess.run([
+                            "bash", "rs/scripts/package-nfpm.sh",
+                            f"packaging/{old}/{config}.yaml", packager, str(output),
+                        ], env=env, check=True)
+                        outputs[config, packager] = output
+
+                    def field(config, key):
+                        return subprocess.check_output([
+                            "dpkg-deb", "--field", str(outputs[config, "deb"]), key,
+                        ], text=True).strip()
+
+                    self.assertEqual(field("nfpm", "Package"), name)
+                    self.assertEqual(field("nfpm", "Breaks"), f"{old} (<< 99.0.0)")
+                    self.assertEqual(field("nfpm", "Replaces"), f"{old} (<< 99.0.0)")
+                    self.assertEqual(field("transition", "Package"), old)
+                    self.assertEqual(field("transition", "Depends"), f"{name} (>= 99.0.0)")
+                    for config in ("nfpm", "transition"):
+                        destination = scratch / f"{name}-{config}"
+                        subprocess.run([
+                            "dpkg-deb", "--extract", str(outputs[config, "deb"]), str(destination),
+                        ], check=True)
+                        files = [p for p in destination.rglob("*") if p.is_file()]
+                        if config == "transition":
+                            self.assertEqual(files, [])
+                        else:
+                            self.assertEqual(files, [destination / "usr/bin" / name])
+                            self.assertEqual(files[0].read_bytes(), binary.read_bytes())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Homebrew and Linux packages inherited Rust crate names, so documented `brew install moq-dev/tap/moq` and `apt install moq-token` could not find them. Publish `moq` and `moq-token` while keeping Cargo crates and release asset names unchanged.

Homebrew publishes each canonical formula with its rename mapping, preserving unrelated migrations. Debian ships empty old-name packages depending on the replacement, with versioned Breaks/Replaces on the new packages. RPM declares the old names as provided and obsoleted. Both the release workflows and local packaging recipe produce the Debian transitions.

## Public API

System package names change from `moq-cli`/`moq-token-cli` to `moq`/`moq-token`. Executables, Cargo APIs, crates, and Windows IDs are unchanged.

## Wire

None.

## Validation

Homebrew migration and Debian/RPM artifact regressions pass in `nix develop --command just gh check`, along with actionlint, workflow coverage, and release-asset tests. Reproduced the old working-directory failure, fixed both the invocation and subprocess paths, and verified RPM Provides/Obsoletes and payload paths. Missing packaging tools skip the local check; strict CI requires them. RPM queries use a temporary database.

Merged current main and preserved its `moq token` installation guidance. Full `just fix` passed without changes. Exact-head Check, Test, WASM, and OBS CI all passed at `9ec2d8385`. The redundant local check/test chain was stopped during check after CI completed. Mutation checks confirm removing either RPM Provides or Obsoletes fails the regression. Actual apt/dnf upgrade transactions remain untested.

## Rollout

The short names become available only after each CLI is released at a version newer than its existing packages. This PR does not cut releases or update production repositories. The dashboard already documents the short names, so no submodule bump or dashboard behavior change is needed.

(written by GPT-6)

