### PR TITLE
ci: reach Cargo through mbx's shim and delete RUST_CARGO

### DIFF
--- a/.github/actions/rust-cache/action.yml
+++ b/.github/actions/rust-cache/action.yml
@@ -1,9 +1,12 @@
 name: Rust cache
-description: Install mbx and restore the Rust build cache cache.yml warms on the default branch.
+description: Install mbx, put its Cargo shim on PATH, and restore the build cache the default branch warms.
 
 inputs:
+  scope:
+    description: Key space for the store. A workflow that builds a different set of artifacts needs its own.
+    default: shared
   save-on-dispatch:
-    description: Let a trusted workflow_dispatch seed the cache (cache.yml only).
+    description: Let a trusted workflow_dispatch seed the cache (the warming workflow only).
     default: "false"
 
 runs:
@@ -16,7 +19,9 @@ runs:
         # Cargo's pruned target tree, the same payload Swatinem carried, with
         # mbx's per-compilation store on top. The `objects` closure is portable
         # across differing target directories, which nothing here needs, and
-        # measured slower.
+        # measured slower. It transports `./target` relative to the working
+        # directory and ignores CARGO_TARGET_DIR, so a workflow that sets one
+        # has to point it there.
         #
         # The key is spelled out because the generated one cannot name this
         # repository's compiler. It keys on `rustc -vV` from PATH, which here is
@@ -33,11 +38,26 @@ runs:
         # even though it is kept in sync with the flake.
         #
         # Every segment the generated layout carries has to be carried here too:
-        # the runner pair, so the two architectures cache.yml warms cannot read
-        # each other, and `target`, so changing `github-cache-mode` cannot
+        # the runner pair, so the two architectures the warm job builds cannot
+        # read each other, and `target`, so changing `github-cache-mode` cannot
         # restore the other payload. The trailing run id rolls the key on every
         # run, which is what lets a repeated `workflow_dispatch` seed a cold
         # cache against GitHub's immutable entries.
-        cache-key: ${{ runner.os }}-${{ runner.arch }}-mbx-target-${{ hashFiles('flake.nix', 'flake.lock', 'rust-toolchain.toml') }}-${{ github.run_id }}-${{ github.run_attempt }}
-        restore-keys: ${{ runner.os }}-${{ runner.arch }}-mbx-target-${{ hashFiles('flake.nix', 'flake.lock', 'rust-toolchain.toml') }}-
+        cache-key: ${{ runner.os }}-${{ runner.arch }}-mbx-target-${{ inputs.scope }}-${{ hashFiles('flake.nix', 'flake.lock', 'rust-toolchain.toml') }}-${{ github.run_id }}-${{ github.run_attempt }}
+        restore-keys: ${{ runner.os }}-${{ runner.arch }}-mbx-target-${{ inputs.scope }}-${{ hashFiles('flake.nix', 'flake.lock', 'rust-toolchain.toml') }}-
         save-on-workflow-dispatch: ${{ inputs.save-on-dispatch }}
+
+    # The shim is how mbx reaches Cargo. The action above only puts `mbx` itself
+    # on PATH, which reaches a build that spells the wrapper out; nothing here
+    # does, and release-plz spawns Cargo where no environment variable could.
+    # `mbx setup` installs a `cargo` launcher instead, and flake.nix puts its
+    # directory in front of the dev shell's pinned toolchain.
+    #
+    # `--status` is the assertion, not decoration: the shim is the only thing
+    # routing Cargo through mbx, so a setup that quietly did nothing would build
+    # every job uncached and still report success.
+    - name: Cargo shim
+      shell: bash
+      run: |
+        mbx setup --yes
+        mbx setup --status

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -106,13 +106,11 @@ jobs:
       - name: Check
         run: nix develop --command just check-all
         env:
-          RUST_CARGO: mbx
           MOQ_STRICT: 1
 
       - name: Test
         if: ${{ !cancelled() }}
         run: nix develop --command just test all
         env:
-          RUST_CARGO: mbx
           MOQ_STRICT: 1
           NEXTEST_PROFILE: ci

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -76,7 +76,6 @@ jobs:
       - name: Check
         run: nix develop --command just check
         env:
-          RUST_CARGO: mbx
           MOQ_STRICT: 1
 
   test:
@@ -120,6 +119,5 @@ jobs:
       - name: Test
         run: nix develop --command just test
         env:
-          RUST_CARGO: mbx
           MOQ_STRICT: 1
           NEXTEST_PROFILE: ci

--- a/.github/workflows/obs.yml
+++ b/.github/workflows/obs.yml
@@ -95,5 +95,3 @@ jobs:
       # the platform's CI preset.
       - name: Build
         run: nix develop --command just obs ci
-        env:
-          RUST_CARGO: mbx

--- a/.github/workflows/release-rs.yml
+++ b/.github/workflows/release-rs.yml
@@ -41,7 +41,9 @@ jobs:
       # against the registry, so cargo-semver-checks would otherwise build
       # rustdoc for every crate, baseline and current, into a throwaway target
       # directory. Pin one absolute path instead so the ~30 crates share their
-      # dependency builds and the cache below can carry them between runs.
+      # dependency builds and the cache below can carry them between runs. It
+      # has to be this path: the cache action transports `./target` relative to
+      # the working directory and does not read CARGO_TARGET_DIR.
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
 
     steps:
@@ -78,18 +80,19 @@ jobs:
             extra-substituters = https://kixelated.cachix.org
             extra-trusted-public-keys = kixelated.cachix.org-1:CmFcV0lyM6KuVM2m9mih0q4SrAa0XyCsiM7GHrz3KKk=
 
-      # Its own key rather than the shared one from .github/actions/rust-cache:
-      # this holds cargo-semver-checks rustdoc, not the check and test artifacts
-      # cache.yml warms, and this workflow only runs on `main` so it is the sole
-      # writer of the key.
+      # Its own scope rather than the shared store cache.yml warms: this holds
+      # cargo-semver-checks rustdoc, not check and test artifacts, and mixing
+      # the two would have each restoring a target tree built for the other.
+      # This workflow only runs on `main`, so it is the sole writer of its scope.
+      #
+      # The action's shim is what gets mbx in here at all. release-plz spawns
+      # Cargo and cargo-semver-checks itself, so no environment variable reaches
+      # them; a `cargo` ahead of the dev shell's toolchain does.
       - name: Rust cache
-        uses: Swatinem/rust-cache@f0d9c3887740aee45f6153b24b3a6b815192ec16 # v2
+        uses: ./.github/actions/rust-cache
         with:
-          # Build scripts link against Nix store paths from the dev shell. Roll
-          # the cache when that shell changes so Cargo never restores executables
-          # whose dynamic linker has disappeared.
-          shared-key: release-rs-${{ hashFiles('flake.nix', 'flake.lock') }}
-          cache-on-failure: true
+          scope: release-rs
+          save-on-dispatch: true
 
       - name: Release
         run: nix develop --command just rs release

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -101,5 +101,3 @@ jobs:
       - name: WASM
         run: nix develop --command just test wasm
         shell: bash -leo pipefail {0}
-        env:
-          RUST_CARGO: mbx

--- a/cpp/obs/justfile
+++ b/cpp/obs/justfile
@@ -15,10 +15,6 @@
 
 set quiet
 
-# Plain `cargo` unless set; CI sets it to `mbx`. See rs/justfile for the rule.
-_rust_cargo := env_var_or_default("RUST_CARGO", "cargo")
-cargo_compile := if _rust_cargo == "" { "cargo" } else { _rust_cargo }
-
 # List all of the available commands.
 default:
     just --list
@@ -195,14 +191,14 @@ _includes:
         exit 1
     fi
 
-    (cd ../.. && {{ cargo_compile }} check --locked --quiet -p libmoq)
+    (cd ../.. && cargo check --locked --quiet -p libmoq)
 
     # Ask cargo where its build script ran rather than reconstructing the path.
     # CARGO_TARGET_DIR, a `--target` triple and a custom profile each move the
     # generated header, and guessing wrong doesn't fail: it type-checks against
     # whatever stale copy the default directory still holds. Replays the check
     # above from cache, so it costs a process rather than a compile.
-    out_dir=$(cd ../.. && {{ cargo_compile }} check --locked -p libmoq --message-format=json |
+    out_dir=$(cd ../.. && cargo check --locked -p libmoq --message-format=json |
         jq -r 'select(.reason == "build-script-executed") | select(.package_id | tostring | test("libmoq")) | .out_dir' |
         tail -1)
     if [ -z "$out_dir" ]; then

--- a/flake.nix
+++ b/flake.nix
@@ -475,15 +475,14 @@
           # host had, which shadows the Cargo shim `mbx setup` installs. Put it
           # back in front, so a bare `cargo` in this shell reaches the same
           # wrapper it reaches outside. `setup --status` is what knows where
-          # that shim lives; it exits non-zero when the host has none, which is
+          # that shim lives; it exits non-zero when there is none, which is
           # every machine that made a different caching choice.
           #
-          # Never in CI, which selects mbx explicitly with RUST_CARGO and
-          # configures it through `.github/actions/rust-cache`. A host shim
-          # would be a second, unconfigured way in, on whichever runner happened
-          # to have been set up that way.
+          # CI included: `.github/actions/rust-cache` runs `mbx setup` so this
+          # finds a shim there too. That is the only way mbx reaches a build
+          # that spawns Cargo itself, which release-plz does.
           shellHook = ''
-            if [ -z "''${CI:-}" ] && status=$(mbx setup --status 2>/dev/null); then
+            if status=$(mbx setup --status 2>/dev/null); then
               shim=$(printf '%s\n' "$status" | sed -n '1s/.*: //p')
               if [ -x "$shim" ]; then
                 export PATH="$(dirname "$shim"):$PATH"
@@ -510,8 +509,8 @@
         formatter = pkgs.nixfmt-tree;
 
         # Heavy Rust CI (clippy / doc / test) runs via `just check` and `just
-        # test` (see rs/justfile). CI selects mbx with RUST_CARGO; local commands
-        # default to plain cargo. Neither path goes through crane.
+        # test` (see rs/justfile), reaching mbx through the Cargo shim the dev
+        # shell puts on PATH. Neither path goes through crane.
         # `nix flake check` is kept -- it still validates flake eval + builds the
         # dev shell -- but no longer compiles the workspace, so it's cheap
         # enough that `just check` runs it on any Nix/Rust input change. Release

--- a/go/scripts/stage.sh
+++ b/go/scripts/stage.sh
@@ -76,7 +76,7 @@ CARGO_PROFILE=()
 [[ "$PROFILE" == "release" ]] && CARGO_PROFILE=(--release)
 
 echo "go stage: building moq-ffi for $HOST_TARGET..." >&2
-"${RUST_CARGO:-cargo}" build --locked ${CARGO_PROFILE[@]+"${CARGO_PROFILE[@]}"} --package moq-ffi \
+cargo build --locked ${CARGO_PROFILE[@]+"${CARGO_PROFILE[@]}"} --package moq-ffi \
     --manifest-path "$WORKSPACE_DIR/Cargo.toml" >&2
 
 TARGET_BASE=$(cargo metadata --format-version 1 --manifest-path "$WORKSPACE_DIR/Cargo.toml" --no-deps |

--- a/justfile
+++ b/justfile
@@ -3,10 +3,6 @@
 
 set unstable
 
-# Plain `cargo` unless set; CI sets it to `mbx`. See rs/justfile for the rule.
-_rust_cargo := env_var_or_default("RUST_CARGO", "cargo")
-cargo_compile := if _rust_cargo == "" { "cargo" } else { _rust_cargo }
-
 # Per-language modules. Language-specific recipes live in their own justfiles.
 mod js
 mod rs
@@ -804,7 +800,7 @@ build:
 
 # Build browser/WASM bindings into @moq/wasm using the pinned wasm-bindgen toolchain.
 wasm:
-    {{ cargo_compile }} build --locked -p moq-wasm --target wasm32-unknown-unknown --profile wasm-release
+    cargo build --locked -p moq-wasm --target wasm32-unknown-unknown --profile wasm-release
     wasm-bindgen --target web --out-name moq \
     	--out-dir js/wasm/dist "${CARGO_TARGET_DIR:-target}/wasm32-unknown-unknown/wasm-release/moq_wasm.wasm"
 

--- a/kt/scripts/generate.sh
+++ b/kt/scripts/generate.sh
@@ -37,7 +37,7 @@ CARGO_PROFILE=()
 [[ "$PROFILE" == "release" ]] && CARGO_PROFILE=(--release)
 
 echo "kt generate: building moq-ffi for $HOST_TARGET..."
-"${RUST_CARGO:-cargo}" build --locked ${CARGO_PROFILE[@]+"${CARGO_PROFILE[@]}"} --package moq-ffi \
+cargo build --locked ${CARGO_PROFILE[@]+"${CARGO_PROFILE[@]}"} --package moq-ffi \
     --manifest-path "$WORKSPACE_DIR/Cargo.toml"
 
 TARGET_BASE=$(cargo metadata --format-version 1 --manifest-path "$WORKSPACE_DIR/Cargo.toml" --no-deps |
@@ -77,7 +77,7 @@ cp "$CDYLIB" "$RES_DIR/"
 
 BINDGEN_OUT=$(mktemp -d)
 trap 'rm -rf "$BINDGEN_OUT"' EXIT
-"${RUST_CARGO:-cargo}" run --locked ${CARGO_PROFILE[@]+"${CARGO_PROFILE[@]}"} --package moq-ffi --bin uniffi-bindgen \
+cargo run --locked ${CARGO_PROFILE[@]+"${CARGO_PROFILE[@]}"} --package moq-ffi --bin uniffi-bindgen \
     --manifest-path "$WORKSPACE_DIR/Cargo.toml" -- \
     generate --library "$CDYLIB" --language kotlin --no-format --out-dir "$BINDGEN_OUT"
 

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -258,9 +258,10 @@ let
   };
 
   # CI checks run via `just check` (clippy / doc) and `just test` (nextest), not
-  # through crane/`nix flake check`. CI selects mbx with RUST_CARGO, while local
-  # commands default to plain Cargo. Which compiler cache backs those runs is a
-  # workflow concern (`.github/actions/rust-cache`), not configured here.
+  # through crane/`nix flake check`. Both reach mbx through the Cargo shim the
+  # dev shell puts on PATH, so nothing spells a wrapper out. Which compiler
+  # cache backs those runs is a workflow concern
+  # (`.github/actions/rust-cache`), not configured here.
   # ./target stays per-job -- the persistent CARGO_TARGET_DIR growth that the old
   # crane checks were introduced to fix doesn't recur.
   # Release artifacts still build via crane `buildPackage` below.

--- a/quest/m0/tooling/justfiles.md
+++ b/quest/m0/tooling/justfiles.md
@@ -75,8 +75,6 @@ Delete:
   `just sub`, `just web` are the only spelling, and `--list` stops showing
   each twice. `just demo` remains the default recipe and `just dev` its
   documented alias.
-- `_rust_cargo`/`cargo_compile`, declared three times. Recipe lines read
-  `${RUST_CARGO:-cargo}` directly.
 
 Rename:
 

--- a/rs/justfile
+++ b/rs/justfile
@@ -9,20 +9,6 @@
 
 set working-directory := '..'
 
-# Plain `cargo` unless set. CI sets it to `mbx`, and so can a developer who
-# wants mbx's shared build store instead of a target/ per worktree.
-#
-# Every recipe that compiles reads it, with three exceptions. `package` hands
-# nfpm a literal target/release path, and a managed target/ is a symlink.
-# `fix`/`wasm-fix` run `cargo fix`, which drops rustc wrappers. `fuzz` puts
-# nightly on PATH so a bare cargo/rustc resolve to it, and the sanitizer flags
-# are what break if anything else sits in front.
-# Empty counts as unset: `RUST_CARGO= just build` is how you opt one command out
-# of a shell that exports it, and just would otherwise hand the recipes an empty
-# program name.
-_rust_cargo := env_var_or_default("RUST_CARGO", "cargo")
-cargo_compile := if _rust_cargo == "" { "cargo" } else { _rust_cargo }
-
 # `moq-net-fuzz` is a workspace member only so it shares the root lockfile; libFuzzer
 # needs a nightly toolchain and sanitizer flags, so `just rs fuzz` is the one recipe
 # that may compile it. Every `--workspace` below therefore carries this, and a new
@@ -53,10 +39,10 @@ check *args:
     just rs _publish-test
     just rs _doc-names-test
     rs/scripts/package-nfpm.test.sh
-    {{ cargo_compile }} clippy --locked --all-targets {{ args }} -- -D warnings
+    cargo clippy --locked --all-targets {{ args }} -- -D warnings
     cargo fmt --all --check
     just rs _doc-names
-    RUSTDOCFLAGS="-D warnings" {{ cargo_compile }} doc --locked --no-deps {{ args }}
+    RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps {{ args }}
     cargo shear
     cargo sort --workspace --check --no-format
 
@@ -413,7 +399,7 @@ fix-changed $FILES:
 
 # Compile the whole workspace on a Windows host. Must run ON Windows.
 windows *args:
-    {{ cargo_compile }} check --locked --workspace --exclude moq-gst {{ no_fuzz }} --all-targets --features "moq-cli/play moq-cli/capture" {{ args }}
+    cargo check --locked --workspace --exclude moq-gst {{ no_fuzz }} --all-targets --features "moq-cli/play moq-cli/capture" {{ args }}
 
 # Runs the `#[cfg(target_os = "macos")]` code past the compiler: moq-video's
 # VideoToolbox encode/decode and its ScreenCaptureKit / AVFoundation capture,
@@ -433,7 +419,7 @@ windows *args:
 
 # Compile the Apple-only code paths. Must run ON macOS.
 macos *args:
-    {{ cargo_compile }} check --locked -p moq-video -p moq-audio --all-targets --all-features {{ args }}
+    cargo check --locked -p moq-video -p moq-audio --all-targets --all-features {{ args }}
 
 # Same idea as `windows`/`macos`, for Android: moq-video's MediaCodec encoder and
 # decoder, its `Surface::HardwareBuffer` variant, and the `frame::android` module
@@ -476,7 +462,7 @@ android *args:
 
 # Compile and lint the browser/WASM bindings, which the host-target check skips.
 wasm *args:
-    {{ cargo_compile }} clippy --locked -p moq-wasm -p moq-mux -p moq-ffi --target wasm32-unknown-unknown --lib {{ args }} -- -D warnings
+    cargo clippy --locked -p moq-wasm -p moq-mux -p moq-ffi --target wasm32-unknown-unknown --lib {{ args }} -- -D warnings
 
 # The `fix` counterpart to `wasm`. `cargo fmt` is scoped rather than `--all`
 # because this runs alongside `fix`, which already formats everything else.
@@ -512,10 +498,10 @@ audit:
 
 # Compile the workspace at the feature extremes.
 features:
-    {{ cargo_compile }} check --locked --workspace {{ no_fuzz }} --all-targets --no-default-features
-    {{ cargo_compile }} clippy --locked --workspace {{ no_fuzz }} --all-targets --all-features -- -D warnings
-    RUSTDOCFLAGS="-D warnings" {{ cargo_compile }} doc --locked --workspace {{ no_fuzz }} --all-features --no-deps
-    {{ cargo_compile }} nextest run --locked --workspace {{ no_fuzz }} --all-targets --all-features
+    cargo check --locked --workspace {{ no_fuzz }} --all-targets --no-default-features
+    cargo clippy --locked --workspace {{ no_fuzz }} --all-targets --all-features -- -D warnings
+    RUSTDOCFLAGS="-D warnings" cargo doc --locked --workspace {{ no_fuzz }} --all-features --no-deps
+    cargo nextest run --locked --workspace {{ no_fuzz }} --all-targets --all-features
 
 # nextest, not `cargo test`, so a wedged test is killed instead of pinning a core
 # until someone notices (`.config/nextest.toml` sets the timeout). The trade is
@@ -548,7 +534,7 @@ features:
 
 # Run the test suite, reporting clippy findings from the same compile.
 test *args:
-    RUSTC_WORKSPACE_WRAPPER="$(command -v clippy-driver || true)" {{ cargo_compile }} nextest run --locked --all-targets {{ args }}
+    RUSTC_WORKSPACE_WRAPPER="$(command -v clippy-driver || true)" cargo nextest run --locked --all-targets {{ args }}
 
 # Same selection as `check-changed`: compiling a crate's test binaries is the
 # expensive half of a test run, so scoping matters more here than anywhere else.
@@ -571,7 +557,7 @@ test-changed $FILES:
 
 # Compile and run the `/// ```` examples, which nextest skips.
 doctest *args:
-    {{ cargo_compile }} test --locked --doc {{ args }}
+    cargo test --locked --doc {{ args }}
 
 # Permutation-test the concurrent handoffs with loom.
 #
@@ -590,8 +576,8 @@ doctest *args:
 # kio's own unit tests are `cfg(not(loom))`: they'd construct loom primitives
 # outside `loom::model`, which panics.
 loom *args:
-    RUSTFLAGS="--cfg loom" {{ cargo_compile }} test --locked --release -p kio --lib loom:: {{ args }}
-    RUSTFLAGS="--cfg loom" {{ cargo_compile }} test --locked --release -p moq-net --test loom {{ args }}
+    RUSTFLAGS="--cfg loom" cargo test --locked --release -p kio --lib loom:: {{ args }}
+    RUSTFLAGS="--cfg loom" cargo test --locked --release -p moq-net --test loom {{ args }}
 
 # Coverage-guided fuzzing of the moq-net wire codecs (libFuzzer, via cargo-fuzz).
 #
@@ -635,17 +621,17 @@ fuzz target *args:
     	rs/moq-net/fuzz/corpus/{{ target }} rs/moq-net/fuzz/seeds/{{ target }} {{ args }}
 
 build:
-    {{ cargo_compile }} build --locked
+    cargo build --locked
 
 # Run a moq-bench preset against a relay, e.g. `just rs bench chat https://relay.example.com`.
 # Extra args pass through, so `--connections 500 --output stats.jsonl` work as-is.
 bench preset url *args:
-    {{ cargo_compile }} run --release -p moq-bench -- --file 'rs/moq-bench/config/{{ preset }}.toml' --client-connect '{{ url }}' {{ args }}
+    cargo run --release -p moq-bench -- --file 'rs/moq-bench/config/{{ preset }}.toml' --client-connect '{{ url }}' {{ args }}
 
 # Sample a process's CPU/memory/context switches on this host (run it where the
 # relay runs; it only reads /proc). E.g. `just rs bench-host --name moq-relay`.
 bench-host *args:
-    {{ cargo_compile }} run --release -p moq-bench --bin moq-bench-host -- {{ args }}
+    cargo run --release -p moq-bench --bin moq-bench-host -- {{ args }}
 
 # Remove the Rust target directory.
 clean:

--- a/rs/libmoq/CMakeLists.txt
+++ b/rs/libmoq/CMakeLists.txt
@@ -41,20 +41,11 @@ if(BUILD_RUST_LIB)
     set(RUST_LIB "${RUST_DIR}/${LIB_PREFIX}moq${LIB_SUFFIX}")
     set(RUST_HEADER "${RUST_TARGET_DIR}/include/moq.h")
 
-    # Same RUST_CARGO knob the justfiles read, so CI's cache wrapper reaches the
-    # one Rust compile this plugin actually pays for. Without it the env var is
-    # set on the job and silently ignored here.
-    if(DEFINED ENV{RUST_CARGO} AND NOT "$ENV{RUST_CARGO}" STREQUAL "")
-        set(CARGO_COMMAND "$ENV{RUST_CARGO}")
-    else()
-        set(CARGO_COMMAND "cargo")
-    endif()
-
     add_custom_target(rust_build ALL
-        COMMAND ${CARGO_COMMAND} build --locked ${CARGO_BUILD_FLAG}
+        COMMAND cargo build --locked ${CARGO_BUILD_FLAG}
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
         BYPRODUCTS ${RUST_LIB} ${RUST_HEADER}
-        COMMENT "Building Rust library with ${CARGO_COMMAND}"
+        COMMENT "Building Rust library"
         VERBATIM
     )
 else()

--- a/test/drill/sensitivity.sh
+++ b/test/drill/sensitivity.sh
@@ -25,9 +25,10 @@ DRILL_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 WORKSPACE=$(cd "$DRILL_DIR/../.." && pwd)
 MUTATIONS="$DRILL_DIR/mutations"
 
-# Plain `cargo` unless set, matching the rs/ recipes: a compile-caching wrapper
-# is what keeps the snapshot build from being a cold build of the world.
-CARGO="${RUST_CARGO:-cargo}"
+# The dev shell puts mbx's Cargo shim ahead of the pinned toolchain, so the
+# plain name is already the compile-caching wrapper that keeps the snapshot
+# build from being a cold build of the world.
+CARGO=cargo
 
 KEEP=0
 BASELINE=1

--- a/test/wasm/run.sh
+++ b/test/wasm/run.sh
@@ -97,7 +97,7 @@ echo "building @moq/wasm..."
 echo "building moq-relay ($PROFILE)..."
 flag=()
 [[ "$PROFILE" == "debug" ]] || flag=(--profile "$PROFILE")
-(cd "$WORKSPACE" && "${RUST_CARGO:-cargo}" build --locked ${flag[@]+"${flag[@]}"} -p moq-relay)
+(cd "$WORKSPACE" && cargo build --locked ${flag[@]+"${flag[@]}"} -p moq-relay)
 TARGET_BASE="${CARGO_TARGET_DIR:-$WORKSPACE/target}"
 [[ -n "$RELAY" ]] || RELAY="$TARGET_BASE/$PROFILE/moq-relay"
 


### PR DESCRIPTION
## Summary

`RUST_CARGO` existed because the only way to route a build through mbx was to spell the wrapper out at every call site: three justfile declarations, the libmoq CMake rule, and the `go`/`kt`/`wasm` scripts. It never reached a build that spawns Cargo itself, which is why `release-rs.yml` stayed on Swatinem while its `cargo-semver-checks` step cost forty minutes (#3547).

`mbx setup` installs a `cargo` launcher instead. The dev shell already put that ahead of the pinned toolchain for local builds; the `CI` guard on it existed only because no runner had one. Have the cache action install it and the guard has nothing left to protect, so plain `cargo` is the wrapper everywhere and the whole seam can go.

Net −17 lines.

## Changes

- **`.github/actions/rust-cache`** runs `mbx setup --yes`, then asserts with `mbx setup --status`. The assertion is the point: with `RUST_CARGO` gone the shim is the only thing routing Cargo through mbx, and a setup that quietly did nothing would build every job uncached and still report success.
- **`flake.nix`** drops the `[ -z "${CI:-}" ]` guard. Jobs that never install mbx no-op exactly as before, since `mbx setup --status` fails when there is no binary.
- **`RUST_CARGO` deleted** from `justfile`, `rs/justfile`, `cpp/obs/justfile`, `rs/libmoq/CMakeLists.txt`, `go/scripts/stage.sh`, `kt/scripts/generate.sh`, `test/wasm/run.sh`, `test/drill/sensitivity.sh`, and the four workflow `env:` blocks. Local behaviour is unchanged: the variable was unset outside CI, so those recipes already resolved to the shim. The stale `_rust_cargo` entry in `quest/m0/tooling/justfiles.md` goes too, since the consolidation it planned is now moot.
- **`release-rs.yml`** moves onto the action with `scope: release-rs`, a new input keeping its key space separate from what `cache.yml` warms. The two hold different things (semver-checks rustdoc vs check and test artifacts) and one prefix would have each restoring a target tree built for the other.

## What deliberately did not move

Six workflows stay on Swatinem, and this is not an oversight:

| Workflow | Trigger | Why |
|---|---|---|
| `nightly.yml`, `smoke.yml` | `schedule` | `shouldSave` only writes on a default-branch push or an opted-in dispatch, so these would restore a store nothing ever writes |
| `release-{go,dart,kt,swift}-ffi` | `tags` | Same, and their cross-compile triples are ones `cache.yml` never warms, so they would be permanently cold |
| `swift.yml` | `push`/`pull_request` | `macos-latest` with `dtolnay/rust-toolchain`, never enters `nix develop`, so the shim cannot reach it |

Moving any of them would be a regression dressed as a migration.

## Public API and wire impact

None. CI configuration, justfile plumbing, and comments.

## Verification

`nix develop --command just check` passes, including `actionlint`, `just gh check`, and the nix/justfile/shell lints. The `flake.nix` change widens the diff scope, so this was the full unscoped suite rather than a scoped one.

One thing this cannot verify locally: whether `mbx setup --yes` installs a standalone shim non-interactively on a Linux runner. Without an active mise shell it can write a `[wrappers.cargo]` entry into a global mise config, so it was not run on a dev machine to find out. The `--status` assertion is what makes the CI answer unambiguous: the job fails loudly rather than silently building uncached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by claude-opus-5)
