### PR TITLE
fix: restore the kio patch and teach crane about it

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,6 +15,11 @@ name: Nightly
 # `#[cfg(target_os = ...)]` code that no Linux job compiles at all, and those
 # runners are throttled too hard to gate every PR on.
 #
+# `nix` is diff-independent because the flake packages are only ever built on a
+# release tag, so a change that compiles under plain cargo can still break every
+# release artifact (crane vendors and stubs sources in ways cargo never does) and
+# nothing notices until the tag is pushed.
+#
 # A failure here lands on main rather than being caught in review, which is the
 # accepted trade. Anything that must block a merge belongs in check.yml.
 
@@ -120,6 +125,35 @@ jobs:
         env:
           NEXTEST_PROFILE: ci
           MOQ_STRICT: 1
+
+  # The release workflows build these flake attributes from a tag. crane splits a
+  # build into a dependency-only stage over stubbed workspace sources and the real
+  # one, so a `[patch.crates-io]` entry or a source filter can break here while
+  # plain cargo stays green. Two packages cover both install phases (staticlib and
+  # binary) and the whole dependency tree between them; the rest share the stages
+  # that actually break.
+  nix:
+    name: Nix (${{ matrix.package }})
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [libmoq, moq-relay]
+    steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
+        with:
+          tool-cache: false
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: DeterminateSystems/nix-installer-action@1d87d45818068401a10cf16bdc5f00b24994a83f # main
+        with:
+          determinate: false
+      - name: Build
+        run: nix build ".#${{ matrix.package }}" --print-build-logs
 
   fuzz:
     name: Fuzz (${{ matrix.target }})

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4328,16 +4328,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kio"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8975d78baeace839a8b35eafa2914a1c49eb96253c16789eb4b8f49e8bd5d8a"
-dependencies = [
- "loom",
- "smallvec",
-]
-
-[[package]]
 name = "kqueue"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4705,7 +4695,7 @@ dependencies = [
  "dispatch2",
  "fixed-resample",
  "hang",
- "kio 0.5.8",
+ "kio",
  "moq-mux",
  "moq-net",
  "objc2 0.6.4",
@@ -4804,7 +4794,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "hang",
- "kio 0.5.8",
+ "kio",
  "moq-audio",
  "moq-json",
  "moq-mux",
@@ -4859,7 +4849,7 @@ dependencies = [
  "bytes",
  "hang",
  "humantime",
- "kio 0.5.8",
+ "kio",
  "m3u8-rs",
  "moq-mux",
  "moq-net",
@@ -4880,7 +4870,7 @@ dependencies = [
  "bytes",
  "criterion",
  "json-patch",
- "kio 0.5.8",
+ "kio",
  "moq-flate",
  "moq-net",
  "serde",
@@ -4918,7 +4908,7 @@ dependencies = [
  "futures",
  "h264-parser",
  "hang",
- "kio 0.5.8",
+ "kio",
  "memchr",
  "moq-json",
  "moq-loc",
@@ -5003,7 +4993,7 @@ dependencies = [
  "criterion",
  "futures",
  "getrandom 0.4.3",
- "kio 0.5.8",
+ "kio",
  "loom",
  "num_enum",
  "rand 0.10.2",
@@ -5191,7 +5181,7 @@ dependencies = [
  "bytes",
  "clap",
  "hang",
- "kio 0.5.8",
+ "kio",
  "moq-mux",
  "moq-native",
  "moq-net",
@@ -10658,7 +10648,7 @@ dependencies = [
  "bytes",
  "http",
  "iroh",
- "kio 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kio",
  "n0-error",
  "n0-future",
  "tokio",
@@ -10677,7 +10667,7 @@ dependencies = [
  "bytes",
  "futures",
  "http",
- "kio 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kio",
  "noq",
  "rustls",
  "rustls-native-certs",
@@ -10714,7 +10704,7 @@ dependencies = [
  "flume",
  "futures",
  "http",
- "kio 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kio",
  "rustls-pki-types",
  "thiserror 2.0.20",
  "tokio",
@@ -10734,7 +10724,7 @@ dependencies = [
  "bytes",
  "futures",
  "http",
- "kio 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "kio",
  "quinn",
  "rustls",
  "rustls-native-certs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,12 @@ web-transport-trait = "0.4.0"
 web-transport-wasm = "0.6"
 x11rb = { version = "0.14.0", features = ["randr", "xfixes"] }
 
+[patch.crates-io]
+# web-transport-quinn and web-transport-iroh depend on kio from crates.io. Without
+# this, the lock carries a second kio whose pin drifts behind the member, and the
+# next publish that reaches both fails to resolve a single version (#3551).
+kio = { path = "rs/kio" }
+
 [profile.dev]
 panic = "abort"
 # Full DWARF is what makes a debug build enormous: the debug `libmoq_ffi.a`

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -24,6 +24,31 @@ let
     filter = filterCargoSources;
   };
 
+  # rs/kio on its own, so the dependency layer below only rebuilds when kio does.
+  kioSource = final.lib.cleanSourceWith {
+    src = ../rs/kio;
+    name = "kio-source";
+    filter = filterCargoSources;
+  };
+
+  # `[patch.crates-io] kio = { path = "rs/kio" }` in the root Cargo.toml points
+  # registry crates (web-transport-quinn, web-transport-iroh) at the workspace
+  # member. crane's dependency-only stage stubs every workspace crate down to an
+  # empty lib.rs, so those registry crates no longer find kio's API and fail to
+  # compile. Put kio's real source back into the dummy tree.
+  buildPackage =
+    args:
+    craneLib.buildPackage (
+      args
+      // {
+        extraDummyScript = ''
+          rm -rf $out/rs/kio
+          cp -r ${kioSource} --no-target-directory $out/rs/kio
+          chmod -R +w $out/rs/kio
+        '';
+      }
+    );
+
   moqRelayArgs = crateInfo ../rs/moq-relay/Cargo.toml // {
     src = cleanCargoSource;
     cargoExtraArgs = "-p moq-relay --features jemalloc";
@@ -69,7 +94,7 @@ let
     # The crate is `moq-token-cli`, but its `[[bin]]` ships as `moq-token`.
     meta.mainProgram = "moq-token";
   };
-  moqTokenPackage = craneLib.buildPackage moqTokenCliArgs;
+  moqTokenPackage = buildPackage moqTokenCliArgs;
 
   moqBenchArgs = crateInfo ../rs/moq-bench/Cargo.toml // {
     src = cleanCargoSource;
@@ -266,16 +291,16 @@ let
   # Release artifacts still build via crane `buildPackage` below.
 in
 {
-  moq-relay = craneLib.buildPackage moqRelayArgs;
+  moq-relay = buildPackage moqRelayArgs;
 
-  moq-cli = craneLib.buildPackage moqCliArgs;
+  moq-cli = buildPackage moqCliArgs;
 
-  moq-bench = craneLib.buildPackage moqBenchArgs;
+  moq-bench = buildPackage moqBenchArgs;
 
   moq-token = moqTokenPackage;
   moq-token-cli = moqTokenPackage;
 
-  moq-boy = craneLib.buildPackage (
+  moq-boy = buildPackage (
     crateInfo ../rs/moq-boy/Cargo.toml
     // {
       src = cleanCargoSource;
@@ -294,9 +319,9 @@ in
     }
   );
 
-  libmoq = craneLib.buildPackage libmoqArgs;
+  libmoq = buildPackage libmoqArgs;
 
-  moq-gst-plugin = craneLib.buildPackage moqGstPluginArgs;
+  moq-gst-plugin = buildPackage moqGstPluginArgs;
 
   # User-facing flake output. Bundles the plugin with wrapped gstreamer
   # tools so a single `nix shell .#moq-gst` gives you gst-inspect-1.0 /


### PR DESCRIPTION
## Why this instead of #3555

#3555 removed `[patch.crates-io] kio = { path = "rs/kio" }` and pinned the registry copy to the freshly published `kio 0.5.8`. That fixes the pin value, not the mechanism: nothing holds the registry entry in step with the workspace member, so the next kio bump reproduces #3551's release failure.

Reproduced on `main` as of fd4f5d82e:

```
$ cargo update -p 'registry+...#kio@0.5.8' --precise 0.5.7   # cargo allows this freely
$ cargo package -p moq-native --allow-dirty --no-verify
error: failed to select a version for `kio`.
    ... required by package `web-transport-iroh v0.7.0`
  versions that meet the requirements `^0.5.4` (locked to 0.5.7) are: 0.5.7
    previously selected package `kio v0.5.8`
      ... which satisfies dependency `kio = "^0.5.8"` of package `moq-net v0.2.19`
```

That is not hypothetical drift: it is exactly how [run 34300670942](https://github.com/moq-dev/moq/actions/runs/34300670942) broke. release-plz bumped the member to 0.5.8 and left the registry pin at 0.5.7. It will do the same at 0.5.9.

With the patch restored, the lock carries one kio and `cargo package -p moq-native` succeeds.

## What broke the first time, and the real fix

The patch points registry crates (`web-transport-quinn`, `web-transport-iroh`) at the workspace member. crane splits a build into a dependency-only stage whose sources are stubbed down to an empty `lib.rs` per workspace crate, so those registry crates compiled against an empty kio and every nix build failed on the `libmoq-v0.5.14` tag ([run 34303702387](https://github.com/moq-dev/moq/actions/runs/34303702387)):

```
error[E0432]: unresolved imports `kio::Park`, `kio::Waiter`
  --> .../web-transport-quinn-0.12.1/src/waiters.rs:10:11
```

`nix/overlay.nix` now wraps `craneLib.buildPackage` with an `extraDummyScript` that puts kio's real source back into the dummy tree, scoped to `rs/kio` so only a kio edit invalidates the cached dependency layer.

## Regression coverage

Nix builds only run on release tags, which is why both #3551 and its fallout reached `main` green. `nightly.yml` gains a `nix build` job over `libmoq` and `moq-relay` (staticlib and binary install phases, and the whole dependency tree between them).

## Verification

- `nix build .#libmoq` succeeds on aarch64-darwin, the target that failed in CI (same lock, byte-identical to the #3551 state).
- `cargo package -p moq-native --allow-dirty --no-verify` succeeds with the patch, fails without it once the registry pin lags.
- `cargo check -p moq-native --all-features`

## Public API and wire impact

None. `[patch]` is workspace-local and is stripped from published manifests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by claude-opus-5)