### PR TITLE
fix: restore Nix builds after kio release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4328,6 +4328,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kio"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8975d78baeace839a8b35eafa2914a1c49eb96253c16789eb4b8f49e8bd5d8a"
+dependencies = [
+ "loom",
+ "smallvec",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4695,7 +4705,7 @@ dependencies = [
  "dispatch2",
  "fixed-resample",
  "hang",
- "kio",
+ "kio 0.5.8",
  "moq-mux",
  "moq-net",
  "objc2 0.6.4",
@@ -4794,7 +4804,7 @@ dependencies = [
  "bytes",
  "getrandom 0.4.3",
  "hang",
- "kio",
+ "kio 0.5.8",
  "moq-audio",
  "moq-json",
  "moq-mux",
@@ -4849,7 +4859,7 @@ dependencies = [
  "bytes",
  "hang",
  "humantime",
- "kio",
+ "kio 0.5.8",
  "m3u8-rs",
  "moq-mux",
  "moq-net",
@@ -4870,7 +4880,7 @@ dependencies = [
  "bytes",
  "criterion",
  "json-patch",
- "kio",
+ "kio 0.5.8",
  "moq-flate",
  "moq-net",
  "serde",
@@ -4908,7 +4918,7 @@ dependencies = [
  "futures",
  "h264-parser",
  "hang",
- "kio",
+ "kio 0.5.8",
  "memchr",
  "moq-json",
  "moq-loc",
@@ -4993,7 +5003,7 @@ dependencies = [
  "criterion",
  "futures",
  "getrandom 0.4.3",
- "kio",
+ "kio 0.5.8",
  "loom",
  "num_enum",
  "rand 0.10.2",
@@ -5181,7 +5191,7 @@ dependencies = [
  "bytes",
  "clap",
  "hang",
- "kio",
+ "kio 0.5.8",
  "moq-mux",
  "moq-native",
  "moq-net",
@@ -10648,7 +10658,7 @@ dependencies = [
  "bytes",
  "http",
  "iroh",
- "kio",
+ "kio 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "n0-error",
  "n0-future",
  "tokio",
@@ -10667,7 +10677,7 @@ dependencies = [
  "bytes",
  "futures",
  "http",
- "kio",
+ "kio 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "noq",
  "rustls",
  "rustls-native-certs",
@@ -10704,7 +10714,7 @@ dependencies = [
  "flume",
  "futures",
  "http",
- "kio",
+ "kio 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustls-pki-types",
  "thiserror 2.0.20",
  "tokio",
@@ -10724,7 +10734,7 @@ dependencies = [
  "bytes",
  "futures",
  "http",
- "kio",
+ "kio 0.5.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quinn",
  "rustls",
  "rustls-native-certs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,12 +186,6 @@ web-transport-trait = "0.4.0"
 web-transport-wasm = "0.6"
 x11rb = { version = "0.14.0", features = ["randr", "xfixes"] }
 
-[patch.crates-io]
-# web-transport-iroh depends on kio from crates.io. Without this, the workspace
-# compiles a second copy of kio alongside the member, and publishing any crate
-# that reaches both fails to resolve a single version.
-kio = { path = "rs/kio" }
-
 [profile.dev]
 panic = "abort"
 # Full DWARF is what makes a debug build enormous: the debug `libmoq_ffi.a`


### PR DESCRIPTION
## Summary

- remove the workspace-wide `kio` crates.io patch now that `kio 0.5.8` is published
- lock the registry copy used by `web-transport-iroh` to `0.5.8`
- restore Crane dependency-only builds, which redirect patched workspace members to dummy sources

## Verification

- `cargo package -p moq-native --allow-dirty`
- `cargo check -p moq-native --all-features`
- `nix build --no-link .#moq-cli .#moq-relay .#moq-token-cli`
- `just fix`
- `just check`
- `just test` (3,629 passed, 7 skipped)

## Public API

None.

## Wire

None.

(written by GPT-5)