### PR TITLE
docs: prefer the moq token subcommand

### DIFF
--- a/doc/bin/relay/auth.md
+++ b/doc/bin/relay/auth.md
@@ -18,8 +18,10 @@ prefixes, and the session can only see that part of the tree.
 
 ## Tokens
 
-Generate a key, sign a token, hand it to the client. `moq token` inside
-[moq-cli](/bin/cli) and the standalone `moq-token` are the same tool.
+Generate a key, sign a token, hand it to the client. Install the
+[moq CLI](/setup/install) and use its `moq token` subcommand.
+For token tooling alone, `cargo install moq-token-cli` installs the standalone
+`moq-token` executable with the same subcommands and options.
 
 ```bash
 # Asymmetric: the relay only needs public.jwk.

--- a/doc/lib/rs/moq-token.md
+++ b/doc/lib/rs/moq-token.md
@@ -20,8 +20,9 @@ that wants the relay's path rules.
 cargo add moq-token
 ```
 
-The CLI is `moq token` in [moq-cli](/bin/cli) or the standalone
-`moq-token-cli` package; both wrap this crate. Examples:
+For command-line use, install the [moq CLI](/setup/install) and run
+`moq token`. The optional standalone `moq-token` executable comes from
+`cargo install moq-token-cli`; both wrap this crate. Examples:
 [`basic.rs`](https://github.com/moq-dev/moq/blob/main/rs/moq-token/examples/basic.rs)
 and
 [`asymmetric.rs`](https://github.com/moq-dev/moq/blob/main/rs/moq-token/examples/asymmetric.rs).

--- a/doc/setup/install.md
+++ b/doc/setup/install.md
@@ -15,11 +15,15 @@ Three binaries and two plugins ship prebuilt:
 | GStreamer plugin | `moqsink`, `moqsrc` | [GStreamer](/bin/gstreamer) elements |
 | OBS plugin | | [OBS Studio](/bin/obs) output and source |
 
+Use `moq token` for keys and tokens; installing `moq-cli` includes it.
+The standalone `moq-token` is optional for users who only need token tooling:
+install it with `cargo install moq-token-cli`.
+
 ## Any platform
 
 ```bash
 # crates.io (needs a Rust toolchain)
-cargo install moq-relay moq-cli moq-token-cli
+cargo install moq-relay moq-cli
 
 # Homebrew (macOS and Linux)
 brew install moq-dev/tap/moq-relay moq-dev/tap/moq-cli
@@ -48,7 +52,7 @@ is available on Debian 12+ and Ubuntu 24.04+.
 curl -fsSL https://apt.moq.dev/moq-keyring.gpg | sudo tee /usr/share/keyrings/moq-keyring.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/moq-keyring.gpg] https://apt.moq.dev stable main" | sudo tee /etc/apt/sources.list.d/moq.list
 sudo apt update
-sudo apt install moq-relay moq-cli moq-token-cli gstreamer1.0-moq
+sudo apt install moq-relay moq-cli gstreamer1.0-moq
 ```
 
 ## Fedora, RHEL, and openSUSE
@@ -57,7 +61,7 @@ Fedora 39+, RHEL 9, Rocky 9, AlmaLinux 9. On openSUSE use `zypper addrepo`.
 
 ```bash
 sudo dnf config-manager --add-repo https://rpm.moq.dev/moq.repo
-sudo dnf install moq-relay moq-cli moq-token-cli gstreamer1-moq
+sudo dnf install moq-relay moq-cli gstreamer1-moq
 ```
 
 Both repositories are signed with the project key, served at
@@ -82,7 +86,6 @@ works without root, and config edits survive upgrades.
 ```powershell
 winget install moq-dev.moq-relay
 winget install moq-dev.moq-cli
-winget install moq-dev.moq-token-cli
 ```
 
 The OBS plugin ships as a zip for Windows x64 and macOS arm64 on the

--- a/js/token/README.md
+++ b/js/token/README.md
@@ -1,6 +1,6 @@
 # moq-token
 
-A Javascript/Typescript library and CLI for implementing authentication with a MoQ relay. For comprehensive documentation including token structure, authorization rules, and examples, see the [Authentication Documentation](../../doc/app/relay/auth.md)
+A Javascript/Typescript library and CLI for implementing authentication with a MoQ relay. For comprehensive documentation including token structure, authorization rules, and examples, see the [Authentication Documentation](../../doc/bin/relay/auth.md)
 
 ## Installation
 

--- a/rs/moq-token/README.md
+++ b/rs/moq-token/README.md
@@ -3,26 +3,26 @@
 A simple JWT and JWK based authentication scheme for moq-relay.
 
 For comprehensive documentation including token structure, authorization rules, and examples, see:
-**[Authentication Documentation](https://github.com/moq-dev/moq/blob/main/doc/app/relay/auth.md)**
+**[Authentication Documentation](https://github.com/moq-dev/moq/blob/main/doc/bin/relay/auth.md)**
 
 ## Quick Usage (symmetric keys)
 
 ```bash
 # generate secret key
-moq-token generate --out key.jwk
+moq token generate --out key.jwk
 # sign a new JWT
-moq-token sign --key key.jwk --root demo --publish bbb > token.jwt
+moq token sign --key key.jwk --root demo --publish bbb > token.jwt
 # verify the JWT
-moq-token verify --key key.jwk < token.jwt
+moq token verify --key key.jwk < token.jwt
 ```
 
 ## Quick Usage (asymmetric keys)
 
 ```bash
 # generate private and public keys
-moq-token generate --algorithm RS256 --out private.jwk --public public.jwk
+moq token generate --algorithm RS256 --out private.jwk --public public.jwk
 # sign a new JWT (using private key)
-moq-token sign --key private.jwk --root demo --publish bbb > token.jwt
+moq token sign --key private.jwk --root demo --publish bbb > token.jwt
 # verify the JWT (using public key)
-moq-token verify --key public.jwk < token.jwt
+moq token verify --key public.jwk < token.jwt
 ```


### PR DESCRIPTION
## Summary

Make `moq token` the default token-tool entry point in installation and authentication guidance. Align the Rust token README examples and repair the Rust and TypeScript README authentication links. Keep `moq-token` documented as an optional standalone executable and retain all Rust library and Cargo crate names. Authentication examples already use the subcommand on main; this aligns the surrounding installation guidance.

## Public API

None. Documentation only.

## Wire

None.

## Validation

Checked generate help and completed ES256 and EdDSA generate/sign/verify round trips with the installed moq 0.9.14 executable. `nix develop --command just fix` and `nix develop --command just check` pass after the README repair. The README HS256/RS256 round trips, including stdin verification, also pass. The companion dashboard change passes `nix develop --command just check` with 178 tests.

Independent of package rename PR #3552; current package names are retained here.

(written by GPT-6)
