### PR TITLE
docs(quest): plan the draft-18 interop defects #3558 and #3559

### DIFF
--- a/quest/m0/3558-ietf-largest-object-encoding.md
+++ b/quest/m0/3558-ietf-largest-object-encoding.md
@@ -1,0 +1,91 @@
+# [S] LARGEST_OBJECT is a bare Location from draft-17 on
+
+## Goal
+
+A draft-17-or-later peer's SUBSCRIBE_OK decodes instead of failing with `short
+buffer`, because moq-net reads LARGEST_OBJECT (0x09) as the two bare varints
+section 10.2 defines rather than a length-prefixed value. The parameter is also
+advertised on every draft that defines it, in that draft's own form, so a
+subscriber can size a backfill against a real Largest Location the first time it
+subscribes to a track with content.
+
+Boundaries: only Message Parameters changed at draft-17. Setup Options and Track
+Properties are still Key-Value-Pairs, so the odd-type Length rule in section
+1.4.3 still governs them and neither codec moves. moq-transport is someone
+else's draft, so nothing under `drafts/` changes, and `mod ietf` is private, so
+no public API moves either.
+
+## Plan
+
+What the tree does today, on main and dev alike:
+
+- `rs/moq-net/src/ietf/parameters.rs` `impl Param for Location` writes two
+  varints inside a length-prefixed value on every draft, explaining itself with
+  "LARGEST_OBJECT (0x09) is an odd type, so the Key-Value-Pair rule gives it a
+  Length on every draft". `location_inner_version` pins the inner varints to the
+  draft-15 encoding for draft-14/15/16.
+- `rs/moq-net/src/ietf/subscribe.rs:249` filters the emit with
+  `Filter::is_draft20(version)`, so the encoder is only ever exercised on
+  draft-20 and the decode path had never met another draft-18 sender.
+- `js/net/src/ietf/parameters.ts` repeats both the length prefix and the comment
+  in its `"location"` case, and `js/net/src/ietf/subscribe.ts:252` repeats the
+  `Filter.isDraft20` gate.
+
+What the drafts say. Draft-16 section 9.2 says "Parameters are serialized as
+Key-Value-Pairs" and section 9.2.2.7 calls LARGEST_OBJECT "a length-prefixed
+Location structure", so the current code is right through draft-16. Draft-17
+replaced that: section 9.3, and section 10.2 from draft-18 on, defines
+`Message Parameter { Type Delta (vi64), Value (..) }` with no Length field at
+all, and lists `Location: Two consecutive varints (Group, Object)` beside
+`Length-prefixed` as separate per-parameter encodings. Section 10.2.11 on
+draft-18 and 19, 10.2.17 on draft-20, makes LARGEST_OBJECT a Location.
+LARGEST_OBJECT is the only odd-typed Message Parameter this touches:
+AUTHORIZATION_TOKEN (0x03), SUBSCRIPTION_FILTER and its LOCATION_FILTER
+successor (0x21), and FILL_PARAMETERS (0x23) each say in their own definition
+that they use length-prefixed encoding.
+
+There is no ambiguity to raise with the working group. cloudflare/moq-rs, the
+IETF-aligned implementation behind Cloudflare's production relays, splits
+`encode_message_params`/`decode_message_params` from its Key-Value-Pair codec on
+its `draft-18-dev` branch, lists LARGEST_OBJECT in
+`TWO_VARINT_VALUE_PARAMETER_TYPES`, and pins the wire bytes `[1, 0x09, 4, 5]` in
+`largest_object_uses_two_inline_varints`. moq-playa and red5-moq-relay read it
+the same way. We are the outlier.
+
+The work:
+
+- `impl Param for Location`: length-prefixed through draft-16, two bare varints
+  from draft-17 on. `location_inner_version` survives only for the draft-16 and
+  earlier branch. Replace the comment with what the two sections actually say
+  and cite them.
+- Drop the `is_draft20` filter in `subscribe.rs` and `isDraft20` in
+  `subscribe.ts`, so SUBSCRIBE_OK carries LARGEST_OBJECT on every draft that
+  defines it once the track has content, which section 10.2.11 makes a MUST. The
+  gate's stated reason is that a peer built before we sent it closes the session
+  over an unexpected SUBSCRIBE_OK parameter; the implementation that reason was
+  written about decodes SUBSCRIBE_OK parameters into a generic `KeyValuePairs`
+  and never rejects an unknown key, on `main` (draft-16, and Cloudflare's
+  deployed draft-14 and draft-16 relays) as well as on `draft-18-dev`. Confirm
+  that against a deployed relay before landing rather than on the source alone.
+- Mirror the encoding fix and the comment in `js/net/src/ietf/parameters.ts`.
+
+Tests, byte-exact per draft rather than round-trip alone, since a round-trip
+against ourselves is what hid this:
+
+- Draft-16 emits the length-prefixed form; draft-17 through draft-20 emit
+  `[count, 0x09, group, object]`, matching cloudflare/moq-rs's own assertion.
+- A draft-18 SUBSCRIBE_OK carrying a bare LARGEST_OBJECT decodes to the right
+  Location instead of `short buffer`. This is the regression test for the
+  report: Group 427 as a two-byte varint currently becomes a demand for 427
+  bytes.
+- The same pair in `js/net`, and the bare form added to the `rs/moq-net/src/fuzz.rs`
+  corpus if it costs nothing.
+
+## Closes
+
+- [#3558](https://github.com/moq-dev/moq/issues/3558) - close this issue when the quest finishes
+
+## Related
+
+- [Publisher priority](/quest/m0/3534-ietf-publisher-priority.md) - the sibling sweep of what a SUBSCRIBE_OK carries
+- [FETCH_OK](/quest/m0/3559-ietf-fetch-ok.md) - the other draft-18 interop defect from the same reporter

--- a/quest/m0/3559-ietf-fetch-ok.md
+++ b/quest/m0/3559-ietf-fetch-ok.md
@@ -55,10 +55,11 @@ The work:
   what the type's own assertions require.
 - Give the fetch the one fact it needs to name a legal range: the group
   `run_subscribe_stream` already snapshots from `live_edge`, recorded under its
-  request id in state shared across the session's streams and dropped when the
-  subscription ends. `Publisher` is `Clone` and carries no per-request map
-  today, so this is a new field on it; keep it to the group, since serving the
-  range is explicitly out of scope.
+  request id and dropped when the subscription ends. Every stream runs on its
+  own `Publisher` clone, so a plain field would be copied per stream and the
+  fetch would never see the subscribe's entry; the map has to sit behind a
+  shared handle so all clones read one table. Keep the entry to the group, since
+  serving the range is explicitly out of scope.
 - End Location becomes the fetch's own Start, `{group, 0}` for the offset-0
   joining fetch we accept: the empty range, and the smallest answer that is not
   smaller than Start. `end_of_track` stays false.
@@ -71,12 +72,18 @@ The work:
 Tests, per version, since the message type is version-dependent and no test
 covers what the publisher actually writes:
 
-- A relative joining FETCH with offset 0 yields 0x18 with that draft's field
-  layout, and 0x7 appears nowhere in the bytes.
+- A relative joining FETCH with offset 0, arriving while its subscription is
+  still active, yields a response whose decoded message type is FETCH_OK
+  (0x18) rather than REQUEST_OK (0x7), with that draft's field layout. Assert
+  on the decoded type, not on 0x7 being absent from the bytes: 0x7 is a legal
+  group id, object id or length, so scanning for it would fail a correct
+  response.
 - On a track whose live edge is past group 0, the End Location is that group
   with object 0 rather than `{0, 0}`. This is the regression test for the
   session close.
-- The refused forms still produce their error message and close the writer.
+- The refused forms still produce their error message and close the writer, and
+  a joining FETCH arriving after its subscription ended finds no entry and is
+  refused rather than reading a stale group.
 
 ## Closes
 

--- a/quest/m0/3559-ietf-fetch-ok.md
+++ b/quest/m0/3559-ietf-fetch-ok.md
@@ -1,0 +1,89 @@
+# [S] A FETCH is answered with FETCH_OK
+
+## Goal
+
+A successful FETCH gets FETCH_OK (0x18) on every negotiated draft, never
+REQUEST_OK (0x7), and its End Location names a range the subscriber will accept
+instead of one that earns a PROTOCOL_VIOLATION. A joining subscriber that pairs
+SUBSCRIBE with a joining FETCH, which is how MSF-01 clients retrieve a catalog,
+completes the fetch and plays.
+
+Boundaries: the fetch response stays empty. The relay opens the data stream,
+writes the FETCH_HEADER and FINs it, exactly as today, because below draft-20
+`subscribe_range` ignores the filter and serves `ServeRange::default()`, which
+starts at the beginning of the latest group, so the group a joining fetch would
+backfill is already arriving on the subscription. Standalone fetches, absolute
+joining fetches, and a non-zero group offset stay refused. Serving a joining
+fetch for real is not worth building: draft-20 removed the joining variant of
+FETCH in favor of the fill fetch streams moq-net already serves. `js/net` throws
+"FETCH messages are not supported" and gets no mirror.
+
+## Plan
+
+What the tree does today:
+
+- `write_fetch_ok` (`rs/moq-net/src/ietf/publisher.rs:1251`) encodes
+  `ietf::FetchOk` only on draft-14. The `Draft15 | Draft16` arm and the `_`
+  default both encode `ietf::RequestOk`, so drafts 15 through 20 answer with the
+  wrong message. moq-playa reports it as
+  `expected FETCH_OK/REQUEST_ERROR on request stream, got REQUEST_OK`.
+- The End Location is the literal `Location { group: 0, object: 0 }`.
+- `run_fetch_stream` binds the joining request id to `_subscribe_id` and drops
+  it, so nothing connects the fetch to the subscription it joins.
+
+What the drafts say. Section 5.2, in the same words on draft-15 through
+draft-20, requires "exactly one FETCH_OK or REQUEST_ERROR in response to a
+FETCH". REQUEST_OK's own definition lists the requests it answers, PUBLISH,
+REQUEST_UPDATE, TRACK_STATUS, SUBSCRIBE_NAMESPACE, SUBSCRIBE_TRACKS and
+PUBLISH_NAMESPACE, and FETCH is not among them on any draft. Section 10.13
+requires End Location to be at least the corresponding FETCH's Start Location,
+"otherwise the receiver MUST close the session with a PROTOCOL_VIOLATION", and
+section 10.12.2.1 puts a relative joining fetch's Start at
+`{Joining Location.Group - Joining Start, 0}`. With the group hardcoded to 0,
+every track whose live edge is past group 0 earns that close, so fixing the
+message type alone would trade one interop failure for another.
+
+`ietf::FetchOk` already has the per-draft layout: Request ID and Group Order on
+draft-14, Request ID alone on 15 and 16, neither from 17 on, with Track
+Properties as the trailing field. It has round-trip tests per version. Only its
+caller is wrong.
+
+The work:
+
+- `write_fetch_ok` encodes `ietf::FetchOk` on every version, with
+  `request_id: Some(..)` through draft-16 and `None` from draft-17 on, which is
+  what the type's own assertions require.
+- Give the fetch the one fact it needs to name a legal range: the group
+  `run_subscribe_stream` already snapshots from `live_edge`, recorded under its
+  request id in state shared across the session's streams and dropped when the
+  subscription ends. `Publisher` is `Clone` and carries no per-request map
+  today, so this is a new field on it; keep it to the group, since serving the
+  range is explicitly out of scope.
+- End Location becomes the fetch's own Start, `{group, 0}` for the offset-0
+  joining fetch we accept: the empty range, and the smallest answer that is not
+  smaller than Start. `end_of_track` stays false.
+- A joining fetch naming a request id with no subscription keeps the existing
+  refusal, alongside the standalone, absolute joining and non-zero offset cases.
+  The literal `500` stays for now; [IETF error codes](/quest/m0/ietf-error-codes.md)
+  already lists `run_fetch_stream` as one of its sites and replaces it with the
+  registered value.
+
+Tests, per version, since the message type is version-dependent and no test
+covers what the publisher actually writes:
+
+- A relative joining FETCH with offset 0 yields 0x18 with that draft's field
+  layout, and 0x7 appears nowhere in the bytes.
+- On a track whose live edge is past group 0, the End Location is that group
+  with object 0 rather than `{0, 0}`. This is the regression test for the
+  session close.
+- The refused forms still produce their error message and close the writer.
+
+## Closes
+
+- [#3559](https://github.com/moq-dev/moq/issues/3559) - close this issue when the quest finishes
+
+## Related
+
+- [IETF error codes](/quest/m0/ietf-error-codes.md) - replaces the 500 the refusals still use
+- [LARGEST_OBJECT](/quest/m0/3558-ietf-largest-object-encoding.md) - the other draft-18 interop defect from the same reporter
+- [TRACK_STATUS refusal](/quest/m0/3492-ietf-track-status-refusal.md) - the same shape: answer the request properly instead of leaving the peer guessing

--- a/quest/m0/README.md
+++ b/quest/m0/README.md
@@ -19,6 +19,8 @@ regression test per Root Cause First.
 - [Jitter estimator](/quest/m0/3479-mux-jitter-flush-span.md) - moq-mux: catalog jitter is the publisher's maximum flush span, never a running minimum
 - [WebKit gate](/quest/m0/webkit-webtransport-gate.md) - js/net: every WebKit engine takes the WebSocket path, not just the Safari brand, so iOS Chrome and Firefox stop freezing after two minutes
 - [IETF error codes](/quest/m0/ietf-error-codes.md) - every code on a moq-transport wire is a registered value for the negotiated draft, requests and stream resets alike
+- [LARGEST_OBJECT](/quest/m0/3558-ietf-largest-object-encoding.md) - moq-net: LARGEST_OBJECT is the bare Location draft-17 defines, so a conforming publisher's SUBSCRIBE_OK stops failing with `short buffer`
+- [FETCH_OK](/quest/m0/3559-ietf-fetch-ok.md) - moq-net: a FETCH is answered with FETCH_OK and a legal End Location, not REQUEST_OK and group 0
 - [Publisher priority](/quest/m0/3534-ietf-publisher-priority.md) - moq-net: a track's publisher priority survives a moq-transport hop instead of being flattened to 0
 - [TRACK_STATUS refusal](/quest/m0/3492-ietf-track-status-refusal.md) - moq-net: TRACK_STATUS gets a NOT_SUPPORTED refusal instead of a silent drop
 - [Connect auth race](/quest/m0/3532-connect-auth-race.md) - moq-native: a 403 on the WebSocket arm no longer fails a connect whose QUIC arm is still in flight; moq-ffi can disable the fallback


### PR DESCRIPTION
Plans two moq-transport interop defects reported against draft-18 as m0 quests. Both claims were verified against the published drafts 14 through 20, and both hold; the drafts say more than the reports did.

## [S] LARGEST_OBJECT is a bare Location from draft-17 on (#3558)

`impl Param for Location` writes two varints inside a length-prefixed value on every draft, so a conforming draft-18 publisher's SUBSCRIBE_OK is refused with `short buffer`.

The cut is **draft-17, not draft-18**. Draft-16 §9.2 says "Parameters are serialized as Key-Value-Pairs" and §9.2.2.7 calls LARGEST_OBJECT "a length-prefixed Location structure", so today's code is right there. Draft-17 replaced that with `Message Parameter { Type Delta, Value }` carrying no Length field at all, listing `Location: Two consecutive varints` beside `Length-prefixed` as separate per-parameter encodings.

**There is no ambiguity to raise with the working group**, contrary to the report's closing note. §1.4.3's odd-type rule still governs Setup Options and Track Properties; it simply no longer governs Message Parameters. `cloudflare/moq-rs`'s `draft-18-dev` branch splits `decode_message_params` from its KVP codec, lists LARGEST_OBJECT in `TWO_VARINT_VALUE_PARAMETER_TYPES`, and pins the bytes `[1, 0x09, 4, 5]`. Three implementations agree; we are the outlier.

The quest also lifts the draft-20-only emit gate to every draft that defines the parameter. The gate exists because a peer might close the session over an unexpected SUBSCRIBE_OK parameter, but the implementation behind that concern decodes those parameters generically and never rejects an unknown key, on both its draft-16 `main` and `draft-18-dev`.

## [S] A FETCH is answered with FETCH_OK (#3559)

`write_fetch_ok` sends REQUEST_OK on **drafts 15 through 20**, not just 16 and later as reported: the `Draft15 | Draft16` arm and the `_` default are both wrong. §5.2 requires "exactly one FETCH_OK or REQUEST_ERROR", and REQUEST_OK's own definition never lists FETCH.

The report missed a second, equally fatal bug: the End Location is hardcoded `{0, 0}`, while §10.13 requires it to reach the FETCH's Start Location and §10.12.2.1 puts a joining fetch's Start at the subscription's group. Fixing only the message type would trade a desync for a PROTOCOL_VIOLATION on any track past its first group, so the quest also records the subscription's group.

The response stays empty rather than growing a real backfill: below draft-20 a plain SUBSCRIBE already starts at the beginning of the latest group, so the subscription carries what the fetch would have returned, and draft-20 removed the joining variant of FETCH in favor of the fill streams moq-net already serves.

## API and wire impact

None. `mod ietf` is private, so neither fix moves a public symbol. Both change what moq-net puts on a moq-transport wire, but moq-transport is an external IETF draft, so nothing under `drafts/` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)