### PR TITLE
docs(quest): plan in-band auth grants and token refresh

### DIFF
--- a/quest/m2/README.md
+++ b/quest/m2/README.md
@@ -21,6 +21,7 @@ can act on. Each still carries its own plan and regression test.
 - [Generation](/quest/m2/hls-generation.md) - init URLs follow the rendition config and segment URLs carry an embedder-supplied generation, so caching can be re-enabled
 - [Wildcard](/quest/m2/wildcard/README.md) - a service advertises a path pattern it could serve instead of enumerating broadcasts
 - [Path patterns](/quest/m2/path-patterns/README.md) - one versioned matcher for every predicate over broadcast paths: tokens, origins, interest
+- [In-band auth](/quest/m2/auth/README.md) - a session tells its peer what it may publish and subscribe to, refreshes its token in band, and fails loud on an out-of-scope publish
 - [OBS native codecs](/quest/m2/obs-moq-video/README.md) - remove FFmpeg decoding dependencies, deliver GPU frames, and use native audio/video encoders
 - [Audio codecs](/quest/m2/audio-codecs/README.md) - a broadcast that plays in the browser plays natively: platform decoders and encoders behind a backend seam, HE-AAC, and channel layouts up to 7.1
 - [Keyframe trigger](/quest/m2/keyframe-trigger.md) - an application can ask the built-in capture encoder for a keyframe

--- a/quest/m2/README.md
+++ b/quest/m2/README.md
@@ -21,7 +21,7 @@ can act on. Each still carries its own plan and regression test.
 - [Generation](/quest/m2/hls-generation.md) - init URLs follow the rendition config and segment URLs carry an embedder-supplied generation, so caching can be re-enabled
 - [Wildcard](/quest/m2/wildcard/README.md) - a service advertises a path pattern it could serve instead of enumerating broadcasts
 - [Path patterns](/quest/m2/path-patterns/README.md) - one versioned matcher for every predicate over broadcast paths: tokens, origins, interest
-- [In-band auth](/quest/m2/auth/README.md) - a session tells its peer what it may publish and subscribe to, refreshes its token in band, and fails loud on an out-of-scope publish
+- [In-band auth](/quest/m2/auth/README.md) - a session tells its peer what it may publish and subscribe to, unions tokens presented in band, and fails loud on an out-of-scope publish
 - [OBS native codecs](/quest/m2/obs-moq-video/README.md) - remove FFmpeg decoding dependencies, deliver GPU frames, and use native audio/video encoders
 - [Audio codecs](/quest/m2/audio-codecs/README.md) - a broadcast that plays in the browser plays natively: platform decoders and encoders behind a backend seam, HE-AAC, and channel layouts up to 7.1
 - [Keyframe trigger](/quest/m2/keyframe-trigger.md) - an application can ask the built-in capture encoder for a keyframe

--- a/quest/m2/auth/README.md
+++ b/quest/m2/auth/README.md
@@ -3,58 +3,74 @@
 ## Goal
 
 A session tells its peer what that peer may publish and subscribe to, and a
-peer can present a new credential without reconnecting. Today a publisher whose
+peer can present credentials without reconnecting. Today a publisher whose
 token allows `baz` but who publishes `foo/bar` waits forever: the relay only
 solicits announcements for the granted prefixes, nothing is written or logged
 on either side, and moq-lite has no announce refusal at all. Tokens ride the
-URL, so a session can never outlive its credential. On-demand publishing needs
-the missing half of this: a publisher must know it is authorized before demand
-arrives, so silence means "nobody wants it yet" instead of "nobody ever will".
+URL, so a session can never outlive its credential and a client holding two
+tokens needs two connections. On-demand publishing needs the missing half of
+this: a publisher must know it is authorized before demand arrives, so silence
+means "nobody wants it yet" instead of "nobody ever will".
 
-This questline adds an AUTH exchange to both wires: a grant after setup, a
-refresh whenever the presenter chooses, and a loud failure when a publish can
-never be honored. It ends with the credential leaving the URL for a session
-that starts anonymous and widens in band.
+This questline adds an AUTH exchange to both wires: one stream per token, a
+grant per token, the union of every accepted token as the session's scope,
+and a loud failure when a publish can never be honored. It ends with the
+credential able to travel in band, while the URL keeps working for every peer
+that predates the stream.
 
 ## Plan
 
 Decisions settled while planning, recorded so review does not relitigate them:
 
-- **Symmetric streams, opened by whoever wants a grant.** Either side of a
-  session may open an AUTH stream; the acceptor answers with the grant for the
-  opener. A moq-net session opens one on both sides right after SETUP, whether
-  or not it presented a credential, so a publish-only client learns it may
-  subscribe to nothing and a relay learns which role its peer will ever play.
-  This is also the answer to
+- **One AUTH stream per token, opened by whoever presents it.** Either side of
+  a session may open one; the acceptor answers with the grant that token
+  earns. A moq-net session opens one on both sides right after SETUP with an
+  empty token, meaning the credential the connection already presented (URL
+  `?jwt=`, mTLS, or nothing), so a publish-only client learns it may subscribe
+  to nothing and a relay learns which role its peer will ever play. This is
+  also the answer to
   [moq-wg #1854](https://github.com/moq-wg/moq-transport/issues/1854): the
   grant names the peer's role in transport.
-- **Every grant answers a token.** The opener's first message is always AUTH,
-  and an empty token means "the credential this connection already presented":
-  URL `?jwt=`, mTLS, or nothing. A later real token on the same stream is a
-  refresh, and once the relay admits anonymous sessions and widens on AUTH, it
-  is also how the initial credential arrives in band.
+- **Tokens union.** A client with two tokens opens two streams and the
+  session's scope is the union of both grants. A refresh is a new stream
+  carrying the new token; nothing replaces or narrows anything. Closing a
+  stream withdraws that token. When a token expires or is revoked and the
+  union would shrink, the session closes `Unauthorized` exactly as expiry does
+  today; when the union is unchanged the session continues and only that
+  stream ends. Resizing a live session in place belongs to
+  [Relay auth](/quest/m2/path-patterns/relay-auth.md), which serves
+  revalidation and token expiry from one path.
 - **A grant is publish prefixes, subscribe prefixes, and an expiry**, in the
-  presenter's own root; the presenter never sees the relay-side root. The
-  prefix encoding is whatever lite-06 ANNOUNCE_REQUEST carries, so
+  presenter's own root; the presenter never sees the relay-side root, and
+  every token in a union shares the connection's root. The prefix encoding is
+  whatever lite-06 ANNOUNCE_REQUEST carries, so
   [Pattern interest](/quest/m2/path-patterns/interest.md) upgrades both to
   patterns in one change. `origin::Producer::allowed()` on an unscoped handle
   yields the single empty prefix, and `scope(&[])` is `None`, so the wire
   keeps that spelling: a list holding `""` is everything, an empty list is
   nothing.
 - **Fail loud by aborting the session.** A publisher whose origin announces a
-  broadcast outside `grant.publish` aborts the session with `Unauthorized`,
-  naming the path, once its outstanding AUTHs are answered. The origin is
+  broadcast outside the union aborts the session with `Unauthorized`, naming
+  the path. The check runs against the grants in hand once the tokens the
+  library itself presented at setup are answered; a token the app adds later
+  is the app's to await before publishing what it unlocks. The origin is
   untouched, so a broadcast shared across sessions (P2P hops, a cluster) is
   refused only where it is refused. Apps that want to decide themselves read
   the grant instead.
-- **Narrowing is refused, for now.** A refresh whose grant does not cover the
-  current one gets AUTH_ERROR and the session keeps running on the old grant
-  until its expiry, matching what revalidation does today. In-place resizing
-  belongs to [Relay auth](/quest/m2/path-patterns/relay-auth.md), which
-  already plans it for revalidation and serves both from one path.
+- **Older peers keep the URL.** WebTransport negotiates the moq version as a
+  subprotocol of the same CONNECT request that carries the URL, so a client
+  cannot learn whether the peer speaks AUTH before the token has to be sent.
+  The client puts the connection credential in the URL as long as any
+  version it offers has no AUTH stream and omits it once the offered set is
+  AUTH-capable; extra tokens go in band and are simply absent on an old peer.
+  Nothing is refused and nothing is silent.
 - **Cluster peers keep mTLS.** A relay opens AUTH toward its peer with an empty
   token like any client; both directions learn the unrestricted grant. Mutual
   scoped trust between relays is a later quest.
+- **Client API is dev's.** Tokens live on `moq_tokio::connect::Config`, the
+  dial-side config already on dev, and `Connection` exposes the live
+  session's auth handle. Quests touching that surface branch from dev, or
+  from main once [merge-dev](/quest/m1/merge-dev.md) lands.
 - **Spec home.** The AUTH stream is lite-06 core in
   `drafts/draft-lcurley-moq-lite.md`, the way routing is. moq-transport gets
   `drafts/draft-lcurley-moq-auth.md`, a setup-option-negotiated extension with
@@ -62,33 +78,35 @@ Decisions settled while planning, recorded so review does not relitigate them:
   the IETF binding of lite's routing.
 - **Naming.** Messages are AUTH / AUTH_OK / AUTH_ERROR like SUBSCRIBE /
   SUBSCRIBE_OK. Rust is `moq_net::auth` with `auth::Grant`, `auth::Handle`,
-  and `auth::Request`; JS mirrors as `connection.auth`.
+  `auth::Token`, and `auth::Request`; JS mirrors as `connection.auth`.
 
-Everything here is additive on main: `Session::auth()` is new, the relay
-derives the grant from the origin handles it already scopes, and lite-06 is an
-opt-in WIP ALPN.
+Everything here is additive: `Session::auth()` is new, the relay derives the
+grant from the origin handles it already scopes, and lite-06 is an opt-in WIP
+ALPN.
 
 ## Quests
 
 - [Lite stream](/quest/m2/auth/lite.md) - both sides of a lite-06 session
-  exchange grants over an AUTH stream, exposed as `Session::auth()`, and an
+  exchange grants over AUTH streams, exposed as `Session::auth()`, and an
   out-of-scope announce aborts the session
-- [Relay refresh](/quest/m2/auth/relay-refresh.md) - the relay verifies a token
-  sent in band, replaces the session's expiry, and refuses a narrowing one
+- [Relay tokens](/quest/m2/auth/relay-refresh.md) - the relay verifies tokens
+  sent in band, unions their grants, and closes only when an expiry shrinks
+  the union
 - [moq-transport](/quest/m2/auth/moq-transport.md) - the same exchange as a
   setup-option extension on draft-17+, specified in a new draft
-- [Bindings](/quest/m2/auth/bindings.md) - grant and refresh reach every
+- [Bindings](/quest/m2/auth/bindings.md) - grants and tokens reach every
   binding through moq-ffi and libmoq
-- [Token in band](/quest/m2/auth/token-in-band.md) - the credential leaves the
-  URL: a session starts anonymous and its first AUTH widens it
+- [Token in band](/quest/m2/auth/token-in-band.md) - the credential can leave
+  the URL: a session starts on what the URL carried and its AUTH streams add
+  the rest, with the URL kept for peers below lite-06
 
 ## Related
 
 - [Relay auth](/quest/m2/path-patterns/relay-auth.md) - resizes a live session
-  on a narrower grant, for revalidation and in-band refresh alike
+  when the union shrinks, for revalidation and token expiry alike
 - [Pattern interest](/quest/m2/path-patterns/interest.md) - moves the grant's
   prefixes to patterns along with ANNOUNCE_REQUEST
 - [Expiring media grants](/quest/m2/processor/grant-lease.md) - a worker's
-  lease renewal is an in-band refresh
+  lease renewal is a new in-band token
 - [Connect auth race](/quest/m0/3532-connect-auth-race.md) - the connect-time
   auth error this questline does not change

--- a/quest/m2/auth/README.md
+++ b/quest/m2/auth/README.md
@@ -1,0 +1,94 @@
+# In-band auth
+
+## Goal
+
+A session tells its peer what that peer may publish and subscribe to, and a
+peer can present a new credential without reconnecting. Today a publisher whose
+token allows `baz` but who publishes `foo/bar` waits forever: the relay only
+solicits announcements for the granted prefixes, nothing is written or logged
+on either side, and moq-lite has no announce refusal at all. Tokens ride the
+URL, so a session can never outlive its credential. On-demand publishing needs
+the missing half of this: a publisher must know it is authorized before demand
+arrives, so silence means "nobody wants it yet" instead of "nobody ever will".
+
+This questline adds an AUTH exchange to both wires: a grant after setup, a
+refresh whenever the presenter chooses, and a loud failure when a publish can
+never be honored. It ends with the credential leaving the URL for a session
+that starts anonymous and widens in band.
+
+## Plan
+
+Decisions settled while planning, recorded so review does not relitigate them:
+
+- **Symmetric streams, opened by whoever wants a grant.** Either side of a
+  session may open an AUTH stream; the acceptor answers with the grant for the
+  opener. A moq-net session opens one on both sides right after SETUP, whether
+  or not it presented a credential, so a publish-only client learns it may
+  subscribe to nothing and a relay learns which role its peer will ever play.
+  This is also the answer to
+  [moq-wg #1854](https://github.com/moq-wg/moq-transport/issues/1854): the
+  grant names the peer's role in transport.
+- **Every grant answers a token.** The opener's first message is always AUTH,
+  and an empty token means "the credential this connection already presented":
+  URL `?jwt=`, mTLS, or nothing. A later real token on the same stream is a
+  refresh, and once the relay admits anonymous sessions and widens on AUTH, it
+  is also how the initial credential arrives in band.
+- **A grant is publish prefixes, subscribe prefixes, and an expiry**, in the
+  presenter's own root; the presenter never sees the relay-side root. The
+  prefix encoding is whatever lite-06 ANNOUNCE_REQUEST carries, so
+  [Pattern interest](/quest/m2/path-patterns/interest.md) upgrades both to
+  patterns in one change. `origin::Producer::allowed()` on an unscoped handle
+  yields the single empty prefix, and `scope(&[])` is `None`, so the wire
+  keeps that spelling: a list holding `""` is everything, an empty list is
+  nothing.
+- **Fail loud by aborting the session.** A publisher whose origin announces a
+  broadcast outside `grant.publish` aborts the session with `Unauthorized`,
+  naming the path, once its outstanding AUTHs are answered. The origin is
+  untouched, so a broadcast shared across sessions (P2P hops, a cluster) is
+  refused only where it is refused. Apps that want to decide themselves read
+  the grant instead.
+- **Narrowing is refused, for now.** A refresh whose grant does not cover the
+  current one gets AUTH_ERROR and the session keeps running on the old grant
+  until its expiry, matching what revalidation does today. In-place resizing
+  belongs to [Relay auth](/quest/m2/path-patterns/relay-auth.md), which
+  already plans it for revalidation and serves both from one path.
+- **Cluster peers keep mTLS.** A relay opens AUTH toward its peer with an empty
+  token like any client; both directions learn the unrestricted grant. Mutual
+  scoped trust between relays is a later quest.
+- **Spec home.** The AUTH stream is lite-06 core in
+  `drafts/draft-lcurley-moq-lite.md`, the way routing is. moq-transport gets
+  `drafts/draft-lcurley-moq-auth.md`, a setup-option-negotiated extension with
+  AUTH, AUTH_OK, and AUTH_ERROR control messages, mirroring how moq-cluster is
+  the IETF binding of lite's routing.
+- **Naming.** Messages are AUTH / AUTH_OK / AUTH_ERROR like SUBSCRIBE /
+  SUBSCRIBE_OK. Rust is `moq_net::auth` with `auth::Grant`, `auth::Handle`,
+  and `auth::Request`; JS mirrors as `connection.auth`.
+
+Everything here is additive on main: `Session::auth()` is new, the relay
+derives the grant from the origin handles it already scopes, and lite-06 is an
+opt-in WIP ALPN.
+
+## Quests
+
+- [Lite stream](/quest/m2/auth/lite.md) - both sides of a lite-06 session
+  exchange grants over an AUTH stream, exposed as `Session::auth()`, and an
+  out-of-scope announce aborts the session
+- [Relay refresh](/quest/m2/auth/relay-refresh.md) - the relay verifies a token
+  sent in band, replaces the session's expiry, and refuses a narrowing one
+- [moq-transport](/quest/m2/auth/moq-transport.md) - the same exchange as a
+  setup-option extension on draft-17+, specified in a new draft
+- [Bindings](/quest/m2/auth/bindings.md) - grant and refresh reach every
+  binding through moq-ffi and libmoq
+- [Token in band](/quest/m2/auth/token-in-band.md) - the credential leaves the
+  URL: a session starts anonymous and its first AUTH widens it
+
+## Related
+
+- [Relay auth](/quest/m2/path-patterns/relay-auth.md) - resizes a live session
+  on a narrower grant, for revalidation and in-band refresh alike
+- [Pattern interest](/quest/m2/path-patterns/interest.md) - moves the grant's
+  prefixes to patterns along with ANNOUNCE_REQUEST
+- [Expiring media grants](/quest/m2/processor/grant-lease.md) - a worker's
+  lease renewal is an in-band refresh
+- [Connect auth race](/quest/m0/3532-connect-auth-race.md) - the connect-time
+  auth error this questline does not change

--- a/quest/m2/auth/bindings.md
+++ b/quest/m2/auth/bindings.md
@@ -1,0 +1,41 @@
+# [M] Bindings
+
+## Goal
+
+Every binding can read a session's grant and refresh its token: moq-ffi and
+libmoq expose it, and the hand-written Python, Swift, Kotlin, Go, and Dart
+wrappers and their docs carry it. An OBS user whose token expires mid-stream
+can be handed a new one without the plugin reconnecting.
+
+## Plan
+
+- `MoqSession` in `rs/moq-ffi/src/session.rs` gains `auth()` returning an
+  `Arc<MoqAuth>` object, the shape `publisher()` uses, with `grant() ->
+  Option<MoqGrant>` (a record: publish prefixes, subscribe prefixes, expiry as
+  a duration), `async grant_changed() -> MoqGrant` so a caller can await the
+  next grant without polling, and `async refresh(token: String) -> MoqGrant`
+  that raises the structured error moq-ffi already maps. `MoqClient` sessions
+  reached through `Reconnect` use the accessor
+  [Relay refresh](/quest/m2/auth/relay-refresh.md) adds.
+- libmoq: `moq_session_auth_grant`, `moq_session_auth_refresh` with the
+  terminal-status callback contract the other async calls use, in
+  `rs/libmoq/src/api.rs` and the session table; regenerate `moq.h`, and update
+  `cpp/obs/src` only if the plugin surfaces a token field, otherwise leave it.
+- Wrappers: `py/moq-rs/moq/session.py`, `swift/Sources/Moq`,
+  `kt/.../Flows.kt` (a `Flow` over `grant_changed`), `go/wrapper/moq/session.go`
+  (context-cancellable like the rest), and `dart/moq/lib/moq.dart`. Kotlin
+  typealiases pick up the raw methods for free; the flow is the idiomatic add.
+- Docs: `doc/lib/{py,swift,kt,go,dart,c}` each gain a short auth section, and
+  `doc/lib/rs` documents `Session::auth()`.
+- Tests: each wrapper's existing session test reads a grant from a local relay
+  and refreshes with a second token minted by `moq token`; the refusal path
+  surfaces the structured error in each language.
+
+On main, additive.
+
+## Required
+
+- [Lite stream](/quest/m2/auth/lite.md) - supplies `Session::auth()`
+- [Relay refresh](/quest/m2/auth/relay-refresh.md) - supplies the
+  `Reconnect::auth()` accessor and a relay that answers a real token, which the
+  wrapper tests need

--- a/quest/m2/auth/bindings.md
+++ b/quest/m2/auth/bindings.md
@@ -2,40 +2,43 @@
 
 ## Goal
 
-Every binding can read a session's grant and refresh its token: moq-ffi and
+Every binding can read a session's grant and present more tokens: moq-ffi and
 libmoq expose it, and the hand-written Python, Swift, Kotlin, Go, and Dart
-wrappers and their docs carry it. An OBS user whose token expires mid-stream
-can be handed a new one without the plugin reconnecting.
+wrappers and their docs carry it. An OBS user whose token is about to expire
+mid-stream can be handed a new one without the plugin reconnecting.
 
 ## Plan
 
 - `MoqSession` in `rs/moq-ffi/src/session.rs` gains `auth()` returning an
   `Arc<MoqAuth>` object, the shape `publisher()` uses, with `grant() ->
   Option<MoqGrant>` (a record: publish prefixes, subscribe prefixes, expiry as
-  a duration), `async grant_changed() -> MoqGrant` so a caller can await the
-  next grant without polling, and `async refresh(token: String) -> MoqGrant`
-  that raises the structured error moq-ffi already maps. `MoqClient` sessions
-  reached through `Reconnect` use the accessor
-  [Relay refresh](/quest/m2/auth/relay-refresh.md) adds.
-- libmoq: `moq_session_auth_grant`, `moq_session_auth_refresh` with the
-  terminal-status callback contract the other async calls use, in
-  `rs/libmoq/src/api.rs` and the session table; regenerate `moq.h`, and update
-  `cpp/obs/src` only if the plugin surfaces a token field, otherwise leave it.
+  a duration) for the union, `async grant_changed() -> MoqGrant` so a caller
+  can await the next change without polling, and `async add(token: String) ->
+  Arc<MoqAuthToken>` whose object carries that token's own `grant()` and
+  `closed()` and whose release withdraws it, raising the structured error
+  moq-ffi already maps on refusal. `MoqClient` sessions reached through the
+  reconnecting connection use the accessor
+  [Relay tokens](/quest/m2/auth/relay-refresh.md) adds.
+- libmoq: `moq_session_auth_grant`, `moq_session_auth_add`, and
+  `moq_auth_token_close` with the terminal-status callback contract the other
+  async calls use, in `rs/libmoq/src/api.rs` and the session table;
+  regenerate `moq.h`, and update `cpp/obs/src` only if the plugin surfaces a
+  token field, otherwise leave it.
 - Wrappers: `py/moq-rs/moq/session.py`, `swift/Sources/Moq`,
   `kt/.../Flows.kt` (a `Flow` over `grant_changed`), `go/wrapper/moq/session.go`
   (context-cancellable like the rest), and `dart/moq/lib/moq.dart`. Kotlin
   typealiases pick up the raw methods for free; the flow is the idiomatic add.
 - Docs: `doc/lib/{py,swift,kt,go,dart,c}` each gain a short auth section, and
   `doc/lib/rs` documents `Session::auth()`.
-- Tests: each wrapper's existing session test reads a grant from a local relay
-  and refreshes with a second token minted by `moq token`; the refusal path
-  surfaces the structured error in each language.
+- Tests: each wrapper's existing session test reads a grant from a local
+  relay, adds a second token minted by `moq token`, sees the union grow, and
+  releases it; the refusal path surfaces the structured error in each
+  language.
 
-On main, additive.
+Additive.
 
 ## Required
 
 - [Lite stream](/quest/m2/auth/lite.md) - supplies `Session::auth()`
-- [Relay refresh](/quest/m2/auth/relay-refresh.md) - supplies the
-  `Reconnect::auth()` accessor and a relay that answers a real token, which the
-  wrapper tests need
+- [Relay tokens](/quest/m2/auth/relay-refresh.md) - supplies the connection
+  accessor and a relay that answers a real token, which the wrapper tests need

--- a/quest/m2/auth/lite.md
+++ b/quest/m2/auth/lite.md
@@ -1,0 +1,119 @@
+# [L] Lite stream
+
+## Goal
+
+Both sides of a moq-lite-06 session learn what they may publish and subscribe
+to. Right after SETUP each side opens an AUTH stream, sends an empty token, and
+receives its grant; `Session::auth()` exposes that grant and lets the app send
+a new token on the same stream. A publisher whose origin announces a broadcast
+outside its grant aborts the session with `Unauthorized` naming the path
+instead of waiting for a solicitation that never comes. Rust and JavaScript
+both speak it, and the lite draft specifies it.
+
+## Plan
+
+### Wire
+
+Add stream type `0x7` AUTH, creator either, to the bidirectional stream table
+in `drafts/draft-lcurley-moq-lite.md` and a section beside Probe modeled on
+it. Messages, encoded like PROBE with the `(i)`, `(b)`, `(s)` notation the
+draft uses:
+
+- `AUTH { Token (b) }`, written only by the opener. An empty token means the
+  credential the connection already presented, or nothing.
+- `AUTH_OK { Publish Count (i), Publish Prefix (s)..., Subscribe Count (i),
+  Subscribe Prefix (s)..., Expires (i) }`, written only by the acceptor. The
+  prefixes use the encoding and rules ANNOUNCE_REQUEST's prefix uses: a list
+  holding the empty prefix grants everything, an empty list grants nothing.
+  Expires is milliseconds until the grant lapses, zero for never.
+- `AUTH_ERROR { Code (i), Reason (s) }`, written only by the acceptor.
+
+Every AUTH is answered in order by exactly one AUTH_OK or AUTH_ERROR. The
+acceptor MAY also write an AUTH_OK unprompted when the grant changes; the
+latest AUTH_OK is always the grant in effect. An AUTH_ERROR leaves the previous
+grant in effect. The stream lives as long as the session; resetting it is not
+a refusal, and a peer that resets an AUTH stream it does not understand (the
+existing unknown-stream rule at the STREAM_TYPE section) leaves the opener
+with no grant, which the client reports as `Unsupported` rather than treating
+as a refusal. Record it in the lite-06 changelog. Run `just drafts check`.
+
+### Model
+
+New module `rs/moq-net/src/auth.rs`, public as `moq_net::auth`:
+
+- `auth::Grant { publish: PathPrefixes, subscribe: PathPrefixes, expires:
+  Option<Instant> }`, a plain value in the presenter's root.
+- `auth::Handle`, cloneable, returned by `Session::auth()`. `grant()` is a
+  watchable current value (`None` until the first AUTH_OK, the `kio` shared
+  cell the session already uses for the peer SETUP is the pattern), and
+  `refresh(token) -> Result<Grant, Error>` writes an AUTH and resolves with the
+  next AUTH_OK or AUTH_ERROR. `requests()` yields `auth::Request { token,
+  accept(Grant), reject(code, reason) }` for the acceptor side; a request left
+  unanswered is a bug, so dropping one rejects with `Unauthorized`.
+- The default acceptor needs no app code: when nothing consumes `requests()`,
+  an empty token is answered from the session's own origin handles, publish
+  from the subscriber half's `origin::Producer::allowed()` and subscribe from
+  the publisher half's `origin::Consumer::allowed()`, with no expiry. A missing
+  half grants nothing. That is what makes the cluster case free: both relays
+  present mTLS, both learn the unrestricted grant. A non-empty token with no
+  consumer is rejected `Unsupported`; the relay is the consumer in
+  [Relay refresh](/quest/m2/auth/relay-refresh.md).
+
+`Session` is protocol-agnostic (`rs/moq-net/src/session.rs` holds a version,
+bandwidth handles, and a boxed driver), so `lite::start` builds the handle and
+hands it to `Session::new`; `ietf::start` hands one whose `grant()` stays
+`None` and whose `refresh` fails `Unsupported` until
+[moq-transport](/quest/m2/auth/moq-transport.md) fills it in.
+
+### Session
+
+Accepted bidi streams are dispatched by the publisher half alone
+(`Publisher::handle` in `rs/moq-net/src/lite/publisher.rs`), which holds only
+the publish-side `origin::Consumer`; the grant needs both halves' `allowed()`,
+so the handle is built in `lite::start` with both handles and shared into the
+publisher and subscriber, the way the peer-setup slot is. Opening: the
+subscriber half opens the AUTH stream where it opens Probe, after the peer
+SETUP resolves, and writes the empty AUTH. Accepting: a new `recv_auth` beside
+`recv_probe` answers each AUTH, on error aborting only that stream.
+
+Fail loud: the publisher half already scopes its origin per solicited prefix;
+add a check that every path its origin announces is covered by
+`grant.publish`, run when the grant arrives and when a broadcast is announced,
+and only while no AUTH is outstanding, so the initial empty AUTH and a
+widening refresh cannot race a publish into a false refusal. On a miss, abort
+the session with `Error::Unauthorized` and put the path in the close reason
+(`lite::start`'s teardown already formats one; log it at error level too,
+since `Error` carries no payload).
+
+Gate everything on `Version::Lite06Wip`; older versions never open the stream
+and `auth().grant()` stays `None` there. Land the accept side and the
+`Unsupported` handling before any build opens the stream, since
+`moq-lite-06-wip` is one ALPN with no sub-version.
+
+### JavaScript
+
+Mirror in `js/net/src/lite/`: `stream.ts` gains `Auth: 7`, an `auth.ts` with
+the three messages, `connection.ts` opens and answers the stream, and
+`Established` in `js/net/src/connection/established.ts` gains `auth` with
+`grant: Getter<Grant | undefined>` (a `@moq/signals` signal like `probe`),
+`refresh(token): Promise<Grant>`, and `requests()`. The publisher in
+`js/net/src/lite/publisher.ts` aborts the connection the same way.
+
+### Docs and tests
+
+Update `doc/concept` where sessions and authorization are described, and the
+moq-net guide if it lists stream types. Tests: encode and decode round trips
+and the version gate; both sides receive a grant from scoped origins,
+including the empty-prefix and empty-list spellings; a publish-only session
+grants no subscribe; an out-of-scope announce aborts with `Unauthorized` and
+names the path in the reason, while an in-scope one does not; a refresh
+resolves with the next reply and an unprompted AUTH_OK replaces the grant; a
+reset AUTH stream reports `Unsupported`; Rust to JS and JS to Rust interop in
+the existing cross-language harness.
+
+On main, additive.
+
+## Related
+
+- [Pattern interest](/quest/m2/path-patterns/interest.md) - moves the prefix
+  fields here and in ANNOUNCE_REQUEST to patterns together

--- a/quest/m2/auth/lite.md
+++ b/quest/m2/auth/lite.md
@@ -40,7 +40,8 @@ never sent, or was already answered, is a protocol violation. The stream
 lives as long as the session; resetting it is not a refusal, and a peer that
 resets an AUTH stream it does not understand (the existing unknown-stream rule
 at the STREAM_TYPE section) leaves the opener with no grant, which the client
-reports as `Unsupported` rather than treating as a refusal. Record it in the lite-06 changelog. Run `just drafts check`.
+reports as `Unsupported` rather than treating as a refusal. Record it in the
+lite-06 changelog. Run `just drafts check`.
 
 ### Model
 

--- a/quest/m2/auth/lite.md
+++ b/quest/m2/auth/lite.md
@@ -3,12 +3,13 @@
 ## Goal
 
 Both sides of a moq-lite-06 session learn what they may publish and subscribe
-to. Right after SETUP each side opens an AUTH stream, sends an empty token, and
-receives its grant; `Session::auth()` exposes that grant and lets the app send
-a new token on the same stream. A publisher whose origin announces a broadcast
-outside its grant aborts the session with `Unauthorized` naming the path
-instead of waiting for a solicitation that never comes. Rust and JavaScript
-both speak it, and the lite draft specifies it.
+to. Right after SETUP each side opens an AUTH stream carrying an empty token
+and receives its grant; `Session::auth()` exposes the union of every grant and
+lets the app present more tokens, each on its own stream. A publisher whose
+origin announces a broadcast outside that union aborts the session with
+`Unauthorized` naming the path instead of waiting for a solicitation that
+never comes. Rust and JavaScript both speak it, and the lite draft specifies
+it.
 
 ## Plan
 
@@ -16,32 +17,30 @@ both speak it, and the lite draft specifies it.
 
 Add stream type `0x7` AUTH, creator either, to the bidirectional stream table
 in `drafts/draft-lcurley-moq-lite.md` and a section beside Probe modeled on
-it. Messages, encoded like PROBE with the `(i)`, `(b)`, `(s)` notation the
-draft uses:
+it. One stream carries one token for the life of that token. Messages,
+encoded like PROBE with the `(i)`, `(b)`, `(s)` notation the draft uses:
 
-- `AUTH { Sequence (i), Token (b) }`, written only by the opener. Sequence
-  starts at 1 and increments per AUTH. An empty token means the credential the
-  connection already presented, or nothing.
-- `AUTH_OK { Sequence (i), Publish Count (i), Publish Prefix (s)...,
-  Subscribe Count (i), Subscribe Prefix (s)..., Expires (i) }`, written only
-  by the acceptor. The prefixes use the encoding and rules ANNOUNCE_REQUEST's
-  prefix uses: a list holding the empty prefix grants everything, an empty
-  list grants nothing. Expires is milliseconds until the grant lapses, zero
-  for never.
-- `AUTH_ERROR { Sequence (i), Code (i), Reason (s) }`, written only by the
-  acceptor.
+- `AUTH { Token (b) }`, written once by the opener as the stream's first
+  message. An empty token means the credential the connection already
+  presented, or nothing.
+- `AUTH_OK { Publish Count (i), Publish Prefix (s)..., Subscribe Count (i),
+  Subscribe Prefix (s)..., Expires (i) }`, written by the acceptor. The
+  prefixes use the encoding and rules ANNOUNCE_REQUEST's prefix uses: a list
+  holding the empty prefix grants everything, an empty list grants nothing.
+  Expires is milliseconds until the grant lapses, zero for never. The acceptor
+  MAY write further AUTH_OK messages on the same stream to update that
+  token's grant, such as a lowered expiry; the latest one is the token's grant.
+- `AUTH_ERROR { Code (i), Reason (s) }`, written by the acceptor. As the
+  first reply it refuses the token; after an AUTH_OK it revokes it. Either
+  way the acceptor then closes the stream.
 
-Every AUTH is answered by exactly one AUTH_OK or AUTH_ERROR echoing its
-Sequence. The acceptor MAY also write an AUTH_OK with Sequence 0 unprompted
-when the grant changes, so an update and a reply are never confused however
-they interleave; the latest AUTH_OK is always the grant in effect. An
-AUTH_ERROR leaves the previous grant in effect. A reply whose Sequence was
-never sent, or was already answered, is a protocol violation. The stream
-lives as long as the session; resetting it is not a refusal, and a peer that
-resets an AUTH stream it does not understand (the existing unknown-stream rule
-at the STREAM_TYPE section) leaves the opener with no grant, which the client
-reports as `Unsupported` rather than treating as a refusal. Record it in the
-lite-06 changelog. Run `just drafts check`.
+A session's scope is the union of the grants of its open AUTH streams. The
+opener withdraws a token by closing or resetting its stream. A stream reset
+before any reply, which is what a peer does with a stream type it does not
+understand (the existing rule at the STREAM_TYPE section), leaves the opener
+with no grant for that token, and the client reports it as `Unsupported`
+rather than a refusal. Record it in the lite-06 changelog. Run
+`just drafts check`.
 
 ### Model
 
@@ -50,29 +49,33 @@ New module `rs/moq-net/src/auth.rs`, public as `moq_net::auth`:
 - `auth::Grant { publish: PathPrefixes, subscribe: PathPrefixes, expires:
   Option<Instant> }`, a plain value in the presenter's root.
 - `auth::Handle`, cloneable, returned by `Session::auth()`. `grant()` is a
-  watchable current value (`None` until the first AUTH_OK, the `kio` shared
-  cell the session already uses for the peer SETUP is the pattern), and
-  `refresh(token) -> Result<Grant, Error>` writes an AUTH and resolves with the
-  reply carrying its Sequence. `requests()` yields `auth::Request { token,
-  accept(Grant), reject(code, reason) }` for the acceptor side; a request left
-  unanswered is a bug, so dropping one rejects with `Unauthorized`.
+  watchable union of every open token's grant (`None` until the first
+  AUTH_OK; the `kio` shared cell the session already uses for the peer SETUP
+  is the pattern). `add(token) -> Result<auth::Token, Error>` opens a stream
+  and resolves with the first reply. `auth::Token` exposes that token's own
+  watchable `grant()` and `closed()`, and dropping it closes the stream,
+  withdrawing the token. `requests()` yields `auth::Request { token,
+  accept(Grant) -> auth::Issued, reject(code, reason) }` for the acceptor
+  side, where `auth::Issued` can `update(Grant)` and `revoke(code, reason)`
+  and its drop ends the stream; a request left unanswered is a bug, so
+  dropping one rejects with `Unauthorized`.
 - The default acceptor needs no app code, and whether it is in charge is
   decided once, before the driver starts, never per message: the server-side
   `moq_net::Request` builder exposes `auth()` before `.ok()`, and a caller
   that takes `requests()` there owns every AUTH the session receives, the
-  initial empty one included. With no such consumer, the driver answers every
-  empty token from the session's own origin handles, publish
-  from the subscriber half's `origin::Producer::allowed()` and subscribe from
-  the publisher half's `origin::Consumer::allowed()`, with no expiry. A missing
+  initial empty one included. With no such consumer, the driver answers the
+  empty token from the session's own origin handles, publish from the
+  subscriber half's `origin::Producer::allowed()` and subscribe from the
+  publisher half's `origin::Consumer::allowed()`, with no expiry. A missing
   half grants nothing. That is what makes the cluster case free: both relays
   present mTLS, both learn the unrestricted grant. A non-empty token with no
   consumer is rejected `Unsupported`; the relay is the consumer in
-  [Relay refresh](/quest/m2/auth/relay-refresh.md).
+  [Relay tokens](/quest/m2/auth/relay-refresh.md).
 
 `Session` is protocol-agnostic (`rs/moq-net/src/session.rs` holds a version,
 bandwidth handles, and a boxed driver), so `lite::start` builds the handle and
 hands it to `Session::new`; `ietf::start` hands one whose `grant()` stays
-`None` and whose `refresh` fails `Unsupported` until
+`None` and whose `add` fails `Unsupported` until
 [moq-transport](/quest/m2/auth/moq-transport.md) fills it in.
 
 ### Session
@@ -82,18 +85,22 @@ Accepted bidi streams are dispatched by the publisher half alone
 the publish-side `origin::Consumer`; the grant needs both halves' `allowed()`,
 so the handle is built in `lite::start` with both handles and shared into the
 publisher and subscriber, the way the peer-setup slot is. Opening: the
-subscriber half opens the AUTH stream where it opens Probe, after the peer
-SETUP resolves, and writes the empty AUTH. Accepting: a new `recv_auth` beside
-`recv_probe` answers each AUTH, on error aborting only that stream.
+subscriber half opens the empty-token AUTH stream where it opens Probe, after
+the peer SETUP resolves, and `add` opens further ones on demand. Accepting: a
+new `recv_auth` beside `recv_probe` runs one stream for the life of its
+token, on error aborting only that stream.
 
 Fail loud: the publisher half already scopes its origin per solicited prefix;
-add a check that every path its origin announces is covered by
-`grant.publish`, run when the grant arrives and when a broadcast is announced,
-and only while no AUTH is outstanding, so the initial empty AUTH and a
-widening refresh cannot race a publish into a false refusal. On a miss, abort
-the session with `Error::Unauthorized` and put the path in the close reason
-(`lite::start`'s teardown already formats one; log it at error level too,
-since `Error` carries no payload).
+add a check that every path its origin announces is covered by the union's
+publish prefixes, run when a grant arrives or changes and when a broadcast is
+announced. It waits only for the tokens the session presented itself at setup
+(the empty one, and the configured ones once
+[Token in band](/quest/m2/auth/token-in-band.md) lands), so a peer that never
+answers an app-added token cannot suspend enforcement; an app awaits `add`
+before publishing what that token unlocks. On a miss, abort the session with
+`Error::Unauthorized` and put the path in the close reason (`lite::start`'s
+teardown already formats one; log it at error level too, since `Error`
+carries no payload).
 
 Gate everything on `Version::Lite06Wip`; older versions never open the stream
 and `auth().grant()` stays `None` there. Land the accept side and the
@@ -103,10 +110,10 @@ and `auth().grant()` stays `None` there. Land the accept side and the
 ### JavaScript
 
 Mirror in `js/net/src/lite/`: `stream.ts` gains `Auth: 7`, an `auth.ts` with
-the three messages, `connection.ts` opens and answers the stream, and
+the three messages, `connection.ts` opens and answers the streams, and
 `Established` in `js/net/src/connection/established.ts` gains `auth` with
 `grant: Getter<Grant | undefined>` (a `@moq/signals` signal like `probe`),
-`refresh(token): Promise<Grant>`, and `requests()`. The publisher in
+`add(token): Promise<Token>`, and `requests()`. The publisher in
 `js/net/src/lite/publisher.ts` aborts the connection the same way.
 
 ### Docs and tests
@@ -116,11 +123,12 @@ moq-net guide if it lists stream types. Tests: encode and decode round trips
 and the version gate; both sides receive a grant from scoped origins,
 including the empty-prefix and empty-list spellings; a publish-only session
 grants no subscribe; an out-of-scope announce aborts with `Unauthorized` and
-names the path in the reason, while an in-scope one does not; a refresh
-resolves with the reply echoing its Sequence even when an unprompted AUTH_OK
-arrives first, and the unprompted one still replaces the grant; a reset AUTH
-stream reports `Unsupported`; Rust to JS and JS to Rust interop in
-the existing cross-language harness.
+names the path in the reason, while an in-scope one does not; two tokens union
+and closing one stream shrinks the union on both sides; an update AUTH_OK
+replaces one token's grant without touching the other; an unanswered
+app-added token does not suspend the check; a reset AUTH stream reports
+`Unsupported`; Rust to JS and JS to Rust interop in the existing
+cross-language harness.
 
 On main, additive.
 

--- a/quest/m2/auth/lite.md
+++ b/quest/m2/auth/lite.md
@@ -37,10 +37,10 @@ when the grant changes, so an update and a reply are never confused however
 they interleave; the latest AUTH_OK is always the grant in effect. An
 AUTH_ERROR leaves the previous grant in effect. A reply whose Sequence was
 never sent, or was already answered, is a protocol violation. The stream
-lives as long as the session; resetting it is not a refusal, and a peer that resets an AUTH stream it does not understand (the
-existing unknown-stream rule at the STREAM_TYPE section) leaves the opener
-with no grant, which the client reports as `Unsupported` rather than treating
-as a refusal. Record it in the lite-06 changelog. Run `just drafts check`.
+lives as long as the session; resetting it is not a refusal, and a peer that
+resets an AUTH stream it does not understand (the existing unknown-stream rule
+at the STREAM_TYPE section) leaves the opener with no grant, which the client
+reports as `Unsupported` rather than treating as a refusal. Record it in the lite-06 changelog. Run `just drafts check`.
 
 ### Model
 

--- a/quest/m2/auth/lite.md
+++ b/quest/m2/auth/lite.md
@@ -19,20 +19,25 @@ in `drafts/draft-lcurley-moq-lite.md` and a section beside Probe modeled on
 it. Messages, encoded like PROBE with the `(i)`, `(b)`, `(s)` notation the
 draft uses:
 
-- `AUTH { Token (b) }`, written only by the opener. An empty token means the
-  credential the connection already presented, or nothing.
-- `AUTH_OK { Publish Count (i), Publish Prefix (s)..., Subscribe Count (i),
-  Subscribe Prefix (s)..., Expires (i) }`, written only by the acceptor. The
-  prefixes use the encoding and rules ANNOUNCE_REQUEST's prefix uses: a list
-  holding the empty prefix grants everything, an empty list grants nothing.
-  Expires is milliseconds until the grant lapses, zero for never.
-- `AUTH_ERROR { Code (i), Reason (s) }`, written only by the acceptor.
+- `AUTH { Sequence (i), Token (b) }`, written only by the opener. Sequence
+  starts at 1 and increments per AUTH. An empty token means the credential the
+  connection already presented, or nothing.
+- `AUTH_OK { Sequence (i), Publish Count (i), Publish Prefix (s)...,
+  Subscribe Count (i), Subscribe Prefix (s)..., Expires (i) }`, written only
+  by the acceptor. The prefixes use the encoding and rules ANNOUNCE_REQUEST's
+  prefix uses: a list holding the empty prefix grants everything, an empty
+  list grants nothing. Expires is milliseconds until the grant lapses, zero
+  for never.
+- `AUTH_ERROR { Sequence (i), Code (i), Reason (s) }`, written only by the
+  acceptor.
 
-Every AUTH is answered in order by exactly one AUTH_OK or AUTH_ERROR. The
-acceptor MAY also write an AUTH_OK unprompted when the grant changes; the
-latest AUTH_OK is always the grant in effect. An AUTH_ERROR leaves the previous
-grant in effect. The stream lives as long as the session; resetting it is not
-a refusal, and a peer that resets an AUTH stream it does not understand (the
+Every AUTH is answered by exactly one AUTH_OK or AUTH_ERROR echoing its
+Sequence. The acceptor MAY also write an AUTH_OK with Sequence 0 unprompted
+when the grant changes, so an update and a reply are never confused however
+they interleave; the latest AUTH_OK is always the grant in effect. An
+AUTH_ERROR leaves the previous grant in effect. A reply whose Sequence was
+never sent, or was already answered, is a protocol violation. The stream
+lives as long as the session; resetting it is not a refusal, and a peer that resets an AUTH stream it does not understand (the
 existing unknown-stream rule at the STREAM_TYPE section) leaves the opener
 with no grant, which the client reports as `Unsupported` rather than treating
 as a refusal. Record it in the lite-06 changelog. Run `just drafts check`.
@@ -47,11 +52,15 @@ New module `rs/moq-net/src/auth.rs`, public as `moq_net::auth`:
   watchable current value (`None` until the first AUTH_OK, the `kio` shared
   cell the session already uses for the peer SETUP is the pattern), and
   `refresh(token) -> Result<Grant, Error>` writes an AUTH and resolves with the
-  next AUTH_OK or AUTH_ERROR. `requests()` yields `auth::Request { token,
+  reply carrying its Sequence. `requests()` yields `auth::Request { token,
   accept(Grant), reject(code, reason) }` for the acceptor side; a request left
   unanswered is a bug, so dropping one rejects with `Unauthorized`.
-- The default acceptor needs no app code: when nothing consumes `requests()`,
-  an empty token is answered from the session's own origin handles, publish
+- The default acceptor needs no app code, and whether it is in charge is
+  decided once, before the driver starts, never per message: the server-side
+  `moq_net::Request` builder exposes `auth()` before `.ok()`, and a caller
+  that takes `requests()` there owns every AUTH the session receives, the
+  initial empty one included. With no such consumer, the driver answers every
+  empty token from the session's own origin handles, publish
   from the subscriber half's `origin::Producer::allowed()` and subscribe from
   the publisher half's `origin::Consumer::allowed()`, with no expiry. A missing
   half grants nothing. That is what makes the cluster case free: both relays
@@ -107,8 +116,9 @@ and the version gate; both sides receive a grant from scoped origins,
 including the empty-prefix and empty-list spellings; a publish-only session
 grants no subscribe; an out-of-scope announce aborts with `Unauthorized` and
 names the path in the reason, while an in-scope one does not; a refresh
-resolves with the next reply and an unprompted AUTH_OK replaces the grant; a
-reset AUTH stream reports `Unsupported`; Rust to JS and JS to Rust interop in
+resolves with the reply echoing its Sequence even when an unprompted AUTH_OK
+arrives first, and the unprompted one still replaces the grant; a reset AUTH
+stream reports `Unsupported`; Rust to JS and JS to Rust interop in
 the existing cross-language harness.
 
 On main, additive.

--- a/quest/m2/auth/moq-transport.md
+++ b/quest/m2/auth/moq-transport.md
@@ -1,0 +1,79 @@
+# [M] moq-transport
+
+## Goal
+
+The grant and refresh exchange works on a moq-transport session between two
+moq-net peers, so `Session::auth()` behaves the same over either wire and an
+IETF publisher fails loud on an out-of-scope PUBLISH_NAMESPACE before sending
+it. A new `drafts/draft-lcurley-moq-auth.md` specifies it as an extension a
+conforming peer can ignore.
+
+## Plan
+
+### Draft
+
+`drafts/draft-lcurley-moq-auth.md`, modeled on `draft-lcurley-moq-solicit.md`
+for the setup option and on `draft-lcurley-moq-cluster.md` for the IANA
+tables. It declares:
+
+- Setup Option `AUTH`, an even key in the `0x40B5x` series the cluster and
+  solicit options use, value `1`. Both endpoints send it; the extension is
+  negotiated only when both did, per the moqt extension rule that the set is
+  fixed once both SETUPs are seen. Draft-17 and later only, since that is the
+  first unified SETUP, the same gate `cluster::supported` applies.
+- Control messages `AUTH`, `AUTH_OK`, `AUTH_ERROR` with the lite field shapes,
+  each carrying a Request ID so an AUTH_OK answers a specific AUTH and an
+  unprompted grant update uses Request ID zero. Track namespaces are tuples on
+  this wire, so a prefix is a namespace tuple, matching how SUBSCRIBE_NAMESPACE
+  spells one. Sent only after negotiation; an endpoint that receives one
+  without negotiating closes with PROTOCOL_VIOLATION, which is what moq-net
+  already does for an unknown request stream.
+- Which existing codes AUTH_ERROR reuses: `UNAUTHORIZED`, `EXPIRED_AUTH_TOKEN`,
+  `MALFORMED_AUTH_TOKEN` from the request error registry.
+- A note relating it to the AUTHORIZATION TOKEN setup option: a token
+  presented there is the connection credential an empty AUTH refers to.
+
+Cite [moq-wg #1854](https://github.com/moq-wg/moq-transport/issues/1854) in
+the introduction: the grant answers which role a peer will play. Run
+`just drafts check`; `doc/.vitepress/drafts.ts` discovers the file by name.
+
+### Code
+
+`rs/moq-net/src/ietf/auth.rs` beside `solicit.rs` and `cluster.rs`: the setup
+option round trip with the tri-state `from_setup` shape solicit uses, the
+three messages as `Message` impls with IDs from the draft, and negotiation
+recorded on the peer state. `run_dispatch` in `ietf/session.rs` routes an AUTH
+request stream to the shared `auth::Handle` from
+[Lite stream](/quest/m2/auth/lite.md); `ietf::start` opens one after SETUP
+when negotiated and sends the empty AUTH, and answers the peer's from the
+origin handles exactly as lite does. The fail-loud check moves into the shared
+handle so the IETF subscriber half consults it before writing
+PUBLISH_NAMESPACE, aborting with `Unauthorized` and the path.
+
+`js/net/src/ietf/auth.ts` mirrors it, wired through `handshake.ts` like
+`Ietf.Cluster.intoSetup` and `fromSetup`, and `ietf/connection.ts` dispatches
+the request stream.
+
+Version-gate on draft-17+; earlier drafts leave `grant()` at `None` and
+`refresh` at `Unsupported`.
+
+### Tests
+
+Setup option round trip on every supported draft and absence on 14 to 16;
+negotiation requires both sides; grants from scoped origins over an IETF
+session in Rust, JS, and across; an out-of-scope path aborts before any
+PUBLISH_NAMESPACE is written; a peer without the option (the relay built
+without it, and the interop runner's reference relay) sees no AUTH stream and
+keeps working. Run `just test smoke-full`.
+
+On main, additive.
+
+## Required
+
+- [Lite stream](/quest/m2/auth/lite.md) - supplies `moq_net::auth` and the
+  shared handle this binds to the IETF wire
+
+## Related
+
+- [IETF error codes](/quest/m0/ietf-error-codes.md) - the registered codes
+  AUTH_ERROR reuses

--- a/quest/m2/auth/moq-transport.md
+++ b/quest/m2/auth/moq-transport.md
@@ -21,11 +21,14 @@ tables. It declares:
   negotiated only when both did, per the moqt extension rule that the set is
   fixed once both SETUPs are seen. Draft-17 and later only, since that is the
   first unified SETUP, the same gate `cluster::supported` applies.
-- Control messages `AUTH`, `AUTH_OK`, `AUTH_ERROR` with the lite field shapes,
-  each carrying a Request ID so an AUTH_OK answers a specific AUTH and an
-  unprompted grant update uses Request ID zero. Track namespaces are tuples on
-  this wire, so a prefix is a namespace tuple, matching how SUBSCRIBE_NAMESPACE
-  spells one. Sent only after negotiation; an endpoint that receives one
+- One long-lived AUTH request stream per direction, the way a subscribe
+  request stream outlives its SUBSCRIBE_OK. The first AUTH carries a Request
+  ID like every request; every AUTH also carries the lite Sequence, and
+  AUTH_OK and AUTH_ERROR echo it, with Sequence 0 for an unprompted update.
+  Correlation is the Sequence, never the Request ID, which the allocator
+  hands out from zero and so cannot double as an update marker. Track
+  namespaces are tuples on this wire, so a prefix is a namespace tuple,
+  matching how SUBSCRIBE_NAMESPACE spells one. Sent only after negotiation; an endpoint that receives one
   without negotiating closes with PROTOCOL_VIOLATION, which is what moq-net
   already does for an unknown request stream.
 - Which existing codes AUTH_ERROR reuses: `UNAUTHORIZED`, `EXPIRED_AUTH_TOKEN`,

--- a/quest/m2/auth/moq-transport.md
+++ b/quest/m2/auth/moq-transport.md
@@ -2,10 +2,10 @@
 
 ## Goal
 
-The grant and refresh exchange works on a moq-transport session between two
-moq-net peers, so `Session::auth()` behaves the same over either wire and an
-IETF publisher fails loud on an out-of-scope PUBLISH_NAMESPACE before sending
-it. A new `drafts/draft-lcurley-moq-auth.md` specifies it as an extension a
+The grant exchange works on a moq-transport session between two moq-net
+peers, so `Session::auth()` behaves the same over either wire and an IETF
+publisher fails loud on an out-of-scope PUBLISH_NAMESPACE before sending it. A
+new `drafts/draft-lcurley-moq-auth.md` specifies it as an extension a
 conforming peer can ignore.
 
 ## Plan
@@ -21,17 +21,15 @@ tables. It declares:
   negotiated only when both did, per the moqt extension rule that the set is
   fixed once both SETUPs are seen. Draft-17 and later only, since that is the
   first unified SETUP, the same gate `cluster::supported` applies.
-- One long-lived AUTH request stream per direction, the way a subscribe
-  request stream outlives its SUBSCRIBE_OK. The first AUTH carries a Request
-  ID like every request; every AUTH also carries the lite Sequence, and
-  AUTH_OK and AUTH_ERROR echo it, with Sequence 0 for an unprompted update.
-  Correlation is the Sequence, never the Request ID, which the allocator
-  hands out from zero and so cannot double as an update marker. Track
-  namespaces are tuples on this wire, so a prefix is a namespace tuple,
-  matching how SUBSCRIBE_NAMESPACE spells one. Sent only after negotiation;
-  an endpoint that receives one without negotiating closes with
-  PROTOCOL_VIOLATION, which is what moq-net already does for an unknown
-  request stream.
+- One AUTH request stream per token, living as long as the token, the way a
+  subscribe request stream outlives its SUBSCRIBE_OK. AUTH carries a Request
+  ID like every request plus the token; AUTH_OK and AUTH_ERROR carry the lite
+  fields and may repeat on the stream with the lite update and revoke
+  meanings; closing the stream withdraws the token. Track namespaces are
+  tuples on this wire, so a prefix is a namespace tuple, matching how
+  SUBSCRIBE_NAMESPACE spells one. Sent only after negotiation; an endpoint
+  that receives one without negotiating closes with PROTOCOL_VIOLATION, which
+  is what moq-net already does for an unknown request stream.
 - Which existing codes AUTH_ERROR reuses: `UNAUTHORIZED`, `EXPIRED_AUTH_TOKEN`,
   `MALFORMED_AUTH_TOKEN` from the request error registry.
 - A note relating it to the AUTHORIZATION TOKEN setup option: a token
@@ -48,27 +46,28 @@ option round trip with the tri-state `from_setup` shape solicit uses, the
 three messages as `Message` impls with IDs from the draft, and negotiation
 recorded on the peer state. `run_dispatch` in `ietf/session.rs` routes an AUTH
 request stream to the shared `auth::Handle` from
-[Lite stream](/quest/m2/auth/lite.md); `ietf::start` opens one after SETUP
-when negotiated and sends the empty AUTH, and answers the peer's from the
-origin handles exactly as lite does. The fail-loud check moves into the shared
-handle so the IETF subscriber half consults it before writing
-PUBLISH_NAMESPACE, aborting with `Unauthorized` and the path.
+[Lite stream](/quest/m2/auth/lite.md); `ietf::start` opens the empty-token
+stream after SETUP when negotiated and answers the peer's from the origin
+handles exactly as lite does, and `add` opens further ones. The fail-loud
+check moves into the shared handle so the IETF subscriber half consults it
+before writing PUBLISH_NAMESPACE, aborting with `Unauthorized` and the path.
 
 `js/net/src/ietf/auth.ts` mirrors it, wired through `handshake.ts` like
 `Ietf.Cluster.intoSetup` and `fromSetup`, and `ietf/connection.ts` dispatches
-the request stream.
+the request streams.
 
-Version-gate on draft-17+; earlier drafts leave `grant()` at `None` and
-`refresh` at `Unsupported`.
+Version-gate on draft-17+; earlier drafts leave `grant()` at `None` and `add`
+at `Unsupported`.
 
 ### Tests
 
 Setup option round trip on every supported draft and absence on 14 to 16;
 negotiation requires both sides; grants from scoped origins over an IETF
-session in Rust, JS, and across; an out-of-scope path aborts before any
-PUBLISH_NAMESPACE is written; a peer without the option (the relay built
-without it, and the interop runner's reference relay) sees no AUTH stream and
-keeps working. Run `just test smoke-full`.
+session in Rust, JS, and across; two tokens union and closing one shrinks the
+union; an out-of-scope path aborts before any PUBLISH_NAMESPACE is written; a
+peer without the option (the relay built without it, and the interop runner's
+reference relay) sees no AUTH stream and keeps working. Run
+`just test smoke-full`.
 
 On main, additive.
 

--- a/quest/m2/auth/moq-transport.md
+++ b/quest/m2/auth/moq-transport.md
@@ -28,9 +28,10 @@ tables. It declares:
   Correlation is the Sequence, never the Request ID, which the allocator
   hands out from zero and so cannot double as an update marker. Track
   namespaces are tuples on this wire, so a prefix is a namespace tuple,
-  matching how SUBSCRIBE_NAMESPACE spells one. Sent only after negotiation; an endpoint that receives one
-  without negotiating closes with PROTOCOL_VIOLATION, which is what moq-net
-  already does for an unknown request stream.
+  matching how SUBSCRIBE_NAMESPACE spells one. Sent only after negotiation;
+  an endpoint that receives one without negotiating closes with
+  PROTOCOL_VIOLATION, which is what moq-net already does for an unknown
+  request stream.
 - Which existing codes AUTH_ERROR reuses: `UNAUTHORIZED`, `EXPIRED_AUTH_TOKEN`,
   `MALFORMED_AUTH_TOKEN` from the request error registry.
 - A note relating it to the AUTHORIZATION TOKEN setup option: a token

--- a/quest/m2/auth/relay-refresh.md
+++ b/quest/m2/auth/relay-refresh.md
@@ -1,64 +1,65 @@
-# [M] Relay refresh
+# [M] Relay tokens
 
 ## Goal
 
-A client sends a new token in band and moq-relay verifies it through the same
-`Auth` path the URL token took: the session's grant and expiry move to the new
-token, a refused or narrowing token gets AUTH_ERROR and leaves the session on
-its current grant, and a session whose credential is about to lapse can renew
-without reconnecting. The grant a client receives carries the token's real
-expiry, and `doc/bin/relay/auth.md` documents the exchange.
+A client presents tokens in band and moq-relay verifies each through the same
+`Auth` path the URL token took: the session's scope is the union of every
+accepted token, a refused token gets AUTH_ERROR and changes nothing, and a
+session whose credential is about to lapse renews by presenting a fresh one
+before the old expires. The grant a client receives carries the token's real
+expiry, an expiry that leaves the union intact ends only that token, and
+`doc/bin/relay/auth.md` documents the exchange.
 
 ## Plan
 
-- `Connection::run` in `rs/moq-relay/src/connection.rs` takes
-  `requests()` from the `moq_net::Request` builder before `.ok()`, so the
-  relay owns the initial empty AUTH too and the driver's fallback never races
-  it. An empty token is answered from the origin
-  handles as the default does, plus `token.expires` from the admitted
-  `AuthToken`. A non-empty token goes through `Auth::verify` with
-  `AuthParams { path, jwt, transport }` built from the admitted session's path
-  and transport, or `verify_mtls` never, since a certificate cannot be
-  replaced in band. mTLS sessions reject a non-empty token as `Unsupported`.
-- Coverage: the new token's root must equal the admitted root, and its publish
-  and subscribe prefixes must cover the current grant (`Scope::covered_by`, the
-  check `Auth::recheck` already performs). Anything else is `AUTH_ERROR
-  { Unauthorized, reason }` naming which side failed, and nothing changes.
-  Widening is accepted: the session's origin handles are rebuilt through
-  `Cluster::publisher` and `Cluster::subscriber` from the new token and
-  swapped in, which is the first live re-scope the relay performs, so keep it
-  behind one function that [Relay auth](/quest/m2/path-patterns/relay-auth.md)
-  later extends to narrowing.
+- `Connection::run` in `rs/moq-relay/src/connection.rs` takes `requests()`
+  from the `moq_net::Request` builder before `.ok()`, so the relay owns the
+  initial empty AUTH too and the driver's fallback never races it. An empty
+  token is answered from the origin handles as the default does, plus
+  `token.expires` from the admitted `AuthToken`. A non-empty token goes
+  through `Auth::verify` with `AuthParams { path, jwt, transport }` built from
+  the admitted session's path and transport; `verify_mtls` never, since a
+  certificate cannot be presented in band. mTLS sessions reject a non-empty
+  token as `Unsupported`.
+- Union: the connection holds the set of accepted `AuthToken`s. Every one
+  must carry the admitted root, else `AUTH_ERROR { Unauthorized }` naming the
+  root. The session's origin handles are rebuilt through `Cluster::publisher`
+  and `Cluster::subscriber` from the union of the set's publish and subscribe
+  prefixes and swapped in whenever the set grows, the first live re-scope the
+  relay performs; keep it behind one function that
+  [Relay auth](/quest/m2/path-patterns/relay-auth.md) later extends to a
+  shrinking union.
 - Expiry: the deadline today is a future borrowing the admitted token inside
-  one `tokio::select!` arm (`Auth::expired`). Hold the current token in a cell
-  the refresh path replaces and re-enter `expired` on change, so the JWT
-  `exp`, the revalidation cadence, and the staleness window all follow the new
-  token. When revalidation lowers `exp` on a proxy-mode session, write an
-  unprompted AUTH_OK (Sequence 0) with the new expiry so the client can
-  refresh in time.
+  one `tokio::select!` arm (`Auth::expired`). Run one `expired` per token in
+  the set instead, and on any firing recompute the union without it: unchanged
+  means `AUTH_ERROR { Expired }` on that token's stream and the session
+  continues, shrunk means `session.abort(Unauthorized)` as today. A token
+  withdrawn by the client (its stream closed) follows the same rule. The
+  revalidation cadence and staleness window run per token as well, and a
+  proxy-mode re-check that lowers a token's `exp` writes an update AUTH_OK on
+  its stream so the client can present a replacement in time.
 - Refusals from the auth API in proxy mode map as connect-time ones do: `404`,
-  empty grant, `401`, `403` are `AUTH_ERROR { Unauthorized }`; an outage keeps
-  the session on its current grant and is reported as `AUTH_ERROR
-  { Timeout }`, never a close.
-- `moq_native::Reconnect` gains `auth()` returning the live session's handle
-  (`None` while disconnected, the shape `ConnectionStatsReader` already uses),
-  and remembers the last accepted token so the next reconnect presents it in
-  the URL query until [Token in band](/quest/m2/auth/token-in-band.md)
-  replaces that.
-- `moq` CLI: `moq publish` and `moq serve` document that a token in the URL
-  is what the initial grant reflects; no new flag until the credential leaves
-  the URL.
-- Docs: `doc/bin/relay/auth.md` gains an "in-band refresh" section beside
-  revalidation stating what a refresh may change, that narrowing is refused
-  today, and that the grant's expiry is the token's `exp`.
-- Tests: a refresh with a later `exp` moves the deadline and the session
-  outlives the original expiry; an expired or invalid token is refused and the
-  session runs to the original deadline; a narrower or different-root token is
-  refused with a reason naming the side; a widening token rebuilds the origin
-  scope and a previously unsolicited prefix is now solicited; an mTLS session
-  refuses a token; a proxy-mode outage keeps the grant.
+  empty grant, `401`, `403` are `AUTH_ERROR { Unauthorized }`; an outage on a
+  new token is `AUTH_ERROR { Timeout }`, and an outage during re-check keeps
+  the token as the staleness rule already does, never a close on its own.
+- The client side names dev's API: `moq_tokio::Connection` gains `auth()`
+  returning the live session's handle (`None` while disconnected, the shape
+  its stats reader already uses), and tokens added through it are presented
+  again on every reconnect. Branch from dev, or from main once
+  [merge-dev](/quest/m1/merge-dev.md) lands.
+- Docs: `doc/bin/relay/auth.md` gains an "in-band tokens" section beside
+  revalidation stating that grants union, that a token needs the admitted
+  root, what an expiry does to the union today, and that the grant's expiry
+  is the token's `exp`.
+- Tests: a second token with a later `exp` and the same scope keeps the
+  session past the first token's expiry, with only the first stream ending;
+  an expired or invalid token is refused and nothing changes; a token with a
+  different root is refused naming it; a token adding a prefix rebuilds the
+  origin scope and the prefix is now solicited; withdrawing the only token
+  covering a prefix closes the session; an mTLS session refuses a token; a
+  proxy-mode outage on re-check keeps the token.
 
-On main, additive.
+Additive.
 
 ## Required
 
@@ -68,7 +69,7 @@ On main, additive.
 ## Related
 
 - [Relay auth](/quest/m2/path-patterns/relay-auth.md) - extends the re-scope
-  to narrowing
+  to a shrinking union
 - [Revalidation updates](/quest/m2/revalidation-updates.md) - the tier and
-  alias outcomes a re-check has; a refresh that changes them follows the same
+  alias outcomes a re-check has; a token that changes them follows the same
   rules

--- a/quest/m2/auth/relay-refresh.md
+++ b/quest/m2/auth/relay-refresh.md
@@ -1,0 +1,71 @@
+# [M] Relay refresh
+
+## Goal
+
+A client sends a new token in band and moq-relay verifies it through the same
+`Auth` path the URL token took: the session's grant and expiry move to the new
+token, a refused or narrowing token gets AUTH_ERROR and leaves the session on
+its current grant, and a session whose credential is about to lapse can renew
+without reconnecting. The grant a client receives carries the token's real
+expiry, and `doc/bin/relay/auth.md` documents the exchange.
+
+## Plan
+
+- `Connection::run` in `rs/moq-relay/src/connection.rs` consumes
+  `session.auth().requests()`. An empty token is answered from the origin
+  handles as the default does, plus `token.expires` from the admitted
+  `AuthToken`. A non-empty token goes through `Auth::verify` with
+  `AuthParams { path, jwt, transport }` built from the admitted session's path
+  and transport, or `verify_mtls` never, since a certificate cannot be
+  replaced in band. mTLS sessions reject a non-empty token as `Unsupported`.
+- Coverage: the new token's root must equal the admitted root, and its publish
+  and subscribe prefixes must cover the current grant (`Scope::covered_by`, the
+  check `Auth::recheck` already performs). Anything else is `AUTH_ERROR
+  { Unauthorized, reason }` naming which side failed, and nothing changes.
+  Widening is accepted: the session's origin handles are rebuilt through
+  `Cluster::publisher` and `Cluster::subscriber` from the new token and
+  swapped in, which is the first live re-scope the relay performs, so keep it
+  behind one function that [Relay auth](/quest/m2/path-patterns/relay-auth.md)
+  later extends to narrowing.
+- Expiry: the deadline today is a future borrowing the admitted token inside
+  one `tokio::select!` arm (`Auth::expired`). Hold the current token in a cell
+  the refresh path replaces and re-enter `expired` on change, so the JWT
+  `exp`, the revalidation cadence, and the staleness window all follow the new
+  token. When revalidation lowers `exp` on a proxy-mode session, write an
+  unprompted AUTH_OK with the new expiry so the client can refresh in time.
+- Refusals from the auth API in proxy mode map as connect-time ones do: `404`,
+  empty grant, `401`, `403` are `AUTH_ERROR { Unauthorized }`; an outage keeps
+  the session on its current grant and is reported as `AUTH_ERROR
+  { Timeout }`, never a close.
+- `moq_native::Reconnect` gains `auth()` returning the live session's handle
+  (`None` while disconnected, the shape `ConnectionStatsReader` already uses),
+  and remembers the last accepted token so the next reconnect presents it in
+  the URL query until [Token in band](/quest/m2/auth/token-in-band.md)
+  replaces that.
+- `moq` CLI: `moq publish` and `moq serve` document that a token in the URL
+  is what the initial grant reflects; no new flag until the credential leaves
+  the URL.
+- Docs: `doc/bin/relay/auth.md` gains an "in-band refresh" section beside
+  revalidation stating what a refresh may change, that narrowing is refused
+  today, and that the grant's expiry is the token's `exp`.
+- Tests: a refresh with a later `exp` moves the deadline and the session
+  outlives the original expiry; an expired or invalid token is refused and the
+  session runs to the original deadline; a narrower or different-root token is
+  refused with a reason naming the side; a widening token rebuilds the origin
+  scope and a previously unsolicited prefix is now solicited; an mTLS session
+  refuses a token; a proxy-mode outage keeps the grant.
+
+On main, additive.
+
+## Required
+
+- [Lite stream](/quest/m2/auth/lite.md) - supplies the AUTH stream and
+  `auth::Request` this consumes
+
+## Related
+
+- [Relay auth](/quest/m2/path-patterns/relay-auth.md) - extends the re-scope
+  to narrowing
+- [Revalidation updates](/quest/m2/revalidation-updates.md) - the tier and
+  alias outcomes a re-check has; a refresh that changes them follows the same
+  rules

--- a/quest/m2/auth/relay-refresh.md
+++ b/quest/m2/auth/relay-refresh.md
@@ -25,8 +25,11 @@ expiry, an expiry that leaves the union intact ends only that token, and
   must carry the admitted root, else `AUTH_ERROR { Unauthorized }` naming the
   root. The session's origin handles are rebuilt through `Cluster::publisher`
   and `Cluster::subscriber` from the union of the set's publish and subscribe
-  prefixes and swapped in whenever the set grows, the first live re-scope the
-  relay performs; keep it behind one function that
+  prefixes, intersected with the role the client declared at SETUP so a
+  publish-only session never starts receiving announcements because a later
+  token happened to carry subscribe prefixes, and swapped in whenever the set
+  grows, the first live re-scope the relay performs; keep it behind one
+  function that
   [Relay auth](/quest/m2/path-patterns/relay-auth.md) later extends to a
   shrinking union.
 - Expiry: the deadline today is a future borrowing the admitted token inside
@@ -43,9 +46,11 @@ expiry, an expiry that leaves the union intact ends only that token, and
   new token is `AUTH_ERROR { Timeout }`, and an outage during re-check keeps
   the token as the staleness rule already does, never a close on its own.
 - The client side names dev's API: `moq_tokio::Connection` gains `auth()`
-  returning the live session's handle (`None` while disconnected, the shape
-  its stats reader already uses), and tokens added through it are presented
-  again on every reconnect. Branch from dev, or from main once
+  returning a handle the connection owns, not the current session's. It
+  stores every token added through it, presents them on each new session as
+  it attaches, unions the live session's grant, and its `add` resolves against
+  the session that is up at the time; a token the app drops is withdrawn from
+  the live session and forgotten. Branch from dev, or from main once
   [merge-dev](/quest/m1/merge-dev.md) lands.
 - Docs: `doc/bin/relay/auth.md` gains an "in-band tokens" section beside
   revalidation stating that grants union, that a token needs the admitted

--- a/quest/m2/auth/relay-refresh.md
+++ b/quest/m2/auth/relay-refresh.md
@@ -11,8 +11,10 @@ expiry, and `doc/bin/relay/auth.md` documents the exchange.
 
 ## Plan
 
-- `Connection::run` in `rs/moq-relay/src/connection.rs` consumes
-  `session.auth().requests()`. An empty token is answered from the origin
+- `Connection::run` in `rs/moq-relay/src/connection.rs` takes
+  `requests()` from the `moq_net::Request` builder before `.ok()`, so the
+  relay owns the initial empty AUTH too and the driver's fallback never races
+  it. An empty token is answered from the origin
   handles as the default does, plus `token.expires` from the admitted
   `AuthToken`. A non-empty token goes through `Auth::verify` with
   `AuthParams { path, jwt, transport }` built from the admitted session's path
@@ -32,7 +34,8 @@ expiry, and `doc/bin/relay/auth.md` documents the exchange.
   the refresh path replaces and re-enter `expired` on change, so the JWT
   `exp`, the revalidation cadence, and the staleness window all follow the new
   token. When revalidation lowers `exp` on a proxy-mode session, write an
-  unprompted AUTH_OK with the new expiry so the client can refresh in time.
+  unprompted AUTH_OK (Sequence 0) with the new expiry so the client can
+  refresh in time.
 - Refusals from the auth API in proxy mode map as connect-time ones do: `404`,
   empty grant, `401`, `403` are `AUTH_ERROR { Unauthorized }`; an outage keeps
   the session on its current grant and is reported as `AUTH_ERROR

--- a/quest/m2/auth/token-in-band.md
+++ b/quest/m2/auth/token-in-band.md
@@ -2,52 +2,66 @@
 
 ## Goal
 
-A client's credential travels inside the session instead of the URL. Every
-client in this repository connects without `?jwt=`, presents the token as its
-first AUTH, and the relay admits the session on the anonymous grant and widens
-it when the token verifies. The URL query keeps working as a legacy path so
-existing deployments and the HTTP endpoints are unaffected, and the token no
-longer appears in access logs, browser history, or the WebSocket fallback's
-request line.
+A client's credentials can travel inside the session instead of the URL, and
+several of them can ride one connection. Every client in this repository
+takes tokens as configuration separate from the address, presents each on its
+own AUTH stream at setup, and the relay admits the session on what the URL
+carried and widens it as the streams are answered. Peers below lite-06 keep
+working unchanged: the client puts the first token in the URL whenever any
+version it offers has no AUTH stream, so nothing is refused and nothing goes
+silent, and the token leaves the URL for good only once the offered set is
+AUTH-capable.
 
 ## Plan
 
-- Client configuration separates the credential from the address:
-  `moq_native::ClientConfig` gains `token`, the `moq` CLI a `--token` and
-  `MOQ_TOKEN` beside the URL, moq-ffi `MoqClient::set_token`, libmoq
-  `moq_client_set_token` (mirrored in the wrappers and `cpp/obs/src`), and
-  `js/net`'s `connect` an options field. A token in both places is a
-  configuration error, refused at connect.
-- moq-net presents it: a lite session sends the configured token as its first
-  AUTH instead of the empty one; a moq-transport session sends it as the
-  AUTHORIZATION TOKEN setup option (`ParameterBytes::AuthorizationToken`,
-  `USE_VALUE`, token type 0) and still opens the AUTH stream with an empty
-  token to learn its grant.
-- The relay admits first, scopes second. An anonymous connection today is
+- Client configuration separates the credential from the address on dev's
+  API: `moq_tokio::connect::Config` gains `tokens`, repeatable as
+  `--connect-token` and `MOQ_CONNECT_TOKEN`, the default set for every dial
+  the client makes. A `?jwt=` in the URL stays a member of the union, which is
+  how cluster dial targets keep their per-peer credential, and per-dial
+  extras use the session's `auth().add()` once connected. moq-ffi
+  `MoqClient::set_tokens`, libmoq `moq_client_set_tokens` (mirrored in the
+  wrappers and `cpp/obs/src`), and `js/net`'s `connect` options field follow.
+- Presenting: WebTransport negotiates the moq version as a subprotocol of
+  the CONNECT request that carries the URL, so the client cannot wait to
+  learn whether the peer speaks AUTH. The client copies the first configured
+  token into the URL query whenever any offered version lacks AUTH (today,
+  everything below lite-06), and omits it once every offered version has the
+  stream; either way every configured token gets its own AUTH stream on an
+  AUTH-capable session, and the URL copy is what the empty-token stream
+  refers to. On moq-transport the first token also rides the AUTHORIZATION
+  TOKEN setup option (`ParameterBytes::AuthorizationToken`, `USE_VALUE`,
+  token type 0), which scopes at accept the way the URL does.
+- The relay admits on the URL, then widens. An anonymous connection today is
   admitted with the public grant when one is configured and refused
-  otherwise; with this quest the refusal waits for the first AUTH, bounded by
-  a short deadline after SETUP, so a client that never presents anything is
-  still refused and a token-bearing one is scoped by the existing widening
-  path from [Relay refresh](/quest/m2/auth/relay-refresh.md). A token in the
-  setup option scopes at accept, as the URL does. `AuthParams::from_url` and
-  `from_path_query` stay for the legacy query.
+  otherwise; with this quest a connection with no URL credential and no
+  public grant is held for a short deadline after SETUP for its first
+  accepted AUTH before being refused, so an AUTH-capable client with tokens
+  only in band gets in and a client that never presents anything is still
+  refused. `AuthParams::from_url` and `from_path_query` stay as the URL path.
 - The WebSocket 403 in [Connect auth race](/quest/m0/3532-connect-auth-race.md)
-  becomes an in-band AUTH_ERROR on the QUIC arm as well; the race keeps its
-  auth-only semantics.
-- Docs: `doc/bin/cli.md`, `doc/bin/relay/auth.md` (legacy query, the
-  admission deadline), `doc/lib/*` client configuration, and every example
-  invocation that carries `?jwt=` in `doc/`, `demo/`, and the READMEs.
-- Tests: a client with a token and no query is scoped exactly as the URL
-  variant; an anonymous client with no public grant is refused at the
-  deadline; a token in both places is refused at connect; the cross-language
-  harness runs with tokens in band.
+  keeps its meaning: a URL credential is still refused at connect on either
+  arm, and an in-band refusal is an AUTH_ERROR after connect.
+- Docs: `doc/bin/cli.md`, `doc/bin/relay/auth.md` (the admission deadline and
+  that the URL token is one member of the union), `doc/lib/*` client
+  configuration, and the example invocations carrying `?jwt=` in `doc/`,
+  `demo/`, and the READMEs, keeping the URL form documented as the way to
+  reach an older relay.
+- Tests: a client with a configured token against an AUTH-capable relay is
+  scoped exactly as the URL variant and the URL carries the token only while
+  an old version is offered; the same client against a lite-05 relay still
+  authenticates through the URL; two configured tokens union; a client with
+  in-band tokens only and no public grant is admitted, and one that presents
+  nothing is refused at the deadline; the cross-language harness runs with
+  tokens configured.
 
-On main, additive.
+Branch from dev, or from main once [merge-dev](/quest/m1/merge-dev.md) lands.
+Additive.
 
 ## Required
 
-- [Relay refresh](/quest/m2/auth/relay-refresh.md) - supplies the verify and
-  widen path the first AUTH reuses
+- [Relay tokens](/quest/m2/auth/relay-refresh.md) - supplies the verify and
+  widen path the configured tokens reuse
 - [Bindings](/quest/m2/auth/bindings.md) - supplies the client surface the new
   token setters sit beside
 - [moq-transport](/quest/m2/auth/moq-transport.md) - supplies the IETF AUTH

--- a/quest/m2/auth/token-in-band.md
+++ b/quest/m2/auth/token-in-band.md
@@ -50,3 +50,5 @@ On main, additive.
   widen path the first AUTH reuses
 - [Bindings](/quest/m2/auth/bindings.md) - supplies the client surface the new
   token setters sit beside
+- [moq-transport](/quest/m2/auth/moq-transport.md) - supplies the IETF AUTH
+  exchange the setup-option token pairs with

--- a/quest/m2/auth/token-in-band.md
+++ b/quest/m2/auth/token-in-band.md
@@ -27,9 +27,10 @@ AUTH-capable.
   learn whether the peer speaks AUTH. The client copies the first configured
   token into the URL query whenever any offered version lacks AUTH (today,
   everything below lite-06), and omits it once every offered version has the
-  stream; either way every configured token gets its own AUTH stream on an
-  AUTH-capable session, and the URL copy is what the empty-token stream
-  refers to. On moq-transport the first token also rides the AUTHORIZATION
+  stream. A token that went into the URL or the setup option is the
+  connection credential, and the empty-token stream is its one and only
+  stream; every other configured token gets its own AUTH stream on an
+  AUTH-capable session, so no token is ever granted twice. On moq-transport the first token also rides the AUTHORIZATION
   TOKEN setup option (`ParameterBytes::AuthorizationToken`, `USE_VALUE`,
   token type 0), which scopes at accept the way the URL does.
 - The relay admits on the URL, then widens. An anonymous connection today is

--- a/quest/m2/auth/token-in-band.md
+++ b/quest/m2/auth/token-in-band.md
@@ -30,9 +30,10 @@ AUTH-capable.
   stream. A token that went into the URL or the setup option is the
   connection credential, and the empty-token stream is its one and only
   stream; every other configured token gets its own AUTH stream on an
-  AUTH-capable session, so no token is ever granted twice. On moq-transport the first token also rides the AUTHORIZATION
-  TOKEN setup option (`ParameterBytes::AuthorizationToken`, `USE_VALUE`,
-  token type 0), which scopes at accept the way the URL does.
+  AUTH-capable session, so no token is ever granted twice. On moq-transport
+  the first token also rides the AUTHORIZATION TOKEN setup option
+  (`ParameterBytes::AuthorizationToken`, `USE_VALUE`, token type 0), which
+  scopes at accept the way the URL does.
 - The relay admits on the URL, then widens. An anonymous connection today is
   admitted with the public grant when one is configured and refused
   otherwise; with this quest a connection with no URL credential and no

--- a/quest/m2/auth/token-in-band.md
+++ b/quest/m2/auth/token-in-band.md
@@ -1,0 +1,52 @@
+# [M] Token in band
+
+## Goal
+
+A client's credential travels inside the session instead of the URL. Every
+client in this repository connects without `?jwt=`, presents the token as its
+first AUTH, and the relay admits the session on the anonymous grant and widens
+it when the token verifies. The URL query keeps working as a legacy path so
+existing deployments and the HTTP endpoints are unaffected, and the token no
+longer appears in access logs, browser history, or the WebSocket fallback's
+request line.
+
+## Plan
+
+- Client configuration separates the credential from the address:
+  `moq_native::ClientConfig` gains `token`, the `moq` CLI a `--token` and
+  `MOQ_TOKEN` beside the URL, moq-ffi `MoqClient::set_token`, libmoq
+  `moq_client_set_token` (mirrored in the wrappers and `cpp/obs/src`), and
+  `js/net`'s `connect` an options field. A token in both places is a
+  configuration error, refused at connect.
+- moq-net presents it: a lite session sends the configured token as its first
+  AUTH instead of the empty one; a moq-transport session sends it as the
+  AUTHORIZATION TOKEN setup option (`ParameterBytes::AuthorizationToken`,
+  `USE_VALUE`, token type 0) and still opens the AUTH stream with an empty
+  token to learn its grant.
+- The relay admits first, scopes second. An anonymous connection today is
+  admitted with the public grant when one is configured and refused
+  otherwise; with this quest the refusal waits for the first AUTH, bounded by
+  a short deadline after SETUP, so a client that never presents anything is
+  still refused and a token-bearing one is scoped by the existing widening
+  path from [Relay refresh](/quest/m2/auth/relay-refresh.md). A token in the
+  setup option scopes at accept, as the URL does. `AuthParams::from_url` and
+  `from_path_query` stay for the legacy query.
+- The WebSocket 403 in [Connect auth race](/quest/m0/3532-connect-auth-race.md)
+  becomes an in-band AUTH_ERROR on the QUIC arm as well; the race keeps its
+  auth-only semantics.
+- Docs: `doc/bin/cli.md`, `doc/bin/relay/auth.md` (legacy query, the
+  admission deadline), `doc/lib/*` client configuration, and every example
+  invocation that carries `?jwt=` in `doc/`, `demo/`, and the READMEs.
+- Tests: a client with a token and no query is scoped exactly as the URL
+  variant; an anonymous client with no public grant is refused at the
+  deadline; a token in both places is refused at connect; the cross-language
+  harness runs with tokens in band.
+
+On main, additive.
+
+## Required
+
+- [Relay refresh](/quest/m2/auth/relay-refresh.md) - supplies the verify and
+  widen path the first AUTH reuses
+- [Bindings](/quest/m2/auth/bindings.md) - supplies the client surface the new
+  token setters sit beside

--- a/quest/m2/path-patterns/relay-auth.md
+++ b/quest/m2/path-patterns/relay-auth.md
@@ -17,9 +17,9 @@ Land reader-first: readers accept v1 before any writer emits it.
   one.
 - Revalidation compares the full versioned grant and resizes a live session
   without a prefix-only widening window.
-- An in-band refresh ([Relay refresh](/quest/m2/auth/relay-refresh.md))
-  goes through the same resize, so a narrower token is accepted and the
-  handles outside it are cancelled instead of refused.
+- An in-band token expiry ([Relay tokens](/quest/m2/auth/relay-refresh.md))
+  goes through the same resize, so a shrinking union cancels the handles
+  outside it instead of closing the session.
 - Keep auth failures explicit: unsupported versions, mixed fields, invalid
   patterns, and scope escapes reject the connection or refresh.
 - Cover JWT, public, static, alias, auth-API, revalidation, HLS, and cluster

--- a/quest/m2/path-patterns/relay-auth.md
+++ b/quest/m2/path-patterns/relay-auth.md
@@ -17,6 +17,9 @@ Land reader-first: readers accept v1 before any writer emits it.
   one.
 - Revalidation compares the full versioned grant and resizes a live session
   without a prefix-only widening window.
+- An in-band refresh ([Relay refresh](/quest/m2/auth/relay-refresh.md))
+  goes through the same resize, so a narrower token is accepted and the
+  handles outside it are cancelled instead of refused.
 - Keep auth failures explicit: unsupported versions, mixed fields, invalid
   patterns, and scope escapes reject the connection or refresh.
 - Cover JWT, public, static, alias, auth-API, revalidation, HLS, and cluster

--- a/quest/m2/processor/grant-lease.md
+++ b/quest/m2/processor/grant-lease.md
@@ -33,3 +33,8 @@ Land the implementation and tests here. The release and the moq.pro
   minting and the audience shape this lease extends
 - [Relay auth](/quest/m2/path-patterns/relay-auth.md) - supplies the v1 native
   authorization owner that enforces handle deadlines
+
+## Related
+
+- [Relay refresh](/quest/m2/auth/relay-refresh.md) - the in-band token
+  refresh a lease renewal rides on

--- a/quest/m2/processor/grant-lease.md
+++ b/quest/m2/processor/grant-lease.md
@@ -36,5 +36,5 @@ Land the implementation and tests here. The release and the moq.pro
 
 ## Related
 
-- [Relay refresh](/quest/m2/auth/relay-refresh.md) - the in-band token
-  refresh a lease renewal rides on
+- [Relay tokens](/quest/m2/auth/relay-refresh.md) - the in-band token a
+  lease renewal presents


### PR DESCRIPTION
## Summary

Plans the `quest/m2/auth/` questline. Today a publisher whose token allows `baz` but who publishes `foo/bar` waits forever: the relay solicits only the granted prefixes, nothing is logged on either side, and moq-lite has no announce refusal. Tokens ride the URL, so a session can never outlive its credential.

Decisions settled in the planning interview and recorded in the questline README:

- Symmetric AUTH streams on lite-06: either side opens one after SETUP with an empty token (meaning the connection's credential) and receives `AUTH_OK { publish prefixes, subscribe prefixes, expires }` or `AUTH_ERROR`. A real token on the same stream is a refresh.
- A publish outside the grant aborts the session with `Unauthorized` naming the path; the grant is also exposed as `Session::auth()` for apps that decide themselves.
- Narrowing refreshes are refused for now; in-place resizing folds into the existing path-patterns relay-auth quest.
- moq-transport gets the same exchange as setup-option-gated control messages on draft-17+, in a new `draft-lcurley-moq-auth.md`, which is also the concrete answer to moq-wg/moq-transport#1854.
- Cluster peers keep mTLS and simply learn the unrestricted grant.

Quests: [L] lite stream, [M] relay refresh, [M] moq-transport, [M] bindings, [M] token in band. Ranked after Path patterns in m2.

## Public API and wire impact

None in this PR; it only adds quests. The planned work is additive on main: `Session::auth()`, a new lite-06 stream type on the opt-in WIP ALPN, and a moq-transport extension a conforming peer ignores.

## Test plan

- `just check` (quest check: 304 documents ok)
- `quest ready quest/m2/auth/token-in-band.md` reports its two blockers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Claude Fable 5.1)
