### PR TITLE
fix(moq-net): abort subscriptions on session shutdown

### DIFF
--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -150,9 +150,12 @@ struct State {
 impl Drop for State {
 	fn drop(&mut self) {
 		// The session dispatcher owns this state and can be dropped at any await.
-		// Abort remaining model producers before receive tasks release their open
-		// group handles. An ordinary unsubscribe removes its entry before this.
+		// Active receive tasks abort their own groups. Cancel any head waiting for
+		// its tail here, along with the track. Ordinary unsubscribe removes its entry.
 		for (_, track) in self.subscribes.drain() {
+			if let Fill::Ready { producer, .. } = &*track.fill.read() {
+				let _ = producer.clone().abort(Error::Cancel);
+			}
 			let _ = track.producer.abort(Error::Cancel);
 		}
 	}
@@ -1750,7 +1753,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		// The peek inside blocks until the publisher produces the group's first object, so
 		// race it against the subscription going away the same way the group read below is.
 		// Otherwise dropping the local subscriber cannot end this handler.
-		let (mut producer, start) = {
+		let (producer, start) = {
 			let mut opening = track.clone();
 			let mut open = std::pin::pin!(self.open_group(stream, &mut opening, &fill, group.group_id));
 			kio::wait(|waiter| {
@@ -1761,6 +1764,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			})
 			.await?
 		};
+
+		let producer = crate::recv::Group::new(producer);
 
 		let res = {
 			let mut serve = std::pin::pin!(self.run_group(group, stream, producer.clone(), timescale, start));
@@ -1938,7 +1943,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 				// `create_frame` is the allocation chokepoint and rejects an oversized
 				// `size` before allocating, so no pre-check is needed.
 				let timestamp = timestamp.unwrap_or_else(crate::Timestamp::now);
-				let mut frame = producer.create_frame(frame::Info { size, timestamp })?;
+				let mut frame = crate::recv::Frame::new(producer.create_frame(frame::Info { size, timestamp })?);
 
 				if let Err(err) = self.run_frame(stream, &mut frame).await {
 					let _ = frame.abort(err.clone());
@@ -2053,14 +2058,14 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		track: &mut track::Producer,
 		timescale: Option<Timescale>,
 	) -> Result<Fill, Error> {
-		let mut head: Option<(u64, u64, group::Producer)> = None;
+		let mut head: Option<(u64, u64, crate::recv::Group)> = None;
 
 		match self.run_fill_objects(stream, track, timescale, &mut head).await {
 			Ok(()) => Ok(match head {
 				Some((sequence, next, producer)) => Fill::Ready {
 					sequence,
 					next,
-					producer,
+					producer: producer.into_inner(),
 				},
 				None => Fill::Done,
 			}),
@@ -2084,7 +2089,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 		stream: &mut Reader<S::RecvStream, Version>,
 		track: &mut track::Producer,
 		timescale: Option<Timescale>,
-		head: &mut Option<(u64, u64, group::Producer)>,
+		head: &mut Option<(u64, u64, crate::recv::Group)>,
 	) -> Result<(), Error> {
 		while let Some(object) = stream.decode_maybe::<ietf::FetchObject>().await? {
 			let ietf::FetchObject::Object {
@@ -2121,7 +2126,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 					};
 
 					let producer = track.create_group(group::Info { sequence })?;
-					*head = Some((sequence, 0, producer));
+					*head = Some((sequence, 0, crate::recv::Group::new(producer)));
 				}
 				// A Group ID on a later object names a different group. We ask for the
 				// current group only, and a publisher refuses a wider fill rather than
@@ -2165,7 +2170,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 
 			// `create_frame` is the allocation chokepoint and rejects an oversized `size`
 			// before allocating, so no pre-check is needed.
-			let mut frame = producer.create_frame(frame::Info { size, timestamp })?;
+			let mut frame = crate::recv::Frame::new(producer.create_frame(frame::Info { size, timestamp })?);
 			if let Err(err) = self.run_frame(stream, &mut frame).await {
 				let _ = frame.abort(err.clone());
 				return Err(err);
@@ -4567,6 +4572,64 @@ mod stitch_tests {
 			let (_, recv) = web_transport_trait::Session::open_bi(&self.session).await.unwrap();
 			Reader::new(recv, VERSION)
 		}
+	}
+
+	/// Both subgroup and fill handlers can be cancelled between objects or mid-payload.
+	#[tokio::test]
+	async fn cancelled_group_receive() {
+		for filling in [false, true] {
+			for partial in [false, true] {
+				let mut wire = if filling {
+					fill_stream(SEQUENCE, &[b"frame"])
+				} else {
+					tail_stream(SEQUENCE, 0, &[b"frame"])
+				};
+				if partial {
+					wire.pop();
+				}
+				let mut h = Harness::new(if filling { Fill::Serving(None) } else { Fill::Done }, vec![]);
+				h.session = ScriptedSession::new(wire);
+				let mut reader = h.stream().await;
+				let mut consumer = h.track.subscribe(None);
+				let mut receiving = Box::pin(async {
+					if filling {
+						h.subscriber.recv_fill(&mut reader).await
+					} else {
+						h.subscriber.recv_group(&mut reader).await
+					}
+				});
+				assert!(futures::poll!(receiving.as_mut()).is_pending());
+				let mut group = consumer.next_group().await.unwrap().unwrap();
+				drop(receiving);
+				assert!(
+					matches!(
+						futures::poll!(Box::pin(group.read_frame())),
+						Poll::Ready(Err(Error::Cancel))
+					),
+					"fill={filling}, partial={partial}"
+				);
+				drop(h.subscriber);
+				assert!(matches!(
+					futures::poll!(Box::pin(consumer.next_group())),
+					Poll::Ready(Err(Error::Cancel))
+				));
+			}
+		}
+	}
+
+	/// A completed fill still owns an unfinished group while waiting for its live tail.
+	#[tokio::test]
+	async fn cancelled_session_aborts_waiting_fill() {
+		let mut h = Harness::new(Fill::Serving(None), vec![fill_stream(SEQUENCE, &[b"frame"])]);
+		let mut reader = h.stream().await;
+		let mut consumer = h.track.subscribe(None);
+		h.subscriber.recv_fill(&mut reader).await.unwrap();
+		let mut group = consumer.next_group().await.unwrap().unwrap();
+		drop(h.subscriber);
+		assert!(matches!(
+			futures::poll!(Box::pin(group.read_frame())),
+			Poll::Ready(Err(Error::Cancel))
+		));
 	}
 
 	/// Every frame of the next group, once it finishes.

--- a/rs/moq-net/src/ietf/subscriber.rs
+++ b/rs/moq-net/src/ietf/subscriber.rs
@@ -147,6 +147,17 @@ struct State {
 	broadcasts: HashMap<PathOwned, BroadcastState>,
 }
 
+impl Drop for State {
+	fn drop(&mut self) {
+		// The session dispatcher owns this state and can be dropped at any await.
+		// Abort remaining model producers before receive tasks release their open
+		// group handles. An ordinary unsubscribe removes its entry before this.
+		for (_, track) in self.subscribes.drain() {
+			let _ = track.producer.abort(Error::Cancel);
+		}
+	}
+}
+
 /// The head of a joined group, delivered on the subscription's fill fetch stream.
 ///
 /// Draft-20's current-group join (section 5.1.6) splits one group across two streams: the

--- a/rs/moq-net/src/lib.rs
+++ b/rs/moq-net/src/lib.rs
@@ -87,6 +87,7 @@ mod ietf;
 mod lite;
 mod model;
 mod path;
+mod recv;
 mod server;
 mod session;
 mod setup;

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -91,6 +91,21 @@ struct TrackEntry {
 	timescale: Option<Timescale>,
 }
 
+// Owns the active subscriptions for exactly as long as `Subscriber::run`.
+// The driver future can be dropped at any await, so cleanup cannot depend on
+// reaching a normal return path.
+struct SubscriptionCleanup(Lock<HashMap<u64, TrackEntry>>);
+
+impl Drop for SubscriptionCleanup {
+	fn drop(&mut self) {
+		// Abort the model producer before receive tasks release their open group
+		// handles. This records session cancellation as the track's terminal state.
+		for (_, entry) in self.0.lock().drain() {
+			let _ = entry.producer.abort(Error::Cancel);
+		}
+	}
+}
+
 impl<S: web_transport_trait::Session> Subscriber<S> {
 	pub fn new(config: SubscriberConfig<S>) -> Self {
 		// Identity for incoming-hop loop detection. Derived from the local
@@ -140,6 +155,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	}
 
 	pub async fn run(self, mut tasks: TaskSet) -> Result<(), Error> {
+		let _cleanup = SubscriptionCleanup(self.subscribes.clone());
 		let bw = self.clone();
 		let dg = self.clone();
 		// The watchdog halves (announce/bandwidth/datagrams) only end the session on

--- a/rs/moq-net/src/lite/subscriber.rs
+++ b/rs/moq-net/src/lite/subscriber.rs
@@ -98,8 +98,8 @@ struct SubscriptionCleanup(Lock<HashMap<u64, TrackEntry>>);
 
 impl Drop for SubscriptionCleanup {
 	fn drop(&mut self) {
-		// Abort the model producer before receive tasks release their open group
-		// handles. This records session cancellation as the track's terminal state.
+		// Group handlers own their cancellation cleanup independently. This records
+		// session cancellation as the track's terminal state.
 		for (_, entry) in self.0.lock().drain() {
 			let _ = entry.producer.abort(Error::Cancel);
 		}
@@ -737,7 +737,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 	pub async fn recv_group(&mut self, stream: &mut Reader<S::RecvStream, Version>) -> Result<(), Error> {
 		let hdr: lite::Group = stream.decode().await?;
 
-		let (mut group, track, timescale) = {
+		let (group, track, timescale) = {
 			let mut subs = self.subscribes.lock();
 			let entry = subs.get_mut(&hdr.subscribe).ok_or(Error::Cancel)?;
 
@@ -747,6 +747,8 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			let group = entry.producer.create_group(group_info)?;
 			(group, entry.producer.clone(), entry.timescale)
 		};
+
+		let group = crate::recv::Group::new(group);
 
 		// The timescale came from TRACK_INFO (read before this subscription was even
 		// registered), so frames decode immediately. No SUBSCRIBE_OK to wait on.
@@ -818,7 +820,7 @@ impl<S: web_transport_trait::Session> Subscriber<S> {
 			// `size` before allocating, so no pre-check is needed. No wire timestamp
 			// (pre-lite-05) means local receive time.
 			let timestamp = timestamp.unwrap_or_else(Timestamp::now);
-			let mut frame = group.create_frame(frame::Info { size, timestamp })?;
+			let mut frame = crate::recv::Frame::new(group.create_frame(frame::Info { size, timestamp })?);
 
 			if let Err(err) = self.run_frame(stream, &mut frame).await {
 				let _ = frame.abort(err.clone());
@@ -866,6 +868,69 @@ mod tests {
 	use crate::util::TaskSet;
 
 	const VERSION: Version = Version::Lite05;
+
+	/// Cancelling a receive task must terminate both an open group and a partial frame.
+	#[tokio::test]
+	async fn cancelled_group_receive() {
+		use crate::{coding::Encode, lite::test_transport::ScriptedSession};
+
+		for partial in [false, true] {
+			let mut wire = Vec::new();
+			lite::Group {
+				subscribe: 0,
+				sequence: 7,
+			}
+			.encode(&mut wire, VERSION)
+			.unwrap();
+			if partial {
+				4u64.encode(&mut wire, VERSION).unwrap();
+				wire.push(1);
+			}
+			let session = ScriptedSession::new(wire);
+			let (_, recv) = web_transport_trait::Session::open_bi(&session).await.unwrap();
+			let (tasks, _task_set) = TaskSet::new();
+			let mut subscriber = Subscriber::new(SubscriberConfig {
+				session,
+				origin: origin::Info::new(crate::Origin::new(1).unwrap()).produce(),
+				recv_bandwidth: None,
+				version: VERSION,
+				peer_setup: Default::default(),
+				cost: None,
+				peer_origin: None,
+				tasks,
+			});
+			let producer = track::Producer::new(
+				Arc::new(crate::broadcast::Info::default()),
+				"video",
+				track::Info::default(),
+			);
+			let mut consumer = producer.subscribe(None);
+			subscriber.subscribes.lock().insert(
+				0,
+				TrackEntry {
+					producer,
+					timescale: None,
+				},
+			);
+			let mut reader = Reader::new(recv, VERSION);
+			let mut receiving = Box::pin(subscriber.recv_group(&mut reader));
+			assert!(futures::poll!(receiving.as_mut()).is_pending());
+			let mut group = consumer.next_group().await.unwrap().unwrap();
+			drop(receiving);
+			assert!(
+				matches!(
+					futures::poll!(Box::pin(group.read_frame())),
+					Poll::Ready(Err(Error::Cancel))
+				),
+				"partial={partial}"
+			);
+			drop(SubscriptionCleanup(subscriber.subscribes.clone()));
+			assert!(matches!(
+				futures::poll!(Box::pin(consumer.next_group())),
+				Poll::Ready(Err(Error::Cancel))
+			));
+		}
+	}
 
 	/// `establish` puts exactly one SUBSCRIBE on the wire, and the id is registered
 	/// before any of it reaches the transport.

--- a/rs/moq-net/src/recv.rs
+++ b/rs/moq-net/src/recv.rs
@@ -1,0 +1,96 @@
+//! Receive-side ownership: cancelled handlers explicitly abort unfinished groups and frames.
+
+use std::ops::{Deref, DerefMut};
+
+use crate::{Error, frame, group};
+
+/// A received group that aborts if its handler is cancelled before finishing or handing it off.
+pub(crate) struct Group(Option<group::Producer>);
+
+impl Group {
+	/// Own a group for the lifetime of its receive handler.
+	pub fn new(producer: group::Producer) -> Self {
+		Self(Some(producer))
+	}
+
+	/// Hand ownership to the next receive stage without closing the group.
+	pub fn into_inner(mut self) -> group::Producer {
+		self.0.take().expect("group owned until consumed")
+	}
+
+	/// Finish receiving without running cancellation cleanup.
+	pub fn finish(mut self) -> Result<(), Error> {
+		self.deref_mut().finish()?;
+		self.0.take();
+		Ok(())
+	}
+
+	/// Abort with the receive error instead of cancellation.
+	pub fn abort(self, err: Error) -> Result<(), Error> {
+		self.into_inner().abort(err)
+	}
+}
+
+impl Deref for Group {
+	type Target = group::Producer;
+
+	fn deref(&self) -> &Self::Target {
+		self.0.as_ref().expect("group owned until consumed")
+	}
+}
+
+impl DerefMut for Group {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		self.0.as_mut().expect("group owned until consumed")
+	}
+}
+
+impl Drop for Group {
+	fn drop(&mut self) {
+		if let Some(producer) = self.0.take() {
+			let _ = producer.abort(Error::Cancel);
+		}
+	}
+}
+
+/// A received frame that aborts before its borrowed group is released on cancellation.
+pub(crate) struct Frame<'a>(Option<frame::Producer<'a>>);
+
+impl<'a> Frame<'a> {
+	/// Own a frame for the lifetime of its receive handler.
+	pub fn new(producer: frame::Producer<'a>) -> Self {
+		Self(Some(producer))
+	}
+
+	/// Finish receiving without running cancellation cleanup.
+	pub fn finish(mut self) -> Result<(), Error> {
+		self.0.take().expect("frame owned until consumed").finish()
+	}
+
+	/// Abort with the receive error instead of cancellation.
+	pub fn abort(mut self, err: Error) -> Result<(), Error> {
+		self.0.take().expect("frame owned until consumed").abort(err)
+	}
+}
+
+impl<'a> Deref for Frame<'a> {
+	type Target = frame::Producer<'a>;
+
+	fn deref(&self) -> &Self::Target {
+		self.0.as_ref().expect("frame owned until consumed")
+	}
+}
+
+impl DerefMut for Frame<'_> {
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		self.0.as_mut().expect("frame owned until consumed")
+	}
+}
+
+impl Drop for Frame<'_> {
+	fn drop(&mut self) {
+		if let Some(producer) = self.0.take() {
+			let _ = producer.abort(Error::Cancel);
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Session cancellation dropped receive-side producers without a terminal reason, causing unfinished-drop warnings. Abort remaining Lite and IETF subscription tracks with `Error::Cancel`.
- Give active receive groups and partial frames cancellation guards, and abort IETF fill heads still waiting for a live tail. Normal completion and fill handoff retain their existing behavior.
- Add CI-covered regressions for cancelled Lite/IETF group handlers, partial frames, and waiting fill heads. The group regressions fail on the original PR head.

## Public API

No signature or export changes. Cancelled inbound tracks, groups, and partial frames report the existing `Error::Cancel`. Receive guards are private to Rust.

## Wire

No changes.

## Validation

- Local: `just fix` and the cancellation regressions pass. The Lite and IETF group regressions failed before the repair.
- Exact-head CI: Check (`just check`), Test (`just test`), and WASM pass. Codex and CodeRabbit reviews are clean.

(written by GPT-6)
