### PR TITLE
fix(claude): keep the direnv hook under the exec arg limit

### DIFF
--- a/.claude/hooks/direnv.sh
+++ b/.claude/hooks/direnv.sh
@@ -10,7 +10,7 @@
 # $CLAUDE_ENV_FILE gets only a line sourcing it. macOS has no per-argument cap,
 # which is why inlining the whole environment appeared to work there.
 
-set -u
+set -eu
 
 MARKER='# moq dev shell'
 
@@ -25,10 +25,6 @@ command -v direnv >/dev/null 2>&1 || exit 0
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 [ -f .envrc ] || exit 0
 
-# SessionStart fires again on resume and clear, and the env file outlives it, so
-# an unguarded append would stack another copy each time.
-grep -qF "$MARKER" "$CLAUDE_ENV_FILE" 2>/dev/null && exit 0
-
 # Clear any inherited direnv state so the dev shell is recomputed in full.
 # Without this, a stale DIRENV_DIFF from the parent process makes direnv assume
 # the env is already loaded and emit nothing.
@@ -37,36 +33,44 @@ unset DIRENV_DIR DIRENV_DIFF DIRENV_WATCHES DIRENV_FILE DIRENV_LAYOUT
 direnv allow . 2>/dev/null || exit 0
 
 raw=$(mktemp) || exit 1
-trap 'rm -f "$raw"' EXIT
+scratch=''
+trap 'rm -f "$raw"; [ -z "$scratch" ] || rm -f "$scratch"' EXIT
 
 # Read the environment with `env -0` rather than a shell builtin: nixpkgs builds
 # the non-interactive `bash` without programmable completion, so `compgen` does
 # not exist inside the very dev shell this hook is here to load.
 if ! direnv exec . env -0 >"$raw"; then
-	echo "direnv hook: could not load the dev shell, see the direnv output above." >&2
-	exit 1
+    echo "direnv hook: could not load the dev shell, see the direnv output above." >&2
+    exit 1
 fi
 
 sidecar=$CLAUDE_ENV_FILE.direnv
+# mktemp keeps credentials private and lets readers retain the old snapshot
+# until the replacement has been written successfully.
+scratch=$(mktemp "$sidecar.XXXXXX")
 
 while IFS= read -r -d '' entry; do
-	name=${entry%%=*}
+    name=${entry%%=*}
 
-	# Skip exported functions (BASH_FUNC_foo%%) and anything else that is not a
-	# plain identifier, since `export` cannot restore those.
-	[[ $name =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+    # Skip exported functions (BASH_FUNC_foo%%) and anything else that is not a
+    # plain identifier, since `export` cannot restore those.
+    [[ $name =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
 
-	# direnv's bookkeeping, and the shell's own state, are not ours to restore.
-	case $name in
-	DIRENV_* | PWD | OLDPWD | SHLVL | _) continue ;;
-	esac
+    # direnv's bookkeeping, and the shell's own state, are not ours to restore.
+    case $name in
+        DIRENV_* | PWD | OLDPWD | SHLVL | _) continue ;;
+    esac
 
-	printf 'export %s=%q\n' "$name" "${entry#*=}"
-done <"$raw" >"$sidecar"
+    printf 'export %s=%q\n' "$name" "${entry#*=}"
+done <"$raw" >"$scratch"
 
-if [ ! -s "$sidecar" ]; then
-	echo "direnv hook: the dev shell exported nothing, so no tools would resolve." >&2
-	exit 1
+if [ ! -s "$scratch" ]; then
+    echo "direnv hook: the dev shell exported nothing, so no tools would resolve." >&2
+    exit 1
 fi
 
+mv -f "$scratch" "$sidecar"
+
+# Refresh on every SessionStart, but install the sourcing line only once.
+grep -qxF "$MARKER" "$CLAUDE_ENV_FILE" 2>/dev/null && exit 0
 printf '%s\n. %q\n' "$MARKER" "$sidecar" >>"$CLAUDE_ENV_FILE"

--- a/.claude/hooks/direnv.sh
+++ b/.claude/hooks/direnv.sh
@@ -36,6 +36,19 @@ raw=$(mktemp) || exit 1
 scratch=''
 trap 'rm -f "$raw"; [ -z "$scratch" ] || rm -f "$scratch"' EXIT
 
+# Clear inherited variables before restoring the snapshot, including variables
+# that .envrc removed. Otherwise later shells inherit those removed values.
+env -0 >"$raw"
+inherited=()
+while IFS= read -r -d '' entry; do
+    name=${entry%%=*}
+    [[ $name =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+    case $name in
+        DIRENV_* | PWD | OLDPWD | SHLVL | _) continue ;;
+    esac
+    inherited+=("$name")
+done <"$raw"
+
 # Read the environment with `env -0` rather than a shell builtin: nixpkgs builds
 # the non-interactive `bash` without programmable completion, so `compgen` does
 # not exist inside the very dev shell this hook is here to load.
@@ -44,30 +57,35 @@ if ! direnv exec . env -0 >"$raw"; then
     exit 1
 fi
 
+if [ ! -s "$raw" ]; then
+    echo "direnv hook: the dev shell exported nothing, so no tools would resolve." >&2
+    exit 1
+fi
+
 sidecar=$CLAUDE_ENV_FILE.direnv
 # mktemp keeps credentials private and lets readers retain the old snapshot
 # until the replacement has been written successfully.
 scratch=$(mktemp "$sidecar.XXXXXX")
 
-while IFS= read -r -d '' entry; do
-    name=${entry%%=*}
+{
+    for name in "${inherited[@]}"; do
+        printf 'unset %s\n' "$name"
+    done
+    while IFS= read -r -d '' entry; do
+        name=${entry%%=*}
 
-    # Skip exported functions (BASH_FUNC_foo%%) and anything else that is not a
-    # plain identifier, since `export` cannot restore those.
-    [[ $name =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+        # Skip exported functions (BASH_FUNC_foo%%) and anything else that is not a
+        # plain identifier, since `export` cannot restore those.
+        [[ $name =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
 
-    # direnv's bookkeeping, and the shell's own state, are not ours to restore.
-    case $name in
-        DIRENV_* | PWD | OLDPWD | SHLVL | _) continue ;;
-    esac
+        # direnv's bookkeeping, and the shell's own state, are not ours to restore.
+        case $name in
+            DIRENV_* | PWD | OLDPWD | SHLVL | _) continue ;;
+        esac
 
-    printf 'export %s=%q\n' "$name" "${entry#*=}"
-done <"$raw" >"$scratch"
-
-if [ ! -s "$scratch" ]; then
-    echo "direnv hook: the dev shell exported nothing, so no tools would resolve." >&2
-    exit 1
-fi
+        printf 'export %s=%q\n' "$name" "${entry#*=}"
+    done <"$raw"
+} >"$scratch"
 
 mv -f "$scratch" "$sidecar"
 

--- a/.claude/hooks/direnv.sh
+++ b/.claude/hooks/direnv.sh
@@ -44,7 +44,7 @@ while IFS= read -r -d '' entry; do
     name=${entry%%=*}
     [[ $name =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
     case $name in
-        DIRENV_* | PWD | OLDPWD | SHLVL | _) continue ;;
+        DIRENV_* | PWD | OLDPWD | SHLVL | _ | SHELLOPTS | BASHOPTS | BASH_VERSINFO | UID | EUID | PPID) continue ;;
     esac
     inherited+=("$name")
 done <"$raw"
@@ -80,7 +80,7 @@ scratch=$(mktemp "$sidecar.XXXXXX")
 
         # direnv's bookkeeping, and the shell's own state, are not ours to restore.
         case $name in
-            DIRENV_* | PWD | OLDPWD | SHLVL | _) continue ;;
+            DIRENV_* | PWD | OLDPWD | SHLVL | _ | SHELLOPTS | BASHOPTS | BASH_VERSINFO | UID | EUID | PPID) continue ;;
         esac
 
         printf 'export %s=%q\n' "$name" "${entry#*=}"

--- a/.claude/hooks/direnv.sh
+++ b/.claude/hooks/direnv.sh
@@ -5,9 +5,15 @@
 # unaffected.
 #
 # direnv only *approves* the .envrc; the actual env is exported into
-# $CLAUDE_ENV_FILE, which Claude Code sources for every later Bash command.
+# $CLAUDE_ENV_FILE, which Claude Code inlines into every later Bash command.
 
 set -u
+
+# Because it is inlined, the file counts against MAX_ARG_STRLEN, the 128KB Linux
+# cap on a single argv entry. Refuse to write more than half of that: past the
+# cap every Bash command dies with E2BIG before the shell even starts.
+MAX_BYTES=65536
+MARKER='# moq dev shell'
 
 # Nothing to export into without this; older Claude Code versions won't set it.
 [ -n "${CLAUDE_ENV_FILE:-}" ] || exit 0
@@ -20,12 +26,41 @@ command -v direnv >/dev/null 2>&1 || exit 0
 cd "$CLAUDE_PROJECT_DIR" || exit 0
 [ -f .envrc ] || exit 0
 
-# Clear any inherited direnv state so `export` recomputes the full diff. Without
-# this, a stale DIRENV_DIFF from the parent process makes direnv assume the env
-# is already loaded and emit nothing.
+# SessionStart fires again on resume and clear, and the env file outlives it, so
+# an unguarded append stacks another full copy each time.
+grep -qF "$MARKER" "$CLAUDE_ENV_FILE" 2>/dev/null && exit 0
+
+# Clear any inherited direnv state so the dev shell is recomputed in full.
+# Without this, a stale DIRENV_DIFF from the parent process makes direnv assume
+# the env is already loaded and emit nothing.
 unset DIRENV_DIR DIRENV_DIFF DIRENV_WATCHES DIRENV_FILE DIRENV_LAYOUT
 
-direnv allow . 2>/dev/null
-direnv export bash >>"$CLAUDE_ENV_FILE" 2>/dev/null
+direnv allow . 2>/dev/null || exit 0
 
-exit 0
+# Snapshot the environment from inside the dev shell rather than using `direnv
+# export`, which also emits DIRENV_DIFF and DIRENV_WATCHES: base64 images of the
+# entire environment, hundreds of KB under a flake, that only direnv reads.
+scratch=$(mktemp) || exit 0
+trap 'rm -f "$scratch"' EXIT
+
+direnv exec . bash -c '
+	for name in $(compgen -e); do
+		case $name in
+		DIRENV_* | PWD | OLDPWD | SHLVL | _) continue ;;
+		esac
+		printf "export %s=%q\n" "$name" "${!name}"
+	done
+' >"$scratch" 2>/dev/null
+
+size=$(wc -c <"$scratch")
+[ "$size" -gt 0 ] || exit 0
+
+if [ "$size" -gt "$MAX_BYTES" ]; then
+    echo "direnv hook: dev shell env is $size bytes, over the $MAX_BYTES cap. Refusing to export it, since Bash would then fail with E2BIG." >&2
+    exit 1
+fi
+
+{
+    echo "$MARKER"
+    cat "$scratch"
+} >>"$CLAUDE_ENV_FILE"

--- a/.claude/hooks/direnv.sh
+++ b/.claude/hooks/direnv.sh
@@ -4,15 +4,14 @@
 # ones. No-op for anyone without direnv or an .envrc, so non-nix setups are
 # unaffected.
 #
-# direnv only *approves* the .envrc; the actual env is exported into
-# $CLAUDE_ENV_FILE, which Claude Code inlines into every later Bash command.
+# Claude Code inlines $CLAUDE_ENV_FILE into the command string of every Bash
+# call, and Linux caps a single argv entry at MAX_ARG_STRLEN, 128KB. This dev
+# shell exports around 190KB, so the environment goes in a sidecar file and
+# $CLAUDE_ENV_FILE gets only a line sourcing it. macOS has no per-argument cap,
+# which is why inlining the whole environment appeared to work there.
 
 set -u
 
-# Because it is inlined, the file counts against MAX_ARG_STRLEN, the 128KB Linux
-# cap on a single argv entry. Refuse to write more than half of that: past the
-# cap every Bash command dies with E2BIG before the shell even starts.
-MAX_BYTES=65536
 MARKER='# moq dev shell'
 
 # Nothing to export into without this; older Claude Code versions won't set it.
@@ -27,7 +26,7 @@ cd "$CLAUDE_PROJECT_DIR" || exit 0
 [ -f .envrc ] || exit 0
 
 # SessionStart fires again on resume and clear, and the env file outlives it, so
-# an unguarded append stacks another full copy each time.
+# an unguarded append would stack another copy each time.
 grep -qF "$MARKER" "$CLAUDE_ENV_FILE" 2>/dev/null && exit 0
 
 # Clear any inherited direnv state so the dev shell is recomputed in full.
@@ -37,30 +36,37 @@ unset DIRENV_DIR DIRENV_DIFF DIRENV_WATCHES DIRENV_FILE DIRENV_LAYOUT
 
 direnv allow . 2>/dev/null || exit 0
 
-# Snapshot the environment from inside the dev shell rather than using `direnv
-# export`, which also emits DIRENV_DIFF and DIRENV_WATCHES: base64 images of the
-# entire environment, hundreds of KB under a flake, that only direnv reads.
-scratch=$(mktemp) || exit 0
-trap 'rm -f "$scratch"' EXIT
+raw=$(mktemp) || exit 1
+trap 'rm -f "$raw"' EXIT
 
-direnv exec . bash -c '
-	for name in $(compgen -e); do
-		case $name in
-		DIRENV_* | PWD | OLDPWD | SHLVL | _) continue ;;
-		esac
-		printf "export %s=%q\n" "$name" "${!name}"
-	done
-' >"$scratch" 2>/dev/null
-
-size=$(wc -c <"$scratch")
-[ "$size" -gt 0 ] || exit 0
-
-if [ "$size" -gt "$MAX_BYTES" ]; then
-    echo "direnv hook: dev shell env is $size bytes, over the $MAX_BYTES cap. Refusing to export it, since Bash would then fail with E2BIG." >&2
-    exit 1
+# Read the environment with `env -0` rather than a shell builtin: nixpkgs builds
+# the non-interactive `bash` without programmable completion, so `compgen` does
+# not exist inside the very dev shell this hook is here to load.
+if ! direnv exec . env -0 >"$raw"; then
+	echo "direnv hook: could not load the dev shell, see the direnv output above." >&2
+	exit 1
 fi
 
-{
-    echo "$MARKER"
-    cat "$scratch"
-} >>"$CLAUDE_ENV_FILE"
+sidecar=$CLAUDE_ENV_FILE.direnv
+
+while IFS= read -r -d '' entry; do
+	name=${entry%%=*}
+
+	# Skip exported functions (BASH_FUNC_foo%%) and anything else that is not a
+	# plain identifier, since `export` cannot restore those.
+	[[ $name =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+
+	# direnv's bookkeeping, and the shell's own state, are not ours to restore.
+	case $name in
+	DIRENV_* | PWD | OLDPWD | SHLVL | _) continue ;;
+	esac
+
+	printf 'export %s=%q\n' "$name" "${entry#*=}"
+done <"$raw" >"$sidecar"
+
+if [ ! -s "$sidecar" ]; then
+	echo "direnv hook: the dev shell exported nothing, so no tools would resolve." >&2
+	exit 1
+fi
+
+printf '%s\n. %q\n' "$MARKER" "$sidecar" >>"$CLAUDE_ENV_FILE"

--- a/.claude/hooks/direnv.test.sh
+++ b/.claude/hooks/direnv.test.sh
@@ -59,4 +59,9 @@ LARGE=1 bash "$hook"
 [[ $(wc -c <"$CLAUDE_ENV_FILE.direnv") -gt 131072 ]]
 [[ $(wc -c <"$CLAUDE_ENV_FILE") -lt 1024 ]]
 bash -c "$(cat "$CLAUDE_ENV_FILE")"
+(
+    export SHELLOPTS
+    bash "$hook"
+    bash -ec '. "$CLAUDE_ENV_FILE"; [[ ${REMOVED_BY_DIRENV+x} != x ]]'
+)
 echo 'direnv hook: regression tests passed'

--- a/.claude/hooks/direnv.test.sh
+++ b/.claude/hooks/direnv.test.sh
@@ -23,9 +23,11 @@ export PATH="$fixture/bin:$PATH"
 export CLAUDE_PROJECT_DIR="$fixture/project"
 export CLAUDE_ENV_FILE="$fixture/session env"
 export SNAPSHOT='first value'
+export REMOVED_BY_DIRENV=present
 umask 022
 bash "$hook"
 [[ $(bash -c '. "$CLAUDE_ENV_FILE"; printf "%s" "$VALUE"') == "$SNAPSHOT" ]]
+bash -c '. "$CLAUDE_ENV_FILE"; [[ ${REMOVED_BY_DIRENV+x} != x ]]'
 mode=$(ls -l "$CLAUDE_ENV_FILE.direnv")
 [[ $mode == -rw-------* ]]
 cp "$CLAUDE_ENV_FILE" "$fixture/original"

--- a/.claude/hooks/direnv.test.sh
+++ b/.claude/hooks/direnv.test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+hook=$(cd "$(dirname "$0")" && pwd)/direnv.sh
+fixture=$(mktemp -d)
+trap 'rm -rf "$fixture"' EXIT
+mkdir "$fixture/bin" "$fixture/project"
+touch "$fixture/project/.envrc"
+cat >"$fixture/bin/direnv" <<'MOCK'
+#!/usr/bin/env bash
+set -eu
+[[ $1 == allow ]] && exit 0
+[[ ${FAIL_CAPTURE:-0} == 0 ]] || exit 1
+printf 'VALUE=%s\0' "$SNAPSHOT"
+if [[ ${LARGE:-0} == 1 ]]; then
+    for ((i = 0; i < 4000; i++)); do
+        printf 'ITEM_%s=abcdefghijklmnopqrstuvwxyz0123456789\0' "$i"
+    done
+fi
+MOCK
+chmod +x "$fixture/bin/direnv"
+export PATH="$fixture/bin:$PATH"
+export CLAUDE_PROJECT_DIR="$fixture/project"
+export CLAUDE_ENV_FILE="$fixture/session env"
+export SNAPSHOT='first value'
+umask 022
+bash "$hook"
+[[ $(bash -c '. "$CLAUDE_ENV_FILE"; printf "%s" "$VALUE"') == "$SNAPSHOT" ]]
+mode=$(ls -l "$CLAUDE_ENV_FILE.direnv")
+[[ $mode == -rw-------* ]]
+cp "$CLAUDE_ENV_FILE" "$fixture/original"
+export SNAPSHOT='second value with $quotes and a
+newline'
+bash "$hook"
+cmp "$CLAUDE_ENV_FILE" "$fixture/original"
+[[ $(bash -c '. "$CLAUDE_ENV_FILE"; printf "%s" "$VALUE"') == "$SNAPSHOT" ]]
+cp "$CLAUDE_ENV_FILE.direnv" "$fixture/snapshot"
+if FAIL_CAPTURE=1 bash "$hook"; then
+    echo 'failed capture was accepted' >&2
+    exit 1
+fi
+cmp "$CLAUDE_ENV_FILE.direnv" "$fixture/snapshot"
+cat >"$fixture/fail-write" <<'MOCK'
+printf() {
+    if [[ $1 == 'export %s=%q\n' ]]; then
+        return 1
+    fi
+    builtin printf "$@"
+}
+MOCK
+if BASH_ENV="$fixture/fail-write" bash "$hook"; then
+    echo 'failed write was accepted' >&2
+    exit 1
+fi
+cmp "$CLAUDE_ENV_FILE.direnv" "$fixture/snapshot"
+LARGE=1 bash "$hook"
+[[ $(wc -c <"$CLAUDE_ENV_FILE.direnv") -gt 131072 ]]
+[[ $(wc -c <"$CLAUDE_ENV_FILE") -lt 1024 ]]
+bash -c "$(cat "$CLAUDE_ENV_FILE")"
+echo 'direnv hook: regression tests passed'

--- a/.claude/hooks/direnv.test.sh
+++ b/.claude/hooks/direnv.test.sh
@@ -29,8 +29,8 @@ bash "$hook"
 mode=$(ls -l "$CLAUDE_ENV_FILE.direnv")
 [[ $mode == -rw-------* ]]
 cp "$CLAUDE_ENV_FILE" "$fixture/original"
-export SNAPSHOT='second value with $quotes and a
-newline'
+export SNAPSHOT="second value with \$quotes and a
+newline"
 bash "$hook"
 cmp "$CLAUDE_ENV_FILE" "$fixture/original"
 [[ $(bash -c '. "$CLAUDE_ENV_FILE"; printf "%s" "$VALUE"') == "$SNAPSHOT" ]]

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -73,6 +73,9 @@ jobs:
       # Locally an absent formatter means less gets checked; here it would mean
       # a green run that checked nothing, which is the failure mode worth
       # spending a preflight on.
+      - name: Test direnv hook
+        run: bash .claude/hooks/direnv.test.sh
+
       - name: Check
         run: nix develop --command just check
         env:


### PR DESCRIPTION
## Summary

- Fix Linux Bash tool failures caused by inlining the roughly 190 KB direnv environment into a single command argument. Store exports in a sidecar and inline only its source line.
- Preserve variables removed by `.envrc` by clearing inherited values before restoring the snapshot.
- Refresh the snapshot on each SessionStart without duplicating the source line. Publish snapshots atomically with mode 0600, preserving the previous snapshot when capture or writing fails.
- Add CI regression coverage for quoting, refresh, permissions, failed capture and writes, and environments larger than 128 KB.

## Public API

None. Local Claude Code tooling only.

## Wire

None.

## Validation

- Focused regression test passes and fails against the original PR head.
- `nix develop`: `just fix`, `just check`, and scoped `just test` pass.
- Focused shell formatting and ShellCheck pass.

(written by GPT-6)
