### PR TITLE
feat(moq-net): add moq-transport draft-21 (moqt-21)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4986,7 +4986,7 @@ dependencies = [
 
 [[package]]
 name = "moq-net"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "arrayvec",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ moq-loc = { version = "0.2.6", path = "rs/moq-loc" }
 moq-msf = { version = "0.4.2", path = "rs/moq-msf" }
 moq-mux = { version = "0.9.14", path = "rs/moq-mux" }
 moq-native = { version = "0.19.17", path = "rs/moq-native", default-features = false }
-moq-net = { version = "0.2.19", path = "rs/moq-net" }
+moq-net = { version = "0.2.20", path = "rs/moq-net" }
 # NVENC bindings, forked from ViliamVadocz/nvidia-video-codec-sdk to dlopen the
 # driver at runtime. Compiles on any platform (macOS included) but only actually
 # used by moq-video on Linux.

--- a/doc/concept/moq-lite.md
+++ b/doc/concept/moq-lite.md
@@ -29,7 +29,7 @@ implement in an afternoon. The wire spec is
 The ALPN picks the protocol family, and a single `SETUP` message from each side
 negotiates the version and capabilities. Neither side waits for the other. The
 Rust and TypeScript stacks currently speak moq-lite 01 through 05 (06 is in
-progress) and moq-transport drafts 14 through 20, and a client offers all of
+progress) and moq-transport drafts 14 through 21, and a client offers all of
 them by default.
 
 ## Discovery

--- a/doc/concept/standard.md
+++ b/doc/concept/standard.md
@@ -11,7 +11,7 @@ with it, while shipping a simpler profile you can use today.
 
 | Spec | Scope | Here |
 | --- | --- | --- |
-| [moq-transport](https://datatracker.ietf.org/doc/draft-ietf-moq-transport/) | The IETF pub/sub protocol | Drafts 14 through 20 negotiated by ALPN; [moq-lite](/concept/moq-lite) is a forward-compatible subset |
+| [moq-transport](https://datatracker.ietf.org/doc/draft-ietf-moq-transport/) | The IETF pub/sub protocol | Drafts 14 through 21 negotiated by ALPN; [moq-lite](/concept/moq-lite) is a forward-compatible subset |
 | [MSF](https://datatracker.ietf.org/doc/draft-ietf-moq-msf/) | The IETF catalog format | Read and written; broadcasts ending in `.msf` select it |
 | [LOC](https://datatracker.ietf.org/doc/draft-ietf-moq-loc/) | The IETF low-overhead container | Supported as a hang container kind |
 | [moq-lite](/draft/moq-lite), [hang](/draft/moq-hang), and friends | This project's own drafts | Normative for the implementation, published to the datatracker from [`drafts/`](https://github.com/moq-dev/moq/tree/main/drafts) |

--- a/js/net/src/connection/accept.ts
+++ b/js/net/src/connection/accept.ts
@@ -30,6 +30,9 @@ export async function accept(transport: WebTransport, url: URL, props?: AcceptPr
 
 	const discovery = props?.discovery ?? true;
 
+	if (protocol === Ietf.ALPN.DRAFT_21) {
+		return acceptAlpn(transport, url, Ietf.Version.DRAFT_21, discovery);
+	}
 	if (protocol === Ietf.ALPN.DRAFT_20) {
 		return acceptAlpn(transport, url, Ietf.Version.DRAFT_20, discovery);
 	}

--- a/js/net/src/connection/connect.ts
+++ b/js/net/src/connection/connect.ts
@@ -198,15 +198,17 @@ async function connectTransport(url: URL, session: WebTransport, discovery: bool
 	// Choose setup encoding based on negotiated WebTransport protocol (if any).
 	let setupVersion: Ietf.Version;
 	const modernVersion =
-		protocol === Ietf.ALPN.DRAFT_20
-			? Ietf.Version.DRAFT_20
-			: protocol === Ietf.ALPN.DRAFT_19
-				? Ietf.Version.DRAFT_19
-				: protocol === Ietf.ALPN.DRAFT_18
-					? Ietf.Version.DRAFT_18
-					: protocol === Ietf.ALPN.DRAFT_17
-						? Ietf.Version.DRAFT_17
-						: undefined;
+		protocol === Ietf.ALPN.DRAFT_21
+			? Ietf.Version.DRAFT_21
+			: protocol === Ietf.ALPN.DRAFT_20
+				? Ietf.Version.DRAFT_20
+				: protocol === Ietf.ALPN.DRAFT_19
+					? Ietf.Version.DRAFT_19
+					: protocol === Ietf.ALPN.DRAFT_18
+						? Ietf.Version.DRAFT_18
+						: protocol === Ietf.ALPN.DRAFT_17
+							? Ietf.Version.DRAFT_17
+							: undefined;
 	if (modernVersion !== undefined) {
 		return await handshakeAlpn(url, session, modernVersion, discovery);
 	} else if (protocol === Ietf.ALPN.DRAFT_16) {
@@ -371,6 +373,7 @@ async function connectWebTransport(
 			Lite.ALPN_04,
 			Lite.ALPN_03,
 			Lite.ALPN,
+			Ietf.ALPN.DRAFT_21,
 			Ietf.ALPN.DRAFT_20,
 			Ietf.ALPN.DRAFT_19,
 			Ietf.ALPN.DRAFT_18,
@@ -444,7 +447,7 @@ async function connectWebSocket(url: URL, delay: number, cancel: Promise<void>):
 	const active = await Promise.race([cancel, timer.then(() => true)]);
 	if (!active) return undefined;
 
-	// Only moq-transport-18 is pinned to qmux-01 today. Every other ALPN we
+	// moq-transport-18 and newer are pinned to qmux-01. Every other ALPN we
 	// support is currently negotiated as `qmux-00.{alpn}` on the wire, but we
 	// don't want to lock that in: set the value to `null` so the polyfill
 	// advertises every QMux draft it knows about and the server picks one.
@@ -455,7 +458,9 @@ async function connectWebSocket(url: URL, delay: number, cancel: Promise<void>):
 		[Lite.ALPN_04]: null,
 		[Lite.ALPN_03]: null,
 		[Lite.ALPN]: null,
+		[Ietf.ALPN.DRAFT_21]: "qmux-01",
 		[Ietf.ALPN.DRAFT_20]: "qmux-01",
+		[Ietf.ALPN.DRAFT_19]: "qmux-01",
 		[Ietf.ALPN.DRAFT_18]: "qmux-01",
 		[Ietf.ALPN.DRAFT_17]: null,
 		[Ietf.ALPN.DRAFT_16]: null,

--- a/js/net/src/ietf/filter.ts
+++ b/js/net/src/ietf/filter.ts
@@ -38,7 +38,14 @@ const TAG_ABSOLUTE_RANGE = 0x4n;
  * present selects the meaning.
  */
 export function isDraft20(version: IetfVersion): boolean {
-	return version === Version.DRAFT_20;
+	return (
+		version !== Version.DRAFT_14 &&
+		version !== Version.DRAFT_15 &&
+		version !== Version.DRAFT_16 &&
+		version !== Version.DRAFT_17 &&
+		version !== Version.DRAFT_18 &&
+		version !== Version.DRAFT_19
+	);
 }
 
 /**

--- a/js/net/src/ietf/ietf.test.ts
+++ b/js/net/src/ietf/ietf.test.ts
@@ -101,7 +101,7 @@ test("Message Parameters: uint8 wire encoding changes in draft 17", async () => 
 		0xff, // QUIC varint 255
 	]);
 
-	for (const version of [Version.DRAFT_17, Version.DRAFT_18, Version.DRAFT_19, Version.DRAFT_20]) {
+	for (const version of [Version.DRAFT_17, Version.DRAFT_18, Version.DRAFT_19, Version.DRAFT_20, Version.DRAFT_21]) {
 		const expected = new Uint8Array([
 			0x01, // parameter count
 			0x20, // SUBSCRIBER_PRIORITY
@@ -133,7 +133,7 @@ test("Message Parameters: Location loses its length prefix at draft-17", async (
 		0x80, // QUIC varint 128
 	]);
 
-	for (const version of [Version.DRAFT_17, Version.DRAFT_18, Version.DRAFT_19, Version.DRAFT_20]) {
+	for (const version of [Version.DRAFT_17, Version.DRAFT_18, Version.DRAFT_19, Version.DRAFT_20, Version.DRAFT_21]) {
 		const expected = new Uint8Array([
 			0x01, // parameter count
 			0x09, // LARGEST_OBJECT
@@ -177,7 +177,7 @@ test("Message Parameters: Location preserves full uint64 values in draft 17", as
 
 	expect(params.largest).toEqual(largest);
 
-	for (const version of [Version.DRAFT_17, Version.DRAFT_18, Version.DRAFT_19, Version.DRAFT_20]) {
+	for (const version of [Version.DRAFT_17, Version.DRAFT_18, Version.DRAFT_19, Version.DRAFT_20, Version.DRAFT_21]) {
 		const encoded = await encodeVersioned(params, version);
 		const decoded = await decodeVersioned(encoded, Parameters.decode, version);
 		expect(decoded.largest).toEqual(largest);
@@ -1484,7 +1484,7 @@ test("group flags round-trip firstObject", async () => {
 			},
 		});
 
-	for (const version of [Version.DRAFT_18, Version.DRAFT_19, Version.DRAFT_20]) {
+	for (const version of [Version.DRAFT_18, Version.DRAFT_19, Version.DRAFT_20, Version.DRAFT_21]) {
 		for (const firstObject of [true, false]) {
 			const encoded = await encodeVersioned(makeGroup(firstObject), version);
 			const decoded = await decodeVersioned(encoded, Group.decode, version);

--- a/js/net/src/ietf/publisher.test.ts
+++ b/js/net/src/ietf/publisher.test.ts
@@ -584,6 +584,7 @@ const ALPNS: Record<IetfVersion, string> = {
 	[Version.DRAFT_18]: ALPN.DRAFT_18,
 	[Version.DRAFT_19]: ALPN.DRAFT_19,
 	[Version.DRAFT_20]: ALPN.DRAFT_20,
+	[Version.DRAFT_21]: ALPN.DRAFT_21,
 };
 
 /**

--- a/js/net/src/ietf/version.ts
+++ b/js/net/src/ietf/version.ts
@@ -49,6 +49,12 @@ export const Version = {
 	 * https://www.ietf.org/archive/id/draft-ietf-moq-transport-20.txt
 	 */
 	DRAFT_20: 0xff000014,
+
+	/**
+	 * draft-ietf-moq-transport-21
+	 * https://www.ietf.org/archive/id/draft-ietf-moq-transport-21.txt
+	 */
+	DRAFT_21: 0xff000015,
 } as const;
 
 export type Version = (typeof Version)[keyof typeof Version];
@@ -62,6 +68,7 @@ export const ALPN = {
 	DRAFT_18: "moqt-18",
 	DRAFT_19: "moqt-19",
 	DRAFT_20: "moqt-20",
+	DRAFT_21: "moqt-21",
 } as const;
 
 /**
@@ -75,7 +82,8 @@ export type IetfVersion =
 	| typeof Version.DRAFT_17
 	| typeof Version.DRAFT_18
 	| typeof Version.DRAFT_19
-	| typeof Version.DRAFT_20;
+	| typeof Version.DRAFT_20
+	| typeof Version.DRAFT_21;
 
 const VERSION_NAMES: Record<number, string> = {
 	[Version.DRAFT_07]: "moq-transport-07",
@@ -86,6 +94,7 @@ const VERSION_NAMES: Record<number, string> = {
 	[Version.DRAFT_18]: "moq-transport-18",
 	[Version.DRAFT_19]: "moq-transport-19",
 	[Version.DRAFT_20]: "moq-transport-20",
+	[Version.DRAFT_21]: "moq-transport-21",
 };
 
 export function versionName(v: Version): string {

--- a/rs/libmoq/src/api.rs
+++ b/rs/libmoq/src/api.rs
@@ -673,7 +673,7 @@ pub extern "C" fn moq_client_close(client: u32) -> i32 {
 ///
 /// By default every supported version is offered and the server picks one. Pass a
 /// subset to pin the negotiation, in the same spelling the CLI uses: `moq-lite-01`
-/// through `moq-lite-06-wip`, or `moq-transport-14` through `moq-transport-20`. An
+/// through `moq-lite-06-wip`, or `moq-transport-14` through `moq-transport-21`. An
 /// empty list restores the default.
 ///
 /// Returns zero on success, or a negative code if the handle is unknown or a version

--- a/rs/moq-native/src/websocket.rs
+++ b/rs/moq-native/src/websocket.rs
@@ -262,10 +262,10 @@ async fn connect_tls_override(
 
 /// The QMux drafts a moq ALPN is allowed to ride on, for `qmux::ws::Client::with_protocols`.
 ///
-/// moq-transport-18 and -19 require qmux-01, so we never pair them with qmux-00.
+/// moq-transport-18 and newer require qmux-01, so we never pair them with qmux-00.
 /// This mirrors the policy in `js/net`'s `connect.ts`. Every other ALPN returns
 /// `&[]`, which qmux expands to every draft it knows about.
-const QMUX01_ONLY_ALPNS: &[&str] = &["moqt-18", "moqt-19", "moqt-20"];
+const QMUX01_ONLY_ALPNS: &[&str] = &["moqt-18", "moqt-19", "moqt-20", "moqt-21"];
 
 fn qmux_versions_for(alpn: &str) -> &'static [qmux::Version] {
 	if QMUX01_ONLY_ALPNS.contains(&alpn) {
@@ -589,7 +589,7 @@ mod tests {
 	}
 
 	#[test]
-	fn moqt_18_and_19_pin_to_qmux01() {
+	fn moqt_18_and_newer_pin_to_qmux01() {
 		// The literals in `qmux_versions_for` must stay the IETF draft ALPNs;
 		// otherwise the pin silently stops matching.
 		assert_eq!(
@@ -597,7 +597,7 @@ mod tests {
 				.iter()
 				.map(|&a| moq_net::Version::from_alpn(a).map(|v| v.code()))
 				.collect::<Vec<_>>(),
-			vec![Some(0xff000012), Some(0xff000013), Some(0xff000014)]
+			vec![Some(0xff000012), Some(0xff000013), Some(0xff000014), Some(0xff000015)]
 		);
 		for &alpn in QMUX01_ONLY_ALPNS {
 			assert_eq!(qmux_versions_for(alpn), &[qmux::Version::QMux01]);

--- a/rs/moq-native/tests/alpn.rs
+++ b/rs/moq-native/tests/alpn.rs
@@ -175,6 +175,12 @@ async fn version_moq_transport_20() {
 	connect_with_version("moq-transport-20").await;
 }
 
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn version_moq_transport_21() {
+	connect_with_version("moq-transport-21").await;
+}
+
 // ── WebTransport: sub-protocol negotiation ──────────────────────────
 // Browser clients use WebTransport (h3 ALPN) and negotiate the MoQ
 // protocol version via sub-protocols in the HTTP CONNECT request.
@@ -243,4 +249,10 @@ async fn webtransport_moq_transport_19() {
 #[tokio::test]
 async fn webtransport_moq_transport_20() {
 	connect_with_webtransport(Some("moq-transport-20")).await;
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn webtransport_moq_transport_21() {
+	connect_with_webtransport(Some("moq-transport-21")).await;
 }

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -1291,6 +1291,12 @@ async fn broadcast_moq_transport_20() {
 	broadcast_test("moqt", Some("moq-transport-20"), Some("moq-transport-20")).await;
 }
 
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_moq_transport_21() {
+	broadcast_test("moqt", Some("moq-transport-21"), Some("moq-transport-21")).await;
+}
+
 // ── Raw QUIC – server supports all versions, client pins one ─────────
 
 #[tracing_test::traced_test]
@@ -1572,6 +1578,12 @@ async fn broadcast_webtransport_moq_transport_19() {
 #[tokio::test]
 async fn broadcast_webtransport_moq_transport_20() {
 	broadcast_test("https", Some("moq-transport-20"), Some("moq-transport-20")).await;
+}
+
+#[tracing_test::traced_test]
+#[tokio::test]
+async fn broadcast_webtransport_moq_transport_21() {
+	broadcast_test("https", Some("moq-transport-21"), Some("moq-transport-21")).await;
 }
 
 // ── WebTransport – server supports all, client pins one ─────────────

--- a/rs/moq-net/Cargo.toml
+++ b/rs/moq-net/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Luke Curley"]
 repository = "https://github.com/moq-dev/moq"
 license = "MIT OR Apache-2.0"
 
-version = "0.2.19"
+version = "0.2.20"
 edition = "2024"
 rust-version.workspace = true
 

--- a/rs/moq-net/src/client.rs
+++ b/rs/moq-net/src/client.rs
@@ -1,7 +1,7 @@
 use crate::origin;
 use crate::{
-	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_20, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05,
-	ALPN_LITE_06_WIP, Consume, Driver, Error, NEGOTIATED, Session, Version, Versions,
+	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_20, ALPN_21, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04,
+	ALPN_LITE_05, ALPN_LITE_06_WIP, Consume, Driver, Error, NEGOTIATED, Session, Version, Versions,
 	coding::{self, Decode, Encode, Stream},
 	ietf, lite, setup, stats,
 };
@@ -152,61 +152,16 @@ impl Client {
 		// If ALPN was used to negotiate the version, use the appropriate encoding.
 		// Default to IETF 14 if no ALPN was used and we'll negotiate the version later.
 		let (encoding, supported) = match session.protocol() {
-			Some(ALPN_20) => {
-				let v = self
-					.versions
-					.select(Version::Ietf(ietf::Version::Draft20))
-					.ok_or(Error::Version)?;
+			Some(alpn @ (ALPN_21 | ALPN_20 | ALPN_19 | ALPN_18 | ALPN_17)) => {
+				let draft = match alpn {
+					ALPN_21 => ietf::Version::Draft21,
+					ALPN_20 => ietf::Version::Draft20,
+					ALPN_19 => ietf::Version::Draft19,
+					ALPN_18 => ietf::Version::Draft18,
+					_ => ietf::Version::Draft17,
+				};
 
-				// Draft-17+: SETUP is exchanged by the connection driver.
-				let protocol = ietf::start(ietf::Config {
-					session: session.clone(),
-					setup: None,
-					request_id_max: None,
-					client: true,
-					publish: publish.clone(),
-					subscribe: subscribe.clone(),
-					peer_origin: self.peer_origin,
-					cost: self.cost,
-					version: ietf::Version::Draft20,
-					path: self.setup_path.clone(),
-					peer_setup_stream: None,
-					peer_declared: None,
-				})?;
-
-				tracing::debug!(version = ?v, "connected");
-				return Ok(Session::new(session, v, None, protocol));
-			}
-			Some(ALPN_19) => {
-				let v = self
-					.versions
-					.select(Version::Ietf(ietf::Version::Draft19))
-					.ok_or(Error::Version)?;
-
-				// Draft-17+: SETUP is exchanged by the connection driver.
-				let protocol = ietf::start(ietf::Config {
-					session: session.clone(),
-					setup: None,
-					request_id_max: None,
-					client: true,
-					publish: publish.clone(),
-					subscribe: subscribe.clone(),
-					peer_origin: self.peer_origin,
-					cost: self.cost,
-					version: ietf::Version::Draft19,
-					path: self.setup_path.clone(),
-					peer_setup_stream: None,
-					peer_declared: None,
-				})?;
-
-				tracing::debug!(version = ?v, "connected");
-				return Ok(Session::new(session, v, None, protocol));
-			}
-			Some(ALPN_18) => {
-				let v = self
-					.versions
-					.select(Version::Ietf(ietf::Version::Draft18))
-					.ok_or(Error::Version)?;
+				let v = self.versions.select(Version::Ietf(draft)).ok_or(Error::Version)?;
 
 				// Draft-17+: SETUP is exchanged by the connection driver.
 				// We advertise the request path in our SETUP for URL-less transports.
@@ -219,33 +174,7 @@ impl Client {
 					subscribe: subscribe.clone(),
 					peer_origin: self.peer_origin,
 					cost: self.cost,
-					version: ietf::Version::Draft18,
-					path: self.setup_path.clone(),
-					peer_setup_stream: None,
-					peer_declared: None,
-				})?;
-
-				tracing::debug!(version = ?v, "connected");
-				return Ok(Session::new(session, v, None, protocol));
-			}
-			Some(ALPN_17) => {
-				let v = self
-					.versions
-					.select(Version::Ietf(ietf::Version::Draft17))
-					.ok_or(Error::Version)?;
-
-				// Draft-17+: SETUP is exchanged by the connection driver.
-				// We advertise the request path in our SETUP for URL-less transports.
-				let protocol = ietf::start(ietf::Config {
-					session: session.clone(),
-					setup: None,
-					request_id_max: None,
-					client: true,
-					publish: publish.clone(),
-					subscribe: subscribe.clone(),
-					peer_origin: self.peer_origin,
-					cost: self.cost,
-					version: ietf::Version::Draft17,
+					version: draft,
 					path: self.setup_path.clone(),
 					peer_setup_stream: None,
 					peer_declared: None,

--- a/rs/moq-net/src/fuzz.rs
+++ b/rs/moq-net/src/fuzz.rs
@@ -49,6 +49,7 @@ const IETF_VERSIONS: &[ietf::Version] = &[
 	ietf::Version::Draft18,
 	ietf::Version::Draft19,
 	ietf::Version::Draft20,
+	ietf::Version::Draft21,
 ];
 
 /// How many types [`lite_wire`] dispatches over.

--- a/rs/moq-net/src/ietf/publish.rs
+++ b/rs/moq-net/src/ietf/publish.rs
@@ -140,7 +140,8 @@ impl PublishDoneStatus {
 			| Version::Draft19
 			// Draft-20 removed SUBSCRIPTION_ENDED (0x3), which this implementation never
 			// emitted, and left the rest of the registry alone.
-			| Version::Draft20 => match self {
+			| Version::Draft20
+			| Version::Draft21 => match self {
 				Self::InternalError => 0x0,
 				Self::TrackEnded => 0x2,
 			},

--- a/rs/moq-net/src/ietf/version.rs
+++ b/rs/moq-net/src/ietf/version.rs
@@ -2,6 +2,7 @@ use std::fmt;
 
 /// An IETF protocol version.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum Version {
 	Draft14,
 	Draft15,

--- a/rs/moq-net/src/ietf/version.rs
+++ b/rs/moq-net/src/ietf/version.rs
@@ -10,6 +10,7 @@ pub enum Version {
 	Draft18,
 	Draft19,
 	Draft20,
+	Draft21,
 }
 
 impl fmt::Display for Version {
@@ -22,6 +23,7 @@ impl fmt::Display for Version {
 			Self::Draft18 => write!(f, "moq-transport-18"),
 			Self::Draft19 => write!(f, "moq-transport-19"),
 			Self::Draft20 => write!(f, "moq-transport-20"),
+			Self::Draft21 => write!(f, "moq-transport-21"),
 		}
 	}
 }
@@ -40,5 +42,118 @@ impl TryFrom<crate::Version> for Version {
 			crate::Version::Ietf(v) => Ok(v),
 			crate::Version::Lite(_) => Err(()),
 		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::coding::Encode;
+	use crate::ietf::{
+		Fetch, FetchType, Fill, Filter, GroupFlags, GroupHeader, GroupOrder, Location, Message, Properties, Publish,
+		RequestId, Subscribe, SubscribeOk,
+	};
+	use crate::{Path, Timescale};
+
+	fn message<M: Message>(msg: &M, version: Version) -> Vec<u8> {
+		let mut buf = Vec::new();
+		msg.encode_msg(&mut buf, version).expect("encode");
+		buf
+	}
+
+	fn field<E: Encode<Version>>(value: &E, version: Version) -> Vec<u8> {
+		let mut buf = Vec::new();
+		value.encode(&mut buf, version).expect("encode");
+		buf
+	}
+
+	/// Draft-21 is editorial: it restructures the document and drops the Connection URL,
+	/// Stream Cancellation, and Examples sections, leaving every codepoint and field
+	/// layout as draft-20 defined them. So it has to encode byte for byte the same, and
+	/// this pins that rather than trusting each version branch to fall forward.
+	#[test]
+	fn draft21_matches_draft20_on_the_wire() {
+		let properties = Properties {
+			timescale: Some(Timescale::new(90_000).unwrap()),
+			group_order: Some(GroupOrder::Descending),
+		};
+
+		let subscribe = Subscribe {
+			request_id: RequestId(1),
+			track_namespace: Path::new("broadcast"),
+			track_name: "video".into(),
+			subscriber_priority: 128,
+			group_order: GroupOrder::Descending,
+			filter: Filter::Relative(3),
+			fill: Some(Fill {
+				filter: Some(Filter::Relative(1)),
+				range_filters: false,
+			}),
+			properties_wanted: false,
+		};
+
+		let subscribe_ok = SubscribeOk {
+			// Draft-17 and newer carry the request on the stream, not in the message.
+			request_id: None,
+			track_alias: 4,
+			largest: Some(Location { group: 5, object: 2 }),
+			properties,
+		};
+
+		let publish = Publish {
+			request_id: RequestId(2),
+			track_namespace: Path::new("broadcast"),
+			track_name: "audio".into(),
+			track_alias: 7,
+			largest_location: Some(Location { group: 9, object: 0 }),
+			forward: true,
+			properties,
+		};
+
+		let fetch = Fetch {
+			request_id: RequestId(3),
+			subscriber_priority: 64,
+			group_order: GroupOrder::Ascending,
+			fetch_type: FetchType::Standalone {
+				namespace: Path::new("broadcast"),
+				track: "video".into(),
+				start: Location { group: 1, object: 0 },
+				end: Location { group: 2, object: 0 },
+			},
+		};
+
+		let group = GroupHeader {
+			track_alias: 4,
+			group_id: 11,
+			sub_group_id: 0,
+			publisher_priority: 128,
+			flags: GroupFlags::default(),
+		};
+
+		assert_eq!(
+			message(&subscribe, Version::Draft20),
+			message(&subscribe, Version::Draft21),
+			"SUBSCRIBE"
+		);
+		assert_eq!(
+			message(&subscribe_ok, Version::Draft20),
+			message(&subscribe_ok, Version::Draft21),
+			"SUBSCRIBE_OK"
+		);
+		assert_eq!(
+			message(&publish, Version::Draft20),
+			message(&publish, Version::Draft21),
+			"PUBLISH"
+		);
+		assert_eq!(
+			message(&fetch, Version::Draft20),
+			message(&fetch, Version::Draft21),
+			"FETCH"
+		);
+		assert_eq!(
+			field(&group, Version::Draft20),
+			field(&group, Version::Draft21),
+			"SUBGROUP_HEADER"
+		);
 	}
 }

--- a/rs/moq-net/src/server.rs
+++ b/rs/moq-net/src/server.rs
@@ -1,7 +1,7 @@
 use crate::origin;
 use crate::{
-	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_20, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04, ALPN_LITE_05,
-	ALPN_LITE_06_WIP, Consume, Driver, Error, NEGOTIATED, Role, Session, Version, Versions,
+	ALPN_14, ALPN_15, ALPN_16, ALPN_17, ALPN_18, ALPN_19, ALPN_20, ALPN_21, ALPN_LITE, ALPN_LITE_03, ALPN_LITE_04,
+	ALPN_LITE_05, ALPN_LITE_06_WIP, Consume, Driver, Error, NEGOTIATED, Role, Session, Version, Versions,
 	coding::{Decode, Encode, Stream},
 	ietf, lite, setup, stats,
 };
@@ -93,29 +93,17 @@ impl Server {
 		};
 
 		let (encoding, supported) = match session.protocol() {
-			Some(ALPN_20) => {
-				self.versions
-					.select(Version::Ietf(ietf::Version::Draft20))
-					.ok_or(Error::Version)?;
-				return self.accept_ietf_modern(session, ietf::Version::Draft20).await;
-			}
-			Some(ALPN_19) => {
-				self.versions
-					.select(Version::Ietf(ietf::Version::Draft19))
-					.ok_or(Error::Version)?;
-				return self.accept_ietf_modern(session, ietf::Version::Draft19).await;
-			}
-			Some(ALPN_18) => {
-				self.versions
-					.select(Version::Ietf(ietf::Version::Draft18))
-					.ok_or(Error::Version)?;
-				return self.accept_ietf_modern(session, ietf::Version::Draft18).await;
-			}
-			Some(ALPN_17) => {
-				self.versions
-					.select(Version::Ietf(ietf::Version::Draft17))
-					.ok_or(Error::Version)?;
-				return self.accept_ietf_modern(session, ietf::Version::Draft17).await;
+			Some(alpn @ (ALPN_21 | ALPN_20 | ALPN_19 | ALPN_18 | ALPN_17)) => {
+				let draft = match alpn {
+					ALPN_21 => ietf::Version::Draft21,
+					ALPN_20 => ietf::Version::Draft20,
+					ALPN_19 => ietf::Version::Draft19,
+					ALPN_18 => ietf::Version::Draft18,
+					_ => ietf::Version::Draft17,
+				};
+
+				self.versions.select(Version::Ietf(draft)).ok_or(Error::Version)?;
+				return self.accept_ietf_modern(session, draft).await;
 			}
 			Some(ALPN_16) => {
 				let v = self

--- a/rs/moq-net/src/setup.rs
+++ b/rs/moq-net/src/setup.rs
@@ -77,7 +77,8 @@ impl SetupVersion {
 			Version::Ietf(ietf::Version::Draft17)
 			| Version::Ietf(ietf::Version::Draft18)
 			| Version::Ietf(ietf::Version::Draft19)
-			| Version::Ietf(ietf::Version::Draft20) => Self::Modern,
+			| Version::Ietf(ietf::Version::Draft20)
+			| Version::Ietf(ietf::Version::Draft21) => Self::Modern,
 			Version::Lite(lite::Version::Lite01) | Version::Lite(lite::Version::Lite02) => Self::LiteLegacy,
 			Version::Lite(_) => Self::Unsupported,
 		}

--- a/rs/moq-net/src/version.rs
+++ b/rs/moq-net/src/version.rs
@@ -26,6 +26,7 @@ pub const ALPNS: &[&str] = &[
 	ALPN_LITE_04,
 	ALPN_LITE_03,
 	ALPN_LITE,
+	ALPN_21,
 	ALPN_20,
 	ALPN_19,
 	ALPN_18,
@@ -48,14 +49,16 @@ pub(crate) const ALPN_17: &str = "moqt-17";
 pub(crate) const ALPN_18: &str = "moqt-18";
 pub(crate) const ALPN_19: &str = "moqt-19";
 pub(crate) const ALPN_20: &str = "moqt-20";
+pub(crate) const ALPN_21: &str = "moqt-21";
 
-const ALL: [Version; 13] = [
+const ALL: [Version; 14] = [
 	Version::Lite(lite::Version::Lite06Wip),
 	Version::Lite(lite::Version::Lite05),
 	Version::Lite(lite::Version::Lite04),
 	Version::Lite(lite::Version::Lite03),
 	Version::Lite(lite::Version::Lite02),
 	Version::Lite(lite::Version::Lite01),
+	Version::Ietf(ietf::Version::Draft21),
 	Version::Ietf(ietf::Version::Draft20),
 	Version::Ietf(ietf::Version::Draft19),
 	Version::Ietf(ietf::Version::Draft18),
@@ -97,6 +100,7 @@ impl Version {
 			Self::Ietf(ietf::Version::Draft18) => "moq-transport-18",
 			Self::Ietf(ietf::Version::Draft19) => "moq-transport-19",
 			Self::Ietf(ietf::Version::Draft20) => "moq-transport-20",
+			Self::Ietf(ietf::Version::Draft21) => "moq-transport-21",
 		}
 	}
 
@@ -116,6 +120,7 @@ impl Version {
 			0xff000012 => Some(Self::Ietf(ietf::Version::Draft18)),
 			0xff000013 => Some(Self::Ietf(ietf::Version::Draft19)),
 			0xff000014 => Some(Self::Ietf(ietf::Version::Draft20)),
+			0xff000015 => Some(Self::Ietf(ietf::Version::Draft21)),
 			_ => None,
 		}
 	}
@@ -136,6 +141,7 @@ impl Version {
 			Self::Ietf(ietf::Version::Draft18) => 0xff000012,
 			Self::Ietf(ietf::Version::Draft19) => 0xff000013,
 			Self::Ietf(ietf::Version::Draft20) => 0xff000014,
+			Self::Ietf(ietf::Version::Draft21) => 0xff000015,
 		}
 	}
 
@@ -157,6 +163,7 @@ impl Version {
 			ALPN_18 => Some(Self::Ietf(ietf::Version::Draft18)),
 			ALPN_19 => Some(Self::Ietf(ietf::Version::Draft19)),
 			ALPN_20 => Some(Self::Ietf(ietf::Version::Draft20)),
+			ALPN_21 => Some(Self::Ietf(ietf::Version::Draft21)),
 			_ => None,
 		}
 	}
@@ -176,6 +183,7 @@ impl Version {
 			Self::Ietf(ietf::Version::Draft18) => ALPN_18,
 			Self::Ietf(ietf::Version::Draft19) => ALPN_19,
 			Self::Ietf(ietf::Version::Draft20) => ALPN_20,
+			Self::Ietf(ietf::Version::Draft21) => ALPN_21,
 		}
 	}
 

--- a/rs/moq-relay/src/websocket.rs
+++ b/rs/moq-relay/src/websocket.rs
@@ -223,9 +223,9 @@ fn subprotocols_acceptable<'a>(requested: impl IntoIterator<Item = &'a [u8]>, su
 /// Newest first so axum's exact-string match picks the freshest one.
 const QMUX_VERSIONS: &[qmux::Version] = &[qmux::Version::QMux01, qmux::Version::QMux00];
 
-/// moq-transport-18 and -19 require qmux-01, so we never pair them with qmux-00.
+/// moq-transport-18 and newer require qmux-01, so we never pair them with qmux-00.
 /// Mirrors `js/net`'s `connect.ts` and moq-native's `websocket_subprotocols`.
-const QMUX01_ONLY_ALPNS: &[&str] = &["moqt-18", "moqt-19", "moqt-20"];
+const QMUX01_ONLY_ALPNS: &[&str] = &["moqt-18", "moqt-19", "moqt-20", "moqt-21"];
 
 /// Subprotocols to advertise on the WebSocket upgrade.
 ///
@@ -236,8 +236,8 @@ const QMUX01_ONLY_ALPNS: &[&str] = &["moqt-18", "moqt-19", "moqt-20"];
 /// qmux can't resolve a moq version from it, and the relay silently
 /// downgrades clients to Lite02 via SETUP-based negotiation.
 ///
-/// `qmux-00.moqt-1{8,9}` is excluded: moq-transport-18 and -19 require qmux-01, so
-/// those pairs are illegal.
+/// `qmux-00.moqt-{18,19,20,21}` is excluded: moq-transport-18 and newer require
+/// qmux-01, so those pairs are illegal.
 fn supported_subprotocols(alpns: &[&str]) -> Vec<String> {
 	let mut out = Vec::with_capacity(QMUX_VERSIONS.len() * alpns.len() + qmux::ALPNS.len());
 	for &alpn in alpns {
@@ -479,14 +479,14 @@ mod tests {
 
 	#[test]
 	fn supported_subprotocols_lists_full_matrix() {
-		// Guard the literals: they must stay the IETF draft-18/19 ALPNs
-		// (wire 0xff000012 / 0xff000013).
+		// Guard the literals: they must stay the IETF draft-18-and-newer ALPNs
+		// (wire 0xff000012 through 0xff000015).
 		assert_eq!(
 			QMUX01_ONLY_ALPNS
 				.iter()
 				.map(|&a| moq_net::Version::from_alpn(a).map(|v| v.code()))
 				.collect::<Vec<_>>(),
-			vec![Some(0xff000012), Some(0xff000013), Some(0xff000014)]
+			vec![Some(0xff000012), Some(0xff000013), Some(0xff000014), Some(0xff000015)]
 		);
 
 		let list = supported_subprotocols(moq_net::ALPNS);
@@ -497,7 +497,7 @@ mod tests {
 		assert_eq!(list.first().map(String::as_str), Some(expected_first.as_str()));
 
 		// Every moq ALPN must appear under every qmux wire version, except the
-		// illegal `qmux-00.moqt-1{8,9}` pairs (moq-transport-18/19 need qmux-01).
+		// illegal `qmux-00.moqt-{18,19,20,21}` pairs (moq-transport-18 and newer need qmux-01).
 		for &version in QMUX_VERSIONS {
 			for &alpn in moq_net::ALPNS {
 				let entry = format!("{}{alpn}", version.prefix());


### PR DESCRIPTION
## Summary

- Add moq-transport draft-21 support in Rust and TypeScript, reusing draft-20 encoding because draft-21 contains editorial changes only.
- Consolidate Rust draft-17-and-newer ALPN handshakes, pin draft-19 and draft-21 to qmux-01 in JavaScript, and extend the draft-20 filter predicate to future drafts.
- Mark `moq_net::ietf::Version` as `#[non_exhaustive]`, manually bump `moq-net` from `0.2.19` to `0.2.20`, and update the documented supported draft range.

## Public API

Adds Rust `ietf::Version::Draft21` and TypeScript `Version.DRAFT_21`, `ALPN.DRAFT_21`, and the corresponding `IetfVersion` member. `moq_net::ALPNS` now includes `moqt-21`.

Rust `ietf::Version` becomes non-exhaustive. This breaks downstream exhaustive matches, which must add a wildcard arm; future draft additions can then avoid that break. Keeping `main` as the base and publishing this as a patch bump are explicit maintainer decisions for this PR.

## Wire

Negotiation adds codepoint `0xff000015` and ALPN `moqt-21`; frame and message layouts retain draft-20 semantics. The local `drafts/` directory has no IETF moq-transport draft to update. The supported range is updated in `doc/concept/standard.md` and `doc/concept/moq-lite.md`.

## Validation

Existing coverage includes draft-20/draft-21 byte equivalence, draft-21 QUIC and WebTransport handshakes and broadcasts, TypeScript cross-version encoding, and QMux ALPN pinning.

On commit `92a53c6a8`, CI Check, OBS, Swift, and WASM passed; the CI Test job is still running. Local JavaScript checks/tests and native Rust Clippy passed. Full local validation is still running; its first attempt was interrupted by a compiler-cache shim pointing into a missing CI runner directory. The first smoke run passed all available client pairs but could not build Python because of that same shim failure; the rerun is pending.

(written by gpt-6-astra)
