### PR TITLE
fix(moq-mux): enforce jitter bounds across media renditions

### DIFF
--- a/doc/lib/rs/moq-mux.md
+++ b/doc/lib/rs/moq-mux.md
@@ -27,7 +27,9 @@ you already have.
 
 `catalog::Rendition::set`, `update`, and `estimate` return errors when a catalog
 edit cannot be serialized or published. Invalid jitter is rejected before the
-edit is retained, including while the initial catalog is reserved. Codec importers
+edit is retained, including while the initial catalog is reserved. Lowering or
+removing an existing audio, video, or text rendition's jitter returns
+`Error::JitterDecreased`; dropping the rendition ends that lifetime. Codec importers
 propagate these errors through their configuration and frame-writing methods.
 
 ```bash

--- a/drafts/draft-lcurley-moq-hang.md
+++ b/drafts/draft-lcurley-moq-hang.md
@@ -482,7 +482,7 @@ It is never a measurement of the network, which a consumer observes for itself a
 A publisher MUST round the value up to a whole number of milliseconds, so a consumer sizing a buffer against it is never handed a bound below the real one.
 A publisher MUST NOT advertise `0`; a track that flushes each frame immediately omits the field instead.
 A consumer receiving `0` SHOULD treat the field as absent, since it is a publisher rounding down rather than a claim of zero delay.
-A publisher MUST NOT lower a previously advertised value, since a burst it emitted once it may emit again.
+For the lifetime of an audio, video, or text rendition, a publisher MUST NOT lower or remove a previously advertised value, since a burst it emitted once it may emit again.
 
 For example:
 
@@ -946,6 +946,7 @@ This document has no IANA actions.
 # Appendix A: Changelog
 
 ## moq-hang-03
+- Clarified that jitter cannot be lowered or removed during the lifetime of an audio, video, or text rendition.
 - Clarified that container importers can estimate jitter from batch media spans without measuring input wait time.
 - Specified the `jitter` field's computation: the publisher's own structure rather than the network, rounded up to whole milliseconds, never `0` (a consumer treats `0` as absent), and never lowered once advertised. The 30 fps and 44.1 kHz AAC examples became 34 and 24.
 

--- a/js/hang/src/catalog/root.test.ts
+++ b/js/hang/src/catalog/root.test.ts
@@ -71,7 +71,7 @@ test("rendition without broadcast reference stays undefined", () => {
 	expect(parsed.video.renditions.video?.broadcast).toBeUndefined();
 });
 
-test("legacy zero jitter is absent for audio and video", () => {
+test("legacy zero jitter is absent for audio, video, and text", () => {
 	const parsed = RootSchema.parse({
 		audio: {
 			renditions: {
@@ -87,7 +87,9 @@ test("legacy zero jitter is absent for audio and video", () => {
 		video: {
 			renditions: { video: { codec: "avc1.64001f", container: { kind: "legacy" }, framerate: 30, jitter: 0 } },
 		},
+		text: { renditions: { text: { format: "vtt", container: { kind: "legacy" }, jitter: 0 } } },
 	});
+	expect(parsed.text?.renditions.text?.jitter).toBeUndefined();
 	expect(parsed.audio?.renditions.audio?.jitter).toBeUndefined();
 	expect(parsed.video?.renditions.video?.jitter).toBeUndefined();
 	expect(JSON.stringify(parsed)).not.toContain('"jitter"');

--- a/js/hang/src/catalog/text.ts
+++ b/js/hang/src/catalog/text.ts
@@ -52,7 +52,12 @@ export const TextConfigSchema = z.object({
 
 	// The maximum jitter before the next cue is flushed, in milliseconds. The player's jitter buffer
 	// should be at least this large; absent means each cue is flushed immediately.
-	jitter: z.optional(u53Schema),
+	jitter: z.optional(
+		z.pipe(
+			u53Schema,
+			z.transform((value) => (value === 0 ? undefined : value)),
+		),
+	),
 });
 
 /** Schema for the catalog text section: a map of track name to rendition config. */

--- a/js/publish/src/catalog.test.ts
+++ b/js/publish/src/catalog.test.ts
@@ -85,14 +85,16 @@ test("a reconnecting subscriber is seeded with the full current catalog", async 
 
 test("catalog producer refuses zero jitter before retaining an edit", () => {
 	const catalog = new CatalogProducer();
-	for (const section of ["audio", "video"] as const) {
+	for (const section of ["audio", "video", "text"] as const) {
 		expect(() =>
 			catalog.mutate((value) => {
 				Object.assign(value, {
 					[section]: {
 						renditions: {
 							media: {
-								codec: "opus",
+								...(section === "text"
+									? { format: "vtt" }
+									: { codec: section === "audio" ? "opus" : "vp8" }),
 								container: { kind: "legacy" },
 								sampleRate: 48000,
 								numberOfChannels: 2,
@@ -109,7 +111,7 @@ test("catalog producer refuses zero jitter before retaining an edit", () => {
 	});
 });
 
-for (const section of ["audio", "video"] as const) {
+for (const section of ["audio", "video", "text"] as const) {
 	test(`catalog refuses ${section} jitter decreases without retaining them`, () => {
 		const catalog = new CatalogProducer();
 		catalog.mutate((value) => {
@@ -117,7 +119,9 @@ for (const section of ["audio", "video"] as const) {
 				[section]: {
 					renditions: {
 						media: {
-							codec: "opus",
+							...(section === "text"
+								? { format: "vtt" }
+								: { codec: section === "audio" ? "opus" : "vp8" }),
 							container: { kind: "legacy" },
 							sampleRate: 48000,
 							numberOfChannels: 2,
@@ -143,7 +147,7 @@ for (const section of ["audio", "video"] as const) {
 		catalog.mutate((value) => {
 			Object.assign(value[section]!.renditions, {
 				media: {
-					codec: "opus",
+					...(section === "text" ? { format: "vtt" } : { codec: section === "audio" ? "opus" : "vp8" }),
 					container: { kind: "legacy" },
 					sampleRate: 48000,
 					numberOfChannels: 2,

--- a/js/publish/src/catalog.ts
+++ b/js/publish/src/catalog.ts
@@ -20,7 +20,7 @@ export class CatalogProducer {
 	mutate(fn: (catalog: Catalog.Root) => void): void {
 		const value = structuredClone(this.#value);
 		fn(value);
-		for (const section of ["audio", "video"] as const) {
+		for (const section of ["audio", "video", "text"] as const) {
 			for (const [name, config] of Object.entries(value[section]?.renditions ?? {})) {
 				if (config.jitter === 0) throw new Error("omit jitter for a track flushed immediately");
 				const previous = this.#value[section]?.renditions[name]?.jitter;

--- a/rs/hang/src/catalog/millis.rs
+++ b/rs/hang/src/catalog/millis.rs
@@ -58,6 +58,19 @@ mod test {
 		catalog
 	}
 
+	#[test]
+	fn text_jitter_encoding() {
+		let mut config = crate::catalog::TextConfig::new(crate::catalog::TextFormat::Vtt);
+		config.jitter = Some(std::time::Duration::from_micros(1));
+		assert_eq!(serde_json::to_value(&config).unwrap()["jitter"], 1);
+		config.jitter = Some(std::time::Duration::ZERO);
+		assert!(serde_json::to_value(&config).is_err());
+		config.jitter = Some(std::time::Duration::MAX);
+		assert!(serde_json::to_value(&config).is_err());
+		let config: crate::catalog::TextConfig = serde_json::from_str(r#"{"format":"vtt","jitter":0}"#).unwrap();
+		assert_eq!(config.jitter, None);
+	}
+
 	/// A sub-millisecond jitter must not reach the wire as 0: 0 means "flushed immediately",
 	/// which is the one thing a consumer must not believe about a track that buffers.
 	#[test]

--- a/rs/hang/src/catalog/text/mod.rs
+++ b/rs/hang/src/catalog/text/mod.rs
@@ -5,9 +5,10 @@ pub use format::*;
 use std::collections::{BTreeMap, btree_map};
 
 use serde::{Deserialize, Serialize};
-use serde_with::{DisplayFromStr, DurationMilliSeconds};
+use serde_with::DisplayFromStr;
 
 use crate::catalog::Container;
+use crate::catalog::millis::MillisCeil;
 
 /// Information about the text (caption/subtitle) tracks in the catalog.
 ///
@@ -118,8 +119,8 @@ pub struct TextConfig {
 	/// The maximum delay, in milliseconds, before the publisher flushes the next cue. A consumer's
 	/// jitter buffer should be at least this large. Absent means each cue is flushed immediately.
 	///
-	/// Serialized as an integer number of milliseconds (sub-ms precision is truncated).
-	#[serde_as(as = "Option<DurationMilliSeconds<u64>>")]
+	/// Serialized as whole milliseconds rounded up. Zero is omitted when reading and refused when writing.
+	#[serde_as(as = "MillisCeil")]
 	#[serde(default)]
 	pub jitter: Option<std::time::Duration>,
 }

--- a/rs/moq-mux/src/catalog/tracks.rs
+++ b/rs/moq-mux/src/catalog/tracks.rs
@@ -434,7 +434,7 @@ impl<E: CatalogExt, C: RenditionConfig<E>> Rendition<E, C> {
 		self.catalog.timestamp(hint)
 	}
 
-	/// Validate and publish the rendition, fulfilling its reservation only after the edit succeeds.
+	/// Validate and publish the rendition without lowering jitter, fulfilling its reservation only on success.
 	///
 	/// Whatever [`Estimate`] fields `config` already carries are authoritative and left alone; the
 	/// rest are filled by [`estimate`](Self::estimate), seeded with anything already measured before
@@ -448,6 +448,11 @@ impl<E: CatalogExt, C: RenditionConfig<E>> Rendition<E, C> {
 		{
 			let mut guard = self.catalog.lock();
 			let mut next = (*guard).clone();
+			if let Some(previous) = C::get_mut(&mut next, &self.name)
+				&& resolved.jitter < previous.estimate().jitter
+			{
+				return Err(crate::Error::JitterDecreased);
+			}
 			config.insert(&mut next, &self.name);
 			// Serialization must succeed before the reserved snapshot retains the edit.
 			serde_json::to_writer(std::io::sink(), &next).map_err(moq_json::Error::from)?;
@@ -493,7 +498,7 @@ impl<E: CatalogExt, C: RenditionConfig<E>> Rendition<E, C> {
 		Ok(())
 	}
 
-	/// Refine the rendition, refusing an unserializable edit before retaining it.
+	/// Refine the rendition, refusing invalid edits or jitter decreases before retaining them.
 	pub fn update(&mut self, f: impl FnOnce(&mut C)) -> crate::Result<()> {
 		if !self.present {
 			return Ok(());
@@ -501,7 +506,11 @@ impl<E: CatalogExt, C: RenditionConfig<E>> Rendition<E, C> {
 		let mut guard = self.catalog.lock();
 		let mut next = (*guard).clone();
 		if let Some(config) = C::get_mut(&mut next, &self.name) {
+			let previous = config.estimate().jitter;
 			f(config);
+			if config.estimate().jitter < previous {
+				return Err(crate::Error::JitterDecreased);
+			}
 		}
 		serde_json::to_writer(std::io::sink(), &next).map_err(moq_json::Error::from)?;
 		*guard = next;
@@ -566,6 +575,68 @@ mod tests {
 			catalog.snapshot().video.renditions.values().next().unwrap().jitter,
 			Some(Duration::from_millis(100))
 		);
+	}
+
+	#[test]
+	fn jitter_decreases_are_not_retained() {
+		fn check<C: RenditionConfig<()> + Clone>(mut config: C) {
+			let mut broadcast = moq_net::broadcast::Info::new().produce();
+			let catalog = super::super::Producer::new(&mut broadcast).unwrap();
+			let mut rendition = Rendition::live(catalog.clone(), "media".into()).unwrap();
+			let initial = Some(Duration::from_millis(100));
+			config.set_estimate(Estimate {
+				jitter: initial,
+				..Default::default()
+			});
+			rendition.set(config.clone()).unwrap();
+			for jitter in [Some(Duration::from_millis(50)), None] {
+				config.set_estimate(Estimate {
+					jitter,
+					..Default::default()
+				});
+				assert!(rendition.set(config.clone()).is_err());
+				assert!(
+					rendition
+						.update(|config| config.set_estimate(Estimate {
+							jitter,
+							..Default::default()
+						}))
+						.is_err()
+				);
+				assert_eq!(
+					C::get_mut(&mut catalog.snapshot(), "media").unwrap().estimate().jitter,
+					initial
+				);
+			}
+			drop(rendition);
+			let mut rendition = Rendition::live(catalog.clone(), "media".into()).unwrap();
+			rendition.set(config).unwrap();
+			rendition
+				.estimate(Estimate {
+					jitter: initial,
+					..Default::default()
+				})
+				.unwrap();
+			assert!(
+				rendition
+					.estimate(Estimate {
+						jitter: Some(Duration::from_millis(50)),
+						..Default::default()
+					})
+					.is_err()
+			);
+			assert_eq!(
+				C::get_mut(&mut catalog.snapshot(), "media").unwrap().estimate().jitter,
+				initial
+			);
+		}
+		check(hang::catalog::VideoConfig::new(hang::catalog::VideoCodec::VP8));
+		check(hang::catalog::AudioConfig::new(
+			hang::catalog::AudioCodec::Opus,
+			48_000,
+			2,
+		));
+		check(hang::catalog::TextConfig::new(hang::catalog::TextFormat::Vtt));
 	}
 
 	#[test]
@@ -677,7 +748,6 @@ mod tests {
 		resolved.coded_height = Some(720);
 		hint.apply(&mut resolved);
 		rendition.set(resolved).unwrap();
-		feed(&mut rendition);
 
 		let snapshot = catalog.snapshot();
 		let published = snapshot.video.renditions.get("v").unwrap();

--- a/rs/moq-mux/src/error.rs
+++ b/rs/moq-mux/src/error.rs
@@ -24,6 +24,10 @@ pub(crate) fn message(err: impl std::error::Error) -> String {
 #[derive(Debug, Clone, thiserror::Error)]
 #[non_exhaustive]
 pub enum Error {
+	/// An edit lowers or removes an existing rendition's jitter bound.
+	#[error("jitter cannot decrease for an existing rendition")]
+	JitterDecreased,
+
 	/// Error from the underlying moq-net transport.
 	#[error("moq: {0}")]
 	Moq(#[from] moq_net::Error),


### PR DESCRIPTION
## Summary

- Rust rendition edits validated serialization but allowed an existing jitter bound to decrease or disappear. Compare staged edits with the current catalog and reject them without retaining the change.
- Apply the shared jitter encoding to text: round milliseconds up, reject zero when publishing, and read legacy zero as absent. Extend JavaScript publisher validation to text.
- Add regressions for audio/video/text edits, rendition retirement, and text encoding. Follow up on #3513.

## Public API

- Add `moq_mux::Error::JitterDecreased` to the non-exhaustive error enum. `Rendition::{set,update,estimate}` now reject jitter decreases; signatures are unchanged.
- `hang::catalog::TextConfig` and JavaScript `TextConfigSchema` normalize legacy zero jitter; text serialization and `CatalogProducer::mutate` reject zero. No FFI or C ABI changes.

## Wire

The catalog shape stays the same. Text jitter now follows the existing whole-millisecond ceiling and zero-omission rules. The hang draft clarifies that audio, video, and text jitter cannot be lowered or removed during a rendition's lifetime.

## Validation

- Reproduced the Rust decrease and Rust/JavaScript text-zero failures before fixing them.
- 83 hang tests and 13 focused JavaScript tests passed.
- TypeScript checks and draft validation passed.
- `just fix` and native strict lint passed. `just check` then stopped during documentation generation because local mbx compiler-wrapper files disappeared.
- Affected-package tests and cross-language smoke validation are running in a fresh Nix session.

(written by GPT-6)
