### PR TITLE
fix: satisfy the nightly license audit

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -49,6 +49,8 @@ allow = [
     "ISC",
     "MIT",
     "MPL-2.0",
+    # libfuzzer-sys vendors LLVM's libFuzzer harness, which is NCSA licensed.
+    "NCSA",
     "Unicode-3.0",
     "Unlicense",
     "Zlib",

--- a/rs/moq-net/fuzz/Cargo.toml
+++ b/rs/moq-net/fuzz/Cargo.toml
@@ -12,6 +12,7 @@
 [package]
 name = "moq-net-fuzz"
 version = "0.0.0"
+license = "MIT OR Apache-2.0"
 publish = false
 edition = "2024"
 autobins = false


### PR DESCRIPTION
The nightly ([34473996355](https://github.com/moq-dev/moq/actions/runs/34473996355), also 34348703531) fails `just rs audit` with two license errors. Both arrived when the moq-net fuzz harness joined the workspace in #3543; the audit is nightly-only by design, so no PR gate caught it.

- `libfuzzer-sys 0.4.13` is `(MIT OR Apache-2.0) AND NCSA`. The NCSA term covers the vendored LLVM libFuzzer harness and is OSI approved / FSF Free, so allow it in `deny.toml`.
- `moq-net-fuzz` has no license field, so cargo-deny treats it as unlicensed. Declare `MIT OR Apache-2.0`, matching every other workspace crate.

```
advisories ok: 0 errors, 0 warnings, 8 notes
      bans ok: 0 errors, 77 warnings, 0 notes
   licenses ok: 0 errors, 0 warnings, 995 notes
    sources ok: 0 errors, 0 warnings, 0 notes
```

Verified with `nix develop --command just rs audit` locally. No API or wire impact.