### PR TITLE
feat(moq-video): convert a surface by reference, and to BGRA

### DIFF
--- a/rs/moq-video/CHANGELOG.md
+++ b/rs/moq-video/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(moq-video)* `Surface::to_bgra` and `to_bgra_with`, the same conversion as
+  `to_rgba` with red and blue exchanged, for the toolkits that want that order
+- *(moq-video)* `Surface::to_rgba` and `to_rgba_with`, which borrow the surface
+  where `into_rgba` consumed it
+- *(moq-video)* `Surface::to_i420` is public, the borrowing counterpart to
+  `into_i420`
+
 ## [0.0.23](https://github.com/moq-dev/moq/compare/moq-video-v0.0.22...moq-video-v0.0.23) - 2026-09-09
 
 ### Added

--- a/rs/moq-video/README.md
+++ b/rs/moq-video/README.md
@@ -112,9 +112,13 @@ downloads it through I420 for you. Every frame carries a `Surface`, a
 `I420`). Match it to take a zero-copy path for a representation you recognize, and fall back to
 `Surface::into_i420()`, which always works. On macOS `Surface::into_pixel_buffer()`
 is the mirror: free for a hardware-decoded frame, an upload for a CPU one.
-`Surface::into_rgba()` is the portable exit for CPU image and UI toolkits,
-returning owned, tightly packed RGBA8 pixels with the surface's color metadata
-applied.
+`Surface::to_rgba()` and `Surface::to_bgra()` are the portable exits for CPU
+image and UI toolkits, returning owned, tightly packed pixels with the surface's
+color metadata applied. Both orders are there because toolkits disagree and the
+conversion is a full pass over the frame: producing the order the caller wants
+costs nothing extra, while producing the other one and swapping two channels
+afterwards costs a second pass. They borrow the surface, so a frame held behind
+an `Arc` shared with something else converts without being unwrapped first.
 Backends are tried hardware-first, like encode:
 
 | Codec | Software | macOS | Windows | Linux | Android |

--- a/rs/moq-video/src/convert.rs
+++ b/rs/moq-video/src/convert.rs
@@ -1,10 +1,16 @@
 //! CPU conversion of native video surfaces to packed pixels.
 //!
-//! [`Surface::into_rgba`](crate::Surface::into_rgba) is the portable rendering
-//! exit: it downloads a GPU surface when necessary, applies the surface's color
-//! space, and returns owned RGBA pixels for an image or UI toolkit.
+//! [`Surface::to_rgba`](crate::Surface::to_rgba) and
+//! [`to_bgra`](crate::Surface::to_bgra) are the portable rendering exits: they
+//! download a GPU surface when necessary, apply the surface's color space, and
+//! return owned pixels for an image or UI toolkit.
+//!
+//! Both channel orders are here because toolkits disagree and the conversion is
+//! a full pass over the frame. Producing the order the caller wants costs
+//! nothing extra; producing the other one and swapping two channels afterwards
+//! costs a second pass, which is what a consumer had to write before.
 
-use yuv::{YuvPlanarImage, yuv420_to_rgba};
+use yuv::{YuvPlanarImage, yuv420_to_bgra, yuv420_to_rgba};
 
 use crate::{Color, Error, Size, Surface};
 
@@ -65,51 +71,134 @@ impl Rgba {
 	}
 }
 
-pub(crate) fn rgba(surface: Surface, config: &Config) -> Result<Rgba, Error> {
+/// Owned, tightly packed BGRA8 pixels in row-major order.
+///
+/// The same bytes as [`Rgba`] with the red and blue channels exchanged. A
+/// separate type rather than a flag, so a buffer in one order cannot be handed
+/// to something expecting the other.
+#[derive(Clone)]
+pub struct Bgra {
+	width: u32,
+	height: u32,
+	stride: usize,
+	data: Vec<u8>,
+}
+
+impl Bgra {
+	/// Image width in pixels.
+	pub fn width(&self) -> u32 {
+		self.width
+	}
+
+	/// Image height in pixels.
+	pub fn height(&self) -> u32 {
+		self.height
+	}
+
+	/// Bytes between adjacent rows, always `width * 4`.
+	pub fn stride(&self) -> usize {
+		self.stride
+	}
+
+	/// Tightly packed BGRA8 pixels.
+	pub fn data(&self) -> &[u8] {
+		&self.data
+	}
+
+	/// Consume the image and return its tightly packed BGRA8 pixels.
+	pub fn into_data(self) -> Vec<u8> {
+		self.data
+	}
+}
+
+/// The geometry and pixels shared by both channel orders.
+struct Packed {
+	width: u32,
+	height: u32,
+	stride: usize,
+	data: Vec<u8>,
+}
+
+/// One `yuv` entry point, named so a failure can say which.
+type Convert =
+	fn(&YuvPlanarImage<'_, u8>, &mut [u8], u32, yuv::YuvRange, yuv::YuvStandardMatrix) -> Result<(), yuv::YuvError>;
+
+/// Downloads `surface` if it is not already on the CPU and converts it through
+/// `convert`.
+///
+/// By reference rather than by value: a caller often holds the surface behind
+/// an `Arc` it cannot unwrap, most obviously a publisher's preview frame, which
+/// is shared with every rendition's encoder and so never has a refcount of one.
+/// Nothing here needs to own the surface, and requiring it forced those callers
+/// into a full-resolution rescale purely to obtain pixels they already had.
+fn packed(surface: &Surface, config: &Config, convert: Convert, name: &str) -> Result<Packed, Error> {
 	let size = Size::new(surface.width(), surface.height());
 	let color = config
 		.color
 		.or_else(|| surface.color())
 		.unwrap_or_else(|| Color::infer(size));
-	let i420 = surface.into_i420()?;
-	let luma = usize::try_from(size.pixels())
-		.map_err(|_| Error::Codec(anyhow::anyhow!("RGBA frame {size}: dimensions too large to represent")))?;
+	let i420 = surface.to_i420()?;
+	let luma = usize::try_from(size.pixels()).map_err(|_| {
+		Error::Codec(anyhow::anyhow!(
+			"{name} frame {size}: dimensions too large to represent"
+		))
+	})?;
 	let stride = size.width.checked_mul(4).ok_or_else(|| {
 		Error::Codec(anyhow::anyhow!(
-			"RGBA frame {size}: row stride is too large to represent"
+			"{name} frame {size}: row stride is too large to represent"
 		))
 	})?;
 	let stride_usize = usize::try_from(stride).map_err(|_| {
 		Error::Codec(anyhow::anyhow!(
-			"RGBA frame {size}: row stride is too large to represent"
+			"{name} frame {size}: row stride is too large to represent"
 		))
 	})?;
 	let len = stride_usize.checked_mul(size.height as usize).ok_or_else(|| {
 		Error::Codec(anyhow::anyhow!(
-			"RGBA frame {size}: byte length is too large to represent"
+			"{name} frame {size}: byte length is too large to represent"
 		))
 	})?;
 	let chroma = luma / 4;
 	let planar = YuvPlanarImage {
-		y_plane: &i420[..luma],
+		y_plane: &i420.data[..luma],
 		y_stride: size.width,
-		u_plane: &i420[luma..luma + chroma],
+		u_plane: &i420.data[luma..luma + chroma],
 		u_stride: size.width / 2,
-		v_plane: &i420[luma + chroma..],
+		v_plane: &i420.data[luma + chroma..],
 		v_stride: size.width / 2,
 		width: size.width,
 		height: size.height,
 	};
 	let mut data = vec![0; len];
 	let (range, matrix) = color.yuv();
-	yuv420_to_rgba(&planar, &mut data, stride, range, matrix)
-		.map_err(|e| Error::Codec(anyhow::anyhow!("yuv420_to_rgba failed for {size}: {e}")))?;
+	convert(&planar, &mut data, stride, range, matrix)
+		.map_err(|e| Error::Codec(anyhow::anyhow!("{name} conversion failed for {size}: {e}")))?;
 
-	Ok(Rgba {
+	Ok(Packed {
 		width: size.width,
 		height: size.height,
 		stride: stride_usize,
 		data,
+	})
+}
+
+pub(crate) fn rgba(surface: &Surface, config: &Config) -> Result<Rgba, Error> {
+	let packed = packed(surface, config, yuv420_to_rgba, "RGBA")?;
+	Ok(Rgba {
+		width: packed.width,
+		height: packed.height,
+		stride: packed.stride,
+		data: packed.data,
+	})
+}
+
+pub(crate) fn bgra(surface: &Surface, config: &Config) -> Result<Bgra, Error> {
+	let packed = packed(surface, config, yuv420_to_bgra, "BGRA")?;
+	Ok(Bgra {
+		width: packed.width,
+		height: packed.height,
+		stride: packed.stride,
+		data: packed.data,
 	})
 }
 
@@ -130,7 +219,7 @@ mod tests {
 		assert_eq!(source.color(), Some(Color::Bt601Limited));
 		assert_eq!(Color::infer(Size::new(1280, 720)), Color::Bt709Limited);
 
-		let image = rgba(Surface::I420(source), &Config::default()).unwrap();
+		let image = rgba(&Surface::I420(source), &Config::default()).unwrap();
 		let center = (image.height as usize / 2 * image.stride) + image.width as usize / 2 * 4;
 		let pixel = &image.data[center..center + 4];
 		assert!(pixel[0] >= 250, "red channel drifted: {pixel:?}");
@@ -143,10 +232,62 @@ mod tests {
 		let size = Size::new(64, 32);
 		let surface = Surface::I420(I420::new(size.width, size.height, vec![128; I420::len(64, 32)]).unwrap());
 
-		let image = rgba(surface, &Config::default()).unwrap();
+		let image = rgba(&surface, &Config::default()).unwrap();
 		assert_eq!(image.width(), size.width);
 		assert_eq!(image.height(), size.height);
 		assert_eq!(image.stride(), size.width as usize * 4);
 		assert_eq!(image.data().len(), image.stride() * size.height as usize);
+	}
+
+	/// The point of shipping BGRA rather than leaving consumers to swap the
+	/// channels: the two orders are the same conversion, so they have to agree
+	/// pixel for pixel with red and blue exchanged. A consumer doing the swap
+	/// itself re-derives the color handling this crate already does, and gets it
+	/// wrong for anything that is not a grayscale test pattern.
+	#[test]
+	fn bgra_is_rgba_with_red_and_blue_exchanged() {
+		let size = Size::new(64, 64);
+		// Saturated rather than gray, or a transposed matrix would still pass.
+		let source = [200u8, 40, 90, 255].repeat(size.pixels() as usize);
+		let i420 = I420::from_rgba(&source, size.width * 4, size.width, size.height).unwrap();
+		let surface = Surface::I420(i420);
+
+		let as_rgba = rgba(&surface, &Config::default()).unwrap();
+		let as_bgra = bgra(&surface, &Config::default()).unwrap();
+
+		assert_eq!(as_bgra.width(), as_rgba.width());
+		assert_eq!(as_bgra.height(), as_rgba.height());
+		assert_eq!(as_bgra.stride(), as_rgba.stride());
+		for (index, (rgba, bgra)) in as_rgba
+			.data()
+			.as_chunks::<4>()
+			.0
+			.iter()
+			.zip(as_bgra.data().as_chunks::<4>().0.iter())
+			.enumerate()
+		{
+			assert_eq!(
+				[bgra[0], bgra[1], bgra[2], bgra[3]],
+				[rgba[2], rgba[1], rgba[0], rgba[3]],
+				"pixel {index}: {bgra:?} is not {rgba:?} with red and blue exchanged",
+			);
+		}
+	}
+
+	/// Converting borrows the surface, so the same one converts twice.
+	///
+	/// The reason this matters is not the second conversion: it is that a
+	/// caller holding an `Arc<Frame>` it cannot unwrap, which is every consumer
+	/// of a publisher's preview, has no way to reach a consuming exit at all.
+	#[test]
+	fn conversion_leaves_the_surface_alone() {
+		let size = Size::new(32, 32);
+		let surface = Surface::I420(I420::new(size.width, size.height, vec![128; I420::len(32, 32)]).unwrap());
+
+		let first = rgba(&surface, &Config::default()).unwrap();
+		let second = bgra(&surface, &Config::default()).unwrap();
+		assert_eq!(first.data().len(), second.data().len());
+		// And the surface is still there to ask again.
+		assert_eq!(surface.width(), size.width);
 	}
 }

--- a/rs/moq-video/src/frame.rs
+++ b/rs/moq-video/src/frame.rs
@@ -559,13 +559,44 @@ impl Surface {
 	/// Always available, whichever variant you hold. Native GPU surfaces are
 	/// downloaded first; CPU I420 is converted directly. The conversion honors
 	/// [`color`](Self::color) and otherwise falls back to [`Color::infer`].
-	pub fn into_rgba(self) -> Result<crate::convert::Rgba, Error> {
-		self.into_rgba_with(&crate::convert::Config::default())
+	pub fn to_rgba(&self) -> Result<crate::convert::Rgba, Error> {
+		self.to_rgba_with(&crate::convert::Config::default())
 	}
 
 	/// Convert to owned RGBA8 pixels with explicit CPU conversion options.
-	pub fn into_rgba_with(self, config: &crate::convert::Config) -> Result<crate::convert::Rgba, Error> {
+	pub fn to_rgba_with(&self, config: &crate::convert::Config) -> Result<crate::convert::Rgba, Error> {
 		crate::convert::rgba(self, config)
+	}
+
+	/// Convert to owned, tightly packed BGRA8 pixels on the CPU.
+	///
+	/// The same conversion as [`to_rgba`](Self::to_rgba) with red and blue
+	/// exchanged. Reach for it when the destination wants that order, which is
+	/// most of them: GPUI's `RenderImage`, Direct2D, and Win32 generally. Doing
+	/// it here is one pass over the frame; converting to RGBA and swapping the
+	/// channels afterwards is two.
+	pub fn to_bgra(&self) -> Result<crate::convert::Bgra, Error> {
+		self.to_bgra_with(&crate::convert::Config::default())
+	}
+
+	/// Convert to owned BGRA8 pixels with explicit CPU conversion options.
+	pub fn to_bgra_with(&self, config: &crate::convert::Config) -> Result<crate::convert::Bgra, Error> {
+		crate::convert::bgra(self, config)
+	}
+
+	/// Convert to owned RGBA8 pixels, consuming the surface.
+	///
+	/// Equivalent to [`to_rgba`](Self::to_rgba); kept because it is the older
+	/// spelling. Prefer the borrowing form, which also works on a surface held
+	/// behind an `Arc`.
+	pub fn into_rgba(self) -> Result<crate::convert::Rgba, Error> {
+		self.to_rgba()
+	}
+
+	/// Convert to owned RGBA8 pixels with explicit options, consuming the
+	/// surface. See [`into_rgba`](Self::into_rgba).
+	pub fn into_rgba_with(self, config: &crate::convert::Config) -> Result<crate::convert::Rgba, Error> {
+		self.to_rgba_with(config)
 	}
 
 	/// The pixels as a CoreVideo pixel buffer, the mirror of
@@ -617,7 +648,13 @@ impl Surface {
 	}
 
 	/// A CPU I420 view, downloading a GPU frame only if necessary.
-	pub(crate) fn to_i420(&self) -> Result<Cow<'_, I420>, Error> {
+	///
+	/// Borrowed for `Surface::I420`, owned for anything that had to come off the
+	/// GPU. The borrowing counterpart to [`into_i420`](Self::into_i420), for a
+	/// caller that cannot give up the surface: a publisher's preview frame is
+	/// shared with every rendition's encoder, so its `Arc` never has a refcount
+	/// of one and no consuming exit is reachable from it.
+	pub fn to_i420(&self) -> Result<Cow<'_, I420>, Error> {
 		match self {
 			#[cfg(target_os = "macos")]
 			Surface::PixelBuffer(s) => Ok(Cow::Owned(s.download_i420()?)),


### PR DESCRIPTION
Two gaps a CPU-drawing consumer hits. Found while porting a GPUI client, but
neither is GPUI-specific: they are what any toolkit that draws pixels itself
runs into.

## Converting needs to borrow

Every public exit from a `Surface` consumed it, so a caller holding one behind
an `Arc` it cannot unwrap could not convert at all. That is not a rare shape. A
publisher's preview frame is the same `Arc` every rendition's encoder is
holding, so with a simulcast ladder its refcount is never one and
`Arc::try_unwrap` never succeeds. The only way out was `Frame::resize`, which
takes `&self`: a full-resolution CPU rescale performed purely to obtain
ownership of pixels the caller already had.

`to_i420` was already there, already returning a `Cow`, just `pub(crate)`. It is
public now, alongside `to_rgba` / `to_rgba_with`. `into_rgba` and
`into_rgba_with` keep working and delegate to them, so nothing downstream
breaks. The conversion itself takes `&Surface`, which also drops a move in the
`Surface::I420` case.

## The channel order

`convert::rgba` hardcoded `yuv420_to_rgba` while the same crate exposes
`yuv420_to_bgra` beside it. A consumer drawing through a toolkit that wants
BGRA pays a second full-frame pass to swap two channels, or reimplements the
conversion and with it the range and matrix mapping this crate already does
correctly. That is GPUI's `RenderImage`, Direct2D, and Win32 generally.

`to_bgra` / `to_bgra_with` is one pass and the same color handling. The
conversion is a full pass over the frame either way, so producing the order the
caller asked for costs nothing extra.

`Bgra` is its own type rather than a flag on `Rgba`, so a buffer in one order
cannot be handed to something expecting the other.

## Notes

`Color::yuv` stays `pub(crate)`. The only reason to publish it was so a consumer
could reimplement the conversion, which is what this removes the need for.

There is no `into_bgra`. With `to_bgra` borrowing, the consuming form adds
nothing; `into_rgba` exists only because it did before.

Checked against `dev` first, per the usual rule: no BGRA entry point, `to_i420`
still `pub(crate)`, and `convert::rgba` unchanged there, so this does not
collide with work in flight.

Tests cover both, and both were checked by mutation. The channel-exchange test
uses a saturated colour rather than grey, because grey passes even with a
transposed matrix.
