### PR TITLE
docs: restore the front page body

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -66,47 +66,89 @@ features:
     details: Host your own CDN, use a 3rd party service, and/or connect P2P via Iroh (native only). Broadcasts are automatically discovered and gossiped.
 ---
 
+
 ## What is MoQ?
 
-Media over QUIC (MoQ) is a live media protocol built on QUIC. A publisher
-sends a **broadcast** made of **tracks**; each track is a series of **groups**
-(a group of pictures, a second of audio, one JSON snapshot). Most groups use
-independent QUIC streams; eligible single-frame groups can use unreliable
-datagrams. Relays forward and cache the stream-delivered groups without parsing
-them, so the same infrastructure carries video, audio, and arbitrary data.
+**Media over QUIC** (MoQ) is a next-generation live media protocol.
+As the name implies, we use QUIC to concurrently transmit media and avoid latency build-up during congestion.
+The protocol is being standardized by the [IETF](https://datatracker.ietf.org/group/moq/about/) and backed by some of the largest tech companies: Google, Cisco, Akamai, Cloudflare, etc.
 
-This project is the reference implementation: a Rust relay and toolchain, a
-TypeScript browser stack, and bindings for C, Python, Kotlin, Swift, Go, and
-Dart. It speaks [moq-lite](/concept/moq-lite), a simple profile that is
-forward-compatible with the IETF [moq-transport](/concept/standard) drafts.
+[moq.dev](https://moq.dev) is an open source implementation written in Rust (native) and TypeScript (web).
+We support compatibility with the *official* [IETF drafts](/draft/), but the main focus is a subset called [moq-lite](/concept/moq-lite) and [hang](/concept/hang).
+The idea is to [build first, argue later](/concept/standard).
+
+See the [concepts](/concept/) page for a breakdown of the layering, rationale, and comparison to other protocols.
 
 ## What you can build
 
 | Use case | Reach for |
 | --- | --- |
-| Twitch-style live streaming | Ingest with [OBS](/bin/obs), [RTMP or SRT](/bin/cli), distribute with [moq-relay](/bin/relay/), watch with [`<moq-watch>`](/lib/js/watch), and keep legacy players via the [HLS gateway](/bin/hls). |
-| Conferencing | [`<moq-publish>`](/lib/js/publish) and [`<moq-watch>`](/lib/js/watch) in the browser, one broadcast per participant, plus the [WebRTC gateway](/bin/rtc) for WHIP/WHEP clients. |
-| Voice and video AI | Server-side media in [Rust](/lib/rs/) or [Python](/lib/py/) with hardware codecs, faster-than-real-time playback in the browser. See [MoQ for AI](/concept/use-case/ai). |
+| Live streaming | Ingest with [OBS](/bin/obs), [RTMP](/bin/rtmp), or [SRT](/bin/srt); distribute with [moq-relay](/bin/relay/); watch with [`<moq-watch>`](/lib/js/watch); keep legacy players via [HLS](/bin/hls). |
+| Conferencing | [`<moq-publish>`](/lib/js/publish) and [`<moq-watch>`](/lib/js/watch) in the browser, one broadcast per participant, plus [WebRTC](/bin/rtc) for WHIP/WHEP clients. |
+| Voice and video AI | Server-side media in [Rust](/lib/rs/) or [Python](/lib/py/), faster-than-real-time playback in the browser. See [MoQ for AI](/concept/use-case/ai). |
 | Real-time data | Chat, game state, telemetry, and control channels over the same relays with [`moq-net`](/lib/rs/moq-net) or [`@moq/net`](/lib/js/net). |
 | Interactive streams | Media down, input up. [MoQ Boy](/bin/demo) is a crowd-controlled Game Boy built this way. |
-| Native and mobile apps | One Rust core behind [Swift](/lib/swift/), [Kotlin](/lib/kt/), [Go](/lib/go/), [Dart](/lib/dart/), and [C](/lib/c/) bindings. |
 
-## Choose a path
+## Setup
 
-| Goal | Start here |
-| --- | --- |
-| Run the demo locally | [Quick start](/setup/) |
-| Install the relay or CLI | [Install](/setup/install) |
-| Publish, play, or convert media | [Applications](/bin/) |
-| Add MoQ to an app | [Libraries](/lib/) |
-| Operate a relay | [moq-relay](/bin/relay/) |
-| Understand the design | [Concepts](/concept/) |
-| Read the specs | [Internet-Drafts](/draft/) |
-| Teach your coding agent | [Agent setup](/setup/agent) |
+Get up and running in seconds with [Nix](https://nixos.org/download.html) ([+Flakes](https://nixos.wiki/wiki/Flakes)), or be lame and [install stuff manually](/setup/install):
 
-## Project links
+```bash
+# Runs a relay, media publisher, and the web server
+nix develop -c just
+```
 
-- [Live demo](https://moq.dev/) and [blog](https://moq.dev/blog)
-- [GitHub](https://github.com/moq-dev/moq)
-- [Discord](https://discord.moq.dev)
-- [IETF MoQ Working Group](https://datatracker.ietf.org/group/moq/about/)
+If everything works, a browser window will pop up demoing how to both publish and watch content via the web.
+
+- Keep reading the [development guide](/setup/dev) to run more advanced demos.
+- Skip ahead to the [production guide](/setup/prod) to see what it takes to deploy this bad boy.
+- Using an AI coding agent? [Teach it MoQ](/setup/agent) with a one-line prompt.
+
+## Applications
+
+There are a bunch of MoQ binaries and plugins.
+
+Some highlights:
+
+- [moq-relay](/bin/relay/) - A server connecting publishers to subscribers, able to form a [self-hosted CDN cluster](/bin/relay/cluster).
+- [moq-cli](/bin/cli) - A CLI that can import and publish MoQ broadcasts from a variety of formats (fMP4, HLS, MPEG-TS, FLV, etc), including via ffmpeg.
+- [obs](/bin/obs) - An OBS plugin, able to publish a MoQ broadcast and/or use MoQ broadcasts as sources.
+- [gstreamer](/bin/gstreamer) - A gstreamer plugin, split into a source and a sink.
+- [rtmp](/bin/rtmp), [srt](/bin/srt), [rtc](/bin/rtc), [hls](/bin/hls) - Gateways to and from the protocols your existing tools speak.
+- [...and more](/bin/)
+
+## Rust Crates 🦀
+
+Integrate MoQ into your application without fear. Focused on native but with [WASM](/lib/rs/#webassembly) support.
+
+Some highlights:
+
+- [moq-net](/lib/rs/moq-net) - Real-time pub/sub with built-in caching, fan-out, and prioritization.
+- [hang](/lib/rs/hang) - The media catalog and container on top of moq-net.
+- [moq-mux](/lib/rs/moq-mux) - Media muxers/demuxers for fMP4, CMAF, MPEG-TS, and FLV.
+- [moq-video](/lib/rs/moq-video) and [moq-audio](/lib/rs/moq-audio) - Native capture, encode, decode, and render with hardware codecs.
+- [...and more](/lib/rs/)
+
+## TypeScript Packages
+
+Run MoQ in a web browser utilizing the latest Web tech.
+Or run on native with polyfills via Node/Bun/Deno.
+
+Some highlights:
+
+- [@moq/net](/lib/js/net) - Real-time pub/sub with built-in caching, fan-out, and prioritization.
+- [@moq/hang](/lib/js/hang) - Performs any media stuff: capture, encode, transmux, decode, render.
+- [@moq/watch](/lib/js/watch) - Subscribe to and render MoQ broadcasts, with an optional `<moq-watch>` UI.
+- [@moq/publish](/lib/js/publish) - Publish media to MoQ broadcasts, with an optional `<moq-publish>` UI.
+- [...and more](/lib/js/)
+
+## Other Languages
+
+FFI bindings around the Rust core, with idiomatic APIs in each language:
+
+- [C](/lib/c/) - `libmoq` static + shared library with an auto-generated header.
+- [Python](/lib/py/) - `asyncio`-friendly bindings, published to PyPI.
+- [Kotlin](/lib/kt/) - Coroutines and `Flow` for Android and the JVM.
+- [Swift](/lib/swift/) - Async sequences for iOS, iPadOS, and macOS.
+- [Go](/lib/go/) - cgo bindings resolved via `go get`.
+- [Dart](/lib/dart/) - Futures and streams for Flutter and the Dart VM.

--- a/doc/index.md
+++ b/doc/index.md
@@ -66,7 +66,6 @@ features:
     details: Host your own CDN, use a 3rd party service, and/or connect P2P via Iroh (native only). Broadcasts are automatically discovered and gossiped.
 ---
 
-
 ## What is MoQ?
 
 **Media over QUIC** (MoQ) is a next-generation live media protocol.


### PR DESCRIPTION
Follow-up to #3606. Restores the original intro, the `nix develop -c just` one-liner, and the Applications / Rust / TypeScript / Other Languages highlight lists from before the August 30 rewrite, with links updated to the current page layout and Dart added. Keeps a trimmed "What you can build" table and drops "Choose a path" (duplicated the nav bar) and "Project links".

`vitepress build` passes with no dead links.

No public API or wire impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

(written by Claude Opus 5)