### PR TITLE
feat(moq-native): expose the dialed authority on Request, including raw QUIC

### DIFF
--- a/rs/moq-native/src/iroh.rs
+++ b/rs/moq-native/src/iroh.rs
@@ -228,14 +228,12 @@ impl EndpointConfig {
 
 /// Accept an iroh connection, negotiate WebTransport or raw QUIC, and complete the
 /// handshake. Returns the established session plus the request URL (raw QUIC carries
-/// none). iroh exposes no client-certificate identity, so the identity is always `None`.
+/// none). iroh exposes no client-certificate identity, so the identity is always `None`,
+/// and it addresses peers by EndpointId rather than a dialed hostname, so the authority
+/// is always `None` too.
 pub(crate) async fn accept(
 	conn: iroh::endpoint::Incoming,
-) -> Result<(
-	web_transport_iroh::Session,
-	Option<Url>,
-	Option<crate::tls::PeerIdentity>,
-)> {
+) -> Result<crate::server::Accepted<web_transport_iroh::Session>> {
 	let conn = conn.accept()?.await?;
 	let alpn = String::from_utf8(conn.alpn().to_vec())?;
 	tracing::Span::current().record("id", conn.stable_id());
@@ -252,12 +250,22 @@ pub(crate) async fn accept(
 				response = response.with_protocol(protocol);
 			}
 			let session = request.respond(response).await.map_err(Error::Server)?;
-			Ok((session, url, None))
+			Ok(crate::server::Accepted {
+				session,
+				url,
+				identity: None,
+				authority: None,
+			})
 		}
 		// Raw QUIC carries no request URL; the path rides the SETUP.
 		alpn if moq_net::ALPNS.contains(&alpn) => {
 			let session = web_transport_iroh::QuicRequest::accept(conn).ok();
-			Ok((session, None, None))
+			Ok(crate::server::Accepted {
+				session,
+				url: None,
+				identity: None,
+				authority: None,
+			})
 		}
 		_ => Err(Error::UnsupportedAlpn(alpn)),
 	}

--- a/rs/moq-native/src/noq.rs
+++ b/rs/moq-native/src/noq.rs
@@ -575,17 +575,14 @@ impl NoqServer {
 
 /// A raw QUIC connection request without WebTransport framing (noq backend).
 /// Accept a QUIC connection, negotiate WebTransport or raw moq, and complete the
-/// handshake (a `200 OK` for WebTransport). Returns the established session plus the
-/// request URL and validated mTLS identity, both captured before the response consumes
-/// the request. Raw QUIC carries no request URL (the path rides the SETUP instead).
+/// handshake (a `200 OK` for WebTransport). Returns the established session, the request
+/// URL and validated mTLS identity (both captured before the response consumes the
+/// request), and the dialed authority (the CONNECT authority on WebTransport, the TLS
+/// SNI on raw QUIC). Raw QUIC carries no request URL (the path rides the SETUP instead).
 pub(crate) async fn accept(
 	conn: noq::Incoming,
 	alpns: Vec<&'static str>,
-) -> Result<(
-	web_transport_noq::Session,
-	Option<Url>,
-	Option<crate::tls::PeerIdentity>,
-)> {
+) -> Result<crate::server::Accepted<web_transport_noq::Session>> {
 	let mut conn = conn.accept()?;
 
 	let handshake = conn
@@ -619,13 +616,20 @@ pub(crate) async fn accept(
 				.map_err(Error::RecvRequest)?;
 			let url = Some(request.url.clone());
 			let identity = crate::tls::PeerIdentity::from_any(request.conn().peer_identity());
+			// The authority the client put in its CONNECT URL.
+			let authority = request.url.host_str().filter(|h| !h.is_empty()).map(str::to_owned);
 
 			let mut response = web_transport_noq::proto::ConnectResponse::OK;
 			if let Some(protocol) = request.protocols.iter().find(|p| alpns.contains(&p.as_str())) {
 				response = response.with_protocol(protocol);
 			}
 			let session = request.respond(response).await.map_err(Error::Server)?;
-			Ok((session, url, identity))
+			Ok(crate::server::Accepted {
+				session,
+				url,
+				identity,
+				authority,
+			})
 		}
 		// Recognize any moq ALPN this server actually offered (its configured versions),
 		// not the global default set. rustls only negotiates an ALPN the server offered, so
@@ -633,9 +637,16 @@ pub(crate) async fn accept(
 		// deliberately absent from `moq_net::ALPNS`.
 		alpn if alpns.contains(&alpn) => {
 			let identity = crate::tls::PeerIdentity::from_any(conn.peer_identity());
-			// Raw QUIC carries no request URL; the path rides the SETUP.
+			// Raw QUIC carries no request URL; the path rides the SETUP. The TLS SNI is the
+			// only authority the client can offer here, and it is optional.
+			let authority = (!host.is_empty()).then_some(host);
 			let session = web_transport_noq::Session::raw(conn);
-			Ok((session, None, identity))
+			Ok(crate::server::Accepted {
+				session,
+				url: None,
+				identity,
+				authority,
+			})
 		}
 		_ => Err(Error::UnsupportedAlpn(alpn)),
 	}

--- a/rs/moq-native/src/quiche.rs
+++ b/rs/moq-native/src/quiche.rs
@@ -699,17 +699,14 @@ fn generate_quiche_cert(
 
 /// A raw QUIC connection request via the quiche backend (not using HTTP/3).
 /// Accept a quiche QUIC connection, negotiate WebTransport or raw moq, and complete the
-/// handshake (a `200 OK` for WebTransport). Returns the established connection plus the
-/// request URL and any validated client identity. Raw QUIC carries no request URL
-/// because the path rides the SETUP instead.
+/// handshake (a `200 OK` for WebTransport). Returns the established connection, the request
+/// URL and any validated client identity, and the dialed authority (the CONNECT authority
+/// on WebTransport, the TLS SNI on raw QUIC). Raw QUIC carries no request URL because the
+/// path rides the SETUP instead.
 pub(crate) async fn accept(
 	incoming: web_transport_quiche::ez::Incoming,
 	alpns: Vec<&'static str>,
-) -> Result<(
-	web_transport_quiche::Connection,
-	Option<Url>,
-	Option<crate::tls::PeerIdentity>,
-)> {
+) -> Result<crate::server::Accepted<web_transport_quiche::Connection>> {
 	tracing::debug!(ip = %incoming.peer_addr(), "accepting via quiche");
 
 	// Accept the connection and wait for it to be established
@@ -728,6 +725,8 @@ pub(crate) async fn accept(
 				.await
 				.map_err(Error::AcceptRequest)?;
 			let url = Some(request.url.clone());
+			// The authority the client put in its CONNECT URL.
+			let authority = request.url.host_str().filter(|h| !h.is_empty()).map(str::to_owned);
 
 			let mut response = web_transport_quiche::proto::ConnectResponse::OK;
 			// Pick the first sub-protocol that we actually support.
@@ -736,15 +735,27 @@ pub(crate) async fn accept(
 				response = response.with_protocol(protocol);
 			}
 			let session = request.respond(response).await.map_err(Error::Accept)?;
-			Ok((session, url, identity))
+			Ok(crate::server::Accepted {
+				session,
+				url,
+				identity,
+				authority,
+			})
 		}
 		// Recognize any moq ALPN this server actually offered (its configured versions),
 		// not the global default set, so opt-in / work-in-progress versions (e.g.
 		// moq-lite-06-wip) that are deliberately absent from `moq_net::ALPNS` still work.
 		alpn if alpns.contains(&alpn) => {
-			// Raw QUIC carries no request URL; the path rides the SETUP.
+			// Raw QUIC carries no request URL; the path rides the SETUP. The TLS SNI is the
+			// only authority the client can offer here, and it is optional.
+			let authority = conn.server_name().filter(|h| !h.is_empty());
 			let session = web_transport_quiche::Connection::raw(conn);
-			Ok((session, None, identity))
+			Ok(crate::server::Accepted {
+				session,
+				url: None,
+				identity,
+				authority,
+			})
 		}
 		_ => Err(Error::UnsupportedAlpn(alpn.to_string())),
 	}

--- a/rs/moq-native/src/quinn.rs
+++ b/rs/moq-native/src/quinn.rs
@@ -589,17 +589,14 @@ impl QuinnServer {
 // ── QuinnRequest ────────────────────────────────────────────────────
 
 /// Accept a QUIC connection, negotiate WebTransport or raw moq, and complete the
-/// handshake (a `200 OK` for WebTransport). Returns the established session plus the
-/// request URL and validated mTLS identity, both captured before the response consumes
-/// the request. Raw QUIC carries no request URL (the path rides the SETUP instead).
+/// handshake (a `200 OK` for WebTransport). Returns the established session, the request
+/// URL and validated mTLS identity (both captured before the response consumes the
+/// request), and the dialed authority (the CONNECT authority on WebTransport, the TLS
+/// SNI on raw QUIC). Raw QUIC carries no request URL (the path rides the SETUP instead).
 pub(crate) async fn accept(
 	conn: quinn::Incoming,
 	alpns: Vec<&'static str>,
-) -> Result<(
-	web_transport_quinn::Session,
-	Option<Url>,
-	Option<crate::tls::PeerIdentity>,
-)> {
+) -> Result<crate::server::Accepted<web_transport_quinn::Session>> {
 	let mut conn = conn.accept()?;
 
 	let handshake = conn
@@ -630,6 +627,8 @@ pub(crate) async fn accept(
 				.map_err(Error::RecvRequest)?;
 			let url = Some(request.url.clone());
 			let identity = crate::tls::PeerIdentity::from_any(request.conn().peer_identity());
+			// The authority the client put in its CONNECT URL.
+			let authority = request.url.host_str().filter(|h| !h.is_empty()).map(str::to_owned);
 
 			let mut response = web_transport_quinn::proto::ConnectResponse::OK;
 			// Pick the first sub-protocol that we actually support.
@@ -641,7 +640,12 @@ pub(crate) async fn accept(
 				response = response.with_protocol(protocol);
 			}
 			let session = request.respond(response).await.map_err(Error::Server)?;
-			Ok((session, url, identity))
+			Ok(crate::server::Accepted {
+				session,
+				url,
+				identity,
+				authority,
+			})
 		}
 		// Recognize any moq ALPN this server actually offered (its configured versions),
 		// not the global default set. rustls only negotiates an ALPN the server offered, so
@@ -649,9 +653,16 @@ pub(crate) async fn accept(
 		// deliberately absent from `moq_net::ALPNS`.
 		alpn if alpns.contains(&alpn) => {
 			let identity = crate::tls::PeerIdentity::from_any(conn.peer_identity());
-			// Raw QUIC carries no request URL; the path rides the SETUP.
+			// Raw QUIC carries no request URL; the path rides the SETUP. The TLS SNI is the
+			// only authority the client can offer here, and it is optional.
+			let authority = (!host.is_empty()).then_some(host);
 			let session = web_transport_quinn::Session::raw(conn);
-			Ok((session, None, identity))
+			Ok(crate::server::Accepted {
+				session,
+				url: None,
+				identity,
+				authority,
+			})
 		}
 		_ => Err(Error::UnsupportedAlpn(alpn)),
 	}

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -1192,6 +1192,9 @@ impl Request {
 	/// The host authority the client dialed, or `None` when the client offered none or the
 	/// transport carries no host (iroh, stream bindings).
 	///
+	/// Reported as offered: rustls clients send no SNI for an IP-literal dial (RFC 6066), so
+	/// quinn/noq see `None`, while BoringSSL clients do send one, so quiche sees the IP.
+	///
 	/// Not the moq-net IETF SETUP `Authority` parameter. Client-asserted and not authenticated,
 	/// so authorize on the token or [`Self::peer_identity`] rather than on this value.
 	pub fn authority(&self) -> Option<&str> {

--- a/rs/moq-native/src/server.rs
+++ b/rs/moq-native/src/server.rs
@@ -538,9 +538,9 @@ impl Server {
 							// Accept the transport (capturing url + mTLS identity) and exchange the
 							// MoQ SETUP up front, so path/role are known before the caller authorizes
 							// (like the stream bindings).
-							let (session, url, identity) = super::noq::accept(_conn, alpns).await?;
+							let Accepted { session, url, identity, authority } = super::noq::accept(_conn, alpns).await?;
 							let request = server.accept_request(session).await?;
-							Ok(Request { transport: Transport::Quic, url, identity, kind: RequestKind::Noq(Box::new(request)) })
+							Ok(Request { transport: Transport::Quic, url, identity, authority, kind: RequestKind::Noq(Box::new(request)) })
 						}.boxed());
 					}
 				}
@@ -549,9 +549,9 @@ impl Server {
 					{
 						let alpns = versions.alpns();
 						self.accept.push(async move {
-							let (session, url, identity) = super::quinn::accept(_conn, alpns).await?;
+							let Accepted { session, url, identity, authority } = super::quinn::accept(_conn, alpns).await?;
 							let request = server.accept_request(session).await?;
-							Ok(Request { transport: Transport::Quic, url, identity, kind: RequestKind::Quinn(Box::new(request)) })
+							Ok(Request { transport: Transport::Quic, url, identity, authority, kind: RequestKind::Quinn(Box::new(request)) })
 						}.boxed());
 					}
 				}
@@ -560,18 +560,18 @@ impl Server {
 					{
 						let alpns = versions.alpns();
 						self.accept.push(async move {
-							let (session, url, identity) = super::quiche::accept(_conn, alpns).await?;
+							let Accepted { session, url, identity, authority } = super::quiche::accept(_conn, alpns).await?;
 							let request = server.accept_request(session).await?;
-							Ok(Request { transport: Transport::Quic, url, identity, kind: RequestKind::Quiche(Box::new(request)) })
+							Ok(Request { transport: Transport::Quic, url, identity, authority, kind: RequestKind::Quiche(Box::new(request)) })
 						}.boxed());
 					}
 				}
 				Some(_conn) = iroh_accept => {
 					#[cfg(feature = "iroh")]
 					self.accept.push(async move {
-						let (session, url, identity) = super::iroh::accept(_conn).await?;
+						let Accepted { session, url, identity, authority } = super::iroh::accept(_conn).await?;
 						let request = server.accept_request(session).await?;
-						Ok(Request { transport: Transport::Iroh, url, identity, kind: RequestKind::Iroh(Box::new(request)) })
+						Ok(Request { transport: Transport::Iroh, url, identity, authority, kind: RequestKind::Iroh(Box::new(request)) })
 					}.boxed());
 				}
 				Some(_res) = ws_accept => {
@@ -582,7 +582,8 @@ impl Server {
 							// slow peer doesn't stall the accept loop (spawned like the others).
 							self.accept.push(async move {
 								let request = server.accept_request(session).await?;
-								Ok(Request { transport: Transport::WebSocket, url: Some(url), identity: None, kind: RequestKind::Qmux(Box::new(request)) })
+								let authority = url.host_str().filter(|h| !h.is_empty()).map(str::to_owned);
+								Ok(Request { transport: Transport::WebSocket, url: Some(url), authority, identity: None, kind: RequestKind::Qmux(Box::new(request)) })
 							}.boxed());
 						}
 						// One connection's upgrade, not the listener's: a failed
@@ -926,6 +927,7 @@ fn spawn_stream_request(
 				let request = Request {
 					transport,
 					url: None,
+					authority: None,
 					identity: None,
 					kind: RequestKind::Qmux(Box::new(request)),
 				};
@@ -953,6 +955,17 @@ pub(crate) enum RequestKind {
 	Iroh(Box<moq_net::Request<web_transport_iroh::Session>>),
 	#[cfg(any(feature = "tcp", all(feature = "uds", unix), feature = "websocket"))]
 	Qmux(Box<moq_net::Request<qmux::Session>>),
+}
+
+/// The transport-level facts a backend captures while accepting a connection, before the
+/// MoQ SETUP. Grouped so the shared accept loop builds a [`Request`] from named fields
+/// rather than a wide tuple.
+#[cfg(any(feature = "noq", feature = "quinn", feature = "quiche", feature = "iroh"))]
+pub(crate) struct Accepted<S> {
+	pub session: S,
+	pub url: Option<Url>,
+	pub identity: Option<crate::tls::PeerIdentity>,
+	pub authority: Option<String>,
 }
 
 /// The network transport carrying an incoming MoQ session.
@@ -1003,6 +1016,9 @@ pub struct Request {
 	/// The request URL, for transports that carry one (QUIC/WebTransport/WebSocket). `None` for the
 	/// URL-less stream bindings, whose request path rides the SETUP instead.
 	url: Option<Url>,
+	/// The authority the client dialed, when it offered one: the TLS SNI on raw QUIC, the CONNECT
+	/// authority on WebTransport. `None` on the URL-less stream bindings and on iroh.
+	authority: Option<String>,
 	/// The peer's validated mTLS identity, captured at the transport handshake (before
 	/// the MoQ SETUP), when the backend supports it.
 	identity: Option<crate::tls::PeerIdentity>,
@@ -1081,6 +1097,7 @@ impl Request {
 		let Request {
 			transport,
 			url,
+			authority,
 			identity,
 			kind,
 		} = self;
@@ -1088,6 +1105,7 @@ impl Request {
 		Request {
 			transport,
 			url,
+			authority,
 			identity,
 			kind,
 		}
@@ -1098,6 +1116,7 @@ impl Request {
 		let Request {
 			transport,
 			url,
+			authority,
 			identity,
 			kind,
 		} = self;
@@ -1105,6 +1124,7 @@ impl Request {
 		Request {
 			transport,
 			url,
+			authority,
 			identity,
 			kind,
 		}
@@ -1117,6 +1137,7 @@ impl Request {
 		let Request {
 			transport,
 			url,
+			authority,
 			identity,
 			kind,
 		} = self;
@@ -1124,6 +1145,7 @@ impl Request {
 		Request {
 			transport,
 			url,
+			authority,
 			identity,
 			kind,
 		}
@@ -1134,6 +1156,7 @@ impl Request {
 		let Request {
 			transport,
 			url,
+			authority,
 			identity,
 			kind,
 		} = self;
@@ -1141,6 +1164,7 @@ impl Request {
 		Request {
 			transport,
 			url,
+			authority,
 			identity,
 			kind,
 		}
@@ -1163,6 +1187,15 @@ impl Request {
 	/// in-band request path.
 	pub fn url(&self) -> Option<&Url> {
 		self.url.as_ref()
+	}
+
+	/// The host authority the client dialed, or `None` when the client offered none or the
+	/// transport carries no host (iroh, stream bindings).
+	///
+	/// Not the moq-net IETF SETUP `Authority` parameter. Client-asserted and not authenticated,
+	/// so authorize on the token or [`Self::peer_identity`] rather than on this value.
+	pub fn authority(&self) -> Option<&str> {
+		self.authority.as_deref()
 	}
 
 	/// The request path the client advertised, uniform across transports.

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -24,6 +24,10 @@ struct ConnectTest<'a> {
 	path: &'a str,
 	/// The request path the server must observe, when the test cares.
 	expect_path: Option<&'a str>,
+	/// The authority the server must observe via [`moq_native::Request::authority`], when the
+	/// test cares. `None` skips the check; `Some(None)` asserts no authority (a bare-IP dial that
+	/// sends no SNI); `Some(Some(host))` asserts that host.
+	expect_authority: Option<Option<&'a str>>,
 	backend: moq_native::QuicBackend,
 	/// Capture qlog traces from both ends into this directory.
 	qlog: Option<&'a std::path::Path>,
@@ -43,6 +47,7 @@ async fn backend_test(scheme: &str, backend: moq_native::QuicBackend) {
 		authority: "localhost",
 		path: "",
 		expect_path: Some(""),
+		expect_authority: Some(Some("localhost")),
 		backend,
 		qlog: None,
 	})
@@ -63,6 +68,7 @@ async fn path_test(scheme: &str, backend: moq_native::QuicBackend) {
 		authority: "localhost",
 		path: "/room?jwt=abc",
 		expect_path: Some("/room"),
+		expect_authority: Some(Some("localhost")),
 		backend,
 		qlog: None,
 	})
@@ -82,6 +88,7 @@ async fn no_sni_test(scheme: &str, backend: moq_native::QuicBackend) {
 		authority: "127.0.0.1",
 		path: "",
 		expect_path: Some(""),
+		expect_authority: Some(None),
 		backend,
 		qlog: None,
 	})
@@ -99,6 +106,7 @@ async fn connect_test(config: ConnectTest<'_>) {
 		authority,
 		path,
 		expect_path,
+		expect_authority,
 		backend,
 		qlog,
 	} = config;
@@ -143,6 +151,7 @@ async fn connect_test(config: ConnectTest<'_>) {
 
 	// ── run server and client concurrently ──────────────────────────
 	let expect_path = expect_path.map(str::to_string);
+	let expect_authority = expect_authority.map(|a| a.map(str::to_string));
 	let server_handle = tokio::spawn(async move {
 		let request = server.accept().await.expect("no incoming connection");
 		// The client wired only a subscriber, so its advertised role reaches the server
@@ -153,6 +162,11 @@ async fn connect_test(config: ConnectTest<'_>) {
 			assert_eq!(request.path(), expect_path);
 		}
 		assert_eq!(request.query(), expect_query.as_deref());
+		// The dialed authority is readable at accept, before the session is accepted: the TLS
+		// SNI on raw QUIC, the CONNECT authority on WebTransport.
+		if let Some(expect_authority) = expect_authority {
+			assert_eq!(request.authority(), expect_authority.as_deref());
+		}
 		let session = request.with_publisher(&pub_origin).ok().await?;
 
 		let _broadcast = broadcast;
@@ -425,6 +439,7 @@ async fn quiche_dual_stack_ipv4() {
 		authority: "127.0.0.1",
 		path: "",
 		expect_path: None,
+		expect_authority: Some(None),
 		backend: moq_native::QuicBackend::Quiche,
 		qlog: None,
 	})
@@ -644,6 +659,7 @@ async fn qlog_test(scheme: &str, backend: moq_native::QuicBackend) -> Vec<std::p
 		authority: "localhost",
 		path: "",
 		expect_path: None,
+		expect_authority: None,
 		backend,
 		qlog: Some(dir.path()),
 	})

--- a/rs/moq-native/tests/backend.rs
+++ b/rs/moq-native/tests/backend.rs
@@ -439,7 +439,8 @@ async fn quiche_dual_stack_ipv4() {
 		authority: "127.0.0.1",
 		path: "",
 		expect_path: None,
-		expect_authority: Some(None),
+		// BoringSSL sends an IP-literal SNI where rustls sends none, so the server sees it.
+		expect_authority: Some(Some("127.0.0.1")),
 		backend: moq_native::QuicBackend::Quiche,
 		qlog: None,
 	})

--- a/rs/moq-native/tests/broadcast.rs
+++ b/rs/moq-native/tests/broadcast.rs
@@ -1754,6 +1754,8 @@ async fn broadcast_websocket() {
 		let request = server.accept().await.expect("no incoming connection");
 		assert_eq!(request.transport(), moq_native::Transport::WebSocket);
 		assert_eq!(request.path(), "");
+		// The dialed host reaches the server as the authority, like the QUIC transports.
+		assert_eq!(request.authority(), Some("localhost"));
 		let session = request.with_publisher(&pub_origin).ok().await?;
 
 		let _broadcast = broadcast;


### PR DESCRIPTION
## Summary

- Adds `Request::authority()`: the hostname the client dialed, populated on every host-bearing
  transport. Raw QUIC takes it from the TLS SNI, WebTransport from the CONNECT URL authority, and the
  WebSocket/qmux arm from the upgrade URL host. iroh (addresses peers by `EndpointId`) and the URL-less
  stream bindings (`tcp`/`unix`) return `None`.
- Field-carry, not URL-derived. The authority is captured at accept into a new private `Request`
  field, so it is available on raw QUIC where `url()` is `None` — raw QUIC carries no request URL
  (that `None` is deliberate, see `b79c2bf0`, and is unchanged here). An earlier URL-synthesis attempt
  only worked on the quinn WebTransport path and returned `None` on the raw arms of noq and quiche.
- Empty is normalized to `None` at the source: an absent or empty SNI and an empty CONNECT host all
  become `None`, so a consumer never sees `Some("")`.
- Motivating use case: a relay that serves many tenants from per-tenant hostnames and resolves tenant
  identity from the host a connection arrived on rather than from the request path. That already
  works over WebTransport via `url()`; native QUIC read the SNI at accept and dropped it. `moq-relay`
  routes by path and never needed the SNI, which is why the accessor was absent. `peer_identity()`,
  `transport()` and `path()` are the existing per-transport convenience accessors this mirrors.
- Internal refactor: the four backend `accept()` fns returned a 3-wide tuple
  `(Session, Option<Url>, Option<PeerIdentity>)`; adding authority would make it 4-wide, so they now
  return a small `pub(crate) struct Accepted<S>` instead.

## Public API changes

- **New (`pub`, additive):** `moq_native::Request::authority(&self) -> Option<&str>`. Targets `main`.
  No existing public item changes signature or behavior — `url()`, `path()`, `query()`, `transport()`,
  `peer_identity()` are untouched.
- **Not public:** the new `Request.authority` field is private and is threaded through all four
  builders (`with_publisher`, `with_subscriber`, `with_peer_origin`, `with_stats`); `Accepted<S>` and
  the changed return types of `{quinn,noq,quiche,iroh}::accept` are `pub(crate)`.
- `authority()` is transport-level (TLS SNI / CONNECT authority) and is explicitly **not** the moq-net
  IETF SETUP `Authority` parameter (`rs/moq-net/src/ietf/parameters.rs`). It is client-asserted and
  unauthenticated; the doc comment says to authorize on the token or `peer_identity()`, not on this.
- **Cross-Package Sync:** `rs/moq-native` is not a row in the table, so no paired update is required.
  Forward note: `rs/moq-ffi`'s `MoqRequest` mirrors `url`/`transport`; an `authority` accessor there
  for parity would be a natural follow-up. Not in this PR.

## Test plan

- `cargo fmt -p moq-native -- --check`: clean.
- `cargo clippy -p moq-native --all-targets -- -D warnings`, default features and `--features noq`: clean.
- `cargo test -p moq-native` (default/quinn): full suite passes. `--features noq`: backend suite passes.
- Authority is asserted **at accept time, before `request.ok()`**, so it is proven available where an
  auth decision would read it. `tests/backend.rs` extends the existing `ConnectTest` config with an
  `expect_authority` field (no new positional helper arg), exercised on quinn and noq:
  - raw QUIC dialing `localhost` → `Some("localhost")` (SNI read at accept);
  - raw QUIC dialing a bare IP → `None` (RFC 6066 forbids an IP-literal SNI, so none is sent);
  - WebTransport dialing `localhost` → `Some("localhost")` (CONNECT authority).
  `tests/broadcast.rs::broadcast_websocket` dials `ws://localhost` and asserts the server observes
  `Some("localhost")`.
- `cargo check -p moq-native --features iroh --all-targets`: clean (iroh arm returns `None`).
- **quiche arm: compiled and tested.** `cargo clippy -p moq-native --features quiche --all-targets -- -D warnings` clean; `cargo test -p moq-native --features quiche`: full suite passes, backend 11/11 (+1 pre-existing `#[ignore]`), including `quiche_raw_quic` / `quiche_raw_quic_path` observing `Some("localhost")` at accept. Doing so surfaced one difference worth knowing: on a bare-IP dial quiche observes `Some("127.0.0.1")` where quinn/noq observe `None`. That is the client, not the accessor — web-transport-quiche passes the URL host to BoringSSL verbatim and BoringSSL sends an IP-literal SNI, while rustls sends none (RFC 6066). The accessor reports what was offered; `quiche_dual_stack_ipv4` now expects the IP and the doc comment says so. Note quiche is not a default feature, so the per-PR Check workflow does not build this arm; the nightly `--all-features` lane does.
- **Field evidence.** We run the same accessor contract (backported onto the older moq-native rev our
  relay pins) in a deployed multi-tenant relay behind an NLB, with a relay-side change that is exactly
  `request.url().and_then(|u| u.host_str())` → `request.authority()`. Observed under real TLS
  handshakes: an encoder's raw-QUIC session resolved to its tenant from the SNI at accept; a peer
  relay's raw-QUIC dial presenting a per-tenant server name resolved on the same path; a session on a
  hostname that maps to no tenant, and a bare-IP dial, both yielded `None` and were refused
  downstream; and the full relay test suite (484 tests) is green against the accessor. No behavior
  change was observed on any existing `url()` caller.

(Written by claude-fable-5.1, from a draft by claude-opus-4.8)

