### PR TITLE
fix(moq-net): scope-check the dynamic fallback in request_broadcast

### DIFF
--- a/doc/bin/relay/index.md
+++ b/doc/bin/relay/index.md
@@ -61,4 +61,4 @@ working configs for development, production, and a cluster.
 - **Address already in use**: something else holds the UDP or TCP port.
 - **Certificate errors**: the hostname must match the certificate. Local browsers need the fingerprint served over `[web.http]`.
 - **Connection timeout**: UDP isn't reaching the relay, or the client URL names the wrong port.
-- **Unauthorized / forbidden**: the token's paths don't cover the connection path. See [path matching](/bin/relay/auth#path-matching).
+- **Unauthorized / forbidden**: the token's paths don't cover the connection path, or the broadcast a session asked for. See [path matching](/bin/relay/auth#path-matching).

--- a/rs/moq-net/src/error.rs
+++ b/rs/moq-net/src/error.rs
@@ -76,7 +76,8 @@ pub enum Error {
 	#[error("protocol violation")]
 	ProtocolViolation,
 
-	/// The peer's token does not grant the requested path or operation.
+	/// The requested path or operation is not granted, either by the peer's token
+	/// or by the scope of the handle it was requested through.
 	#[error("unauthorized")]
 	Unauthorized,
 

--- a/rs/moq-net/src/model/origin.rs
+++ b/rs/moq-net/src/model/origin.rs
@@ -643,17 +643,21 @@ impl Drop for ExclusionGuard {
 
 /// How a path resolves against the announce tree for one consumer.
 ///
-/// `Excluded` is deliberately not folded into `Missing`: they mean opposite
-/// things to a caller holding a dynamic handler. Missing is "nobody here, go
-/// ask"; excluded is "here, but not for you", and asking a handler to route it
-/// anyway is how a split-horizon violation gets in through the back door.
+/// Neither `Excluded` nor `OutOfScope` is folded into `Missing`. Missing is
+/// "nobody here, go ask"; both of the others are "not for you", and asking a
+/// handler to route one anyway is how a split-horizon violation, or a scope
+/// bypass, gets in through the back door.
 enum Resolved {
 	/// A broadcast this consumer may read: the shared front, or a single source
 	/// pinned because the front holds a route back through the requester.
 	Found(broadcast::Consumer),
 	/// The path is live, but every route to it flows through the requester.
 	Excluded,
-	/// Nothing is published at the path, or it is outside the consumer's scope.
+	/// The path is outside the consumer's scope, whether or not anything is
+	/// published there. Distinct from `Missing` because the difference is about
+	/// the asker rather than the tree: see [`Consumer::request_broadcast`].
+	OutOfScope,
+	/// Nothing is published at the path.
 	Missing,
 }
 
@@ -2923,8 +2927,8 @@ impl Consumer {
 	}
 
 	/// Internal synchronous lookup: how the broadcast at `path` resolves for this
-	/// consumer, telling "announced but every route loops back through you" apart
-	/// from "nothing here".
+	/// consumer, telling "announced but every route loops back through you" and
+	/// "outside your scope" apart from "nothing here".
 	///
 	/// Races announcement gossip (a freshly-connected consumer sees `Missing` even when
 	/// the broadcast is about to arrive), so it is not public. [`Self::request_broadcast`]
@@ -2933,7 +2937,7 @@ impl Consumer {
 	fn resolve(&self, path: impl AsPath) -> Resolved {
 		let path = path.as_path();
 		let Some(rest) = self.nodes.get(&path) else {
-			return Resolved::Missing;
+			return Resolved::OutOfScope;
 		};
 		let state = self.nodes.tree.lock();
 		state.resolve_broadcast(&rest, self.exclude)
@@ -2944,7 +2948,7 @@ impl Consumer {
 	pub(crate) fn get_broadcast(&self, path: impl AsPath) -> Option<broadcast::Consumer> {
 		match self.resolve(path) {
 			Resolved::Found(broadcast) => Some(broadcast),
-			Resolved::Excluded | Resolved::Missing => None,
+			Resolved::Excluded | Resolved::OutOfScope | Resolved::Missing => None,
 		}
 	}
 
@@ -3023,8 +3027,9 @@ impl Consumer {
 	///
 	/// The returned future resolves to [`Error::Unroutable`] when no broadcast is reachable and no
 	/// dynamic handler exists. A request that is registered while a handler is live but then loses
-	/// every handler before being served also resolves to [`Error::Unroutable`]. Unlike an announced
-	/// broadcast, a dynamically served one is never visible to [`Self::announced`].
+	/// every handler before being served also resolves to [`Error::Unroutable`]. A path outside this
+	/// consumer's scope resolves to [`Error::Unauthorized`]. Unlike an announced broadcast, a
+	/// dynamically served one is never visible to [`Self::announced`].
 	pub fn request_broadcast(&self, path: impl AsPath) -> kio::Pending<Requesting> {
 		let path = path.as_path();
 
@@ -3039,9 +3044,19 @@ impl Consumer {
 		// serve this requester is unroutable, not missing: a handler resolves paths
 		// with no route chain to check, so falling through would let it route around
 		// the split horizon and rebuild the loop.
+		//
+		// A path outside the consumer's scope falls to the same rule for the same
+		// reason, and to the same error [`Producer::create_broadcast`] already
+		// returns for a scope miss on the write side. The handler has no scope to
+		// check either. A `Request` carries only a path, and a handler obtained
+		// from any view drains one shared queue, so a consumer that may not read a
+		// path must not be able to ask for it to be created. Otherwise the
+		// consumer's scope holds on the announced path and not on this one, and the
+		// gap widens with every handler an application installs.
 		match self.resolve(&path) {
 			Resolved::Found(broadcast) => return kio::Pending::new(Requesting::ready(broadcast).with_stats(scope)),
 			Resolved::Excluded => return kio::Pending::new(Requesting::failed(Error::Unroutable)),
+			Resolved::OutOfScope => return kio::Pending::new(Requesting::failed(Error::Unauthorized)),
 			Resolved::Missing => {}
 		}
 
@@ -6288,6 +6303,109 @@ mod tests {
 			dynamic.requested_broadcast().now_or_never().is_some(),
 			"a genuinely missing path must still fall back"
 		);
+	}
+
+	/// A path outside the consumer's scope never reaches the dynamic handler.
+	///
+	/// `scope` is a read filter over the announce tree, so an out-of-scope path
+	/// resolves to nothing there, and "nothing here" is exactly what sends a
+	/// request to the handler. A `Request` carries only a path, so the handler
+	/// cannot tell who asked and would create the broadcast on the requester's
+	/// behalf, which is `scope` holding on one path and not the other.
+	#[tokio::test]
+	async fn test_out_of_scope_path_never_reaches_the_dynamic_handler() {
+		let origin = Origin::random().produce();
+		let mut dynamic = origin.dynamic();
+
+		let scoped = origin.consume().scope(&["tenant-a".into()]).unwrap();
+
+		// `tenant-a-other` shares a character prefix but not a segment, so this
+		// also pins that the check is segment-aware rather than textual.
+		for path in ["tenant-b/live", "tenant-a-other/live"] {
+			// now_or_never rather than await: the refusal is synchronous, and a
+			// request that instead reached the queue would stay pending forever
+			// waiting on a handler that never accepts it.
+			let refused = scoped
+				.request_broadcast(path)
+				.now_or_never()
+				.expect("an out-of-scope request must be refused synchronously, not queued");
+			assert!(matches!(refused, Err(Error::Unauthorized)));
+			assert!(
+				dynamic.requested_broadcast().now_or_never().is_none(),
+				"the dynamic handler was asked to create a broadcast the requester may not read"
+			);
+		}
+	}
+
+	/// Out of scope is refused with no handler live too, where the old code
+	/// answered `Unroutable` after falling through to an empty queue.
+	#[tokio::test]
+	async fn test_out_of_scope_path_is_unauthorized_without_a_handler() {
+		let origin = Origin::random().produce();
+		let scoped = origin.consume().scope(&["tenant-a".into()]).unwrap();
+
+		let refused = scoped
+			.request_broadcast("tenant-b/live")
+			.now_or_never()
+			.expect("an out-of-scope request must be refused synchronously, not queued");
+		assert!(matches!(refused, Err(Error::Unauthorized)));
+	}
+
+	/// The check refuses only what it should: an unannounced path *inside* the
+	/// scope still falls back to the handler and is served.
+	#[tokio::test]
+	async fn test_in_scope_path_still_reaches_the_dynamic_handler() {
+		let origin = Origin::random().produce();
+		let mut dynamic = origin.dynamic();
+
+		let scoped = origin.consume().scope(&["tenant-a".into()]).unwrap();
+		let requested = scoped.request_broadcast("tenant-a/live");
+
+		// Registration and `accept` are both synchronous, so `now_or_never`
+		// throughout: a regression that over-refuses fails here rather than
+		// hanging on a handler request that never arrives.
+		let served = broadcast::Info::new().produce();
+		let request = dynamic
+			.requested_broadcast()
+			.now_or_never()
+			.expect("an in-scope request must reach the handler")
+			.unwrap();
+		assert_eq!(request.path(), &Path::new("tenant-a/live"));
+		request.accept(&served);
+
+		let broadcast = requested.now_or_never().expect("served synchronously").unwrap();
+		assert!(broadcast.is_clone(&served.consume()));
+	}
+
+	/// An unscoped consumer is scoped to the whole tree, so every path is in
+	/// scope and the fallback is unchanged for it.
+	///
+	/// This is the case an application relying on a catch-all handler depends
+	/// on, and it holds structurally rather than by special case: the default
+	/// node is the empty prefix, and every path has the empty prefix.
+	#[tokio::test]
+	async fn test_whole_tree_scope_still_reaches_the_dynamic_handler() {
+		let origin = Origin::random().produce();
+		let mut dynamic = origin.dynamic();
+
+		for (consumer, path) in [
+			(origin.consume(), "tenant-a/live"),
+			(origin.consume().scope(&["".into()]).unwrap(), "tenant-b/live"),
+		] {
+			let requested = consumer.request_broadcast(path);
+
+			let served = broadcast::Info::new().produce();
+			let request = dynamic
+				.requested_broadcast()
+				.now_or_never()
+				.expect("a whole-tree request must reach the handler")
+				.unwrap();
+			assert_eq!(request.path(), &Path::new(path));
+			request.accept(&served);
+
+			let broadcast = requested.now_or_never().expect("served synchronously").unwrap();
+			assert!(broadcast.is_clone(&served.consume()));
+		}
 	}
 
 	/// When every route flows through the requester, the path is unroutable for


### PR DESCRIPTION
## Summary

`origin::Consumer::request_broadcast` applies the consumer's scope on its announced fast path and
not on its dynamic fallback, so a scoped consumer can have a broadcast it may not read created on
its behalf.

Root cause, one line: `resolve` returns `Resolved::Missing` for an out-of-scope path, the same value
it returns when nothing is published there, and `Missing` is exactly what falls through to the
`Dynamic` queue.

The handler cannot make up the difference, which is why this has to be fixed in `moq-net` rather
than in the application holding the handler:

- a `Request` exposes only `path()`; it carries no principal;
- `Dynamic` is per-*producer*, and `DynamicState` is cloned through every derivation
  (`Producer::scope`, `Producer::with_root`, `Consumer::scope`, `Producer::consume`), so every
  handler obtained from any view drains **one shared** `requests` queue. N per-session handlers
  would race for one queue rather than partition by session.

So the scope is known inside `request_broadcast` and nowhere the handler can reach.

The fix splits the conflation the way `Excluded` already is, using the reasoning already written
down above the enum:

> `Excluded` is deliberately not folded into `Missing`: they mean opposite things to a caller
> holding a dynamic handler. Missing is "nobody here, go ask"; excluded is "here, but not for
> you", and asking a handler to route it anyway is how a split-horizon violation gets in through
> the back door.

Out-of-scope is the same class, "not for you", so `resolve` now reports `OutOfScope` distinctly and
`request_broadcast` refuses it instead of asking a handler to route it. Three call sites, no second
lookup, and the doc comment on `Missing` stops lying by conflation.

## Who this affects

`moq-relay` hands the session a token-scoped serving origin
(`cluster.rs:637`: `self.origin.with_root(&token.root)?.scope(&token.subscribe)`), and
`lite::Publisher::serving_origin` is what `request_broadcast` is called on for an incoming
SUBSCRIBE/FETCH, so the bypassed scope is a remote subscriber's own token grant.

**The shipped `moq-relay` binary is not currently exposed**, because it installs no origin-level
`Dynamic` handler: with no handler live the fallback fails `Unroutable` and the request never
registers. The only two origin-level handlers in the repo (`moq-mux/src/source.rs`,
`moq-video/src/decode/consumer.rs`) are `#[cfg(test)]` and whole-tree. So the hole is in the
primitive, and it opens for any application that adds a handler to serve broadcasts on demand, which
is what a relay doing demand-driven upstream resolution does, and is how we found it. This is a
latent authorization gap rather than a live one, and the fix is worth having before the first handler
ships rather than after.

The sibling lookup is already safe and needs no change: `announced_broadcast` scopes a fresh consumer
(`self.scope(...)?`) and additionally guards on `allowed()`, so an out-of-scope path returns `None`
before it can wait forever. Its only wart is that the `None` also conflates out-of-scope with closed,
and un-conflating it would change a published signature, so that belongs on `dev` rather than here.

## Error choice: `Unauthorized`, not `Unroutable`

There is a direct precedent in the same file: `Producer::create_broadcast` (`origin.rs:1115`) already
answers an identical `self.nodes.get(&path)` scope miss with
`.ok_or(Error::Unauthorized)?`, documented as *"Fails with `Error::Unauthorized` if `path` is outside
the prefixes this producer may publish under (after `scope`/`with_root`)"*. `rs/moq-ffi` writes the
same vocabulary (`origin.rs`: "Surfaces Error::Unauthorized (out of scope)"). This change makes the
consumer read path symmetric with the producer write path rather than introducing a new convention.

`Excluded` keeps `Unroutable` and that stays right: the requester *is* authorized there and only the
route loops back through it, so there is genuinely no route. An out-of-scope path is the opposite, a
route that exists and may not be used.

On disclosure: the fix is strictly *less* disclosing than today, since a live handler currently serves
the out-of-scope broadcast outright. It does create one new observable distinction, between the
caller's own grant and the tree's contents, which the caller could already infer from its own handle.
Answering `Unroutable` instead would actively mislead, sending an operator hunting for a missing
publisher when the cause is the grant. `request_broadcast`'s doc comment now lists both outcomes, and
`Error::Unauthorized`'s own doc is widened to cover the handle-scope case both callers rely on.

## Shape considered and rejected

`Resolved` could carry the error instead of naming the reason: `Refused(Error)` collapses `Excluded`
and `OutOfScope` into one variant, so a third refusal reason would be a one-line change in `resolve`
rather than three. Named variants were kept because `Excluded` is an established concept referenced by
name in comments and tests around `Consumer::excluding`, and because the wire-error choice belongs at
the refusal site in `Consumer` rather than inside `OriginNode::resolve_broadcast`, which reasons about
routes and not about error codes. Happy to switch if you prefer the collapsed form.

## API changes

- **No public API change.** `request_broadcast`'s signature is untouched; `Resolved` is a private
  enum, so adding a variant is not a breaking change and no external `match` can see it.
- **Behavior change, deliberately:** a scoped consumer requesting an out-of-scope path now resolves
  `Unauthorized` instead of (a) being served by a handler, or (b) resolving `Unroutable` when no
  handler is live. Only (b) changes an already-observable error value, and only for a path the
  consumer was never scoped for. It has its own test, since it is the case the shipped relay can
  reach.
- A whole-tree consumer is unaffected, structurally rather than by special case: `OriginNodes`
  defaults to the empty prefix and every path has the empty prefix, so a catch-all handler behaves
  exactly as before. Both spellings are covered by a test, a bare `consume()` and an explicit
  `scope(&[""])`.
- **Cross-Package Sync:** the `rs/moq-net` wire/API row asks for `js/net`, `doc/concept` and
  `drafts/draft-lcurley-moq-lite.md`. None applies, checked rather than assumed:
  - **`js/net`: nothing to change.** `js/net/src/origin.ts` is only the hop-id `Origin`
    (`OriginSchema`, `randomOrigin`, `MAX_HOPS`); there is no announce tree, no `scope`, and no
    `requestBroadcast`, so the primitive this fixes does not exist there.
  - **`drafts/`: no wire-format change.** No message, SETUP parameter, field, framing or enum value
    is added or altered; an existing error code is returned in a case that previously returned a
    different existing code or nothing at all. The drafts' only `unroutable` references are the
    exclusion case (`draft-lcurley-moq-lite.md`, `draft-lcurley-moq-cluster.md`), which is unchanged.
  - **`doc/concept`: nothing to change.** No `doc/concept` page documents the dynamic fallback. The
    only page mentioning `request_broadcast` is `doc/lib/dart/index.md`, a client-side binding
    example whose origin is root-scoped, and neither `moq-ffi` nor `libmoq` exposes
    `Consumer::scope`, so no binding consumer can construct a consumer that reaches the new error.
  - **One doc line IS updated**, from the `rs/moq-relay` behavior row rather than the `moq-net` one:
    `doc/bin/relay/index.md`'s troubleshooting entry said `Unauthorized` means "the token's paths
    don't cover the connection path", which this change makes incomplete, since a requested
    broadcast can now produce it too.

## Test plan

Repo gates, scoped to the changed crate:

- `just rs check -p moq-net`: clean (`cargo clippy --locked --all-targets -- -D warnings`,
  `cargo fmt --all --check`, `cargo shear`, `cargo sort --workspace --check`).
- `just rs test -p moq-net`: **1022/1022 pass** (nextest, `--all-targets`).
- `just rs doctest -p moq-net`: 8 pass, 2 ignored.

Four tests added beside the split-horizon analogue they are modeled on
(`test_excluded_path_never_reaches_the_dynamic_handler`):

- `test_out_of_scope_path_never_reaches_the_dynamic_handler`: a consumer scoped to `tenant-a`
  requesting `tenant-b/live` resolves `Unauthorized`, **and** `requested_broadcast().now_or_never()`
  is `None`, so the assertion is that the handler never saw it rather than merely that the caller got
  an error. Also covers `tenant-a-other/live`, pinning that the check is segment-aware rather than
  textual.
- `test_out_of_scope_path_is_unauthorized_without_a_handler`: the no-handler case, which is the one
  an existing caller can observe changing (`Unroutable` before, `Unauthorized` after).
- `test_in_scope_path_still_reaches_the_dynamic_handler`: the same scoped consumer's unannounced
  in-scope path still reaches the handler and is served, so the check refuses only what it should.
- `test_whole_tree_scope_still_reaches_the_dynamic_handler`: a root consumer and a `scope(&[""])`
  consumer both still reach the handler.

**Regression test fails without the fix** (per Root Cause First), and fails *fast*: neutralizing just
the `OutOfScope` arm makes both refusal tests panic at
`an out-of-scope request must be refused synchronously, not queued`. That message is why every new
test asserts through `now_or_never()` rather than `await`. Registration and `accept` are both
synchronous, so nothing needs to wait; and an unrefused out-of-scope request registers on the queue
and stays pending forever, so an `await`-shaped test hangs instead of failing (measured: it wedged a
`cargo test` run for ~40 minutes before being killed).

Verified downstream in a relay application, against the equivalent patch path-pinned at the older
`moq-net` rev that application pins (same check, adapted to a revision with no `Resolved` enum): a
token-scoped session, with a real HS256 JWT run through that application's own verifier, has its
out-of-scope `request_broadcast` refused and never reaching the demand handler, while a pre-existing
whole-tree anonymous session test confirms its explicit request still resolves. Reverting only the
`moq-net` file under that pin fails *only* the out-of-scope test and leaves the other two passing.
Its own integration suite (two in-process relays, real wire clients) also passes with the patch
underneath, including three concurrent `request_broadcast` calls coalescing onto one handler request.

(Written by claude-opus-5)
