### PR TITLE
feat(moq-ffi): expose the reconnect epoch and QUIC stream cap

### DIFF
--- a/dart/moq/lib/moq.dart
+++ b/dart/moq/lib/moq.dart
@@ -24,6 +24,7 @@ final class Moq {
     String? tlsCert,
     String? tlsKey,
     String? bind,
+    int? maxStreams,
     MoqOriginProducer? publish,
     MoqOriginProducer? subscribe,
   }) async {
@@ -40,6 +41,7 @@ final class Moq {
       if (tlsCert != null) client.setTlsCert(path: tlsCert);
       if (tlsKey != null) client.setTlsKey(path: tlsKey);
       if (bind != null) client.setBind(addr: bind);
+      if (maxStreams != null) client.setQuicMaxStreams(maxStreams: maxStreams);
       if (publish != null) client.setPublish(origin: publish);
       if (subscribe != null) client.setConsume(origin: subscribe);
 
@@ -81,6 +83,10 @@ final class Moq {
   /// Resolve an existing broadcast at [path].
   Future<MoqBroadcastConsumer> requestBroadcast(String path) =>
       session.consumer().requestBroadcast(path: path);
+
+  /// The connection epoch: 1 for the connect that built this session, one more
+  /// on each reconnect. A server-accepted session stays at 1.
+  int get epoch => session.epoch();
 
   /// Gracefully close the session and stop the client.
   void close() {

--- a/dart/moq_ffi/lib/src/moq.dart
+++ b/dart/moq_ffi/lib/src/moq.dart
@@ -1563,8 +1563,8 @@ class MoqBackoff {
   MoqBackoff({
     this.initialMs = 1000,
     this.multiplier = 2,
-    this.maxMs = 30000,
-    this.timeoutMs = 300000,
+    this.maxMs = 5000,
+    this.timeoutMs = 10000,
   });
 }
 
@@ -5791,6 +5791,7 @@ abstract class MoqClientInterface {
   void setBind({required String addr});
   void setConsume({required MoqOriginProducer? origin});
   void setPublish({required MoqOriginProducer? origin});
+  void setQuicMaxStreams({required int maxStreams});
   void setReconnect({required bool enabled});
   void setTlsCert({required String? path});
   void setTlsDisableVerify({required bool disable});
@@ -5885,6 +5886,16 @@ class MoqClient implements MoqClientInterface {
       uniffi_moq_ffi_fn_method_moqclient_set_publish(
         uniffiClonePointer(),
         FfiConverterOptionalMoqOriginProducer.lower(origin),
+        status,
+      );
+    }, null);
+  }
+
+  void setQuicMaxStreams({required int maxStreams}) {
+    return rustCall((status) {
+      uniffi_moq_ffi_fn_method_moqclient_set_quic_max_streams(
+        uniffiClonePointer(),
+        FfiConverterUInt64.lower(maxStreams),
         status,
       );
     }, null);
@@ -5991,6 +6002,7 @@ abstract class MoqSessionInterface {
   void cancel({required int code});
   Future<void> closed();
   MoqOriginConsumer consumer();
+  int epoch();
   MoqOriginProducer publisher();
   void shutdown();
   MoqConnectionStats stats();
@@ -6048,6 +6060,17 @@ class MoqSession implements MoqSessionInterface {
         status,
       ),
       FfiConverterMoqOriginConsumer.lift,
+      null,
+    );
+  }
+
+  int epoch() {
+    return rustCallWithLifter(
+      (status) => uniffi_moq_ffi_fn_method_moqsession_epoch(
+        uniffiClonePointer(),
+        status,
+      ),
+      FfiConverterUInt64.lift,
       null,
     );
   }
@@ -9288,6 +9311,15 @@ external void uniffi_moq_ffi_fn_method_moqclient_set_publish(
   Pointer<RustCallStatus> uniffiStatus,
 );
 
+@Native<Void Function(Pointer<Void>, Uint64, Pointer<RustCallStatus>)>(
+  assetId: _uniffiAssetId,
+)
+external void uniffi_moq_ffi_fn_method_moqclient_set_quic_max_streams(
+  Pointer<Void> ptr,
+  int max_streams,
+  Pointer<RustCallStatus> uniffiStatus,
+);
+
 @Native<Void Function(Pointer<Void>, Int8, Pointer<RustCallStatus>)>(
   assetId: _uniffiAssetId,
 )
@@ -9385,6 +9417,14 @@ external Pointer<Void> uniffi_moq_ffi_fn_method_moqsession_closed(
   assetId: _uniffiAssetId,
 )
 external Pointer<Void> uniffi_moq_ffi_fn_method_moqsession_consumer(
+  Pointer<Void> ptr,
+  Pointer<RustCallStatus> uniffiStatus,
+);
+
+@Native<Uint64 Function(Pointer<Void>, Pointer<RustCallStatus>)>(
+  assetId: _uniffiAssetId,
+)
+external int uniffi_moq_ffi_fn_method_moqsession_epoch(
   Pointer<Void> ptr,
   Pointer<RustCallStatus> uniffiStatus,
 );
@@ -10201,6 +10241,9 @@ external int uniffi_moq_ffi_checksum_method_moqclient_set_consume();
 external int uniffi_moq_ffi_checksum_method_moqclient_set_publish();
 
 @Native<Uint16 Function()>(assetId: _uniffiAssetId)
+external int uniffi_moq_ffi_checksum_method_moqclient_set_quic_max_streams();
+
+@Native<Uint16 Function()>(assetId: _uniffiAssetId)
 external int uniffi_moq_ffi_checksum_method_moqclient_set_reconnect();
 
 @Native<Uint16 Function()>(assetId: _uniffiAssetId)
@@ -10229,6 +10272,9 @@ external int uniffi_moq_ffi_checksum_method_moqsession_closed();
 
 @Native<Uint16 Function()>(assetId: _uniffiAssetId)
 external int uniffi_moq_ffi_checksum_method_moqsession_consumer();
+
+@Native<Uint16 Function()>(assetId: _uniffiAssetId)
+external int uniffi_moq_ffi_checksum_method_moqsession_epoch();
 
 @Native<Uint16 Function()>(assetId: _uniffiAssetId)
 external int uniffi_moq_ffi_checksum_method_moqsession_publisher();
@@ -10718,7 +10764,7 @@ void _checkApiChecksums() {
   if (uniffi_moq_ffi_checksum_method_moqclient_cancel() != 29949) {
     throw UniffiInternalError.panicked("UniFFI API checksum mismatch");
   }
-  if (uniffi_moq_ffi_checksum_method_moqclient_connect() != 52298) {
+  if (uniffi_moq_ffi_checksum_method_moqclient_connect() != 65409) {
     throw UniffiInternalError.panicked("UniFFI API checksum mismatch");
   }
   if (uniffi_moq_ffi_checksum_method_moqclient_set_backoff() != 28024) {
@@ -10731,6 +10777,10 @@ void _checkApiChecksums() {
     throw UniffiInternalError.panicked("UniFFI API checksum mismatch");
   }
   if (uniffi_moq_ffi_checksum_method_moqclient_set_publish() != 29680) {
+    throw UniffiInternalError.panicked("UniFFI API checksum mismatch");
+  }
+  if (uniffi_moq_ffi_checksum_method_moqclient_set_quic_max_streams() !=
+      21959) {
     throw UniffiInternalError.panicked("UniFFI API checksum mismatch");
   }
   if (uniffi_moq_ffi_checksum_method_moqclient_set_reconnect() != 24915) {
@@ -10764,6 +10814,9 @@ void _checkApiChecksums() {
     throw UniffiInternalError.panicked("UniFFI API checksum mismatch");
   }
   if (uniffi_moq_ffi_checksum_method_moqsession_consumer() != 62364) {
+    throw UniffiInternalError.panicked("UniFFI API checksum mismatch");
+  }
+  if (uniffi_moq_ffi_checksum_method_moqsession_epoch() != 32695) {
     throw UniffiInternalError.panicked("UniFFI API checksum mismatch");
   }
   if (uniffi_moq_ffi_checksum_method_moqsession_publisher() != 55435) {

--- a/doc/lib/dart/index.md
+++ b/doc/lib/dart/index.md
@@ -42,6 +42,11 @@ track.appendGroup().writeFrame(frame: MoqFrame(payload: bytes));
 moq.close();
 ```
 
+Sessions reconnect with backoff when the transport drops and re-announce local
+broadcasts. `moq.epoch` counts the connections, 1 on the first, pairing with
+`session.status()` to log each reconnect; `maxStreams` raises the peer's
+inbound stream cap for a subscriber to many tracks.
+
 Cancelling a stream releases the native cursor. The package re-exports
 `moq_ffi`, so the full generated API is available without a second import.
 

--- a/doc/lib/go/index.md
+++ b/doc/lib/go/index.md
@@ -74,6 +74,13 @@ usable, while a stream read (`Next`, `RecvGroup`, `ReadFrame`, and the
 `iter.Seq2` iterators over them) cancels the stream it reads, which is what a
 range loop over a cancelled context wants.
 
+Sessions reconnect with backoff when the transport drops and re-announce local
+broadcasts, so a worker rides out a relay restart. `Session().Epoch()` counts
+the connections, 1 on the first, pairing with `Session().Status(ctx)` to log
+each reconnect by number; `moq.WithBackoff` tunes the pacing, with
+`moq.RetryForever` as the timeout; and `moq.WithQUICMaxStreams` raises the
+peer's inbound stream cap for a subscriber to many tracks.
+
 `moq.Listen` accepts sessions with per-request `Accept`/`Reject`. JSON tracks
 take anything `encoding/json` handles and return `json.RawMessage`. The rest
 of the [shared feature list](/lib/#what-every-binding-can-do) maps one to

--- a/doc/lib/index.md
+++ b/doc/lib/index.md
@@ -34,6 +34,7 @@ The wrapped bindings share one feature set, so the language pages only show
 how it looks in that language:
 
 - **Connect** to a relay with TLS options (system roots, custom CA, fingerprint pinning, mTLS) and a JWT in the URL, or **serve** sessions yourself and accept or reject each request by path.
+- **Reconnect** automatically with backoff when the transport drops, with `status`/`epoch` reporting each (re)connect and backoff tunable down to retrying forever. The peer's inbound QUIC stream limit is configurable for subscribe-heavy clients.
 - **Discover** broadcasts by prefix, wait for a specific one, or request an unannounced one.
 - **Publish and subscribe to media** with the hang catalog filled in from the bitstream, plus raw pixels or PCM in and out with the codec running inside the binding (VideoToolbox, Media Foundation, NVENC, openh264, Opus).
 - **Raw tracks** of arbitrary bytes with timestamps, sparse or replayed groups, per-subscriber priority and max age, and best-effort datagrams.

--- a/doc/lib/kt/index.md
+++ b/doc/lib/kt/index.md
@@ -49,6 +49,12 @@ Moq.connect("https://relay.example.com").use { moq ->
 }
 ```
 
+Sessions reconnect with backoff when the transport drops and re-announce local
+broadcasts. `moq.epoch()` counts the connections, 1 on the first, pairing with
+`MoqSession.status` to log each reconnect; the `backoff` argument tunes the
+pacing (`timeoutMs = 0` retries forever); and `maxStreams` raises the peer's
+inbound stream cap.
+
 `Server.listen(bind, tlsGenerate = ...)` accepts sessions with per-request
 `accept()`/`reject()`. JSON tracks take `@Serializable` types
 (`publishJsonSnapshot`, `publishJsonStream`, `valuesAs<T>()`), and the rest of

--- a/doc/lib/py/index.md
+++ b/doc/lib/py/index.md
@@ -62,6 +62,12 @@ async def main():
 asyncio.run(main())
 ```
 
+Sessions reconnect with backoff when the transport drops and re-announce local
+broadcasts. `session.epoch()` counts the connections, 1 on the first, pairing
+with `session.status()` to log each reconnect; `moq.Backoff` tunes the pacing
+(`timeout_ms=0` retries forever); and `moq.connect(..., max_streams=...)`
+raises the peer's inbound stream cap.
+
 Everything in the [shared feature list](/lib/#what-every-binding-can-do) is
 here: `moq.Server` with per-request accept/reject, `fetch_group` and
 `fetch_media_group`, `dynamic()` handlers for on-demand tracks and

--- a/doc/lib/swift/index.md
+++ b/doc/lib/swift/index.md
@@ -56,6 +56,11 @@ session.shutdown()
 For a self-signed relay on your own test network, `client.setTlsVerify(false)`
 accepts any certificate; prefer `setTlsRoots` or a fingerprint anywhere else.
 
+Sessions reconnect with backoff when the transport drops and re-announce local
+broadcasts. `session.epoch()` counts the connections, 1 on the first, pairing
+with `session.status()` to log each reconnect; `client.setBackoff` tunes the
+pacing; and `client.setQuicMaxStreams` raises the peer's inbound stream cap.
+
 `Server` binds, generates or loads TLS, and hands you each request to
 `accept()` or `reject(code:)`. JSON tracks take `Codable` types
 (`publishJsonSnapshot(name:of:)`, `subscribeJsonStream(name:as:)`), and the

--- a/go/wrapper/backoff_internal_test.go
+++ b/go/wrapper/backoff_internal_test.go
@@ -12,7 +12,7 @@ import (
 // to the reconnect loop. Passing it through unresolved turns the most natural
 // literal a caller writes, Backoff{}, into an unthrottled dial loop.
 func TestBackoffFfiResolvesUnsetFields(t *testing.T) {
-	defaults := ffi.MoqBackoff{InitialMs: 1000, Multiplier: 2, MaxMs: 30000, TimeoutMs: 300000}
+	defaults := ffi.MoqBackoff{InitialMs: 1000, Multiplier: 2, MaxMs: 5000, TimeoutMs: 10000}
 
 	cases := []struct {
 		name string
@@ -26,13 +26,13 @@ func TestBackoffFfiResolvesUnsetFields(t *testing.T) {
 		},
 		{
 			name: "a partial override keeps the defaults for everything else",
-			in:   Backoff{Max: 5 * time.Second},
-			want: ffi.MoqBackoff{InitialMs: 1000, Multiplier: 2, MaxMs: 5000, TimeoutMs: 300000},
+			in:   Backoff{Max: time.Second},
+			want: ffi.MoqBackoff{InitialMs: 1000, Multiplier: 2, MaxMs: 1000, TimeoutMs: 10000},
 		},
 		{
 			name: "RetryForever is the only way to reach the native zero timeout",
 			in:   Backoff{Timeout: RetryForever},
-			want: ffi.MoqBackoff{InitialMs: 1000, Multiplier: 2, MaxMs: 30000, TimeoutMs: 0},
+			want: ffi.MoqBackoff{InitialMs: 1000, Multiplier: 2, MaxMs: 5000, TimeoutMs: 0},
 		},
 		{
 			name: "negatives fall back instead of wrapping to ~1.8e19 ms",
@@ -42,7 +42,7 @@ func TestBackoffFfiResolvesUnsetFields(t *testing.T) {
 		{
 			name: "a sub-millisecond delay floors at 1ms instead of truncating to zero",
 			in:   Backoff{Initial: time.Nanosecond},
-			want: ffi.MoqBackoff{InitialMs: 1, Multiplier: 2, MaxMs: 30000, TimeoutMs: 300000},
+			want: ffi.MoqBackoff{InitialMs: 1, Multiplier: 2, MaxMs: 5000, TimeoutMs: 10000},
 		},
 		{
 			name: "explicit values pass through",

--- a/go/wrapper/client.go
+++ b/go/wrapper/client.go
@@ -22,6 +22,7 @@ type clientConfig struct {
 	tlsCert            *string
 	tlsKey             *string
 	bind               *string
+	quicMaxStreams     *uint64
 	reconnect          *bool
 	backoff            *Backoff
 	publish            *OriginProducer
@@ -38,8 +39,8 @@ type clientConfig struct {
 type Backoff struct {
 	Initial    time.Duration // delay before the first retry (default 1s)
 	Multiplier uint32        // applied to the delay after each failure (default 2)
-	Max        time.Duration // ceiling on the delay (default 30s)
-	Timeout    time.Duration // give up after this long (default 5m)
+	Max        time.Duration // ceiling on the delay (default 5s)
+	Timeout    time.Duration // give up after this long (default 10s)
 }
 
 // RetryForever, passed as Backoff.Timeout, keeps a reconnecting session retrying
@@ -49,8 +50,8 @@ const RetryForever time.Duration = -1
 const (
 	defaultBackoffInitial    = time.Second
 	defaultBackoffMultiplier = 2
-	defaultBackoffMax        = 30 * time.Second
-	defaultBackoffTimeout    = 5 * time.Minute
+	defaultBackoffMax        = 5 * time.Second
+	defaultBackoffTimeout    = 10 * time.Second
 )
 
 // ffi resolves the unset fields, which is load-bearing rather than cosmetic:
@@ -141,6 +142,15 @@ func WithBind(addr string) ClientOption {
 	return func(c *clientConfig) { c.bind = &addr }
 }
 
+// WithQUICMaxStreams caps the concurrent QUIC streams the peer may open toward
+// this connection (default 1024). MoQ opens a stream per group, and for a
+// subscriber those arrive from the relay, so a client subscribing to many tracks
+// wants this raised. A publisher's own streams are bounded by the relay's
+// advertised limit, not this one. Ignored by the WebSocket fallback.
+func WithQUICMaxStreams(maxStreams uint64) ClientOption {
+	return func(c *clientConfig) { c.quicMaxStreams = &maxStreams }
+}
+
 // WithReconnect toggles automatic reconnecting. It is on by default: the
 // session redials with backoff whenever the transport drops, and broadcasts
 // consumed through it ride out the gap. Pass false for a one-shot dial whose
@@ -213,6 +223,9 @@ func Dial(ctx context.Context, url string, opts ...ClientOption) (*Client, error
 			inner.Cancel()
 			return nil, err
 		}
+	}
+	if cfg.quicMaxStreams != nil {
+		inner.SetQuicMaxStreams(*cfg.quicMaxStreams)
 	}
 	if cfg.reconnect != nil {
 		inner.SetReconnect(*cfg.reconnect)

--- a/go/wrapper/reconnect_test.go
+++ b/go/wrapper/reconnect_test.go
@@ -1,0 +1,235 @@
+package moq_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"moq.dev/moq"
+)
+
+// reconnectTimeout bounds the relay-restart test; its backoff floor is 50ms, so
+// even a slow CI machine reconnects well inside this.
+const reconnectTimeout = 30 * time.Second
+
+// relay is a local MoQ server plus the sessions it accepted, so a test can drop
+// both the way a fleet deploy does and bring a replacement up on the same port.
+type relay struct {
+	server *moq.Server
+	addr   string
+
+	mu       sync.Mutex
+	sessions []*moq.Session
+}
+
+// startRelay binds a relay at addr (an ephemeral loopback port when addr is
+// host:0) and accepts sessions until ctx ends. Binding is retried so a restart
+// can reuse the port the old process just released.
+func startRelay(t *testing.T, ctx context.Context, addr string) *relay {
+	t.Helper()
+
+	var server *moq.Server
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		var err error
+		server, err = moq.Listen(ctx, addr, moq.WithTLSGenerate("localhost"))
+		if err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("relay did not bind %s: %v", addr, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	r := &relay{server: server, addr: server.LocalAddr()}
+	go func() {
+		for req, err := range server.Requests(ctx) {
+			if err != nil {
+				return
+			}
+			session, err := req.Accept(ctx)
+			if err != nil {
+				continue
+			}
+			r.mu.Lock()
+			r.sessions = append(r.sessions, session)
+			r.mu.Unlock()
+			// Hold the session until it closes, like Server.Serve does.
+			go func() { _ = session.Closed(ctx) }()
+		}
+	}()
+	return r
+}
+
+// restart drops every session and the listener, then binds a fresh relay on the
+// same port: the client-visible shape of a fleet deploy.
+func (r *relay) restart(t *testing.T, ctx context.Context) *relay {
+	t.Helper()
+
+	r.mu.Lock()
+	for _, session := range r.sessions {
+		session.Cancel(0)
+	}
+	r.sessions = nil
+	r.mu.Unlock()
+
+	_ = r.server.Close()
+	return startRelay(t, ctx, r.addr)
+}
+
+// dialWorker connects as a Worker would: automatic reconnects with fast retries
+// that never give up, against a relay with a self-signed certificate.
+func dialWorker(t *testing.T, ctx context.Context, url string) *moq.Client {
+	t.Helper()
+
+	client, err := moq.Dial(ctx, url,
+		moq.WithTLSVerify(false),
+		moq.WithBackoff(moq.Backoff{
+			Initial: 50 * time.Millisecond,
+			Max:     time.Second,
+			Timeout: moq.RetryForever,
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+// waitEpoch blocks until the session reports at least want connections, proving
+// the worker redialed rather than just reusing the transport.
+func waitEpoch(t *testing.T, ctx context.Context, session *moq.Session, want uint64) {
+	t.Helper()
+
+	for session.Epoch() < want {
+		select {
+		case <-ctx.Done():
+			t.Fatalf("epoch = %d, want >= %d", session.Epoch(), want)
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+// awaitAnnouncement drains announcements until an active one names path.
+func awaitAnnouncement(t *testing.T, ctx context.Context, announced *moq.Announced, path string) {
+	t.Helper()
+
+	for {
+		ann, err := announced.Next(ctx)
+		if err != nil {
+			t.Fatalf("waiting for %q: %v", path, err)
+		}
+		if ann == nil {
+			t.Fatalf("announcement stream ended before %q", path)
+		}
+		if ann.Active() && ann.Path() == path {
+			return
+		}
+	}
+}
+
+// A Go worker survives a relay restart the way a libmoq worker does: the session
+// redials with backoff, the publisher re-announces its broadcast to the fresh
+// relay, and the subscriber's subscription receives frames again. The epoch
+// pairs with Status so a worker can log each reconnect.
+func TestReconnectAcrossRelayRestart(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), reconnectTimeout)
+	defer cancel()
+
+	current := startRelay(t, ctx, "127.0.0.1:0")
+	url := "https://" + current.addr
+
+	// Publisher: a continuous track keeps a frame available on the far side of
+	// the restart, since an unwatched live track drops what it writes.
+	publisher := dialWorker(t, ctx, url)
+	defer publisher.Close()
+
+	broadcast, err := publisher.CreateBroadcast("live")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer broadcast.Finish()
+
+	track, err := broadcast.PublishTrack("data", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer track.Finish()
+
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_ = track.WriteFrame(moq.Frame{Payload: fmt.Appendf(nil, "frame-%d", i)})
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	// Subscriber: finds the broadcast and reads a frame before the restart, so
+	// the post-restart read proves delivery resumed rather than never started.
+	subscriber := dialWorker(t, ctx, url)
+	defer subscriber.Close()
+
+	announced, err := subscriber.Announced("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer announced.Cancel()
+
+	awaitAnnouncement(t, ctx, announced, "live")
+
+	before, err := subscriber.RequestBroadcast(ctx, "live")
+	if err != nil {
+		t.Fatal(err)
+	}
+	trackConsumer, err := before.SubscribeTrack(ctx, "data", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer trackConsumer.Cancel()
+
+	if frame, err := trackConsumer.ReadFrame(ctx); err != nil || frame == nil {
+		t.Fatalf("frame before restart: frame=%+v err=%v", frame, err)
+	}
+
+	// Drop every session and the listener, then bind a replacement on the same
+	// port: a deploy, with an origin the replacement has never seen.
+	current = current.restart(t, ctx)
+	defer func() { _ = current.server.Close() }()
+
+	// Both workers observe the reconnect and advance their epoch past the first.
+	waitEpoch(t, ctx, publisher.Session(), 2)
+	waitEpoch(t, ctx, subscriber.Session(), 2)
+
+	// The publisher re-announces the broadcast the fresh relay never saw.
+	awaitAnnouncement(t, ctx, announced, "live")
+
+	// The subscriber resolves the re-announced broadcast again and receives
+	// frames, which is how a worker follows a relay restart: the old handle's
+	// broadcast closed with its source, and the announcement is what re-anchors.
+	after, err := subscriber.RequestBroadcast(ctx, "live")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resumed, err := after.SubscribeTrack(ctx, "data", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resumed.Cancel()
+
+	frame, err := resumed.ReadFrame(ctx)
+	if err != nil {
+		t.Fatalf("frame after restart: %v", err)
+	}
+	if frame == nil {
+		t.Fatal("frame after restart: nil")
+	}
+}

--- a/go/wrapper/session.go
+++ b/go/wrapper/session.go
@@ -36,6 +36,16 @@ func (s *Session) Status(ctx context.Context) (ConnectionStatus, error) {
 	return runCancellable(ctx, s.inner.Shutdown, s.inner.Status)
 }
 
+// Epoch is the connection epoch: 1 for the connect that built this session, one
+// more on each reconnect. A server-accepted session stays at 1.
+//
+// Pair it with Status to log each reconnect by number: a StatusConnected whose
+// Epoch grew is a reconnect. Like Status, it reports the current state, so a
+// drop that reconnects between reads is coalesced away.
+func (s *Session) Epoch() uint64 {
+	return s.inner.Epoch()
+}
+
 // Stats snapshots the current connection statistics.
 func (s *Session) Stats() ConnectionStats {
 	return s.inner.Stats()

--- a/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Moq.kt
+++ b/kt/moq/src/jvmAndAndroidMain/kotlin/dev/moq/Moq.kt
@@ -62,6 +62,14 @@ class Moq internal constructor(
      */
     suspend fun requestBroadcast(path: String): MoqBroadcastConsumer = session.consumer().requestBroadcast(path)
 
+    /**
+     * The connection epoch: 1 for the connect that built this session, one more on
+     * each reconnect. A server-accepted session stays at 1.
+     *
+     * Pair it with [MoqSession.status] to log each reconnect by number.
+     */
+    fun epoch(): ULong = session.epoch()
+
     /** Gracefully shut down the session and cancel the client, releasing the native handles. */
     override fun close() {
         session.shutdown()
@@ -79,6 +87,9 @@ class Moq internal constructor(
          * @param tlsCert path to a PEM certificate chain to present for mTLS.
          * @param tlsKey path to a PEM private key to present for mTLS.
          * @param bind local socket address to bind, e.g. "0.0.0.0:0".
+         * @param maxStreams cap on the concurrent QUIC streams the peer may open toward
+         *   this connection; MoQ opens one stream per group, and for a subscriber those
+         *   arrive from the relay, so subscribing to many tracks may want this raised.
          * @param reconnect set false for a one-shot dial. By default the session redials
          *   with backoff whenever the transport drops; watch [MoqSession.status] for the
          *   transitions.
@@ -103,6 +114,7 @@ class Moq internal constructor(
             backoff: Backoff? = null,
             publish: MoqOriginProducer? = null,
             subscribe: MoqOriginProducer? = null,
+            maxStreams: ULong? = null,
         ): Moq {
             val client = MoqClient()
             try {
@@ -113,6 +125,7 @@ class Moq internal constructor(
                 if (tlsCert != null) client.setTlsCert(tlsCert)
                 if (tlsKey != null) client.setTlsKey(tlsKey)
                 if (bind != null) client.setBind(bind)
+                if (maxStreams != null) client.setQuicMaxStreams(maxStreams)
                 if (reconnect != null) client.setReconnect(reconnect)
                 if (backoff != null) client.setBackoff(backoff)
                 if (publish != null) client.setPublish(publish)

--- a/py/moq-rs/moq/client.py
+++ b/py/moq-rs/moq/client.py
@@ -47,6 +47,7 @@ class Client:
         tls_cert: str | None = None,
         tls_key: str | None = None,
         bind: str | None = None,
+        max_streams: int | None = None,
         reconnect: bool = True,
         backoff: Backoff | None = None,
         publish: OriginProducer | None = None,
@@ -60,6 +61,7 @@ class Client:
         self._tls_cert = tls_cert
         self._tls_key = tls_key
         self._bind = bind
+        self._max_streams = max_streams
         self._reconnect = reconnect
         self._backoff = backoff
 
@@ -90,6 +92,8 @@ class Client:
             self._inner.set_tls_key(self._tls_key)
         if self._bind is not None:
             self._inner.set_bind(self._bind)
+        if self._max_streams is not None:
+            self._inner.set_quic_max_streams(self._max_streams)
         if not self._reconnect:
             self._inner.set_reconnect(False)
         if self._backoff is not None:
@@ -171,6 +175,7 @@ def connect(
     tls_cert: str | None = None,
     tls_key: str | None = None,
     bind: str | None = None,
+    max_streams: int | None = None,
     reconnect: bool = True,
     backoff: Backoff | None = None,
     publish: OriginProducer | None = None,
@@ -192,6 +197,7 @@ def connect(
         tls_cert=tls_cert,
         tls_key=tls_key,
         bind=bind,
+        max_streams=max_streams,
         reconnect=reconnect,
         backoff=backoff,
         publish=publish,

--- a/py/moq-rs/moq/session.py
+++ b/py/moq-rs/moq/session.py
@@ -52,6 +52,14 @@ class Session:
         are the ones that already healed. Do not count outages with it."""
         return await self._inner.status()
 
+    def epoch(self) -> int:
+        """The connection epoch: 1 for the connect that built this session, one more
+        on each reconnect. A server-accepted session stays at 1.
+
+        Pair it with :meth:`status` to log each reconnect by number; a
+        ``CONNECTED`` status whose epoch grew is a reconnect."""
+        return self._inner.epoch()
+
     def cancel(self, code: int) -> None:
         """Close the session with the given error code."""
         self._inner.cancel(code)

--- a/rs/moq-ffi/src/session.rs
+++ b/rs/moq-ffi/src/session.rs
@@ -10,6 +10,8 @@ use crate::origin::{MoqOriginConsumer, MoqOriginProducer};
 #[cfg(not(target_arch = "wasm32"))]
 struct Client {
 	config: moq_tokio::connect::Config,
+	/// QUIC transport tuning the dial applies, e.g. `quic_max_streams`.
+	quic: moq_tokio::quic::Config,
 	publish: Option<Arc<MoqOriginProducer>>,
 	consume: Option<Arc<MoqOriginProducer>>,
 }
@@ -17,11 +19,7 @@ struct Client {
 #[cfg(not(target_arch = "wasm32"))]
 impl Client {
 	async fn connect(&self, url: Url) -> Result<Arc<MoqSession>, MoqError> {
-		let client = self
-			.config
-			.clone()
-			.init(Default::default())
-			.map_err(map_connect_error)?;
+		let client = self.config.clone().init(self.quic.clone()).map_err(map_connect_error)?;
 
 		// Materialize both origin sides so the session can publish/subscribe and the FFI can
 		// always hand back a publisher/consumer.
@@ -203,6 +201,15 @@ mod tests {
 		assert_eq!(state.config.tls.cert, None);
 		assert_eq!(state.config.tls.key, None);
 	}
+
+	#[test]
+	fn sets_the_quic_stream_cap() {
+		let client = MoqClient::new();
+		assert_eq!(client.task.lock().unwrap().quic.max_streams, None);
+
+		client.set_quic_max_streams(4096);
+		assert_eq!(client.task.lock().unwrap().quic.max_streams, Some(4096));
+	}
 }
 
 /// Retry pacing for the automatic reconnect (see [`MoqClient::set_backoff`]).
@@ -210,7 +217,8 @@ mod tests {
 /// The delay starts at `initial_ms`, multiplies by `multiplier` after each failed
 /// attempt, and caps at `max_ms`. After `timeout_ms` of consecutive failures the
 /// connection gives up for good (0 retries forever); the window resets whenever a
-/// session stays up past `initial_ms`.
+/// session stays up past `initial_ms`. The defaults mirror the native
+/// [`moq_tokio::Backoff`]: 1s, x2, 5s, and a 10s window.
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone, Debug, uniffi::Record)]
 pub struct MoqBackoff {
@@ -221,10 +229,10 @@ pub struct MoqBackoff {
 	#[uniffi(default = 2)]
 	pub multiplier: u32,
 	/// Maximum delay between reconnect attempts, in milliseconds.
-	#[uniffi(default = 30000)]
+	#[uniffi(default = 5000)]
 	pub max_ms: u64,
 	/// Time spent retrying before giving up, in milliseconds. 0 retries forever.
-	#[uniffi(default = 300000)]
+	#[uniffi(default = 10000)]
 	pub timeout_ms: u64,
 }
 
@@ -379,6 +387,7 @@ impl MoqClient {
 		Arc::new(Self {
 			task: Task::new(Client {
 				config: moq_tokio::connect::Config::default(),
+				quic: moq_tokio::quic::Config::default(),
 				publish: None,
 				consume: None,
 			}),
@@ -460,6 +469,19 @@ impl MoqClient {
 		Ok(())
 	}
 
+	/// Cap the concurrent QUIC streams the peer may open toward this connection.
+	/// Defaults to 1024.
+	///
+	/// MoQ opens a stream per group, and for a subscriber those arrive from the relay,
+	/// so a client subscribing to many tracks wants this raised. A publisher's own
+	/// streams are bounded by the peer's advertised limit, not this one. Ignored by
+	/// the WebSocket fallback.
+	pub fn set_quic_max_streams(&self, max_streams: u64) {
+		if let Some(mut state) = self.task.lock() {
+			state.quic.max_streams = Some(max_streams);
+		}
+	}
+
 	/// Enable or disable automatic reconnecting. Enabled by default.
 	///
 	/// When enabled, the session returned by [`connect`](Self::connect) redials with
@@ -503,8 +525,8 @@ impl MoqClient {
 	/// The returned session automatically reconnects with backoff when the transport
 	/// drops (unless disabled via [`set_reconnect`](Self::set_reconnect)), and broadcasts
 	/// consumed through it ride out the gap. Watch [`MoqSession::status`] for the
-	/// connect/disconnect transitions and [`MoqSession::closed`] for the connection
-	/// giving up for good.
+	/// connect/disconnect transitions, [`MoqSession::epoch`] for the reconnect count,
+	/// and [`MoqSession::closed`] for the connection giving up for good.
 	///
 	/// Both origin sides are always accessible via [`MoqSession::publisher`] and
 	/// [`MoqSession::consumer`], without the caller constructing a [`MoqOriginProducer`]
@@ -722,6 +744,20 @@ impl MoqSession {
 				}
 			})
 			.await
+	}
+
+	/// The connection epoch: 1 for the connect this session was built from, one more
+	/// on each reconnect. A server-accepted session is a single transport, so it stays 1.
+	///
+	/// The count pairs with [`status`](Self::status): a `Connected` transition whose
+	/// epoch grew is a reconnect, so a worker can log each one by number. Migrations
+	/// count too, since the replacement is a new session.
+	pub fn epoch(&self) -> u64 {
+		match &self.inner {
+			#[cfg(not(target_arch = "wasm32"))]
+			Inner::Connection(connection) => connection.epoch(),
+			Inner::Session(_) => 1,
+		}
 	}
 
 	/// Close the session with the given error code, stopping any reconnect loop.

--- a/rs/moq-ffi/src/test.rs
+++ b/rs/moq-ffi/src/test.rs
@@ -2701,6 +2701,7 @@ async fn client_reconnects_and_resumes_announcements() {
 		.expect("status timed out")
 		.expect("status errored");
 	assert_eq!(status, MoqConnectionStatus::Connected);
+	assert_eq!(cs.epoch(), 1);
 
 	// Kill the transport under the client, simulating a relay restart.
 	// Nothing accepts the redial until the gate opens.
@@ -2723,6 +2724,16 @@ async fn client_reconnects_and_resumes_announcements() {
 		.expect("reconnect status timed out")
 		.expect("reconnect status errored");
 	assert_eq!(status, MoqConnectionStatus::Connected);
+
+	// The reconnect advances the epoch. The watcher may land just after the status
+	// edge it watched, so poll rather than assume ordering.
+	tokio::time::timeout(TIMEOUT, async {
+		while cs.epoch() < 2 {
+			tokio::time::sleep(Duration::from_millis(10)).await;
+		}
+	})
+	.await
+	.expect("the epoch did not advance on reconnect");
 
 	let server_session = tokio::time::timeout(TIMEOUT, accept)
 		.await

--- a/rs/moq-tokio/src/connection.rs
+++ b/rs/moq-tokio/src/connection.rs
@@ -435,6 +435,10 @@ impl GoawayConfig {
 struct State {
 	/// Current connection status, or `None` before the first connect.
 	status: Option<Status>,
+	/// How many sessions have been live on this handle, counting the current one.
+	/// Advanced by `Shared::connected` with the same write that publishes `status`,
+	/// so a reader can't see `Connected` without its epoch.
+	epoch: u64,
 	/// The negotiated MoQ version of the live session, or `None` when disconnected.
 	version: Option<Version>,
 	/// Set when the reconnect loop permanently gives up (reconnect timeout exceeded).
@@ -470,6 +474,7 @@ impl Shared {
 		}
 		if let Ok(mut state) = self.state.write() {
 			state.status = Some(Status::Connected);
+			state.epoch += 1;
 			state.version = Some(session.version());
 			state.session = Some(session.clone());
 		}
@@ -560,9 +565,9 @@ pub struct ConnectionSnapshot {
 /// and [`recv_bandwidth`](Self::recv_bandwidth) track the live session and reset while disconnected.
 /// The extra toggle a plain session doesn't have is the connection lifecycle: [`established`](Self::established)
 /// waits for the first session, [`connected`](Self::connected) reads the current state synchronously,
-/// and [`status`](Self::status) waits for the next change. [`closed`](Self::closed)
-/// waits for the loop to stop. Clones share the loop; it stops when the last
-/// clone drops (or on an explicit [`close`](Self::close)).
+/// [`epoch`](Self::epoch) counts the sessions so far, and [`status`](Self::status) waits for the
+/// next change. [`closed`](Self::closed) waits for the loop to stop. Clones share the loop; it
+/// stops when the last clone drops (or on an explicit [`close`](Self::close)).
 #[derive(Clone)]
 #[must_use = "dropping the Connection stops the dial; hold it for as long as you want the session"]
 pub struct Connection {
@@ -1006,6 +1011,16 @@ impl Connection {
 	/// state rather than the next change.
 	pub fn connected(&self) -> bool {
 		self.state.read().status == Some(Status::Connected)
+	}
+
+	/// How many sessions have been live on this handle: 1 after the first connect,
+	/// one more per reconnect (and per GOAWAY migration, which is a new session too).
+	///
+	/// Advanced in the same write that publishes [`Status::Connected`], so reading
+	/// after a `Connected` status never returns a stale count. Zero only if no
+	/// session has connected yet, which [`established`](Self::established) rules out.
+	pub fn epoch(&self) -> u64 {
+		self.state.read().epoch
 	}
 
 	/// The negotiated MoQ version of the live session, or `None` while disconnected.

--- a/rs/moq-tokio/tests/reconnect.rs
+++ b/rs/moq-tokio/tests/reconnect.rs
@@ -55,6 +55,35 @@ async fn a_transient_failure_retries_until_the_budget_runs_out() {
 	);
 }
 
+/// The epoch advances in the same write that reports `Connected`, so a caller
+/// pairing [`Connection::status`] with [`Connection::epoch`] never sees a stale
+/// count, however fast the redial.
+#[tokio::test]
+async fn the_epoch_advances_on_reconnect() {
+	let (port, mut sessions, _task) = spawn_server().await;
+	let url: url::Url = format!("tcp://localhost:{port}/").parse().expect("parse url");
+	let mut connection = quick_client(Default::default()).connect(url);
+
+	let status = tokio::time::timeout(Duration::from_secs(10), connection.status())
+		.await
+		.expect("status timed out")
+		.expect("status failed");
+	assert_eq!(status, moq_tokio::Status::Connected);
+	assert_eq!(connection.epoch(), 1, "the first connect is epoch 1");
+
+	// Dropping the server's handle closes the session, so the loop redials.
+	let session = sessions.recv().await.expect("server stopped accepting");
+	drop(session);
+
+	tokio::time::timeout(Duration::from_secs(10), async {
+		while connection.epoch() < 2 {
+			tokio::time::sleep(Duration::from_millis(10)).await;
+		}
+	})
+	.await
+	.expect("the epoch never advanced past the first connect");
+}
+
 /// A stream-only moq server on a free loopback TCP port.
 ///
 /// Returns the port, a receiver yielding every accepted session (so a test can

--- a/swift/Sources/Moq/Client.swift
+++ b/swift/Sources/Moq/Client.swift
@@ -49,6 +49,14 @@ public final class Client: Sendable {
         try ffi.setBind(addr: addr)
     }
 
+    /// Cap the concurrent QUIC streams the peer may open toward this connection
+    /// (defaults to 1024). MoQ opens a stream per group, and for a subscriber
+    /// those arrive from the relay, so subscribing to many tracks may want this
+    /// raised. Ignored by the WebSocket fallback.
+    public func setQuicMaxStreams(_ maxStreams: UInt64) {
+        ffi.setQuicMaxStreams(maxStreams: maxStreams)
+    }
+
     /// Wire the origin whose local broadcasts get advertised to the remote. If
     /// left unset, `connect` auto-creates one, reachable via `Session.publisher`.
     public func setPublish(_ origin: OriginProducer?) {
@@ -127,6 +135,15 @@ public final class Session: Sendable {
     /// are the ones that already healed. Don't count outages with it.
     public func status() async throws -> ConnectionStatus {
         try await ffi.status()
+    }
+
+    /// The connection epoch: 1 for the connect that built this session, one more
+    /// on each reconnect. A server-accepted session stays at 1.
+    ///
+    /// Pair it with `status()` to log each reconnect by number: a `.connected`
+    /// status whose epoch grew is a reconnect.
+    public func epoch() -> UInt64 {
+        ffi.epoch()
     }
 
     /// Close the session with the given error code. Code 0 means "no error";


### PR DESCRIPTION
## Summary

- #2618 made FFI sessions reconnect, but a worker cannot tell a reconnect from the initial connect without counting status edges. Add `moq_tokio::Connection::epoch`, advanced with the same write that publishes `Connected`, and expose it as `MoqSession::epoch`: 1 on the initial connect, one more per (re)connect, mirroring libmoq's status report loop. Server-accepted sessions stay 1.
- Add `MoqClient::set_quic_max_streams`, threaded through the shared quic config instead of the hardcoded defaults. It caps peer-initiated streams, which is what a subscriber to many tracks raises.
- Align `MoqBackoff` defaults with the shared `Backoff`: 1s initial, x2, 5s max, 10s window (was 30s/5m). `timeout_ms = 0` still retries forever.
- Wrap both in the Go, Python, Kotlin, Swift, and Dart wrappers, and document them on the shared feature list and every binding page.
- Go regression test restarts a relay mid-run and observes the re-announced broadcast, a fresh subscriber frame after re-resolving, and the epoch advancing on both workers. A `moq-tokio` test covers the epoch directly.

## Public API

Additive; nothing renamed or removed.

- `moq_tokio::Connection::epoch() -> u64`
- `MoqSession::epoch() -> u64` (every UniFFI binding)
- `MoqClient::set_quic_max_streams(max_streams: u64)` (native)
- Go: `moq.Session.Epoch()`, `moq.WithQUICMaxStreams`
- Python: `Client(max_streams=...)`, `moq.connect(..., max_streams=...)`, `Session.epoch()`
- Kotlin: `Moq.connect(maxStreams = ...)`, `Moq.epoch()`
- Swift: `Client.setQuicMaxStreams`, `Session.epoch()`
- Dart: `Moq.connect(maxStreams: ...)`, `Moq.epoch`

Default change on `dev`: `MoqBackoff.max_ms` 30000 -> 5000 and `timeout_ms` 300000 -> 10000, matching the native `Backoff` defaults.

## Wire

None.

(written by deepseek-v4.1-flash)