### PR TITLE
docs(quest): plan hot-path CPU and copy-budget work

### DIFF
--- a/quest/m1/perf/README.md
+++ b/quest/m1/perf/README.md
@@ -41,6 +41,8 @@ backend we ship today.
 
 - [Frame send](/quest/m1/perf/frame-send.md) - a frame reaches quiche as zero-copy appends instead of two copying stream_send calls
 - [Ingest batch](/quest/m1/perf/ingest-batch.md) - relay ingest pays one lock, wake, and clock read per chunk burst instead of per chunk
+- [Stamp egress keep-alive once per fill](/quest/m1/perf/egress-keepalive.md) - fanout send does not clock every batched frame
+- [Decode without a second copy](/quest/m1/perf/coding-decode.md) - varint-length paths and byte strings copy payload once
 - [#3122](/quest/m1/perf/3122-moq-uring-2-5-of-relay-cpu-is-vdso-clock-reads-the-drive.md) - moq-uring: ~2.5% of relay CPU is vdso clock reads; the drive loop and its callers each re-read Instant::now()
 - [Cache shard](/quest/m1/perf/cache-shard.md) - stop hammering one process-global cache line and one clock read per frame from every worker
 - [Slot flags](/quest/m1/perf/slot-flags.md) - track delivery stops taking nested group locks under the track lock
@@ -63,3 +65,4 @@ backend we ship today.
 - [Worker metrics](/quest/m1/uring-metrics.md) - the counters these quests are judged by
 - [noq parity gate](/quest/m2/quic/noq-parity.md) - the benchmark that
   decides whether quiche can go, run on these worker primitives
+- [Origin lookup CPU](/quest/m2/origin-cpu/README.md) - announce/subscribe table, not uring

--- a/quest/m1/perf/README.md
+++ b/quest/m1/perf/README.md
@@ -41,8 +41,8 @@ backend we ship today.
 
 - [Frame send](/quest/m1/perf/frame-send.md) - a frame reaches quiche as zero-copy appends instead of two copying stream_send calls
 - [Ingest batch](/quest/m1/perf/ingest-batch.md) - relay ingest pays one lock, wake, and clock read per chunk burst instead of per chunk
-- [Stamp egress keep-alive once per fill](/quest/m1/perf/egress-keepalive.md) - fanout send does not clock every batched frame
-- [Decode without a second copy](/quest/m1/perf/coding-decode.md) - varint-length paths and byte strings copy payload once
+- [Egress cache refresh](/quest/m1/perf/egress-keepalive.md) - measure refresh costs while preserving slow-reader retention
+- [Owned decoding copies](/quest/m1/perf/coding-decode.md) - measure and reduce owned decode allocations and copies
 - [#3122](/quest/m1/perf/3122-moq-uring-2-5-of-relay-cpu-is-vdso-clock-reads-the-drive.md) - moq-uring: ~2.5% of relay CPU is vdso clock reads; the drive loop and its callers each re-read Instant::now()
 - [Cache shard](/quest/m1/perf/cache-shard.md) - stop hammering one process-global cache line and one clock read per frame from every worker
 - [Slot flags](/quest/m1/perf/slot-flags.md) - track delivery stops taking nested group locks under the track lock

--- a/quest/m1/perf/coding-decode.md
+++ b/quest/m1/perf/coding-decode.md
@@ -1,33 +1,32 @@
-# [S] Decode paths and byte strings without a second copy
+# [S] Reduce owned path and byte-string decode copies
 
 ## Goal
 
-Varint-length `Vec<u8>` / `String` / `Path` decode copies payload once.
-Fuzz and regression tests still pass.
+Reduce measured allocation and payload-copy costs for owned byte strings,
+strings, and paths without changing decoded values, errors, or wire bytes.
 
 ## Plan
 
-`coding/decode.rs` for `Vec<u8>`:
+`rs/moq-net/src/coding/decode.rs` decodes `Vec<u8>` through
+`Buf::copy_to_bytes` followed by `to_vec`; `String` consumes that vector.
+The first operation can return a shared view for a contiguous `Bytes` input,
+but may allocate and copy for another `Buf`. Do not count every call as a
+payload copy or assume a twofold improvement on production readers.
 
-```
-let bytes = buf.copy_to_bytes(size);  // Bytes alloc
-Ok(bytes.to_vec())                    // second copy
-```
+Benchmark the actual reader input types, contiguous and chained buffers,
+lengths 8 B through 1 KiB, and representative announcement messages. Compare
+safe copying into an initialized vector with the current implementation.
+Preserve bounds checks before allocation and UTF-8 validation. Keep owned
+return types; borrowed decoding and new public APIs are outside this quest.
 
-`String` then `from_utf8`s that vec; `Path` and `Cow<str>` go through
-`String`. `Bytes` decode already does a single `copy_to_bytes`. The TODO
-"Support borrowed strings" is only valid where the buffer outlives the
-message (the reader's `BytesMut` is not that).
-
-Decode `Vec<u8>` with `Buf::copy_to_slice` into `Vec::with_capacity`, or
-decode `Path`/`String` from `Bytes` plus a UTF-8 check without the extra
-copy.
-
-Acceptance: new `rs/moq-net/benches/coding.rs`: varint + path + string
-roundtrip, sizes 8 B–1 KiB, plus announce-message encode/decode. About 2×
-fewer payload copies on decode. `just rs fuzz path` (or the existing net
-fuzz targets) still pass.
+Register a Criterion target in `moq-net` for discovery by `just bench`.
+Report allocations, copied bytes, and throughput with paired base/current
+runs. Retain the current implementation if no useful win is measured.
+Add normal-CI regressions for fragmented input, truncated lengths/payloads,
+invalid UTF-8, empty values, and path normalization; run the existing net
+fuzz targets with `just rs fuzz path` and commit any regression inputs.
 
 ## Related
 
-- [Reader buffering](/quest/m2/stream-buffering.md) - JS `Reader.#fill`, not this
+- [Reader buffering](/quest/m2/stream-buffering.md) - JS receive assembly
+- [Benchmark comparisons](/quest/m2/performance-comparisons.md) - measurement conventions

--- a/quest/m1/perf/coding-decode.md
+++ b/quest/m1/perf/coding-decode.md
@@ -1,0 +1,33 @@
+# [S] Decode paths and byte strings without a second copy
+
+## Goal
+
+Varint-length `Vec<u8>` / `String` / `Path` decode copies payload once.
+Fuzz and regression tests still pass.
+
+## Plan
+
+`coding/decode.rs` for `Vec<u8>`:
+
+```
+let bytes = buf.copy_to_bytes(size);  // Bytes alloc
+Ok(bytes.to_vec())                    // second copy
+```
+
+`String` then `from_utf8`s that vec; `Path` and `Cow<str>` go through
+`String`. `Bytes` decode already does a single `copy_to_bytes`. The TODO
+"Support borrowed strings" is only valid where the buffer outlives the
+message (the reader's `BytesMut` is not that).
+
+Decode `Vec<u8>` with `Buf::copy_to_slice` into `Vec::with_capacity`, or
+decode `Path`/`String` from `Bytes` plus a UTF-8 check without the extra
+copy.
+
+Acceptance: new `rs/moq-net/benches/coding.rs`: varint + path + string
+roundtrip, sizes 8 B–1 KiB, plus announce-message encode/decode. About 2×
+fewer payload copies on decode. `just rs fuzz path` (or the existing net
+fuzz targets) still pass.
+
+## Related
+
+- [Reader buffering](/quest/m2/stream-buffering.md) - JS `Reader.#fill`, not this

--- a/quest/m1/perf/egress-keepalive.md
+++ b/quest/m1/perf/egress-keepalive.md
@@ -1,32 +1,35 @@
-# [S] Stamp egress keep-alive once per prefetch fill
+# [S] Measure and reduce egress cache-refresh overhead
 
 ## Goal
 
-Fanout send stamps cache expiry once per Prefetch/Buffer fill (or per
-`refresh_interval`), not once per batched frame. Group expiry tests still
-pass.
+Reduce measured cache-refresh overhead during batched delivery without
+expiring a group while a slow subscriber or FETCH reader is draining it.
+Retain the current behavior if the improvement is within measurement noise.
 
 ## Plan
 
-Prefetch fill already stamps once per 8 frames. `refresh_if_stale` only
-re-stamps after `refresh_interval`. The wire publishers then call
-`group.keep_alive()` per batched frame (`lite/publisher.rs`,
-`ietf/publisher.rs`), which always does `state.read().charge.refresh()` →
-`pool.stamp()` → `Instant::now()`. That undoes both amortizations on the
-fanout send path.
+`group::Consumer::keep_alive` takes a state read guard and calls
+`Charge::refresh`. Both lite and IETF publishers call it between completed
+frame writes. This protects a drain that spans longer than `latency_max`;
+a stamp only at batch fill is insufficient. `Charge::touch` already skips
+population accounting when the coarse timestamp has not advanced.
 
-Reuse `refresh_if_stale` (or stamp once per `poll_read_frames` fill) on
-both serve loops. Keep `slow_prefetch_reader_survives_expiry`.
+Measure read-guard, clock, and atomic costs separately for fast fanout and
+flow-controlled readers, including SUBSCRIBE and FETCH. Preserve per-frame
+liveness refresh unless an alternative proves the same retention behavior.
+Do not introduce another clock or pool-accounting mechanism: those belong to
+[Cache shard](/quest/m1/perf/cache-shard.md). Recheck its implementation
+before optimizing the remaining publisher overhead.
 
-This is model egress stamping, not ingest-batch (ingest lock/clock) and
-not uring #3122 (drive loop clock).
-
-Acceptance: existing `group_read_frames` / `track_fanout_group` plus a
-lite session drain. Clock reads / `charge.refresh` per delivered frame drop
-to ~1 per fill. No expiry regression.
+Extend the existing group and track Criterion targets and add a bounded
+session regression to normal CI. Keep
+`slow_batch_reader_survives_expiry_with_keep_alive`, and cover expiry scans
+while a batch drains, cancellation, and eventual expiry after reads stop.
+Report delivered bytes, refresh cost, CPU, and throughput for paired runs;
+fewer refresh calls alone are not evidence of a win.
 
 ## Related
 
-- [Ingest batch](/quest/m1/perf/ingest-batch.md) - ingest, not egress
-- [#3122](/quest/m1/perf/3122-moq-uring-2-5-of-relay-cpu-is-vdso-clock-reads-the-drive.md) - uring drive loop
-- [kio wake](/quest/m1/perf/kio-wake.md) - park/wake locks, not cache stamps
+- [Cache shard](/quest/m1/perf/cache-shard.md) - owns shared accounting and clock costs
+- [Ingest batch](/quest/m1/perf/ingest-batch.md) - ingest batching
+- [#3122](/quest/m1/perf/3122-moq-uring-2-5-of-relay-cpu-is-vdso-clock-reads-the-drive.md) - runtime clock costs

--- a/quest/m1/perf/egress-keepalive.md
+++ b/quest/m1/perf/egress-keepalive.md
@@ -1,0 +1,32 @@
+# [S] Stamp egress keep-alive once per prefetch fill
+
+## Goal
+
+Fanout send stamps cache expiry once per Prefetch/Buffer fill (or per
+`refresh_interval`), not once per batched frame. Group expiry tests still
+pass.
+
+## Plan
+
+Prefetch fill already stamps once per 8 frames. `refresh_if_stale` only
+re-stamps after `refresh_interval`. The wire publishers then call
+`group.keep_alive()` per batched frame (`lite/publisher.rs`,
+`ietf/publisher.rs`), which always does `state.read().charge.refresh()` →
+`pool.stamp()` → `Instant::now()`. That undoes both amortizations on the
+fanout send path.
+
+Reuse `refresh_if_stale` (or stamp once per `poll_read_frames` fill) on
+both serve loops. Keep `slow_prefetch_reader_survives_expiry`.
+
+This is model egress stamping, not ingest-batch (ingest lock/clock) and
+not uring #3122 (drive loop clock).
+
+Acceptance: existing `group_read_frames` / `track_fanout_group` plus a
+lite session drain. Clock reads / `charge.refresh` per delivered frame drop
+to ~1 per fill. No expiry regression.
+
+## Related
+
+- [Ingest batch](/quest/m1/perf/ingest-batch.md) - ingest, not egress
+- [#3122](/quest/m1/perf/3122-moq-uring-2-5-of-relay-cpu-is-vdso-clock-reads-the-drive.md) - uring drive loop
+- [kio wake](/quest/m1/perf/kio-wake.md) - park/wake locks, not cache stamps

--- a/quest/m2/README.md
+++ b/quest/m2/README.md
@@ -38,12 +38,12 @@ can act on. Each still carries its own plan and regression test.
 - [Benchmark comparisons](/quest/m2/performance-comparisons.md) - retained evidence, repeated paired runs, and uncertainty for performance claims
 - [Relay profiling](/quest/m2/performance-profiles.md) - reproducible CPU and allocation captures under the existing workloads
 - [Browser benchmarks](/quest/m2/browser-benchmarks.md) - measure JS transport, container, decode, and render costs in an identified browser
-- [JS publish and watch hot paths](/quest/m2/js-hotpath/README.md) - bound decode queues, drop extra copies, and stop one-stream-per-Opus-frame
+- [JS publish and watch hot paths](/quest/m2/js-hotpath/README.md) - measure decode retention, copies, header writes, and bounded audio groups
 - [Reader buffering](/quest/m2/stream-buffering.md) - measure and bound repeated prefix copying under fragmented input
 - [Traffic counter contention](/quest/m2/stats-contention.md) - quantify shared atomic accounting costs across fanout workers
 - [CMAF copies](/quest/m2/cmaf-copy-budget.md) - establish and reduce the browser container copy budget without changing ownership
-- [Mux and gateway copy budgets](/quest/m2/mux-copies/README.md) - import, export, and live HLS transmux copy coded bytes once
-- [Consume JSON snapshot patches](/quest/m2/json-merge.md) - catalog-sized deltas do not clone patch nodes into the baseline
+- [Mux and gateway copy budgets](/quest/m2/mux-copies/README.md) - measure and reduce payload copies in import, export, and live HLS
+- [Consume JSON snapshot patches](/quest/m2/json-merge.md) - measure consuming patches in snapshot encoding and decoding
 - [Relay memory](/quest/m2/relay-memory.md) - remeasure what an announcement costs after prefix routes
 - [Origin lookup CPU](/quest/m2/origin-cpu/README.md) - announce and subscribe stay cheap as the live advertisement set grows
 - [Route gauge](/quest/m2/route-gauge.md) - an operator sees how many routes a relay holds for a path

--- a/quest/m2/README.md
+++ b/quest/m2/README.md
@@ -42,6 +42,7 @@ can act on. Each still carries its own plan and regression test.
 - [Reader buffering](/quest/m2/stream-buffering.md) - measure and bound repeated prefix copying under fragmented input
 - [Traffic counter contention](/quest/m2/stats-contention.md) - quantify shared atomic accounting costs across fanout workers
 - [CMAF copies](/quest/m2/cmaf-copy-budget.md) - establish and reduce the browser container copy budget without changing ownership
+- [RTMP interleaving](/quest/m2/rtmp-interleaving.md) - isolate partial messages before optimizing assembly copies
 - [Mux and gateway copy budgets](/quest/m2/mux-copies/README.md) - measure and reduce payload copies in import, export, and live HLS
 - [Consume JSON snapshot patches](/quest/m2/json-merge.md) - measure consuming patches in snapshot encoding and decoding
 - [Relay memory](/quest/m2/relay-memory.md) - remeasure what an announcement costs after prefix routes

--- a/quest/m2/README.md
+++ b/quest/m2/README.md
@@ -38,10 +38,14 @@ can act on. Each still carries its own plan and regression test.
 - [Benchmark comparisons](/quest/m2/performance-comparisons.md) - retained evidence, repeated paired runs, and uncertainty for performance claims
 - [Relay profiling](/quest/m2/performance-profiles.md) - reproducible CPU and allocation captures under the existing workloads
 - [Browser benchmarks](/quest/m2/browser-benchmarks.md) - measure JS transport, container, decode, and render costs in an identified browser
+- [JS publish and watch hot paths](/quest/m2/js-hotpath/README.md) - bound decode queues, drop extra copies, and stop one-stream-per-Opus-frame
 - [Reader buffering](/quest/m2/stream-buffering.md) - measure and bound repeated prefix copying under fragmented input
 - [Traffic counter contention](/quest/m2/stats-contention.md) - quantify shared atomic accounting costs across fanout workers
 - [CMAF copies](/quest/m2/cmaf-copy-budget.md) - establish and reduce the browser container copy budget without changing ownership
+- [Mux and gateway copy budgets](/quest/m2/mux-copies/README.md) - import, export, and live HLS transmux copy coded bytes once
+- [Consume JSON snapshot patches](/quest/m2/json-merge.md) - catalog-sized deltas do not clone patch nodes into the baseline
 - [Relay memory](/quest/m2/relay-memory.md) - remeasure what an announcement costs after prefix routes
+- [Origin lookup CPU](/quest/m2/origin-cpu/README.md) - announce and subscribe stay cheap as the live advertisement set grows
 - [Route gauge](/quest/m2/route-gauge.md) - an operator sees how many routes a relay holds for a path
 - [PoP skipping](/quest/m2/pop-skipping/README.md) - short cold paths for unpopular broadcasts without losing warm backhaul dedup
 - [E2EE](/quest/m2/e2ee/README.md) - TypeScript and Rust peers interoperate over encrypted broadcasts no relay can decrypt

--- a/quest/m2/browser-benchmarks.md
+++ b/quest/m2/browser-benchmarks.md
@@ -36,4 +36,5 @@ an identified browser version on a real WebTransport connection.
 
 - [Reader buffering](/quest/m2/stream-buffering.md) - fragmented receive workloads
 - [CMAF copies](/quest/m2/cmaf-copy-budget.md) - container workload and ownership checks
+- [JS publish and watch hot paths](/quest/m2/js-hotpath/README.md) - first optimization consumers of this harness
 - [Benchmark comparisons](/quest/m2/performance-comparisons.md) - reporting conventions

--- a/quest/m2/cmaf-copy-budget.md
+++ b/quest/m2/cmaf-copy-budget.md
@@ -40,3 +40,4 @@ their share of end-to-end playback cost is not yet measured.
 
 - [Browser benchmarks](/quest/m2/browser-benchmarks.md) - container and playback measurement
 - [Reader buffering](/quest/m2/stream-buffering.md) - upstream payload assembly costs
+- [Mux and gateway copy budgets](/quest/m2/mux-copies/README.md) - the Rust container copies

--- a/quest/m2/js-hotpath/README.md
+++ b/quest/m2/js-hotpath/README.md
@@ -1,0 +1,24 @@
+# JS publish and watch hot paths
+
+## Goal
+
+Browser publish and watch drop extra GPU surfaces, PCM copies, per-frame
+allocs, and stream opens. Each child names a Bun microbench or a real
+WebTransport + WebCodecs measurement.
+[Browser benchmarks](/quest/m2/browser-benchmarks.md) is the harness to
+extend, not a second one.
+
+## Quests
+
+- [Bound watch video decode](/quest/m2/js-hotpath/watch-decode.md) - O(1) live `VideoFrame`s, not O(delay × fps)
+- [Watch audio copies](/quest/m2/js-hotpath/watch-audio.md) - `copyTo` into the SAB; mute disconnects the worklet
+- [IETF object header encode](/quest/m2/js-hotpath/ietf-object-encode.md) - no `WritableStream` per frame
+- [Coalesce stream writes](/quest/m2/js-hotpath/write-coalesce.md) - one WebTransport write per object
+- [Publish audio grouping](/quest/m2/js-hotpath/publish-audio.md) - stop opening one QUIC stream per Opus frame
+- [Capture worklet SAB](/quest/m2/js-hotpath/capture-sab.md) - no structured-clone of PCM every quantum
+
+## Related
+
+- [Browser benchmarks](/quest/m2/browser-benchmarks.md) - the runner
+- [Reader buffering](/quest/m2/stream-buffering.md) - JS Reader copies
+- [CMAF copies](/quest/m2/cmaf-copy-budget.md) - container samples

--- a/quest/m2/js-hotpath/README.md
+++ b/quest/m2/js-hotpath/README.md
@@ -2,23 +2,34 @@
 
 ## Goal
 
-Browser publish and watch drop extra GPU surfaces, PCM copies, per-frame
-allocs, and stream opens. Each child names a Bun microbench or a real
-WebTransport + WebCodecs measurement.
-[Browser benchmarks](/quest/m2/browser-benchmarks.md) is the harness to
-extend, not a second one.
+Measure and reduce browser decode retention, PCM copies, header allocations,
+and stream-open overhead while preserving public APIs and ownership contracts.
+
+## Plan
+
+Every child requires the shared browser benchmark harness before execution.
+Use the same fixtures and paired base/current measurements, record browser and
+codec configuration, and verify delivered output so dropped work cannot appear
+to be a speedup. Microbenchmarks may isolate costs in Bun; browser conclusions
+require real WebTransport or WebCodecs as appropriate. Wire bounded correctness
+coverage into CI, at least nightly, without imposing timing gates on shared
+runners. A measured no-win completes a quest with retained evidence.
+
+Each child can land independently once its required harness is available.
+Keep internal implementation choices private. Datagram delivery, public frame
+ownership changes, and payload headroom redesign are outside this line.
 
 ## Quests
 
-- [Bound watch video decode](/quest/m2/js-hotpath/watch-decode.md) - O(1) live `VideoFrame`s, not O(delay × fps)
-- [Watch audio copies](/quest/m2/js-hotpath/watch-audio.md) - `copyTo` into the SAB; mute disconnects the worklet
-- [IETF object header encode](/quest/m2/js-hotpath/ietf-object-encode.md) - no `WritableStream` per frame
-- [Coalesce stream writes](/quest/m2/js-hotpath/write-coalesce.md) - one WebTransport write per object
-- [Publish audio grouping](/quest/m2/js-hotpath/publish-audio.md) - stop opening one QUIC stream per Opus frame
-- [Capture worklet SAB](/quest/m2/js-hotpath/capture-sab.md) - no structured-clone of PCM every quantum
+- [Bound watch video decode](/quest/m2/js-hotpath/watch-decode.md) - bound decoded retention without changing public frame ownership
+- [Watch audio copies](/quest/m2/js-hotpath/watch-audio.md) - reduce PCM copies while preserving ring semantics
+- [IETF object properties](/quest/m2/js-hotpath/ietf-object-encode.md) - remove temporary property-encoding streams
+- [Coalesce stream writes](/quest/m2/js-hotpath/write-coalesce.md) - combine headers while retaining separate payload writes
+- [Publish audio grouping](/quest/m2/js-hotpath/publish-audio.md) - compare bounded groups on every supported transport
+- [Capture worklet storage](/quest/m2/js-hotpath/capture-sab.md) - measure a bounded shared capture ring against message copies
 
 ## Related
 
-- [Browser benchmarks](/quest/m2/browser-benchmarks.md) - the runner
-- [Reader buffering](/quest/m2/stream-buffering.md) - JS Reader copies
+- [Browser benchmarks](/quest/m2/browser-benchmarks.md) - shared prerequisite
+- [Reader buffering](/quest/m2/stream-buffering.md) - receive assembly
 - [CMAF copies](/quest/m2/cmaf-copy-budget.md) - container samples

--- a/quest/m2/js-hotpath/capture-sab.md
+++ b/quest/m2/js-hotpath/capture-sab.md
@@ -1,0 +1,24 @@
+# [M] Capture worklet writes PCM into a SharedArrayBuffer
+
+## Goal
+
+The COOP/COEP capture path has no per-quantum structured clone of PCM.
+The postMessage fallback still works. xruns do not increase.
+
+## Plan
+
+`js/publish/src/audio/capture-worklet.ts` `postMessage`s planar channels
+every ~128 samples (~2.7 ms at 48 kHz) with no transfer. Watch already has
+a lock-free SAB ring (`js/watch/src/audio/shared-ring-buffer.ts`).
+
+Reuse (or share) the watch SAB writer in the capture worklet; main thread
+reads. Keep postMessage fallback when COOP/COEP is off (same split as
+watch).
+
+Acceptance: browser publish, COOP on/off: audio-thread CPU, main-thread
+allocations, capture-to-encode latency. SAB path has no per-quantum clone.
+
+## Related
+
+- [Capture frame buffers](/quest/m2/capture-frame-buffers.md) - native X11/GDI, not this
+- [Watch audio copies](/quest/m2/js-hotpath/watch-audio.md) - the playback SAB

--- a/quest/m2/js-hotpath/capture-sab.md
+++ b/quest/m2/js-hotpath/capture-sab.md
@@ -1,24 +1,43 @@
-# [M] Capture worklet writes PCM into a SharedArrayBuffer
+# [M] Reduce capture worklet PCM message copies
 
 ## Goal
 
-The COOP/COEP capture path has no per-quantum structured clone of PCM.
-The postMessage fallback still works. xruns do not increase.
+Reduce measured capture PCM messaging cost in cross-origin-isolated browsers
+without increasing overruns, dropped samples, or capture-to-encode latency.
+The postMessage fallback remains supported.
 
 ## Plan
 
-`js/publish/src/audio/capture-worklet.ts` `postMessage`s planar channels
-every ~128 samples (~2.7 ms at 48 kHz) with no transfer. Watch already has
-a lock-free SAB ring (`js/watch/src/audio/shared-ring-buffer.ts`).
+`js/publish/src/audio/capture-worklet.ts` sends planar channels with
+postMessage each render quantum without transferring the buffers. Measure
+those copies and main-thread allocation before adding shared storage.
 
-Reuse (or share) the watch SAB writer in the capture worklet; main thread
-reads. Keep postMessage fallback when COOP/COEP is off (same split as
-watch).
+Use a bounded single-producer/single-consumer ring if measurements justify
+it. Reuse the watch ring's proven mechanics where suitable, but do not couple
+publish to the watch package or assume a playback timeline is a capture FIFO.
+Keep any shared helper internal. Publish availability only after all planes
+are written and never block the audio thread waiting for the main thread.
 
-Acceptance: browser publish, COOP on/off: audio-thread CPU, main-thread
-allocations, capture-to-encode latency. SAB path has no per-quantum clone.
+Use coalesced message notifications to wake the reader without cloning PCM;
+prove that a write racing the reader becoming idle cannot lose its wakeup.
+Specify bounded overflow handling with observable dropped-sample counts and
+preserve timestamp discontinuities. Cover channel/sample-rate changes,
+shutdown and restart, stale wakeups after context closure, reader stalls, and
+unavailable cross-origin isolation.
+Do not assume render quantum size is fixed; retain actual frame counts.
+
+Measure browser audio-thread CPU, allocation, copied bytes, queue occupancy,
+and capture-to-encode latency for isolated and fallback paths. Include a
+stalled-reader case and verify output samples/counts so discarded work cannot
+look like an optimization. Wire bounded correctness coverage into CI;
+retain the current path if the shared ring does not yield a useful win.
+No public API or wire change belongs to this quest.
+
+## Required
+
+- [Browser benchmarks](/quest/m2/browser-benchmarks.md) - shared measurement and browser CI harness
 
 ## Related
 
-- [Capture frame buffers](/quest/m2/capture-frame-buffers.md) - native X11/GDI, not this
-- [Watch audio copies](/quest/m2/js-hotpath/watch-audio.md) - the playback SAB
+- [Capture frame buffers](/quest/m2/capture-frame-buffers.md) - native capture storage
+- [Watch audio copies](/quest/m2/js-hotpath/watch-audio.md) - playback ring mechanics

--- a/quest/m2/js-hotpath/ietf-object-encode.md
+++ b/quest/m2/js-hotpath/ietf-object-encode.md
@@ -1,0 +1,26 @@
+# [S] Encode IETF object timestamps without a WritableStream
+
+## Goal
+
+IETF object header encode allocates nothing beyond the payload. Wire bytes
+do not change.
+
+## Plan
+
+`encodeObjectExtensions` in `js/net/src/ietf/object.ts` builds a `Writer`
+over a `WritableStream` for every object with a timestamp, pushes ~10-byte
+varints as chunks, concatenates, then writes length+bytes. Lite already
+writes timestamp varints straight onto the group stream.
+
+Encode properties into `Writer`'s 9-byte scratch (or a 16-byte buffer) the
+way `Writer.u62` already does. No stream, no concat.
+
+Acceptance: Bun microbench, `Frame.encode` × 10k at 1 KiB and 100 KiB
+payloads. Header encode allocs drop to ~0 beyond the payload. Optional
+browser IETF publish vs lite for GC. No wire-byte change.
+
+## Related
+
+- [CMAF copies](/quest/m2/cmaf-copy-budget.md) - container samples
+- [Reader buffering](/quest/m2/stream-buffering.md) - `Reader.#fill`
+- [Coalesce stream writes](/quest/m2/js-hotpath/write-coalesce.md) - the write syscall, not this header

--- a/quest/m2/js-hotpath/ietf-object-encode.md
+++ b/quest/m2/js-hotpath/ietf-object-encode.md
@@ -1,26 +1,35 @@
-# [S] Encode IETF object timestamps without a WritableStream
+# [S] Encode IETF object properties without a temporary stream
 
 ## Goal
 
-IETF object header encode allocates nothing beyond the payload. Wire bytes
-do not change.
+Reduce object-property encode allocations while emitting identical bytes
+for every supported IETF version and preserving the public Writer API.
 
 ## Plan
 
-`encodeObjectExtensions` in `js/net/src/ietf/object.ts` builds a `Writer`
-over a `WritableStream` for every object with a timestamp, pushes ~10-byte
-varints as chunks, concatenates, then writes length+bytes. Lite already
-writes timestamp varints straight onto the group stream.
+`encodeObjectExtensions` in `js/net/src/ietf/object.ts` creates a temporary
+Writer and WritableStream, copies their emitted chunks, and concatenates
+those chunks for timestamp-bearing objects. Replace that internal staging
+with bounded byte encoding after measuring it.
 
-Encode properties into `Writer`'s 9-byte scratch (or a 16-byte buffer) the
-way `Writer.u62` already does. No stream, no concat.
+Derive storage size from the actual fields and negotiated varint encoding;
+do not assume a fixed scratch size covers every supported version. Preserve
+absolute versus delta property IDs, timestamp conversion, absent timestamps,
+and numeric bounds. A reused buffer must remain owned until the outer write
+has completed; overlapping writes must not overwrite its bytes.
 
-Acceptance: Bun microbench, `Frame.encode` × 10k at 1 KiB and 100 KiB
-payloads. Header encode allocs drop to ~0 beyond the payload. Optional
-browser IETF publish vs lite for GC. No wire-byte change.
+Add version-matrix byte-equivalence tests to normal JS CI, including varint
+boundaries, maximum supported timestamps, missing properties, and write
+failures. Register a repeatable JS microbenchmark using the repository's
+benchmark conventions, with small audio and large video payloads and with
+and without timestamps. Measure property allocations separately from payload
+storage. Retain a measured no-win without replacing the implementation.
+Browser claims require a real WebTransport run in an identified browser.
+
+## Required
+
+- [Browser benchmarks](/quest/m2/browser-benchmarks.md) - shared measurement and browser CI harness
 
 ## Related
 
-- [CMAF copies](/quest/m2/cmaf-copy-budget.md) - container samples
-- [Reader buffering](/quest/m2/stream-buffering.md) - `Reader.#fill`
-- [Coalesce stream writes](/quest/m2/js-hotpath/write-coalesce.md) - the write syscall, not this header
+- [Coalesce stream writes](/quest/m2/js-hotpath/write-coalesce.md) - outer transport writes

--- a/quest/m2/js-hotpath/publish-audio.md
+++ b/quest/m2/js-hotpath/publish-audio.md
@@ -1,0 +1,28 @@
+# [M] Stop opening one QUIC stream per Opus frame
+
+## Goal
+
+Audio publish stream-open rate drops from ~50/s to GOP-like. Lag and drift
+are no worse than grouping. Loss is still concealed.
+
+## Plan
+
+`js/publish/src/audio/encoder.ts` writes each Opus frame as its own group
+so "the relay can forward it without waiting for a group boundary." At
+20 ms that is 50 unidirectional streams/s, competing with video GOPs for
+WebTransport stream credit (`Writer.tryOpen(..., waitUntilAvailable: false)`).
+
+Prefer datagrams when the session has them and the payload fits; otherwise
+a short-lived group of N frames or one audio group stream. Preserve PLC in
+the catalog.
+
+This is an intentional grouping change, not a micro-opt. Measure before
+committing to datagrams vs grouped streams.
+
+Acceptance: browser publish to a local relay: stream-open rate,
+`QuotaExceeded`/dropped groups, encoder input-to-output lag. Stream opens
+drop from ~50/s. Lag/drift no worse than grouping.
+
+## Related
+
+- [Browser benchmarks](/quest/m2/browser-benchmarks.md) - publish scenario

--- a/quest/m2/js-hotpath/publish-audio.md
+++ b/quest/m2/js-hotpath/publish-audio.md
@@ -1,28 +1,43 @@
-# [M] Stop opening one QUIC stream per Opus frame
+# [M] Reduce audio stream opens with bounded groups
 
 ## Goal
 
-Audio publish stream-open rate drops from ~50/s to GOP-like. Lag and drift
-are no worse than grouping. Loss is still concealed.
+Reduce audio stream-open overhead with bounded groups while retaining audio
+on lite, IETF, and qmux/WebSocket paths. Preserve public APIs and catalog
+semantics, and measure latency and loss behavior against one-frame groups.
 
 ## Plan
 
-`js/publish/src/audio/encoder.ts` writes each Opus frame as its own group
-so "the relay can forward it without waiting for a group boundary." At
-20 ms that is 50 unidirectional streams/s, competing with video GOPs for
-WebTransport stream credit (`Writer.tryOpen(..., waitUntilAvailable: false)`).
+`js/publish/src/audio/encoder.ts` publishes each Opus frame as its own group.
+At 20 ms per frame this opens about 50 streams per second. Establish whether
+stream credit or stream-open work is a meaningful cost before changing it.
 
-Prefer datagrams when the session has them and the payload fits; otherwise
-a short-lived group of N frames or one audio group stream. Preserve PLC in
-the catalog.
+Compare short, duration-bounded groups against the current baseline. Forward
+frames as they arrive rather than buffering an entire group before sending.
+Close the final partial group on stop and start a new group on discontinuity
+or configuration change. Bound group duration so late join and cancellation
+do not depend on an indefinitely open stream. Preserve packet-loss concealment
+metadata and the existing subscriber behavior at group boundaries.
 
-This is an intentional grouping change, not a micro-opt. Measure before
-committing to datagrams vs grouped streams.
+Use reliable grouped delivery on every supported transport. Datagram delivery
+is outside this quest: session support does not imply support at every hop or
+subscriber, and the watch path does not currently consume datagrams.
 
-Acceptance: browser publish to a local relay: stream-open rate,
-`QuotaExceeded`/dropped groups, encoder input-to-output lag. Stream opens
-drop from ~50/s. Lag/drift no worse than grouping.
+Measure stream opens, stream-credit failures, dropped groups, encoder lag,
+end-to-end latency, drift, late-join delay, and loss recovery under identical
+clean and impaired workloads. Include simultaneous video and stalled readers.
+Choose a group duration only from those comparisons; retain one-frame groups
+if the overhead saving does not justify the latency or loss tradeoff.
+
+Add CI regressions for final-group completion, discontinuity, late join,
+reconnect, and audio delivery on stream-only sessions. Run smoke-full for the
+cross-language delivery paths. Reuse the audio quality harness's metrics and
+impairment fixtures when available rather than creating a second definition.
+
+## Required
+
+- [Browser benchmarks](/quest/m2/browser-benchmarks.md) - shared measurement and browser CI harness
 
 ## Related
 
-- [Browser benchmarks](/quest/m2/browser-benchmarks.md) - publish scenario
+- [Audio quality harness](/quest/m2/audio-quality-harness/browser.md) - audio measurements

--- a/quest/m2/js-hotpath/watch-audio.md
+++ b/quest/m2/js-hotpath/watch-audio.md
@@ -1,30 +1,41 @@
-# [S] Copy decoded audio into the ring and idle the worklet when muted
+# [M] Reduce decoded audio copies into the playback ring
 
 ## Goal
 
-The SAB playback path allocates 0 PCM arrays per packet and copies at most
-once (twice on wrap). A muted or paused watch does not run
-`AudioWorkletProcessor.process`. Unmute stays under 50 ms.
+Reduce measured PCM allocation and copying on SAB playback without changing
+ring timing, channel behavior, or the postMessage fallback.
 
 ## Plan
 
-`#emit` in `js/watch/src/audio/decoder.ts` does `new Float32Array(frames)`
-per channel, `AudioData.copyTo`, then a JS loop into the SAB. Two full PCM
-copies plus allocs at packet rate.
+The decoder copies each AudioData plane into a temporary Float32Array before
+inserting it into the shared ring. Measure that cost separately from decode
+and worklet processing at representative channel counts and sample rates.
 
-`copyTo` into a wrap-aware SAB view. Keep the alloc path for the
-postMessage transport (it transfers those buffers).
+Design a ring-owned write operation rather than exposing its storage.
+Preserve trimming, gaps, late-packet handling, channel fill, and wrap logic.
+Map each planar channel explicitly through planeIndex, source frameOffset,
+frameCount, and the destination ring offset, including both wrap segments.
+Use distinct left/right samples to detect channel swaps in the wrap test.
+Publish the atomic write position only after all channel planes are complete;
+failed writes must not expose partially initialized audio. Verify whether
+AudioData.copyTo accepts the intended shared destination in supported browsers
+before choosing direct copies or a reusable staging buffer.
 
-`#runWorklet` always builds `AudioContext` + worklet. Mute sets `enabled`
-false (stops download) but the worklet stays connected. Disconnect the
-worklet or suspend the context when `enabled` is false; keep the module
-registered so unmute stays instant. The file already notes this.
+Keep the transferring postMessage path working when cross-origin isolation
+is unavailable. Cover wrap, partial capacity, discontinuities, missing
+channels, and concurrent worklet reads with correctness tests in CI. Use
+browser measurements for allocation volume, copied bytes, glitches, and
+latency; retain the existing path if no useful improvement is measured.
 
-Acceptance: browser stereo 48 kHz: allocation volume and copy bytes/s on
-the SAB path. Playwright, tab audible vs muted 10 s:
-`AudioWorkletProcessor.process` count ~0 when muted; unmute <50 ms.
+Mute/pause already disconnects the gain node from the destination in
+`audio/emitter.ts`. Additional suspension or graph teardown is not part of
+this copy optimization; require a reproduced residual CPU problem before
+planning that separately.
+
+## Required
+
+- [Browser benchmarks](/quest/m2/browser-benchmarks.md) - shared measurement and browser CI harness
 
 ## Related
 
-- [Time stretch](/quest/m2/watch-audio-time-stretch.md) - WSOLA in the worklet, not ingest copies
-- [Browser benchmarks](/quest/m2/browser-benchmarks.md) - harness
+- [Time stretch](/quest/m2/watch-audio-time-stretch.md) - playback processing

--- a/quest/m2/js-hotpath/watch-audio.md
+++ b/quest/m2/js-hotpath/watch-audio.md
@@ -1,0 +1,30 @@
+# [S] Copy decoded audio into the ring and idle the worklet when muted
+
+## Goal
+
+The SAB playback path allocates 0 PCM arrays per packet and copies at most
+once (twice on wrap). A muted or paused watch does not run
+`AudioWorkletProcessor.process`. Unmute stays under 50 ms.
+
+## Plan
+
+`#emit` in `js/watch/src/audio/decoder.ts` does `new Float32Array(frames)`
+per channel, `AudioData.copyTo`, then a JS loop into the SAB. Two full PCM
+copies plus allocs at packet rate.
+
+`copyTo` into a wrap-aware SAB view. Keep the alloc path for the
+postMessage transport (it transfers those buffers).
+
+`#runWorklet` always builds `AudioContext` + worklet. Mute sets `enabled`
+false (stops download) but the worklet stays connected. Disconnect the
+worklet or suspend the context when `enabled` is false; keep the module
+registered so unmute stays instant. The file already notes this.
+
+Acceptance: browser stereo 48 kHz: allocation volume and copy bytes/s on
+the SAB path. Playwright, tab audible vs muted 10 s:
+`AudioWorkletProcessor.process` count ~0 when muted; unmute <50 ms.
+
+## Related
+
+- [Time stretch](/quest/m2/watch-audio-time-stretch.md) - WSOLA in the worklet, not ingest copies
+- [Browser benchmarks](/quest/m2/browser-benchmarks.md) - harness

--- a/quest/m2/js-hotpath/watch-decode.md
+++ b/quest/m2/js-hotpath/watch-decode.md
@@ -1,36 +1,46 @@
-# [M] Bound watch video decode and stop cloning presented frames
+# [M] Bound decoded video waiting for presentation
 
 ## Goal
 
-Delayed playback holds O(1) decoded `VideoFrame`s, not O(delay × fps).
-Instant mode does not regress time-to-first-paint. The present path keeps
-at most one live frame plus at most one for TTV.
+Delayed playback retains a bounded amount of decoded video independent of
+the requested playback delay. Preserve public frame ownership and retention
+contracts, discontinuity handling, and instant-mode time to first paint.
 
 ## Plan
 
-`js/watch/src/video/decoder.ts`: the WebCodecs output callback is `async`
-and `await`s `sync.wait(timestamp)` while the original `VideoFrame` is
-still open (`close()` is in `finally`). The decoder does not wait on that
-promise. The submit loop calls `decoder.decode(chunk)` with no
-`decodeQueueSize` cap. Audio already parks encoded frames via `ring.wait()`
-before `AudioDecoder.decode`.
+The video decoder's async output callback can wait for presentation while
+holding a VideoFrame, but WebCodecs does not await that callback. Measure
+submitted chunks, decodeQueueSize, pending outputs, and retained frames
+separately to reproduce accumulation before changing scheduling.
 
-Per presented frame the output callback clones (sometimes twice: first
-frame plus after wait), `Decoder.#runActive` clones again, and the renderer
-clones again for `out.frame`.
+Keep encoded work upstream until it approaches the playhead and bound decode
+submission as well as pending decoded output. Define mandatory chunk-count,
+encoded-byte, and decoder-queue limits; stop pulling upstream when full and
+resume on progress or cancellation rather than accumulating a second queue. Account for codec dependencies,
+decoder reordering, and asynchronous output; decodeQueueSize alone is not the
+number of live VideoFrames. State the resulting bound, including required
+reorder/lookahead frames, rather than requiring exactly one decoded frame.
 
-Keep encoded chunks until the playhead is near (same backpressure as
-audio). Output callback should clone-or-drop the latest frame and return
-synchronously. Transfer ownership down the chain; the renderer draws then
-closes. Optionally pause submit when `decodeQueueSize` is above a small
-bound. Keep the first-frame clone for TTV.
+Preserve the retained out.frame signals exposed by the decoder and renderer.
+Keep the first-frame/instant behavior and close internal frames exactly once
+on presentation, replacement, failure, cancellation, and reset. Public clone
+removal or ownership redesign is outside this quest. Do not turn delayed
+playback into latest-frame dropping or deadlock a decoder awaiting more input.
 
-Acceptance: real-browser WebCodecs (Playwright / `just test` driver):
-1080p30, `delay=2s` and `instant`. Record `decodeQueueSize`, live
-`VideoFrame` count, heap, dropped frames, TTF. Delayed mode holds O(1)
-decoded frames. Instant mode TTF does not regress.
+Use real WebCodecs with representative codecs, 1080p30 delayed playback,
+instant mode, and a delay sweep. Measure live frames, memory, decode queue,
+presentation cadence, dropped frames, and time to first paint. Include
+pause/resume, end of input, codec change, and discontinuity while output is
+parked. Wire bounded correctness cases into browser CI and retain paired
+performance results; skipping frames cannot count as a performance win.
+
+Coordinate with #3056's reset/generation protection without absorbing its
+separate timeline change or weakening the current discontinuity behavior.
+
+## Required
+
+- [Browser benchmarks](/quest/m2/browser-benchmarks.md) - shared measurement and browser CI harness
 
 ## Related
 
-- [#3056](/quest/m1/3056-watch-video-decoder-captures-the-rewind-generation-at.md) - rewind/reset, not this queue
-- [Browser benchmarks](/quest/m2/browser-benchmarks.md) - harness
+- [#3056](/quest/m1/3056-watch-video-decoder-captures-the-rewind-generation-at.md) - discontinuity reset

--- a/quest/m2/js-hotpath/watch-decode.md
+++ b/quest/m2/js-hotpath/watch-decode.md
@@ -1,0 +1,36 @@
+# [M] Bound watch video decode and stop cloning presented frames
+
+## Goal
+
+Delayed playback holds O(1) decoded `VideoFrame`s, not O(delay × fps).
+Instant mode does not regress time-to-first-paint. The present path keeps
+at most one live frame plus at most one for TTV.
+
+## Plan
+
+`js/watch/src/video/decoder.ts`: the WebCodecs output callback is `async`
+and `await`s `sync.wait(timestamp)` while the original `VideoFrame` is
+still open (`close()` is in `finally`). The decoder does not wait on that
+promise. The submit loop calls `decoder.decode(chunk)` with no
+`decodeQueueSize` cap. Audio already parks encoded frames via `ring.wait()`
+before `AudioDecoder.decode`.
+
+Per presented frame the output callback clones (sometimes twice: first
+frame plus after wait), `Decoder.#runActive` clones again, and the renderer
+clones again for `out.frame`.
+
+Keep encoded chunks until the playhead is near (same backpressure as
+audio). Output callback should clone-or-drop the latest frame and return
+synchronously. Transfer ownership down the chain; the renderer draws then
+closes. Optionally pause submit when `decodeQueueSize` is above a small
+bound. Keep the first-frame clone for TTV.
+
+Acceptance: real-browser WebCodecs (Playwright / `just test` driver):
+1080p30, `delay=2s` and `instant`. Record `decodeQueueSize`, live
+`VideoFrame` count, heap, dropped frames, TTF. Delayed mode holds O(1)
+decoded frames. Instant mode TTF does not regress.
+
+## Related
+
+- [#3056](/quest/m1/3056-watch-video-decoder-captures-the-rewind-generation-at.md) - rewind/reset, not this queue
+- [Browser benchmarks](/quest/m2/browser-benchmarks.md) - harness

--- a/quest/m2/js-hotpath/write-coalesce.md
+++ b/quest/m2/js-hotpath/write-coalesce.md
@@ -1,0 +1,27 @@
+# [M] Coalesce per-frame WebTransport writes
+
+## Goal
+
+The data path does one `WritableStreamDefaultWriter.write` per object or
+frame. Payload is not copied except a small header prefix. Already-buffered
+single-chunk writes do not regress.
+
+## Plan
+
+Each media frame is 2–4 `await writer.write()` calls (timestamp, length,
+payload, sometimes extensions) in lite `#runGroup` and IETF `Frame.encode`.
+Scratch is reused only because writes are awaited, so headers cannot
+pipeline.
+
+`Writer.writeFrame(headerFields, payload)` that copies the ~1–20 header
+bytes in front of the payload, or a 2-chunk write if the platform supports
+it without copy. Keep the primitive `u53` API for control messages.
+
+Acceptance: real WebTransport, not Bun: audio 20 ms + video 30 fps. Count
+`write` calls and CPU. One write per object on the data path.
+
+## Related
+
+- [Reader buffering](/quest/m2/stream-buffering.md) - the read side
+- [IETF object header encode](/quest/m2/js-hotpath/ietf-object-encode.md) - header construction
+- [Browser benchmarks](/quest/m2/browser-benchmarks.md) - harness

--- a/quest/m2/js-hotpath/write-coalesce.md
+++ b/quest/m2/js-hotpath/write-coalesce.md
@@ -1,27 +1,40 @@
-# [M] Coalesce per-frame WebTransport writes
+# [M] Coalesce frame headers without copying payloads
 
 ## Goal
 
-The data path does one `WritableStreamDefaultWriter.write` per object or
-frame. Payload is not copied except a small header prefix. Already-buffered
-single-chunk writes do not regress.
+Reduce measured WebTransport write overhead by combining frame header fields
+while preserving payload ownership, public APIs, wire bytes, and backpressure.
 
 ## Plan
 
-Each media frame is 2–4 `await writer.write()` calls (timestamp, length,
-payload, sometimes extensions) in lite `#runGroup` and IETF `Frame.encode`.
-Scratch is reused only because writes are awaited, so headers cannot
-pipeline.
+Lite and IETF encode a frame through multiple awaited writes. Count writes
+for each negotiated version and frame shape rather than assuming one fixed
+count. Writer accepts a single Uint8Array, and payloads have no guaranteed
+prefix headroom, so a single contiguous header-plus-payload write generally
+requires copying the payload.
 
-`Writer.writeFrame(headerFields, payload)` that copies the ~1–20 header
-bytes in front of the payload, or a 2-chunk write if the platform supports
-it without copy. Keep the primitive `u53` API for control messages.
+Scope the optimization to internal header encoding: assemble header fields
+into an owned bounded buffer, write that header, then write the existing
+payload. Derive the bound from supported versions and fields. Retain scratch
+until its write settles; preserve ordering, typed transport errors, reset,
+and cancellation. Do not add an exported Writer method or change producer
+buffer ownership. Payload concatenation and headroom redesign are outside
+this quest.
 
-Acceptance: real WebTransport, not Bun: audio 20 ms + video 30 fps. Count
-`write` calls and CPU. One write per object on the data path.
+Compare write calls, header allocations, copied bytes, CPU, and latency on
+real WebTransport with small audio and large video payloads, including empty
+payloads and slow readers. Expect fewer header writes, not a universal single
+write per frame. Keep the current path if savings are not repeatable.
+
+Add CI byte-equivalence tests across supported versions and delayed/rejected
+write tests that catch scratch reuse, reordered bytes, and lost errors.
+Keep already-buffered writes and control-message behavior unchanged.
+
+## Required
+
+- [Browser benchmarks](/quest/m2/browser-benchmarks.md) - shared measurement and browser CI harness
 
 ## Related
 
-- [Reader buffering](/quest/m2/stream-buffering.md) - the read side
-- [IETF object header encode](/quest/m2/js-hotpath/ietf-object-encode.md) - header construction
-- [Browser benchmarks](/quest/m2/browser-benchmarks.md) - harness
+- [Reader buffering](/quest/m2/stream-buffering.md) - receive assembly
+- [IETF object properties](/quest/m2/js-hotpath/ietf-object-encode.md) - property construction

--- a/quest/m2/json-merge.md
+++ b/quest/m2/json-merge.md
@@ -1,24 +1,33 @@
-# [S] Consume JSON snapshot patches instead of cloning them
+# [S] Consume owned JSON snapshot patches
 
 ## Goal
 
-A snapshot consumer/encoder step on catalog-sized documents does not clone
-patch nodes into the baseline. Reconstructed `Value` is identical.
+Reduce measured patch-application allocations in snapshot encoding and
+decoding while preserving reconstructed values, emitted bytes, and errors.
 
 ## Plan
 
-After each delta, `moq-json` `snapshot/encoder.rs` calls
-`json_patch::merge(&Value)`, which clones patch nodes into `last`. The
-existing `rs/moq-json/benches/codec.rs` already compares `merge_owned` vs
-`json_patch::merge`. Production still uses the cloning merge.
+Both `snapshot/encoder.rs` and `snapshot/decoder.rs` in `moq-json` own a
+patch before passing it by reference to `json_patch::merge`. The encoder
+has already serialized that patch; the decoder has just parsed it.
+`rs/moq-json/benches/codec.rs` contains a consuming `merge_owned` comparison.
 
-Switch production merge to the consuming `merge_owned` already in the bench
-(or equivalent) only if `decode_patch` shows a real gap on catalog-sized
-fixtures. Do not change wire bytes.
+Measure complete encoder and decoder steps on catalog-sized documents,
+including ownership acquisition, serialization, compression, and parsing.
+Compare the existing `decode_patch`, consumer, and baseline cases. Keep
+fixture setup outside the timed interval, but do not exclude an ownership
+copy that production would need.
 
-Acceptance: existing `codec.rs` `decode_patch` / `consumer` / `baseline`.
-Consumer step down on `big_static` / hang-catalog-sized docs. Identical
-reconstructed `Value`. A measured no-win abandons the quest.
+Move a consuming merge into private production code only if end-to-end
+measurements justify it. Match merge-patch semantics for object deletion,
+nested objects, arrays, scalar replacement, null, and empty patches.
+Share the production helper with the benchmark rather than maintaining a
+second algorithm there. Preserve encoder grouping and compression state.
+
+Add equivalence regressions to normal CI, including compressed and plain
+multi-delta roundtrips. Retain paired allocations and throughput results;
+a measured no-win completes the quest without a production change.
+No public API or wire change is needed.
 
 ## Related
 

--- a/quest/m2/json-merge.md
+++ b/quest/m2/json-merge.md
@@ -1,0 +1,25 @@
+# [S] Consume JSON snapshot patches instead of cloning them
+
+## Goal
+
+A snapshot consumer/encoder step on catalog-sized documents does not clone
+patch nodes into the baseline. Reconstructed `Value` is identical.
+
+## Plan
+
+After each delta, `moq-json` `snapshot/encoder.rs` calls
+`json_patch::merge(&Value)`, which clones patch nodes into `last`. The
+existing `rs/moq-json/benches/codec.rs` already compares `merge_owned` vs
+`json_patch::merge`. Production still uses the cloning merge.
+
+Switch production merge to the consuming `merge_owned` already in the bench
+(or equivalent) only if `decode_patch` shows a real gap on catalog-sized
+fixtures. Do not change wire bytes.
+
+Acceptance: existing `codec.rs` `decode_patch` / `consumer` / `baseline`.
+Consumer step down on `big_static` / hang-catalog-sized docs. Identical
+reconstructed `Value`. A measured no-win abandons the quest.
+
+## Related
+
+- [Benchmark comparisons](/quest/m2/performance-comparisons.md) - reporting conventions

--- a/quest/m2/mux-copies/README.md
+++ b/quest/m2/mux-copies/README.md
@@ -1,0 +1,19 @@
+# Mux and gateway copy budgets
+
+## Goal
+
+Import, export, and live HLS transmux copy coded bytes once (or not at
+all when a `Bytes` view is already the hang frame). Each child lands a
+Criterion target under `moq-mux` (or the gateway crate) plus an identity
+check against the current output.
+
+[CMAF copies](/quest/m2/cmaf-copy-budget.md) is the JS container. This
+line is Rust.
+
+## Quests
+
+- [fMP4 import and fragment encode](/quest/m2/mux-copies/fmp4.md) - stop copying mdat two or three times
+- [CMAF hang groups passthrough](/quest/m2/mux-copies/cmaf-passthrough.md) - live HLS does not remux samples it already has
+- [Annex-B split](/quest/m2/mux-copies/annexb.md) - complete AUs are not copied per NAL
+- [MPEG-TS ingest](/quest/m2/mux-copies/ts.md) - no 188-byte bounce plus drain-shift
+- [FLV and RTMP tag bodies](/quest/m2/mux-copies/flv-rtmp.md) - one copy from tag buffer to hang payload

--- a/quest/m2/mux-copies/README.md
+++ b/quest/m2/mux-copies/README.md
@@ -2,18 +2,40 @@
 
 ## Goal
 
-Import, export, and live HLS transmux copy coded bytes once (or not at
-all when a `Bytes` view is already the hang frame). Each child lands a
-Criterion target under `moq-mux` (or the gateway crate) plus an identity
-check against the current output.
+Measure Rust container and gateway payload copying, then remove redundant work
+where the improvement survives representative benchmarks. Each child ships
+independently without changing public APIs, wire formats, or supported input.
 
-[CMAF copies](/quest/m2/cmaf-copy-budget.md) is the JS container. This
-line is Rust.
+## Plan
+
+Count copied payload bytes, header and metadata work, allocations, and retained
+buffer memory separately. A `Bytes` clone or slice is not a payload copy. Report
+CPU and allocation results for identical fixtures and caller chunk sizes before
+and after a change; do not promise a universal copy count or speedup in advance.
+
+Each child adds representative Criterion coverage discoverable by `just bench`
+and correctness fixtures wired into existing CI tests. Use the Nix shell and
+`just bench <base>` for comparison, keeping the same benchmark cases available
+on both measured implementations. Check A/A noise and an intentionally redundant
+copy variant so the benchmark can detect the proposed improvement. A new case
+without a base sample is not evidence of a speedup.
+
+A child may complete with retained benchmarks and documented findings if no
+repeatable improvement justifies the added complexity. Keep an optimization only
+when it improves the measured workload without a material regression in other
+covered shapes or retained memory. These are implementation optimizations;
+public API or wire changes require separate planning.
 
 ## Quests
 
-- [fMP4 import and fragment encode](/quest/m2/mux-copies/fmp4.md) - stop copying mdat two or three times
-- [CMAF hang groups passthrough](/quest/m2/mux-copies/cmaf-passthrough.md) - live HLS does not remux samples it already has
-- [Annex-B split](/quest/m2/mux-copies/annexb.md) - complete AUs are not copied per NAL
-- [MPEG-TS ingest](/quest/m2/mux-copies/ts.md) - no 188-byte bounce plus drain-shift
-- [FLV and RTMP tag bodies](/quest/m2/mux-copies/flv-rtmp.md) - one copy from tag buffer to hang payload
+- [fMP4 import](/quest/m2/mux-copies/fmp4.md) - measure and reduce mdat extraction copies
+- [fMP4 fragment encoding](/quest/m2/mux-copies/fmp4-encode.md) - measure and reduce sample concatenation and header work
+- [CMAF hang groups passthrough](/quest/m2/mux-copies/cmaf-passthrough.md) - avoid measured HLS sample remux work where semantics match
+- [Annex-B split](/quest/m2/mux-copies/annexb.md) - measure complete access-unit ingestion and assembly
+- [MPEG-TS ingest](/quest/m2/mux-copies/ts.md) - measure packet-buffer and reader-adapter copies
+- [FLV tag bodies](/quest/m2/mux-copies/flv-rtmp.md) - reduce duplicate tag-body and media-payload copies
+- [RTMP chunk assembly](/quest/m2/mux-copies/rtmp.md) - reduce unnecessary assembly of complete messages
+
+## Related
+
+- [CMAF copies](/quest/m2/cmaf-copy-budget.md) - browser container ownership and copying

--- a/quest/m2/mux-copies/annexb.md
+++ b/quest/m2/mux-copies/annexb.md
@@ -1,27 +1,36 @@
-# [M] Scan Annex-B in place on complete access units
+# [M] Measure and reduce complete access-unit assembly
 
 ## Goal
 
-The complete-AU path copies coded bytes at most once per AU. RTC ingest
-CPU drops without changing published Annex-B.
+Reduce measured Annex-B ingestion and assembly work on verified complete access
+units while preserving parsing, parameter sets, grouping, emitted media, and
+error behavior. Keep public APIs and wire formats unchanged.
 
 ## Plan
 
-`NalIterator` `copy_to_bytes` per NAL; `Split` copies each NAL into a new
-AU (`extend_from_slice` start code + nal). `Avc1::transform` clones the AU,
-splits, then length-prefixes. RTC H.264 `Bridge::push` runs Split on AUs
-str0m already reassembled.
+`Split::decode` copies input into its tail and assembles output access units.
+`NalIterator::copy_to_bytes` on `Bytes`/`BytesMut` splits shared storage, and
+`Bytes::clone` in `Avc1::transform` does not copy payload. Measure the actual tail,
+assembly, and length-prefix output copies rather than counting those operations
+as extra NAL copies.
 
-Scan in place; emit one AU `Bytes` slice when the AU is already contiguous.
-RTC/FLV/TS skip Split when the caller already has a complete AU (only
-inject missing SPS/PPS on keyframes). Length-prefix by rewriting prefixes
-in one buffer when 4-byte start codes already match.
+RTC's H.264 bridge calls Split on reassembled frames. Explore an internal path
+for known complete access units that preserves validation, SPS/PPS handling,
+keyframe detection, start-code normalization, and parameter-only behavior.
+Shared or differently sized start-code prefixes may still require an output
+copy. Do not introduce a new exported fast-path API.
 
-Acceptance: Criterion `h264.split` / `h264.avc1_transform` on a 1080p
-IDR+P GOP; RTC ingest microbench of `Bridge::push`. ≤1 copy of coded bytes
-per AU on the complete-AU path.
+TS currently assumes one access unit per video PES and calls Split then flush;
+retain its behavior unless fixtures establish that a proposed optimization is
+equivalent, including multiple units, partial input, and discontinuities. FLV
+already carries length-prefixed samples and does not run this splitter.
+
+Add Criterion Split, Avc1-transform, and RTC bridge cases for representative
+IDR/P frames, mixed start-code lengths, parameter-only input, and caller chunk
+sizes. Wire parsing/output equivalence and malformed/boundary regressions into
+existing mux/RTC CI tests. Follow the measurement and no-win completion rules
+in the [questline](/quest/m2/mux-copies/README.md).
 
 ## Related
 
-- [MPEG-TS ingest](/quest/m2/mux-copies/ts.md) - TS still runs Split today
-- [FLV and RTMP tag bodies](/quest/m2/mux-copies/flv-rtmp.md) - FLV also
+- [MPEG-TS ingest](/quest/m2/mux-copies/ts.md) - packet transport work outside access-unit assembly

--- a/quest/m2/mux-copies/annexb.md
+++ b/quest/m2/mux-copies/annexb.md
@@ -1,0 +1,27 @@
+# [M] Scan Annex-B in place on complete access units
+
+## Goal
+
+The complete-AU path copies coded bytes at most once per AU. RTC ingest
+CPU drops without changing published Annex-B.
+
+## Plan
+
+`NalIterator` `copy_to_bytes` per NAL; `Split` copies each NAL into a new
+AU (`extend_from_slice` start code + nal). `Avc1::transform` clones the AU,
+splits, then length-prefixes. RTC H.264 `Bridge::push` runs Split on AUs
+str0m already reassembled.
+
+Scan in place; emit one AU `Bytes` slice when the AU is already contiguous.
+RTC/FLV/TS skip Split when the caller already has a complete AU (only
+inject missing SPS/PPS on keyframes). Length-prefix by rewriting prefixes
+in one buffer when 4-byte start codes already match.
+
+Acceptance: Criterion `h264.split` / `h264.avc1_transform` on a 1080p
+IDR+P GOP; RTC ingest microbench of `Bridge::push`. ≤1 copy of coded bytes
+per AU on the complete-AU path.
+
+## Related
+
+- [MPEG-TS ingest](/quest/m2/mux-copies/ts.md) - TS still runs Split today
+- [FLV and RTMP tag bodies](/quest/m2/mux-copies/flv-rtmp.md) - FLV also

--- a/quest/m2/mux-copies/cmaf-passthrough.md
+++ b/quest/m2/mux-copies/cmaf-passthrough.md
@@ -1,30 +1,39 @@
-# [L] Splice CMAF hang groups into HLS segments
+# [L] Measure and reduce CMAF remux work in HLS
 
 ## Goal
 
-CMAF→CMAF HLS export does not demux+remux samples. CPU is at least 2×
-lower and coded bytes are copied at most once. Sample payload and `tfdt`
-match the remux path.
+Reduce measured CMAF-to-CMAF HLS export work by preserving existing fragments
+where their semantics match the requested segment. Keep public APIs, wire
+formats, supported input, and HLS behavior unchanged.
 
 ## Plan
 
-`moq-hls` `Rendition::segment` FETCHes every group, `Muxer::read` parses
-each moof+mdat into samples (`Bytes::copy_from_slice` per sample), then
-`encode_fragment` concatenates payloads and encodes the moof twice. fMP4
-ingest already published complete per-track fragments as hang frames.
+fMP4 import already publishes per-track CMAF fragments. `Muxer::init` preserves
+the catalog init with track-id normalization, but `Muxer::read` decodes fetched
+groups into media samples and HLS subsequently encodes fragments again. Measure
+that remaining work before choosing an internal passthrough path.
 
-For `Container::Cmaf`, splice/rewrite existing fragments (track id /
-`mfhd` / `tfdt` only). Keep the sample path for Legacy/LOC.
+Determine which valid fragment layouts can preserve payload ranges while
+normalizing the output's track identity and sequence. Account for data offsets
+and all affected boxes rather than assuming only `tfdt`, `mfhd`, and track id
+need attention. Preserve native timescale, decode and presentation timestamps,
+sample durations and flags, composition offsets, multiple fragments per group,
+and HLS segment boundaries and duration reporting. Keep the existing sample
+path for Legacy/LOC and valid inputs outside the optimization's eligibility.
+Malformed or unsupported data must retain existing errors; never recover from
+validation errors by switching paths or silently dropping data.
 
-Edge fan-out (N viewers × N transmux) is the downstream
-moq.pro `quest/m2/perf/live-hls-singleflight` quest. This is the remux
-inside one call.
+Compare equivalent HLS workloads before and after on audio/video segments using
+`rs/moq-mux/src/container/fmp4/test_data/bbb.mp4` and generated boundary cases.
+Wire semantic sample/timing equivalence, init consistency, multi-fragment groups,
+and malformed-input checks into existing mux/HLS CI tests. Container bytes need
+not be identical to ffmpeg output. Follow the measurement and no-win completion
+rules in the [questline](/quest/m2/mux-copies/README.md).
 
-Acceptance: Criterion `muxer.cmaf_passthrough` vs `muxer.sample_remux` on
-`bbb.mp4` segments (1 s / 6 s, 1080p + audio). Hang roundtrip: import fMP4
-→ HLS segment bytes vs `ffmpeg -c copy`. Byte-identical samples and `tfdt`.
+Request deduplication and downstream moq.pro fan-out are outside this quest.
 
 ## Related
 
-- [fMP4 import and fragment encode](/quest/m2/mux-copies/fmp4.md) - the remux path this skips
-- [CMAF copies](/quest/m2/cmaf-copy-budget.md) - JS
+- [Fragment encoding](/quest/m2/mux-copies/fmp4-encode.md) - the remux path this may bypass
+- [fMP4 import](/quest/m2/mux-copies/fmp4.md) - source-fragment ownership
+- [CMAF copies](/quest/m2/cmaf-copy-budget.md) - browser implementation

--- a/quest/m2/mux-copies/cmaf-passthrough.md
+++ b/quest/m2/mux-copies/cmaf-passthrough.md
@@ -1,0 +1,30 @@
+# [L] Splice CMAF hang groups into HLS segments
+
+## Goal
+
+CMAF→CMAF HLS export does not demux+remux samples. CPU is at least 2×
+lower and coded bytes are copied at most once. Sample payload and `tfdt`
+match the remux path.
+
+## Plan
+
+`moq-hls` `Rendition::segment` FETCHes every group, `Muxer::read` parses
+each moof+mdat into samples (`Bytes::copy_from_slice` per sample), then
+`encode_fragment` concatenates payloads and encodes the moof twice. fMP4
+ingest already published complete per-track fragments as hang frames.
+
+For `Container::Cmaf`, splice/rewrite existing fragments (track id /
+`mfhd` / `tfdt` only). Keep the sample path for Legacy/LOC.
+
+Edge fan-out (N viewers × N transmux) is the downstream
+moq.pro `quest/m2/perf/live-hls-singleflight` quest. This is the remux
+inside one call.
+
+Acceptance: Criterion `muxer.cmaf_passthrough` vs `muxer.sample_remux` on
+`bbb.mp4` segments (1 s / 6 s, 1080p + audio). Hang roundtrip: import fMP4
+→ HLS segment bytes vs `ffmpeg -c copy`. Byte-identical samples and `tfdt`.
+
+## Related
+
+- [fMP4 import and fragment encode](/quest/m2/mux-copies/fmp4.md) - the remux path this skips
+- [CMAF copies](/quest/m2/cmaf-copy-budget.md) - JS

--- a/quest/m2/mux-copies/flv-rtmp.md
+++ b/quest/m2/mux-copies/flv-rtmp.md
@@ -1,0 +1,25 @@
+# [S] One copy from FLV/RTMP tag body to hang payload
+
+## Goal
+
+FLV import and whole-message RTMP chunks copy coded bytes once, from the
+tag/chunk buffer to the hang payload.
+
+## Plan
+
+FLV `Bytes::copy_from_slice` of the tag body, then `write_video` copies
+`data` again. RTMP chunks `extend_from_slice` into `current_payload_data`
+(needed for split chunks); default chunk size makes this a second copy of
+every AVC NALU.
+
+`split_to` the tag from `BytesMut` and slice AVC payload without a second
+copy. For whole-message RTMP chunks, freeze the chunk bytes instead of
+copying into a new `BytesMut`.
+
+Acceptance: Criterion `flv.import` plus RTMP chunk deserializer on a 1080p
+FLV/AVC recording.
+
+## Related
+
+- [FLV script tags](/quest/m2/flv-script.md) - metadata, not media copies
+- [Annex-B split](/quest/m2/mux-copies/annexb.md) - NAL copies after the tag

--- a/quest/m2/mux-copies/flv-rtmp.md
+++ b/quest/m2/mux-copies/flv-rtmp.md
@@ -1,25 +1,29 @@
-# [S] One copy from FLV/RTMP tag body to hang payload
+# [S] Measure and reduce FLV tag-body copies
 
 ## Goal
 
-FLV import and whole-message RTMP chunks copy coded bytes once, from the
-tag/chunk buffer to the hang payload.
+Reduce measured FLV tag-body and media-payload copying without changing codecs,
+metadata, timestamps, published media, public APIs, or wire formats.
 
 ## Plan
 
-FLV `Bytes::copy_from_slice` of the tag body, then `write_video` copies
-`data` again. RTMP chunks `extend_from_slice` into `current_payload_data`
-(needed for split chunks); default chunk size makes this a second copy of
-every AVC NALU.
+FLV import copies a tag body from its input buffer and then copies the selected
+media payload again. Samples are already in their length-prefixed codec shape;
+there is no Annex-B splitter to remove on this path.
 
-`split_to` the tag from `BytesMut` and slice AVC payload without a second
-copy. For whole-message RTMP chunks, freeze the chunk bytes instead of
-copying into a new `BytesMut`.
+Investigate detaching a complete tag and sharing its media range through private
+parsing helpers. Preserve legacy and enhanced tags, multitrack routing,
+configuration records, timestamp offsets, partial-input behavior, and existing
+validation/errors. Measure retained backing-buffer memory when small samples
+share a large input allocation.
 
-Acceptance: Criterion `flv.import` plus RTMP chunk deserializer on a 1080p
-FLV/AVC recording.
+Add Criterion import cases for representative legacy AVC/AAC and enhanced tags
+with varied input chunk sizes. Wire payload/catalog/timing equivalence and
+fragmented/malformed-tag fixtures into existing mux CI tests. Follow the
+measurement and no-win completion rules in the
+[questline](/quest/m2/mux-copies/README.md).
 
 ## Related
 
-- [FLV script tags](/quest/m2/flv-script.md) - metadata, not media copies
-- [Annex-B split](/quest/m2/mux-copies/annexb.md) - NAL copies after the tag
+- [FLV script tags](/quest/m2/flv-script.md) - independent metadata work
+- [RTMP chunk assembly](/quest/m2/mux-copies/rtmp.md) - independently shippable transport work

--- a/quest/m2/mux-copies/fmp4-encode.md
+++ b/quest/m2/mux-copies/fmp4-encode.md
@@ -1,0 +1,27 @@
+# [M] Measure and reduce fMP4 fragment encoding copies
+
+## Goal
+
+Reduce measured sample concatenation and fragment-header work without changing
+encoded media semantics, public APIs, or the wire format.
+
+## Plan
+
+`container/fmp4/mod.rs` collects frame payloads into an mdat Vec, encodes moof
+once to determine offsets, and encodes it again before copying mdat into the
+output. Measure payload copies separately from metadata cloning and encoding.
+
+Investigate sizing or reserving the header and copying sample payloads directly
+into the final output. Preserve checked sizes and offsets, decode and presentation
+timing, flags, duration handling, and existing errors. Avoid duplicating box
+layout logic unless its maintenance cost is justified by the measurements.
+
+Add Criterion cases with 1, 30, and 180 samples, audio and video, and differing
+sample sizes. Wire round-trip semantic checks and overflow, duration, and offset
+regressions into existing mux tests. Follow the measurement and no-win completion
+rules in the [questline](/quest/m2/mux-copies/README.md).
+
+## Related
+
+- [fMP4 import](/quest/m2/mux-copies/fmp4.md) - separately shippable importer work
+- [CMAF passthrough](/quest/m2/mux-copies/cmaf-passthrough.md) - may bypass this encoder for eligible HLS inputs

--- a/quest/m2/mux-copies/fmp4.md
+++ b/quest/m2/mux-copies/fmp4.md
@@ -1,30 +1,31 @@
-# [M] Cut fMP4 import and fragment-encode copies
+# [M] Measure and reduce fMP4 import copies
 
 ## Goal
 
-Coded bytes are copied once into the hang frame on import (zero extra if
-the sliced `Bytes` can be the frame). `encode_fragment` allocates once for
-the output fragment. Groups, `tfdt`, and catalog do not change.
+Reduce measured payload copying during fMP4 import while preserving published
+CMAF fragments' media, groups, timing, catalog, and input validation. Keep the
+public API and wire format unchanged.
 
 ## Plan
 
-`container/fmp4/import.rs` `drain` fully decodes `Any::Mdat` (owned
-`mdat.data`) and `consumed.slice` of the same bytes. `extract` then
-`track_mdat_data.to_vec()` and re-encodes moof twice for `data_offset`.
+`container/fmp4/import.rs` decodes an owned `Any::Mdat`, retains a view of the
+consumed input, copies each selected track range into `Mdat::data`, and encodes
+that data into the output fragment. Measure these distinct ownership steps.
 
-`encode_fragment` flattens payloads with `flat_map(|f| f.payload.iter().copied())`,
-encodes moof, clears, encodes again, and clones `TrunEntry`.
+Investigate reading mdat ranges from shared input and writing selected payloads
+directly into the final fragment. Do not assume header rewriting can share a
+single contiguous output without copying. Preserve box-boundary validation,
+track selection, multi-traf/trun offsets, sample flags, durations, composition
+offsets, native timescales, and existing malformed-input errors. Check retained
+input-buffer memory as well as allocation counts.
 
-Parse moof only; treat mdat as a `Bytes` view. Rewrite offsets without
-cloning sample bytes when the range is already contiguous. Size the moof
-from `Trun` layout (or encode headers into a reserved prefix); write mdat
-with `extend_from_slice`.
-
-Acceptance: Criterion `fmp4.import` and `fmp4.encode_fragment` on
-`test_data/bbb.mp4` and a multi-traf file; 1 / 30 / 180 samples. Count
-copied payload bytes. No change in groups/`tfdt`/catalog.
+Add Criterion import cases using
+`rs/moq-mux/src/container/fmp4/test_data/bbb.mp4` plus generated multi-traf/trun
+and fragmented-input fixtures. Wire semantic comparison and malformed-input
+regressions into the existing mux tests. Follow the measurement and no-win
+completion rules in the [questline](/quest/m2/mux-copies/README.md).
 
 ## Related
 
-- [CMAF copies](/quest/m2/cmaf-copy-budget.md) - JS encode/decode
-- [CMAF hang groups passthrough](/quest/m2/mux-copies/cmaf-passthrough.md) - skip remux entirely on the HLS path
+- [Fragment encoding](/quest/m2/mux-copies/fmp4-encode.md) - separately shippable exporter work
+- [CMAF passthrough](/quest/m2/mux-copies/cmaf-passthrough.md) - HLS consumer of imported fragments

--- a/quest/m2/mux-copies/fmp4.md
+++ b/quest/m2/mux-copies/fmp4.md
@@ -1,0 +1,30 @@
+# [M] Cut fMP4 import and fragment-encode copies
+
+## Goal
+
+Coded bytes are copied once into the hang frame on import (zero extra if
+the sliced `Bytes` can be the frame). `encode_fragment` allocates once for
+the output fragment. Groups, `tfdt`, and catalog do not change.
+
+## Plan
+
+`container/fmp4/import.rs` `drain` fully decodes `Any::Mdat` (owned
+`mdat.data`) and `consumed.slice` of the same bytes. `extract` then
+`track_mdat_data.to_vec()` and re-encodes moof twice for `data_offset`.
+
+`encode_fragment` flattens payloads with `flat_map(|f| f.payload.iter().copied())`,
+encodes moof, clears, encodes again, and clones `TrunEntry`.
+
+Parse moof only; treat mdat as a `Bytes` view. Rewrite offsets without
+cloning sample bytes when the range is already contiguous. Size the moof
+from `Trun` layout (or encode headers into a reserved prefix); write mdat
+with `extend_from_slice`.
+
+Acceptance: Criterion `fmp4.import` and `fmp4.encode_fragment` on
+`test_data/bbb.mp4` and a multi-traf file; 1 / 30 / 180 samples. Count
+copied payload bytes. No change in groups/`tfdt`/catalog.
+
+## Related
+
+- [CMAF copies](/quest/m2/cmaf-copy-budget.md) - JS encode/decode
+- [CMAF hang groups passthrough](/quest/m2/mux-copies/cmaf-passthrough.md) - skip remux entirely on the HLS path

--- a/quest/m2/mux-copies/rtmp.md
+++ b/quest/m2/mux-copies/rtmp.md
@@ -1,0 +1,28 @@
+# [M] Measure and reduce RTMP message assembly copies
+
+## Goal
+
+Reduce measured redundant assembly of complete RTMP messages while preserving
+chunk parsing, message delivery, public APIs, and the wire format.
+
+## Plan
+
+The chunk deserializer splits bytes from its input buffer and copies them into
+`current_payload_data`. Assembly is necessary across split chunks; a complete
+message already held contiguously may permit a shared payload instead. Measure
+both cases without assuming the negotiated chunk size fits typical video frames.
+
+Keep the optimization private. Preserve chunk-stream interleaving, extended
+timestamps, negotiated chunk-size changes, partial network reads, malformed
+input errors, and ordering. Bound retained backing-buffer memory and verify that
+later input-buffer mutation cannot alter delivered message bytes.
+
+Add Criterion cases for complete messages, split messages, and interleaved chunk
+streams with representative audio/video sizes. Wire message/timestamp equality,
+ownership, and chunk-boundary regressions into existing RTMP CI tests. Follow
+the measurement and no-win completion rules in the
+[questline](/quest/m2/mux-copies/README.md).
+
+## Related
+
+- [FLV tag bodies](/quest/m2/mux-copies/flv-rtmp.md) - independent container parsing copies

--- a/quest/m2/mux-copies/rtmp.md
+++ b/quest/m2/mux-copies/rtmp.md
@@ -12,6 +12,10 @@ The chunk deserializer splits bytes from its input buffer and copies them into
 message already held contiguously may permit a shared payload instead. Measure
 both cases without assuming the negotiated chunk size fits typical video frames.
 
+The current parser has one assembly buffer across chunk streams. Complete the
+interleaving prerequisite before collecting the optimization baseline, so both
+measured implementations deliver correct interleaved messages.
+
 Keep the optimization private. Preserve chunk-stream interleaving, extended
 timestamps, negotiated chunk-size changes, partial network reads, malformed
 input errors, and ordering. Bound retained backing-buffer memory and verify that
@@ -22,6 +26,19 @@ streams with representative audio/video sizes. Wire message/timestamp equality,
 ownership, and chunk-boundary regressions into existing RTMP CI tests. Follow
 the measurement and no-win completion rules in the
 [questline](/quest/m2/mux-copies/README.md).
+
+Add a long-running retention test with complete-message churn, interleaved
+messages, and a small live payload held while large input batches are released.
+Measure unique backing allocation capacity, including storage pinned by returned
+payloads, after processing and after dropping them. Before accepting shared
+payloads, check in a numeric byte ceiling for each fixed fixture and assert it
+in CI; the ceiling must not grow with the number of completed messages. Account
+for active reassembly separately. Copy out an eligible payload when sharing
+would exceed the retention ceiling, and preserve isolation from later writes.
+
+## Required
+
+- [RTMP interleaving](/quest/m2/rtmp-interleaving.md) - correct independent message assembly before measuring copies
 
 ## Related
 

--- a/quest/m2/mux-copies/ts.md
+++ b/quest/m2/mux-copies/ts.md
@@ -1,25 +1,39 @@
-# [M] Cut MPEG-TS ingest copies
+# [M] Measure and reduce MPEG-TS packet copies
 
 ## Goal
 
-TS import is linear in input size without extra 188-byte copies or
-`scratch.drain` shifts. Tracks, PTS, and SCTE-35 match today.
+Reduce measured packet-buffer and reader-adapter work during TS import while
+preserving tracks, timing, metadata, input recovery, and published media. Keep
+public APIs and wire formats unchanged.
 
 ## Plan
 
-SRT `feed` → `scratch.extend_from_slice` → copy 188-byte `pkt` →
-`Feed.data.extend_from_slice` → `Read::read` copies into mpeg2ts.
-`scratch.drain(..off)` shifts the tail. Then H.264 Split copies NALs
-again.
+`Import::decode` copies caller input into scratch, makes a 188-byte packet copy,
+and copies that packet through the shared Feed adapter into mpeg2ts. Its
+`scratch.drain(..off)` runs once per decode after whole packets have been
+consumed, usually shifting less than 188 trailing bytes; this is not evidence
+of quadratic behavior. Measure copy costs with varied caller chunk sizes.
 
-Cursor over scratch (no drain). Feed mpeg2ts from `&pkt` without the mutex
-`Feed` bounce, or parse PES without the `Read` adapter. Keep Split changes
-in [annexb](/quest/m2/mux-copies/annexb.md).
+Investigate reducing packet and Feed copies while preserving the persistent
+reader's PAT/PMT state and routing. Keep resynchronization, continuity and
+discontinuity handling, partial packets, PES assembly, EOF behavior, and
+SCTE-35/private sections intact. Do not replace the parser or bypass its
+validation merely to meet an assumed copy budget. Annex-B assembly is separate.
 
-Acceptance: Criterion `ts.import` on `bbb.ts` / `kyrion_mpeg2av_ac3.ts`;
-SRT ingest of the same bytes. Compare CPU vs `ffmpeg -c copy` to null.
+Add Criterion cases using
+`rs/moq-mux/src/container/ts/test_data/bbb.ts` and
+`rs/moq-mux/src/container/ts/test_data/kyrion_mpeg2av_ac3.ts`, including small,
+packet-aligned, and large chunks. Wire published-media/timestamp/metadata
+comparisons and damaged/fragmented-input regressions into existing mux CI tests.
+Exercise SRT integration if its code changes. Compare identical before/after
+workloads; ffmpeg numbers are contextual, not a correctness or speedup gate.
+Follow the measurement and no-win completion rules in the
+[questline](/quest/m2/mux-copies/README.md).
+
+Include a long-running feed that bounds retained scratch storage after consumed
+packets are reclaimed; cursor-based parsing must not retain the whole stream.
 
 ## Related
 
-- [#3489](/quest/m2/3489-ts-import-stream-liveness.md) - liveness, not copies
-- [Annex-B split](/quest/m2/mux-copies/annexb.md) - NAL copies after PES
+- [TS stream liveness](/quest/m2/3489-ts-import-stream-liveness.md) - independent observability work
+- [Annex-B assembly](/quest/m2/mux-copies/annexb.md) - codec work after PES reassembly

--- a/quest/m2/mux-copies/ts.md
+++ b/quest/m2/mux-copies/ts.md
@@ -1,0 +1,25 @@
+# [M] Cut MPEG-TS ingest copies
+
+## Goal
+
+TS import is linear in input size without extra 188-byte copies or
+`scratch.drain` shifts. Tracks, PTS, and SCTE-35 match today.
+
+## Plan
+
+SRT `feed` → `scratch.extend_from_slice` → copy 188-byte `pkt` →
+`Feed.data.extend_from_slice` → `Read::read` copies into mpeg2ts.
+`scratch.drain(..off)` shifts the tail. Then H.264 Split copies NALs
+again.
+
+Cursor over scratch (no drain). Feed mpeg2ts from `&pkt` without the mutex
+`Feed` bounce, or parse PES without the `Read` adapter. Keep Split changes
+in [annexb](/quest/m2/mux-copies/annexb.md).
+
+Acceptance: Criterion `ts.import` on `bbb.ts` / `kyrion_mpeg2av_ac3.ts`;
+SRT ingest of the same bytes. Compare CPU vs `ffmpeg -c copy` to null.
+
+## Related
+
+- [#3489](/quest/m2/3489-ts-import-stream-liveness.md) - liveness, not copies
+- [Annex-B split](/quest/m2/mux-copies/annexb.md) - NAL copies after PES

--- a/quest/m2/origin-cpu/README.md
+++ b/quest/m2/origin-cpu/README.md
@@ -1,0 +1,15 @@
+# Origin lookup CPU
+
+## Goal
+
+Announce, subscribe, and exact-path resolve stay cheap as the live
+advertisement set grows. Chat (`moq-bench/config/announce.toml`) and a
+cluster mesh (one cursor per peer) are the shapes this must not explode on.
+
+[Relay memory](/quest/m2/relay-memory.md) is bytes per announcement. This
+line is lookup CPU.
+
+## Quests
+
+- [Index the origin route table](/quest/m2/origin-cpu/origin-index.md) - `best_route` and cursor sync stop scanning every live advertisement
+- [Origin local tree](/quest/m2/origin-cpu/origin-tree.md) - exact-path resolve does not lock and hash every path segment

--- a/quest/m2/origin-cpu/README.md
+++ b/quest/m2/origin-cpu/README.md
@@ -2,14 +2,20 @@
 
 ## Goal
 
-Announce, subscribe, and exact-path resolve stay cheap as the live
-advertisement set grows. Chat (`moq-bench/config/announce.toml`) and a
-cluster mesh (one cursor per peer) are the shapes this must not explode on.
+Measure and reduce origin lookup and update CPU under many broadcasts,
+alternative sources, and announcement consumers. Separate path traversal,
+route selection, and output-sized replay costs before changing structures.
 
-[Relay memory](/quest/m2/relay-memory.md) is bytes per announcement. This
-line is lookup CPU.
+Each quest is independently shippable and retains paired measurements and
+CI correctness coverage. Share registered benchmark fixtures when available;
+a useful finding that no optimization is warranted also completes a quest.
 
 ## Quests
 
-- [Index the origin route table](/quest/m2/origin-cpu/origin-index.md) - `best_route` and cursor sync stop scanning every live advertisement
-- [Origin local tree](/quest/m2/origin-cpu/origin-tree.md) - exact-path resolve does not lock and hash every path segment
+- [Route-selection CPU](/quest/m2/origin-cpu/origin-index.md) - measure and optimize per-broadcast source selection
+- [Origin local tree](/quest/m2/origin-cpu/origin-tree.md) - measure and optimize path traversal under churn
+
+## Related
+
+- [Relay memory](/quest/m2/relay-memory.md) - memory rather than lookup CPU
+- [Path patterns](/quest/m2/path-patterns/README.md) - matching and authorization contracts

--- a/quest/m2/origin-cpu/origin-index.md
+++ b/quest/m2/origin-cpu/origin-index.md
@@ -1,0 +1,39 @@
+# [L] Index the origin route table
+
+## Goal
+
+`best_route`, announce cursor replay, and `request_broadcast` are logarithmic
+(or otherwise sublinear) in the number of live advertisements. Hop/cost/
+split-horizon ranking does not change.
+
+## Plan
+
+`OriginState::routes` is a `Vec<RouteEntry>` with the comment "Scans are
+linear: the table holds one entry per live advertisement."
+`best_route` collects every covering entry into a `Vec` then takes longest
+prefix plus `route_order`. Every announce runs `sync_route` across all
+cursors, and `sync_cursor` re-filters the entire list.
+
+Keep one source of truth, but index by path prefix (radix / segment tree /
+`BTreeMap` of prefixes with a covering-chain walk). `best_route` walks the
+path's prefix chain. `sync_route` recomputes only cursors whose scopes
+intersect the changed prefix. Keep `route_order` (cost, hop length, FNV,
+newest id). Do not shard the origin across workers (out of scope in
+[perf](/quest/m1/perf/README.md)).
+
+Fold the empty `HashSet::new()` on the miss path (`request_broadcast`) into
+the same signature change: `best_route` takes `Option<&HashSet<u64>>` or a
+static empty set.
+
+Acceptance: new Criterion target `rs/moq-net/benches/origin.rs`: announce N
+prefixes, then `best_route` / `request_broadcast` / cursor replay; sweep
+N = 1k/10k/100k, cursors = 1/8/64. Plus `just bench` with
+`rs/moq-bench/config/announce.toml`. Lookup and announce CPU flat in N (or
+log N). Hop/cost/split-horizon tests in `origin.rs` still pass. Zero alloc
+on the common "no refused ids" lookup.
+
+## Related
+
+- [Relay memory](/quest/m2/relay-memory.md) - bytes per announcement, not this CPU
+- [Route gauge](/quest/m2/route-gauge.md) - operator visibility
+- [Origin local tree](/quest/m2/origin-cpu/origin-tree.md) - the other origin structure

--- a/quest/m2/origin-cpu/origin-index.md
+++ b/quest/m2/origin-cpu/origin-index.md
@@ -1,39 +1,37 @@
-# [L] Index the origin route table
+# [M] Measure and reduce origin route-selection CPU
 
 ## Goal
 
-`best_route`, announce cursor replay, and `request_broadcast` are logarithmic
-(or otherwise sublinear) in the number of live advertisements. Hop/cost/
-split-horizon ranking does not change.
+Reduce demonstrated route-selection overhead while preserving source
+identity, ranking, exclusion, failover, and announcement behavior.
 
 ## Plan
 
-`OriginState::routes` is a `Vec<RouteEntry>` with the comment "Scans are
-linear: the table holds one entry per live advertisement."
-`best_route` collects every covering entry into a `Vec` then takes longest
-prefix plus `route_order`. Every announce runs `sync_route` across all
-cursors, and `sync_cursor` re-filters the entire list.
+The current `rs/moq-net/src/model/origin.rs` stores alternative sources in
+`FrontState::routes` per broadcast. `FrontState::best_route` selects from
+that set; it does not scan a global advertisement table. Trace current
+lookup, source-update, and announcement paths before choosing an index.
 
-Keep one source of truth, but index by path prefix (radix / segment tree /
-`BTreeMap` of prefixes with a covering-chain walk). `best_route` walks the
-path's prefix chain. `sync_route` recomputes only cursors whose scopes
-intersect the changed prefix. Keep `route_order` (cost, hop length, FNV,
-newest id). Do not shard the origin across workers (out of scope in
-[perf](/quest/m1/perf/README.md)).
+Add a registered Criterion target using public origin operations. Sweep
+broadcast count, sources per broadcast, cursor count, and update churn
+independently. Separate initial replay from incremental notification and
+exact-path lookup; replay must pay for every result it emits. Use
+`rs/moq-bench/config/announce.toml` to check that microbenchmark wins survive relay load.
 
-Fold the empty `HashSet::new()` on the miss path (`request_broadcast`) into
-the same signature change: `best_route` takes `Option<&HashSet<u64>>` or a
-static empty set.
+Optimize only a measured bottleneck. Compare a retained linear scan at small
+source counts with any proposed cache or index, accounting for invalidation,
+extra memory, and update cost. Preserve the complete current `route_order`
+and exclusion rules. No replacement matcher, route semantics, public API,
+or wire change belongs here.
 
-Acceptance: new Criterion target `rs/moq-net/benches/origin.rs`: announce N
-prefixes, then `best_route` / `request_broadcast` / cursor replay; sweep
-N = 1k/10k/100k, cursors = 1/8/64. Plus `just bench` with
-`rs/moq-bench/config/announce.toml`. Lookup and announce CPU flat in N (or
-log N). Hop/cost/split-horizon tests in `origin.rs` still pass. Zero alloc
-on the common "no refused ids" lookup.
+Acceptance includes paired CPU/allocation results and CI regressions for
+source replacement and removal, route changes, exclusion changes, failover, and scoped
+announcement delivery. A measured no-win closes the quest with retained
+evidence. Do not claim sublinear replay when the result set grows linearly.
 
 ## Related
 
-- [Relay memory](/quest/m2/relay-memory.md) - bytes per announcement, not this CPU
-- [Route gauge](/quest/m2/route-gauge.md) - operator visibility
-- [Origin local tree](/quest/m2/origin-cpu/origin-tree.md) - the other origin structure
+- [Relay memory](/quest/m2/relay-memory.md) - memory measurements
+- [Origin local tree](/quest/m2/origin-cpu/origin-tree.md) - path traversal costs
+- [Path patterns](/quest/m2/path-patterns/README.md) - owns future matching semantics
+- [Wildcard advertisements](/quest/m2/wildcard/README.md) - owns future route resolution

--- a/quest/m2/origin-cpu/origin-index.md
+++ b/quest/m2/origin-cpu/origin-index.md
@@ -15,8 +15,16 @@ lookup, source-update, and announcement paths before choosing an index.
 Add a registered Criterion target using public origin operations. Sweep
 broadcast count, sources per broadcast, cursor count, and update churn
 independently. Separate initial replay from incremental notification and
-exact-path lookup; replay must pay for every result it emits. Use
-`rs/moq-bench/config/announce.toml` to check that microbenchmark wins survive relay load.
+exact-path lookup; replay must pay for every result it emits.
+
+Validate alternate-source wins with a relay workload where the same content
+and publisher identity reaches each broadcast over multiple peer routes.
+Assert the observed source count, then exercise route changes, withdrawal,
+and failover while checking delivered output. Independent publishers reusing
+a path are not equivalent: content replacement must not masquerade as multiple
+routes to one publisher. Add this workload to the existing benchmark runner.
+Keep `rs/moq-bench/config/announce.toml` as a single-source regression control;
+its unique per-connection paths do not validate alternate-source scaling.
 
 Optimize only a measured bottleneck. Compare a retained linear scan at small
 source counts with any proposed cache or index, accounting for invalidation,

--- a/quest/m2/origin-cpu/origin-tree.md
+++ b/quest/m2/origin-cpu/origin-tree.md
@@ -1,0 +1,31 @@
+# [M] Flatten the origin local tree
+
+## Goal
+
+Exact-path create/resolve is not linear in path depth times mutex plus
+string hash. Memory per node drops. Prune-on-empty and identity check on
+remove stay.
+
+## Plan
+
+`OriginNode` nests `HashMap<String, Lock<OriginNode>>`. `resolve_broadcast`
+locks each segment. `entry` does `dir.to_string()` on insert. A path of
+depth D pays D mutexes and D string hashes, while the full path is already
+an interned `Arc<str>` on `PathOwned`. Local ingest (`create_broadcast`)
+and exact-path resolve walk this before the route table.
+
+One lock on the tree, or a concurrent map keyed by interned segment / full
+path. Store `Arc<str>` (or an index into the parent `Path`) instead of
+owned `String`.
+
+Independently completable from [origin-index](/quest/m2/origin-cpu/origin-index.md)
+but both edit `origin.rs`; rebase rather than combine unless they land
+together.
+
+Acceptance: same new `origin.rs` Criterion: create/resolve D-segment paths,
+N = 10k–100k, depth 2–8. Resolve CPU not linear in D×lock.
+
+## Related
+
+- [Index the origin route table](/quest/m2/origin-cpu/origin-index.md) - advertised routes, not this tree
+- [Relay memory](/quest/m2/relay-memory.md) - `RouteEntry` / `ServeState`, not `OriginNode`

--- a/quest/m2/origin-cpu/origin-tree.md
+++ b/quest/m2/origin-cpu/origin-tree.md
@@ -1,31 +1,36 @@
-# [M] Flatten the origin local tree
+# [M] Measure and reduce origin path-traversal overhead
 
 ## Goal
 
-Exact-path create/resolve is not linear in path depth times mutex plus
-string hash. Memory per node drops. Prune-on-empty and identity check on
-remove stay.
+Reduce measured exact-path create/resolve costs while preserving scoped
+views, notifications, source reservations, and prune-on-empty behavior.
 
 ## Plan
 
-`OriginNode` nests `HashMap<String, Lock<OriginNode>>`. `resolve_broadcast`
-locks each segment. `entry` does `dir.to_string()` on insert. A path of
-depth D pays D mutexes and D string hashes, while the full path is already
-an interned `Arc<str>` on `PathOwned`. Local ingest (`create_broadcast`)
-and exact-path resolve walk this before the route table.
+`OriginNode` contains `HashMap<String, Lock<OriginNode>>` children.
+Traversal locks nodes by segment and insertion owns each segment string.
+`PathOwned` can share `Arc<str>` storage; shared storage does not imply
+interning or constant-time hashing.
 
-One lock on the tree, or a concurrent map keyed by interned segment / full
-path. Store `Arc<str>` (or an index into the parent `Path`) instead of
-owned `String`.
+Benchmark public create/resolve operations with 10k through 100k paths,
+depths 2 through 8, shared and disjoint prefixes, and concurrent churn.
+Measure lock contention, allocations, memory, and tail latency. Account for
+bytes hashed rather than promising cost independent of path length.
 
-Independently completable from [origin-index](/quest/m2/origin-cpu/origin-index.md)
-but both edit `origin.rs`; rebase rather than combine unless they land
-together.
+Compare the current tree with a simpler locking or lookup arrangement only
+if the baseline identifies a useful win. Preserve source reservations,
+stale-owner identity checks, announcement registration/replay, scoped roots,
+and removal during replacement. A global lock must not improve a serial
+microbenchmark at the expense of concurrent publishers.
 
-Acceptance: same new `origin.rs` Criterion: create/resolve D-segment paths,
-N = 10k–100k, depth 2–8. Resolve CPU not linear in D×lock.
+Register a Criterion target independently if the route-selection quest has
+not landed. Wire lifecycle and scope regressions into normal CI and retain
+paired results. Keep the current tree if alternatives do not improve the
+measured workload. Coordinate with pattern scopes so storage changes retain
+their literal-head notification and filtering requirements.
 
 ## Related
 
-- [Index the origin route table](/quest/m2/origin-cpu/origin-index.md) - advertised routes, not this tree
-- [Relay memory](/quest/m2/relay-memory.md) - `RouteEntry` / `ServeState`, not `OriginNode`
+- [Route-selection CPU](/quest/m2/origin-cpu/origin-index.md) - per-broadcast alternatives
+- [Relay memory](/quest/m2/relay-memory.md) - memory measurements
+- [Origin scopes](/quest/m2/path-patterns/origin.md) - future pattern-scoped views

--- a/quest/m2/rtmp-interleaving.md
+++ b/quest/m2/rtmp-interleaving.md
@@ -13,10 +13,13 @@ remaining message lengths. Preserve the public API and wire format.
 message on A followed by a chunk on B therefore shares assembly bytes, and
 B's remaining length is computed against A's buffered payload.
 
-First reproduce this with a deterministic regression: split a message on A,
-complete a shorter message on B, then finish A. Assert exact payloads, stream
-IDs, types, and timestamps, including the case where B is shorter than A's
-already buffered data. The current implementation must fail the test.
+First reproduce this with deterministic regressions: pause A between complete
+RTMP chunks, complete a single-chunk message on B, then finish A. Test B both
+shorter and longer than A's already buffered data, exercising underflow and
+payload mixing separately. Drain get_next_message with empty input until None;
+assert exact payloads, completion order, stream IDs, types, timestamps, and no
+residual message. Splitting within a chunk tests fragmented input separately;
+it is not valid CSID interleaving. The current implementation must fail.
 
 Keep partial-message state per chunk-stream ID while retaining one parser for
 the incoming byte stream. Preserve per-ID header compression and timestamp
@@ -24,9 +27,14 @@ history, chunk-size changes between messages, partial reads, and completion
 order. Validate lengths before subtraction or allocation; malformed input must
 return an error rather than corrupting another stream's state.
 
-Bound and reclaim incomplete-message state under the existing input limits;
-cover completion and teardown and verify that repeated ID reuse does not retain
-old payloads. Keep this correctness repair separate from shared-buffer or copy
+Set explicit per-connection limits on active chunk-stream IDs and aggregate
+retained assembly bytes. Chunk size and the 24-bit per-message length do not
+bound the aggregate. Check budgets before allocating or extending state; reject
+the input and release connection state on exhaustion using the existing error
+path. Choose and document numeric internal limits against supported client
+workloads before implementation is accepted. Test each limit independently,
+including many incomplete IDs, and verify reclamation on completion, teardown,
+and repeated ID reuse. Keep this correctness repair separate from shared-buffer or copy
 optimizations. Add the regression and fragmented/header-format cases to normal
 RTMP CI tests and run smoke-full for gateway interoperability.
 

--- a/quest/m2/rtmp-interleaving.md
+++ b/quest/m2/rtmp-interleaving.md
@@ -1,0 +1,35 @@
+# [M] Reassemble interleaved RTMP chunk streams independently
+
+## Goal
+
+Interleaved RTMP chunk streams produce the same complete messages and timestamps
+as each stream decoded independently, without mixing payloads or underflowing
+remaining message lengths. Preserve the public API and wire format.
+
+## Plan
+
+`ChunkDeserializer` keeps previous headers per chunk-stream ID but has one
+`current_payload_data` and one current message for all IDs. An incomplete
+message on A followed by a chunk on B therefore shares assembly bytes, and
+B's remaining length is computed against A's buffered payload.
+
+First reproduce this with a deterministic regression: split a message on A,
+complete a shorter message on B, then finish A. Assert exact payloads, stream
+IDs, types, and timestamps, including the case where B is shorter than A's
+already buffered data. The current implementation must fail the test.
+
+Keep partial-message state per chunk-stream ID while retaining one parser for
+the incoming byte stream. Preserve per-ID header compression and timestamp
+history, chunk-size changes between messages, partial reads, and completion
+order. Validate lengths before subtraction or allocation; malformed input must
+return an error rather than corrupting another stream's state.
+
+Bound and reclaim incomplete-message state under the existing input limits;
+cover completion and teardown and verify that repeated ID reuse does not retain
+old payloads. Keep this correctness repair separate from shared-buffer or copy
+optimizations. Add the regression and fragmented/header-format cases to normal
+RTMP CI tests and run smoke-full for gateway interoperability.
+
+## Related
+
+- [RTMP copies](/quest/m2/mux-copies/rtmp.md) - optimization requires this correct baseline


### PR DESCRIPTION
## Summary

- Plan measured CPU and copy reductions for origin lookup, cache refresh, owned decoding, JSON snapshots, browser media, and Rust mux/gateway paths.
- Ground each quest in current code, retain correctness and lifecycle contracts, and allow measured no-win outcomes. Split fMP4 import/encoding and FLV/RTMP into independently shippable quests.
- Separate RTMP interleaving correctness into a prerequisite and require bounded retained-buffer measurements before copy optimization.
- Require the shared browser benchmark harness. Keep audio on bounded reliable groups, preserve public frame ownership, and coalesce headers without copying payloads.

## Public API

None. These are plans; the planned optimizations preserve current public contracts.

## Wire

None. Require equivalent encoding and delivery behavior in the implementation tests.

(written by GPT-6)
