### PR TITLE
docs(quest): audit dev API and consumer contracts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@ For each finding:
 - If you disagree with the finding, reply and move on.
 
 # Follow-ups
+
 If you encounter issues, or findings that are out of scope, create follow-up quests.
 They should be unplanned and just a summary of the problem, maybe with a potential solution.
 The user will need to run `/plan-quests` to fully scope them.

--- a/quest/m1/README.md
+++ b/quest/m1/README.md
@@ -16,6 +16,18 @@ with the current dev tree before starting.
 
 ## Quests
 
+- [FFI read lanes](/quest/m1/api-ffi-read-lanes.md) - pending group and datagram reads progress independently on one subscription
+- [Connection recovery](/quest/m1/api-connection-recovery.md) - refreshed URLs recover shared/private handles under one terminal-state contract
+- [Relay embedding](/quest/m1/api-relay-embedding.md) - custom routes retain the owner of listeners, workers, and shutdown
+- [Numeric API invariants](/quest/m1/api-numeric-invariants.md) - accepted timescales and delivery properties are wire-encodable without truncation
+- [FFI frame cursor](/quest/m1/api-ffi-frame-cursor.md) - empty groups and cancelled reads do not become false EOF or lost frames
+- [JS wrapper lifetime](/quest/m1/api-js-wrapper-lifecycle.md) - closing or leaving JSON/binary readers releases their owned demand
+- [FFI configuration](/quest/m1/api-ffi-configuration.md) - configuration applies or fails explicitly rather than depending on lock timing
+- [Subscription bounds](/quest/m1/api-subscription-bounds.md) - local and requested ranges use consistent exclusive ends
+- [Readable input contract](/quest/m1/api-getter-contract.md) - accepted Getter types match runtime behavior
+- [JSON edit transaction](/quest/m1/api-json-edit-commit.md) - failed publication cannot disappear into a guard-drop warning
+- [JS wrapper configuration](/quest/m1/api-js-wrapper-config.md) - constructor shapes agree and consumer options exclude ignored producer knobs
+- [Publisher finish ownership](/quest/m1/api-producer-finish.md) - terminal Rust methods consume their handles while group cuts remain reusable
 - [Worker metrics](/quest/m1/uring-metrics.md) - per-worker io_uring counters at `/metrics`, so the runtime's own health is visible
 - [Stream sessions](/quest/m1/uring-tcp/README.md) - serve WebSocket and HTTP from the io_uring workers, where io_uring pays off most
 - [qlog](/quest/m1/uring-qlog.md) - io_uring workers write qlog traces instead of refusing the setting
@@ -72,4 +84,5 @@ with the current dev tree before starting.
 - [Route cold cost](/quest/m1/route-cold-cost.md) - MoqRoute carries warm and cold, so an observed route re-announces intact
 - [Anonymous rank](/quest/m1/anonymous-route-rank.md) - moq-net: a route through an anonymous hop ranks below every identified route at any cost, and hop 0 travels the chain to say so
 - [#2248](/quest/m1/2248-moq-mux-rebase-fmp4-export-timestamps-for-late-subscribers.md) - moq-mux: rebase fMP4 export timestamps for late subscribers
+- [External API proof](/quest/m1/api-release-proof.md) - packaged callers exercise real moq.pro use cases and record each audit finding's disposition
 - [Merge dev](/quest/m1/merge-dev.md) - dev lands on main with a closing keyword for every issue it fixed

--- a/quest/m1/api-connection-recovery.md
+++ b/quest/m1/api-connection-recovery.md
@@ -1,0 +1,39 @@
+# [M] Give Connection one recovery and terminal-state contract
+
+## Goal
+
+Changing `share` or transport options does not change whether refreshed
+credentials can recover a connection, and `closed` always describes the
+handle's actual terminal state.
+
+## Plan
+
+At dev `e2350b39a`, the shared path rejects `Connection.closed` on an auth
+failure but leaves its Effect alive (`js/net/src/connection/pool.ts:214`).
+Changing URL can acquire another loop and reconnect with an already-rejected
+`closed`. The private path creates one Reload (`:229`), whose auth failure
+permanently closes its Effect (`connection/reload.ts:316,342`); changing URL
+cannot revive it. These are source-traced behaviors, not runtime proofs yet.
+
+Real caller: moq.pro `app/src/lib/live.svelte.ts:75,113` renews JWTs and sets
+the connection URL. The audit read `/home/kixelated/work/moq.pro`; no consumer
+files were changed. Its pinned API is older, so preserve this use case rather
+than treating old type names as defects in the new API.
+
+Decided: a new URL can recover the same handle;
+expose attempt failures separately and reserve `closed` for final disposal.
+Align the observable close result with other net
+handles where practical; settle the chosen type before implementing it.
+
+Test shared/private auth failure followed by URL replacement, exhausted
+retries, disable/re-enable, explicit close, and lease cleanup. Ensure a
+terminal handle cannot reconnect and a recoverable one has not signalled
+terminal closure. Use existing connection tests plus the external consumer
+fixture; no timer-based workaround for the state-machine discrepancy.
+
+Public API: likely breaking lifecycle/close observation changes. Wire: no
+format change. Run JS checks and tests and the browser reconnect proof.
+
+## Related
+
+- [Close classification](/quest/m1/js-close-classification.md) - owns stream failure classes and media error visibility, not Connection lifetime

--- a/quest/m1/api-ffi-configuration.md
+++ b/quest/m1/api-ffi-configuration.md
@@ -1,0 +1,31 @@
+# [L] Make FFI configuration changes apply or fail explicitly
+
+## Goal
+
+Client, server, and pending-request configuration never silently ignores a
+call because an async operation owns the state or the handle is closed.
+
+## Plan
+
+At dev `e2350b39a`, client setters in `rs/moq-ffi/src/session.rs:399-518`,
+server setters in `server.rs:78-129`, and request origin setters at `:242`
+use `if let Some(state) = self.task.lock()` and otherwise succeed without
+changing anything. Even `set_bind` returns `Ok(())`. `ffi.rs:126` documents
+that the lock returns `None` for both busy and cancelled state. A pending
+connect/accept therefore makes configuration depend on scheduling.
+
+Decided: configuration records captured at
+construction/connect/listen/accept, with the lifecycle boundary visible in
+the API.
+Settle snapshot timing, handle reuse, and pending-request origins before
+implementation. Do not preserve silent no-op setters as compatibility shims.
+
+Reproduce mutation during a pending operation and after cancellation, then
+test the chosen apply-or-error contract for each object family. Update every
+handwritten wrapper and relevant C ABI entry, generated bindings through their
+normal flow, examples, and language docs in the same change. Existing server
+`cert_fingerprints` distinguishes busy and cancelled state and provides a
+reference for the smaller design.
+
+Public API: breaking configuration lifecycle or setter results. Wire: none.
+Run `just check`, `just test`, and `just test smoke-full`.

--- a/quest/m1/api-ffi-frame-cursor.md
+++ b/quest/m1/api-ffi-frame-cursor.md
@@ -1,0 +1,35 @@
+# [S] Preserve the FFI frame cursor across empty groups and cancellation
+
+## Goal
+
+The raw first-frame-per-group convenience returns EOF only when its track
+ends, and cancelling one pending read does not silently discard that group's
+eventual first frame.
+
+## Plan
+
+At dev `e2350b39a`, `TrackInner::read_frame`
+(`rs/moq-ffi/src/consumer.rs:425`) takes the next group into a local variable
+and directly returns its first frame. An empty completed group produces
+`None`, contradicting the track-EOF promise at `:523`. Empty groups are
+constructible through `producer.rs:701,824`. Cancellation while waiting for
+the first frame drops the local group after the ordered cursor advanced.
+These are source-traced cases, not executed regressions yet.
+
+Keep the pending group in the reader state, loop past completed empty groups,
+and preserve it when only an individual async call is cancelled. Retain the
+documented first-frame-per-group semantics; this quest does not turn the
+convenience into an all-frames reader. Define mixed calls to `next_group` and
+`read_frame` explicitly so persistent state cannot duplicate or lose a group.
+
+Add FFI regressions for an empty group on an open track, empty then populated
+groups, and cancellation after group acquisition followed by a successful
+read of its first frame. Verify terminal cancellation still releases demand.
+Check the Python, Swift, Kotlin, and Go conveniences against that behavior.
+
+Public API: behavioral correction without a signature change. Wire: none.
+Run `just check`, `just test`, and `just test smoke-full`.
+
+## Related
+
+- [FFI read lanes](/quest/m1/api-ffi-read-lanes.md) - changes the same reader state; coordinate ownership without making either fix depend on the other

--- a/quest/m1/api-ffi-read-lanes.md
+++ b/quest/m1/api-ffi-read-lanes.md
@@ -1,0 +1,32 @@
+# [M] Let FFI group and datagram reads progress independently
+
+## Goal
+
+A pending group read never prevents a datagram read from completing, and a
+pending datagram read never prevents a group read on the same subscription.
+
+## Plan
+
+Source evidence at dev `e2350b39a`: `MoqTrackConsumer` owns one
+`Task<TrackInner>` (`rs/moq-ffi/src/consumer.rs:459`). Both read lanes use it
+(`:507`, `:535`), and `Task::drive` holds its mutex across the entire awaited
+operation (`rs/moq-ffi/src/ffi.rs:203`). Start a group read on an idle track,
+then read and publish a datagram: the datagram reader waits for the group
+operation to release the lock. Reversing the calls reverses the starvation.
+This is source-traced, not yet an executed regression.
+
+Implement independent progress in the shared FFI core while preserving one
+subscription, one delivery-mode commitment, subscription control, and bounded
+buffering. Prefer demand-driven polling coordination; do not hide the lock
+problem behind an eager unbounded queue, a second subscription, or a timeout.
+
+Reproduce both directions in the existing FFI suite, including ordered and
+arrival modes, update during a pending read, per-call cancellation, and whole
+handle cancellation. `test.rs:2156` currently exercises the lanes sequentially.
+Go read deadlines cancel the entire handle (`go/wrapper/subscribe.go:282`);
+preserve that documented distinction from cancellation of an individual
+native async call unless a separate API decision changes it.
+
+Public API: preserve the current surface if the shared implementation can
+satisfy it; any handle split needs a maintainer decision and all wrappers.
+Wire: none. Run `just check`, `just test`, and `just test smoke-full`.

--- a/quest/m1/api-getter-contract.md
+++ b/quest/m1/api-getter-contract.md
@@ -1,0 +1,29 @@
+# [S] Align readable input types with accepted Getter implementations
+
+## Goal
+
+A value accepted as a component's readable input by TypeScript either works
+at runtime or is rejected by the public type before the component is built.
+
+## Plan
+
+At dev `e2350b39a`, `GetterInit<T> = T | Getter<T>` advertises structural
+readables (`js/signals/src/index.ts:318`), but `getter` rejects unbranded
+implementations (`:329-338`). `io.test.ts:98` deliberately constructs a typed
+foreign Getter and expects a throw. The audit ran this suite: 17 tests passed,
+including that mismatch. `Derived` helps map values but does not make the
+advertised input protocol accurate for external reactive adapters.
+
+Decided: accept any conforming Getter without wrapping it or installing an
+unowned subscription.
+Keep cross-package-version Signal compatibility and distinguish readable
+objects from ordinary data deliberately; do not silently freeze a readable.
+
+Add compile-time and runtime examples for foreign adapters, built-in readers,
+read-only component outputs, and plain values. Verify notifications and
+unsubscribe behavior, including a queued change at subscription time. Update
+the existing rejection test to encode the chosen contract, and document it
+on GetterInit, Inputs, and getter together.
+
+Public API: accepted readable types/behavior change. Wire: none. Run the
+existing signals tests and JS declaration builds.

--- a/quest/m1/api-js-wrapper-config.md
+++ b/quest/m1/api-js-wrapper-config.md
@@ -1,0 +1,32 @@
+# [M] Give JSON and binary wrappers consistent configuration
+
+## Goal
+
+Switching JSON/binary modes does not unexpectedly change constructor shape,
+and a consumer's config does not accept producer-only knobs that do nothing.
+
+## Plan
+
+At dev `e2350b39a`, JSON Snapshot Producer alone takes `{ track, ... }`
+(`js/json/src/snapshot/producer.ts:7,27`); other producers and consumers take
+`(track, config)`. The snapshot move was intentional in #2393 (`d7160da73`),
+so account for that rationale. Snapshot Consumer also takes encoder Config
+(`snapshot/consumer.ts:22`), accepting `initial` and `deltaRatio` although its
+decoder only reads schema and compression (`snapshot/decoder.ts:28`).
+
+Decided: standardize track-owning wrappers on an options object, preserving
+the deliberate snapshot choice. Separate producer and consumer options and
+keep bare codecs separate from track ownership.
+
+Migrate all JSON/binary modes and imports, docs, demo recipes, and the external
+consumer fixture together. Do not add old constructor aliases. Add negative
+type coverage for producer-only consumer options and check emitted package
+declarations. Existing functional tests should continue proving codec behavior.
+Schema validation for stream/window is a separate capability decision; do not
+silently expand this quest into changing their data model.
+
+Public API: breaking constructor/config types. Wire: none. Run JS check/test.
+
+## Related
+
+- [Wrapper lifecycle](/quest/m1/api-js-wrapper-lifecycle.md) - independent ownership behavior on the same wrapper family

--- a/quest/m1/api-js-wrapper-lifecycle.md
+++ b/quest/m1/api-js-wrapper-lifecycle.md
@@ -1,0 +1,33 @@
+# [M] Make JSON and binary wrapper ownership releasable
+
+## Goal
+
+A caller can stop an owned JSON/binary reader, including a pending read, and
+release its subscription. Exiting its async iterator does not leave demand
+alive. Producers can distinguish clean completion from caller-requested failure.
+
+## Plan
+
+At dev `e2350b39a`, all five JS JSON/binary consumers keep a private `#track`
+and expose no close/disposal operation. Their async iterators have no cleanup:
+`js/json/src/{snapshot,stream,window}/consumer.ts` and
+`js/binary/src/{snapshot,stream}/consumer.ts`. For example, JSON stream's
+constructor is at `:50` and its iterator at `:135`. The underlying track keeps
+each sink until its closed signal fires (`js/net/src/track.ts:493-525`).
+Breaking a `for await` therefore leaves a subscription with no accessible
+cleanup handle if the caller passed a temporary subscriber.
+
+Decided: follow net's `close(error?)` shape,
+close the owned track/current group, and use iterator `finally` cleanup.
+Retain producer `finish` as successful completion and allow explicit failure
+through the chosen close contract. Specify idempotence, pending-read wakeup,
+and post-close behavior. Do not close an unrelated publisher or sibling reader.
+
+Test normal completion, early break, exception in the loop body, explicit
+close during a pending read, repeat close, and error propagation in existing
+JSON/binary suites. Assert underlying demand disappears without manually
+retaining and closing a separate net handle. Be explicit that returning an
+iterator while its `next()` is pending needs a callable cancellation path.
+
+Public API: adds lifecycle methods and changes early-iterator-exit behavior.
+Wire: subscription teardown only, no format change. Run JS check/test.

--- a/quest/m1/api-json-edit-commit.md
+++ b/quest/m1/api-json-edit-commit.md
@@ -1,0 +1,39 @@
+# [S] Make JSON snapshot edit failures observable
+
+## Goal
+
+Editing a Rust JSON snapshot cannot appear successful while publication
+failed and the only indication is a warning in a log.
+
+## Plan
+
+At dev `e2350b39a`, `snapshot::Producer::lock` returns a mutable guard that
+publishes on drop. `rs/moq-json/src/snapshot/producer.rs:182` catches the
+publication error and logs it. The explicit `Guard::commit` already reports
+the error, but the ergonomic default discards it.
+
+Decided: keep publish-on-drop so forgetting commit does not discard an edit.
+Preserve explicit commit for immediate error handling, and make failures from
+implicit publication observable through producer state. Specify what happens
+when a commit fails, during unwinding, and when the track has already ended.
+Keep this scoped to edit transactions; do not change snapshot wire encoding.
+
+The requested compile-time enforcement is unavailable from `#[must_use]`:
+the audit compiled a must-use Guard with `let mut guard = Guard; guard.edit();`
+and no commit using rustc 1.95.0 `--emit=metadata -D warnings`, successfully.
+The attribute catches an ignored result, not a bound guard subsequently
+dropped without a particular method call. See the
+[Rust reference](https://doc.rust-lang.org/reference/attributes/diagnostics.html#the-must_use-attribute).
+Do not sell an advisory annotation as an enforced transaction protocol, or
+discard dirty edits based on that false guarantee.
+
+Search every `Producer::lock` use, including catalog helpers and
+external examples. Add regression tests proving an uncommitted edit has the
+chosen behavior, an explicit failed commit reports an error, and successful
+edits still emit the expected snapshot/delta. Existing JSON tests must own
+these cases so normal CI exercises them.
+
+Public API: preserve automatic publication; the error-observation surface
+must be scoped before implementation and may be additive. This remains a
+pre-merge contract review recommendation, not an automatic merge blocker.
+Wire: no framing change; preserve successful drop publication.

--- a/quest/m1/api-numeric-invariants.md
+++ b/quest/m1/api-numeric-invariants.md
@@ -1,0 +1,39 @@
+# [M] Make accepted numeric API values encodable
+
+## Goal
+
+Every accepted timescale and track delivery property survives encoding without
+truncation, precision loss, or a refusal by the matching reader. Reject invalid
+input at the public boundary, before publishing partially written metadata.
+
+## Plan
+
+Audit evidence at dev `e2350b39a` (2026-09-12):
+
+- `rs/moq-net/src/model/time.rs:73` implements `From<NonZero<u64>>` without
+  the varint bound enforced by `Timescale::new`. `NonZero::new(u64::MAX)`
+  therefore constructs a scale that `lite/track.rs:86` cannot encode.
+- `js/net/src/time.ts:83` uses `Number.isInteger`, accepting unsafe integers.
+  Executed against the current source: `Timescale(2 ** 53)`,
+  `Timescale(2 ** 62)`, and `Timescale(1e100)` all succeed.
+- `js/net/src/track.ts:80-92` accepts unchecked priority/timescale and finite
+  ages beyond the writer's safe integer range. `stream.ts:448` warns and
+  continues in `u53`, while the matching reader refuses unsafe values.
+  `Writer.u8` also wraps an out-of-range priority through `setUint8`.
+
+Replace the infallible Rust conversion with a checked conversion, routing all
+construction through the invariant. Validate JavaScript safe integer ranges,
+priority, and encoded duration bounds at their public entry points; writers
+must also refuse malformed input before emitting bytes. Preserve intentional
+unit conversion and rounding, documenting the supported precision. Do not
+broaden this into a new numeric framework or force JS numbers to represent
+the entire Rust u64 domain.
+
+Add boundary regressions to the existing Rust model/codec and JS time/track/
+writer suites: zero, negative, fractional, NaN/infinity, safe maximum and one
+past it, varint maximum and one past it, and priority 255/256. Prove valid
+metadata round-trips and rejected writes emit no malformed field.
+
+Public API: the Rust `From` removal is breaking; JS invalid inputs now throw.
+Wire: no format change, only refusal of values outside the existing domain.
+Run `just check`, `just test`, and `just test smoke-full`.

--- a/quest/m1/api-producer-finish.md
+++ b/quest/m1/api-producer-finish.md
@@ -1,0 +1,37 @@
+# [M] Make terminal Rust publisher operations consume their handle
+
+## Goal
+
+Finishing a publisher consumes that handle, matching the repository's
+ownership convention and preventing subsequent writes through the same value.
+Operations that only cut a group remain reusable.
+
+## Plan
+
+At dev `e2350b39a`, JSON window `Producer::finish(self)` contrasts with
+JSON snapshot/stream and binary snapshot/stream `finish(&mut self)`:
+`rs/moq-json/src/window/producer.rs:74`,
+`rs/moq-json/src/snapshot/producer.rs:126`,
+`rs/moq-json/src/stream/producer.rs:69`, and
+`rs/moq-binary/src/{snapshot,stream}/producer.rs:79,81`.
+Mux also has terminal `finish(&mut self)` beside consuming `abort(self)`
+(`rs/moq-mux/src/container/producer.rs:419,431`). These leave a value callable
+after its shared track has ended, turning an ownership error into a later
+runtime failure. This is a consistency recommendation, not a reproduced bug.
+
+Apply the existing consuming-terminal-operation convention to these public
+wrappers. Audit net track/group finish separately while updating calls:
+internal borrowed state machines may need private helpers, but do not expose
+compatibility shims. Keep nonterminal `cut`/`finish_group` distinct. Preserve
+last-drop cleanup and specify whether a failed final flush still consumes the
+handle. Clones can still observe shared termination; do not promise that
+consuming one handle statically invalidates other clones.
+
+Update call sites using Option::take or explicit ownership where appropriate,
+including examples and native media publishers. Keep regression coverage for
+successful flush, failed flush, and clone termination, and use compile-fail
+documentation to prove the same value cannot write after finish. Wire that
+documentation check into CI if it is not already run.
+
+Public API: breaking receiver ownership. Wire: no framing change; preserve
+clean end and error propagation. Run affected Rust check/test recipes.

--- a/quest/m1/api-relay-embedding.md
+++ b/quest/m1/api-relay-embedding.md
@@ -1,0 +1,38 @@
+# [L] Preserve relay runtime ownership for embedders
+
+## Goal
+
+An application adds routes and uses relay handles without copying startup,
+worker serving, shutdown, and joining logic or silently dropping new listeners.
+
+## Plan
+
+At dev `e2350b39a`, `rs/moq-relay/src/relay.rs:9-37` recommends destructuring
+the non-exhaustive Relay with `..`, claiming startup changes arrive safely
+through load. Public workers and uring fields own bound sockets (`:73,81`);
+discarding them can remove QUIC while the embedding code still compiles.
+The warning names workers but omits uring. Serving correctly requires the
+lifecycle logic in `Relay::run` (`:306` onward).
+
+Actual moq.pro edge code uses that embedding pattern and its own serving loop
+(`rs/edge/src/main.rs:88,317` in `/home/kixelated/work/moq.pro`). Its dependency
+is older; the finding is the silent migration hazard under worker/uring
+configuration, not a claim that its current deployed configuration is broken.
+
+Decided: an owning relay runner with custom routes and borrowed/cloned
+application handles. Retain startup, listener selection, worker ownership,
+error propagation, and shutdown joins inside the owner. This is distinct from
+fixing the worker implementation itself or designing new drain semantics.
+
+Add an external-crate example/test with a custom route and live QUIC request
+under shared Tokio, worker Tokio, and Linux io_uring. Prove stopping the owner
+releases listeners and joins workers. Wire every supported configuration into
+normal or nightly CI. Update relay docs in the same change.
+
+Public API: breaking embedding ownership. Wire: no format change. Run relevant
+relay checks/tests and `just test smoke-full` if gateway paths change.
+
+## Related
+
+- [Worker lifetime](/quest/m1/2964-quic-workers-dropping-one-split-server-resizes-the.md) - correctness inside a split worker group
+- [Relay drain API](/quest/m2/drain/relay-drain-api.md) - policy for new arrivals during drain

--- a/quest/m1/api-release-proof.md
+++ b/quest/m1/api-release-proof.md
@@ -1,0 +1,88 @@
+# [L] Prove the dev API through packaged external consumers
+
+## Goal
+
+Before publishing the dev API, representative external browser and native
+callers build and exercise the intended contracts, and every finding in the
+2026-09-12 audit has an explicit fix or deferral decision.
+
+## Plan
+
+The audit inspected dev `e2350b39a6ce9bd0734841fc4b4ce399ee195562`, fetched
+from origin on 2026-09-12, against main and the actual consumer at
+`/home/kixelated/work/moq.pro`. Consumer code was read without modification;
+it targets an older API. Compile migrations alone are not upstream defects.
+
+Coverage included Rust origin/announce, sessions, track subscription/control,
+group/frame ownership, timestamp invariants, bandwidth handles, JSON/binary
+publishers, mux/hang boundaries, browser net/signals and JSON/binary wrappers,
+watch/publish integration, shared FFI with C and native language wrappers,
+and relay embedding. This is a source/API audit, not an exhaustive behavioral
+proof of every exported symbol, platform backend, codec, or protocol version.
+
+New findings and recommendations, ordered by consequence:
+
+| Finding | Evidence status | Quest |
+|---|---|---|
+| FFI pending reads serialize independent datagram/group lanes | Source-traced starvation | [Read lanes](/quest/m1/api-ffi-read-lanes.md) |
+| Shared/private connections disagree on credential-refresh recovery and terminal state | Source-traced; real JWT-refresh caller | [Connection](/quest/m1/api-connection-recovery.md) |
+| Relay embedding can discard newly added socket owners without a compile error | Source-traced; real edge embedding pattern | [Embedding](/quest/m1/api-relay-embedding.md) |
+| Accepted numeric properties can truncate or fail only at encoding/receiving | JS unsafe timescales reproduced; remaining paths source-traced | [Numeric invariants](/quest/m1/api-numeric-invariants.md) |
+| FFI first-frame convenience treats empty groups as EOF and loses an acquired group on cancellation | Source-traced | [Frame cursor](/quest/m1/api-ffi-frame-cursor.md) |
+| JSON/binary readers hide the subscription cleanup handle | Source-traced retention | [Wrapper lifetime](/quest/m1/api-js-wrapper-lifecycle.md) |
+| FFI configuration setters silently succeed without applying a value | Source-traced busy/closed branch | [Configuration](/quest/m1/api-ffi-configuration.md) |
+| Local inclusive ends cannot express the empty exclusive range | Existing C adapter documents the mismatch | [Bounds](/quest/m1/api-subscription-bounds.md) |
+| Typed Getter input can be rejected solely for lacking an internal brand | Existing 17-test signals suite executed, including rejection test | [Readable contract](/quest/m1/api-getter-contract.md) |
+| JSON edit guard logs failed implicit publication | Source-traced error suppression | [Edit transaction](/quest/m1/api-json-edit-commit.md) |
+| Wrapper constructors diverge and consumers accept ignored producer knobs | Signature/implementation comparison | [Wrapper config](/quest/m1/api-js-wrapper-config.md) |
+| Terminal publisher methods inconsistently retain the caller's handle | Signature comparison; maintainability recommendation | [Finish ownership](/quest/m1/api-producer-finish.md) |
+
+Recommend resolving behavioral failures and published contract choices before
+merge. Cosmetic consistency can be deferred explicitly if the maintainer
+accepts the later breaking change. The table is a disposition checklist, not
+an automatic declaration that every proposed quest must be implemented first.
+Record each disposition and its fixing revision in the merge proof.
+
+Build a small public fixture against packaged exports, outside workspace
+hoisting and path aliases, modelling:
+
+- Connection, announcements, credential refresh, and publication replacement.
+  moq.pro `app/src/lib/live.svelte.ts:75,113` is the reference use case.
+- Stats snapshots versus retained rollup groups; choose the intended mode
+  instead of mechanically replacing a removed read helper.
+- Catalog-only reading with full snapshots followed by deltas. The old
+  consumer `app/src/lib/broadcastCatalog.svelte.ts:46` assumes every frame is
+  a full catalog. Use Json.Snapshot.Consumer and the catalog schema as the
+  upstream watch path does (`js/watch/src/broadcast.ts:304`); generic JSON
+  reads plus schema validation do not reconstruct merge patches.
+- Embedded relay with custom routes and application workers, based on
+  moq.pro `rs/edge/src/main.rs:88,317`, through the settled owning API.
+
+Do not copy the private application into the public repo. Include dependency
+deduplication in packaged validation: moq.pro already tests physical package
+identity (`app/test/deps.test.ts`); the module-local Connection pool and private
+net hooks deserve a real two-copy test. Duplicate-copy failure remains an
+unverified hypothesis until reproduced, not an established audit defect.
+
+Update migration docs beside the affected APIs, including Connection exports,
+broadcast.track(...).subscribe(...), Ordered readers, JSON modes, and the
+moq_native to moq_tokio transition. Do not reintroduce obsolete wrappers to
+avoid migration. Run the fixture in CI, record package versions and exact
+revisions, and let moq.pro's separately owned pin/release process adopt the
+proved surface. This quest does not bump packages or deploy the consumer.
+
+Public API: no additional API change beyond the fixing quests; fixture and
+documentation prove the chosen surface. Wire: no new format. Use existing
+browser/native integration recipes and cross-language smoke as appropriate.
+
+## Related
+
+- [Merge dev](/quest/m1/merge-dev.md) - records the final release and interop proof
+- [Binding announce parity](/quest/m1/3190-align-origin-broadcast-creation-naming-across-language.md) - already owns create/announce/dynamic naming across native wrappers
+- [Structured binding errors](/quest/m1/3187-preserve-structured-protocol-error-codes-across-ffi-and-c.md) - already owns error representation
+- [Binding rate control](/quest/m1/binding-rate-control.md) - already owns allocator parity
+- [Browser allocator](/quest/m1/2709-per-broadcast-bandwidth-estimates-and-reservation.md) - already owns browser bandwidth sharing
+- [Group overflow](/quest/m1/group-overflow-abort.md) - already owns group caps and writer-visible overrun
+- [Close classification](/quest/m1/js-close-classification.md) - already owns media error visibility
+- [C ABI parity](/quest/m1/2152-libmoq-c-abi-catch-up-with-the-moq-ffi-surface.md) - already owns C request/server omissions
+- [C fetch](https://github.com/moq-dev/moq/blob/e2350b39a6ce9bd0734841fc4b4ce399ee195562/quest/m2/libmoq-fetch.md) - already owns the missing C fetch entry point

--- a/quest/m1/api-subscription-bounds.md
+++ b/quest/m1/api-subscription-bounds.md
@@ -1,0 +1,33 @@
+# [M] Give local and requested subscription ranges consistent ends
+
+## Goal
+
+A caller can express an empty range and translate requested delivery bounds
+to local filtering without off-by-one conversions or extra delivered groups.
+Keep local filtering distinct from aggregated upstream demand.
+
+## Plan
+
+At dev `e2350b39a`, `track::Subscription::end` is an exclusive `Position`
+(`rs/moq-net/src/model/subscription.rs:66`), but `Subscriber::end_at` and
+`Ordered::end_at` take an inclusive group number (`model/track.rs:3569,3717`).
+`Position::before` cannot represent anything below group 0. The C adapter
+explicitly acknowledges this and maps an empty end to inclusive group 0
+(`rs/libmoq/src/consume.rs:633`), relying on upstream demand to suppress it.
+That is inadequate as a local range contract, especially with other readers
+keeping wider aggregate demand alive.
+
+Decided: use exclusive ends consistently, including local group/frame caps.
+Preserve the
+ability to raise/remove a cap without skipping held groups. Do not conflate
+moving a local cursor with requesting historical data.
+
+Audit group caps, Ordered forwarding, Lite/IETF adaptations, C raw reads,
+JS equivalents, and all language range wrappers. Test empty ranges, group 0,
+frame-limited ends, unbounded ends, maximum positions, and narrowing/widening
+while another subscriber requests everything. Put regressions in existing
+CI suites and run cross-language smoke.
+
+Public API: likely breaking cap signatures or semantics. Wire: preserve the
+existing exclusive wire encoding; update the matching draft only if the
+chosen behavior changes what peers observe.

--- a/quest/m1/merge-dev.md
+++ b/quest/m1/merge-dev.md
@@ -59,4 +59,5 @@ lands.
 
 ## Related
 
+- [External API proof](/quest/m1/api-release-proof.md) - the pre-merge audit inventory, real consumer fixture, and explicit fix/deferral decisions
 - [Dart announce](/quest/m1/dart-announce.md) - waits on this merge, so it cannot be required here

--- a/quest/m1/merge-dev.md
+++ b/quest/m1/merge-dev.md
@@ -19,6 +19,7 @@ lands.
 
 ## Required
 
+- [External API proof](/quest/m1/api-release-proof.md) - the packaged consumer fixture and explicit fix/deferral decisions must be recorded before merge
 - [Archive](/quest/m1/archive/README.md) - moq.pro needs archive-backed recording on the release dev produces
 - [Announce handle](/quest/m1/announce-handle.md) - the origin surface the merge ships
 - [#3190](/quest/m1/3190-align-origin-broadcast-creation-naming-across-language.md) - every native binding on that surface
@@ -59,5 +60,4 @@ lands.
 
 ## Related
 
-- [External API proof](/quest/m1/api-release-proof.md) - the pre-merge audit inventory, real consumer fixture, and explicit fix/deferral decisions
 - [Dart announce](/quest/m1/dart-announce.md) - waits on this merge, so it cannot be required here


### PR DESCRIPTION
## Summary

- Audit dev `e2350b39a` against Rust, browser, native binding, and real moq.pro call sites; create 12 focused finding/recommendation quests and one packaged external-consumer proof quest.
- Record the selected range, connection recovery, configuration, relay ownership, readable input, and wrapper contracts. Keep JSON publish-on-drop after verifying that `#[must_use]` cannot enforce a later commit.
- Distinguish reproduced behavior from source-traced findings and deduplicate existing announce, error, bandwidth, group overflow, and C parity work. The proof quest records fix/deferral decisions without making every recommendation a merge blocker.
- Require that external API proof before Merge dev can become ready, so the fixture and disposition record cannot be skipped.
- Fix the missing blank line in CONTRIBUTING.md required by the repository-wide formatter.

## Public API

Planning only; no exports or implementation changed. Each quest records its prospective API impact. The audit revision is dev; this documentation PR targets main and preserves its existing quest tree.

## Wire

None. Quests distinguish validation/behavior corrections from any future format changes.

## Validation

- Nix `just fix`, `just check` (350 quest documents), and scoped `just test` pass; no affected implementation packages.
- Executed unsafe JavaScript timescale constructor examples and the 17-test signals input suite against the audited dev source.
- Rust `#[must_use]` forgotten-commit example compiles with `--emit=metadata -D warnings`.
- FFI concurrency, cancellation, and relay scenarios remain source-traced and have explicit regression requirements in their quests.

(written by GPT-6)
