### PR TITLE
fix(kio): bound waiter registration work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4240,13 +4240,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.98"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -10380,9 +10379,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -10393,9 +10392,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10403,9 +10402,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -10413,9 +10412,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -10426,18 +10425,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.71"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af5ec93229ad9ccd0a545a516dec76dc276613f278f6a91aa6b463d5b33d42d0"
+checksum = "895a2607575412a4eda1df892084a375ea10dfeadc4d7d2ab87b854e4ddc7ba1"
 dependencies = [
  "async-trait",
  "cast",
@@ -10457,9 +10456,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.71"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c81b9fef827e575e0e54431736d1baa0d700315d8c62cfef1f61fa3aad0cbeb"
+checksum = "4288cb0ebe215033bf949ae1fd046726daa4c32a157f24b9dc6ac387a52aa759"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10468,9 +10467,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.121"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4d8ae7ad5440360e9799dfd42857d126454a88441ddf72d288ef83fa47f527"
+checksum = "33ff1c1b360982e93b6d8ea9c04836f71dba0817a16f91e229cf3a51bdd9d987"
 
 [[package]]
 name = "wasm-streams"
@@ -10621,9 +10620,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/rs/kio/benches/waiter.rs
+++ b/rs/kio/benches/waiter.rs
@@ -18,8 +18,7 @@ use std::task::{Context, Waker};
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use kio::{Park, Waiter, WaiterList};
 
-/// Live-waiter populations to sweep. The top end is the inline capacity, past which
-/// the list spills to the heap.
+/// Live-waiter populations spanning inline storage and heap spill.
 const SIZES: [usize; 4] = [1, 2, 8, 32];
 
 /// A list holding `n` live registrations, plus the waiters keeping them live.
@@ -35,8 +34,7 @@ fn populated(n: usize) -> (WaiterList, Vec<Waiter>) {
 	(list, waiters)
 }
 
-/// Register the first waiter on a newly constructed list, including lazy list
-/// initialization in the measured path.
+/// Register the first waiter on a newly constructed list.
 fn bench_register_first(c: &mut Criterion) {
 	c.bench_function("waiter_register_first", |b| {
 		b.iter_batched(
@@ -50,8 +48,8 @@ fn bench_register_first(c: &mut Criterion) {
 	});
 }
 
-/// Register a fresh waiter into a list of N live entries: the dedup scan misses,
-/// the dead-slot probe finds nothing, and the entry is appended.
+/// Register a fresh waiter into a list of N live entries: the dead-slot probe
+/// finds nothing, and the entry is appended.
 fn bench_register(c: &mut Criterion) {
 	let mut g = c.benchmark_group("waiter_register_live");
 	for &n in &SIZES {
@@ -72,23 +70,22 @@ fn bench_register(c: &mut Criterion) {
 	g.finish();
 }
 
-/// Re-register a waiter already in a list of N live entries: the record fast path,
-/// which is the steady-state cost of a poll that re-runs while still parked. Flat
-/// in N, since membership is settled by the waiter's own record, not a scan.
+/// Re-poll with a still-registered waiter, including retirement and slot reuse.
 fn bench_reregister(c: &mut Criterion) {
 	let mut g = c.benchmark_group("waiter_reregister");
 	for &n in &SIZES {
 		g.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
-			let (mut list, waiters) = populated(n);
-			let last = waiters.last().unwrap();
-			b.iter(|| last.register(&mut list));
+			let (mut list, _waiters) = populated(n);
+			let mut park = Park::default();
+			let cx = Context::from_waker(Waker::noop());
+			b.iter(|| park.hold(&cx).register(&mut list));
 		});
 	}
 	g.finish();
 }
 
-/// Register a fresh waiter into a list whose N entries are all dead: the dedup scan
-/// misses and the probe reclaims a slot in place.
+/// Register a fresh waiter into a list whose N entries are all dead: the probe
+/// reclaims a slot in place.
 fn bench_register_dead(c: &mut Criterion) {
 	let mut g = c.benchmark_group("waiter_register_dead");
 	for &n in &SIZES {
@@ -121,11 +118,10 @@ fn bench_cancel(c: &mut Criterion) {
 
 /// The cycle a poll function actually drives: hold the park, register with L lists,
 /// then one list wakes. The re-poll arrives with live registrations still parked on
-/// the other lists, which is exactly the case `Park` must not retire on.
+/// the other lists, requiring retirement before re-registration.
 fn bench_park_cycle(c: &mut Criterion) {
 	let mut g = c.benchmark_group("waiter_park_cycle");
-	// 16 lists overflow the waiter's record table, exercising eviction and the
-	// scan fallback rather than the pure record fast path.
+	// Include broad polls that remain parked on many quiet lists.
 	for &lists in &[1usize, 2, 4, 8, 16] {
 		g.bench_with_input(BenchmarkId::from_parameter(lists), &lists, |b, &n| {
 			let cx = Context::from_waker(Waker::noop());
@@ -169,9 +165,8 @@ fn bench_fanout_cycle(c: &mut Criterion) {
 }
 
 /// The fan-out cycle when every waiter is also parked on a second, never-woken list
-/// (a value list and a closed list under one lock, say). The live second
-/// registration is what forecloses the registered-nowhere fast path, so this is the
-/// worst case for rebuilding the drained list.
+/// (a value list and a closed list under one lock, say). Each partial wake requires
+/// a new waiter, so this includes allocation and reclamation at high fan-out.
 fn bench_fanout_cycle_parked(c: &mut Criterion) {
 	let mut g = c.benchmark_group("waiter_fanout_cycle_parked");
 	for &n in &FANOUT {
@@ -179,19 +174,14 @@ fn bench_fanout_cycle_parked(c: &mut Criterion) {
 		g.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
 			let mut list = WaiterList::new();
 			let mut parked = WaiterList::new();
-			let waiters: Vec<_> = (0..n)
-				.map(|_| {
-					let waiter = Waiter::new(Waker::noop().clone());
-					waiter.register(&mut parked);
-					waiter
-				})
-				.collect();
+			let mut parks: Vec<_> = (0..n).map(|_| Park::default()).collect();
+			let cx = Context::from_waker(Waker::noop());
 			b.iter(|| {
-				for waiter in &waiters {
+				for park in &mut parks {
+					let waiter = park.hold(&cx);
 					waiter.register(&mut list);
 					waiter.register(&mut parked);
 				}
-				// Drain the production way: snapshot under the lock, wake outside.
 				list.take().wake();
 			});
 		});

--- a/rs/kio/src/loom.rs
+++ b/rs/kio/src/loom.rs
@@ -253,17 +253,10 @@ fn queue_close_wakes_a_parked_pop() {
 	});
 }
 
-/// A poll parked on two lists is re-woken by one while still registered with the
-/// other. The re-poll reuses the parked waiter, so re-registering into the drained
-/// list must actually land (not be skipped as a false duplicate), and re-registering
-/// into the still-parked list must dedup rather than stack.
-///
-/// The terminal wake is on the *drained* list, so an execution whose re-poll fails
-/// to re-register there parks forever, which loom reports as a deadlock. `parked` is
-/// never woken at all: it exists to keep the waiter's registrations live across
-/// re-polls, which is exactly the state the old code retired on.
+/// A partial wake retires the waiter still parked on the quiet list. The new
+/// registration must hear a terminal wake on the drained list or the task hangs.
 #[test]
-fn a_reused_waiter_hears_the_drained_list_again() {
+fn a_replaced_waiter_hears_the_drained_list_again() {
 	loom::model(|| {
 		let woken = Fan::new();
 		let parked = Fan::new();
@@ -286,26 +279,14 @@ fn a_reused_waiter_hears_the_drained_list_again() {
 		// Register before reading `done`, as in `a_held_wake_is_never_lost`: the
 		// other order has a window where the store and both wakes land between the
 		// read and the registration.
-		//
-		// The closure holds its own waiter rather than using the parked one: loom's
-		// `block_on` waker fails `will_wake` between polls (its vtable is a
-		// const-promoted static, duplicated across codegen units in release builds),
-		// so `Park` retires every poll under loom and would never model the reuse
-		// this test exists for. Waking the first poll's waker still unparks the
-		// task, so a stable identity is safe here.
-		block_on({
-			let mut stable = None;
-			wait(move |parked_waiter| {
-				let waiter = stable.get_or_insert_with(|| Waiter::new(parked_waiter.waker().clone()));
-				woken.register(waiter);
-				parked.register(waiter);
-
-				match done.load(Ordering::SeqCst) {
-					true => Poll::Ready(()),
-					false => Poll::Pending,
-				}
-			})
-		});
+		block_on(wait(|waiter| {
+			woken.register(waiter);
+			parked.register(waiter);
+			match done.load(Ordering::SeqCst) {
+				true => Poll::Ready(()),
+				false => Poll::Pending,
+			}
+		}));
 
 		waker.join().unwrap();
 	});

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -54,6 +54,8 @@ impl Waiter {
 	}
 
 	/// Register this waiter with a [`WaiterList`] for future notification.
+	///
+	/// Delegates to [`WaiterList::register`], which is not idempotent.
 	pub fn register(&self, list: &mut WaiterList) {
 		list.register(self);
 	}
@@ -113,10 +115,15 @@ impl WaiterList {
 
 	/// Register a waiter.
 	///
-	/// Performs a small, bounded amount of garbage collection: probes the
-	/// slot at the rotating cursor, replacing it in place if dead. The
-	/// cursor advances on each append so the probe window covers the
-	/// whole list over time.
+	/// Not idempotent: a waiter already in the list is appended again.
+	/// [`Park::hold`] retires any waiter that still has live registrations
+	/// before the next poll, so the in-tree poll path never stacks
+	/// duplicates. Callers that retain a waiter across polls must drop it
+	/// before registering again.
+	///
+	/// Each call probes at most two slots at the rotating cursor and reuses
+	/// a dead one in place. The cursor advances on each live probe so the
+	/// window covers the list over time.
 	pub fn register(&mut self, waiter: &Waiter) {
 		let new_weak = Arc::downgrade(waiter.shared());
 
@@ -787,6 +794,15 @@ mod tests {
 			Waiter::noop().register(&mut list);
 		}
 		assert!(list.entries.len() <= 2);
+	}
+
+	#[test]
+	fn register_appends_a_live_waiter() {
+		let mut list = WaiterList::new();
+		let waiter = Waiter::new(Waker::noop().clone());
+		waiter.register(&mut list);
+		waiter.register(&mut list);
+		assert_eq!(list.entries.len(), 2, "a live waiter must not dedup");
 	}
 
 	#[test]

--- a/rs/kio/src/waiter.rs
+++ b/rs/kio/src/waiter.rs
@@ -5,7 +5,7 @@ use std::{
 	pin::Pin,
 	// std, not `crate::sync`: loom's Arc has no `downgrade`, and `Waker::from` takes
 	// std's. See `sync.rs`.
-	sync::{Arc, OnceLock, Weak, atomic::AtomicU64},
+	sync::{Arc, OnceLock, Weak},
 	task::{Context, Poll, Wake, Waker},
 };
 
@@ -17,128 +17,15 @@ use crate::{
 };
 
 /// Number of slots stored inline before spilling to the heap.
-///
-/// Sized for the common list, not the worst one. The array lives inside the
-/// enclosing `Arc<Mutex<State<T>>>`, so every list pays it whether or not
-/// anything ever parks, and a state cell holds three lists. At 32 that was 840 B
-/// of mostly-empty slots on every channel; downstream in moq-net a broadcast
-/// holds four to five cells and a cached group holds one, so it dominated their
-/// footprint.
-///
-/// It cannot go to zero, because `take()` moves the entries out to be woken
-/// outside the lock: a spilled list hands its heap buffer to the snapshot, which
-/// frees it, so the capacity does not survive a wake and the next registration
-/// re-allocates. Inline slots have no such cost. That makes this the count of
-/// waiters a list can hold without allocating once per wake, measured per
-/// take/wake cycle:
-///
-/// | inline | `WaiterList` | allocs/cycle at 2 / 4 / 8 waiters |
-/// |---|---|---|
-/// | 32 | 296 B | 0 / 0 / 0 |
-/// | 8 | 104 B | 0 / 0 / 0 |
-/// | 4 | 72 B | 0 / 0 / 1 |
-/// | 2 | 56 B | 0 / 1 / 2 |
-///
-/// Sizes are the layout without `smallvec/union`; a build where something else
-/// turns that on (glib, wgpu-hal) is 8 B smaller per list.
-///
-/// 4 keeps the steady state allocation-free for the small lists that dominate
-/// while giving back most of the memory. A genuinely hot fan-out list spills
-/// under any of these; it did at 32 too. `tests/waiter_allocs.rs` pins both halves
-/// of that trade, and `the_list_stays_small` pins the size.
-///
-/// One inline slot plus a `Vec` for the rest reaches the same 56 B as 2 inline
-/// slots, but allocates from the *second* waiter rather than the third, so it is
-/// strictly worse than the row it ties.
 const INLINE_WAITERS: usize = 4;
-
-/// Registrations remembered per waiter identity for O(1) dedup. A poll typically
-/// parks on a small handful of lists; a poll cycling through more than this many
-/// evicts its own records and falls back to the scan, so the cap bounds memory,
-/// never correctness.
-const RECORDED_LISTS: usize = 8;
-
-/// The shared identity behind a [`Waiter`], referenced weakly by every list entry.
-struct Identity {
-	/// The task waker the lists deliver to.
-	waker: Waker,
-
-	/// Registrations this identity has made. A record matching a list's current
-	/// epoch proves the registration is still in place, and a stale one proves it
-	/// is gone: live entries only leave through a drain, every drain bumps the
-	/// epoch, and every registration refreshes the record. Either way membership is
-	/// settled in O(1); only a missing record (never registered, or evicted) needs
-	/// the scan.
-	recorded: Mutex<Records>,
-}
-
-/// The record table behind an [`Identity`].
-#[derive(Default)]
-struct Records {
-	/// `(list id, list epoch)` pairs, at most [`RECORDED_LISTS`] of them.
-	entries: SmallVec<[(u64, u64); RECORDED_LISTS]>,
-
-	/// State for choosing an eviction victim pseudo-randomly. Deterministic
-	/// policies (FIFO, LRU) evict exactly the next-needed record when a poll
-	/// cycles through more lists than the cap, degrading every registration to the
-	/// scan; a random victim keeps an expected `cap / lists` fraction of hits
-	/// instead.
-	seed: u64,
-}
-
-/// What an identity's records prove about its membership in one list.
-enum Presence {
-	/// Recorded at the list's current epoch: still registered.
-	Present,
-	/// Recorded at an older epoch: the drain that bumped it removed every entry,
-	/// and registering again would have refreshed the record, so: not registered.
-	Absent,
-	/// No record (never registered, or evicted): membership must be checked.
-	Unknown,
-}
-
-impl Identity {
-	/// What the records prove about membership in list `id` at `epoch`.
-	///
-	/// Also refreshes the record to `(id, epoch)` before returning. That is sound
-	/// even though the caller has not registered yet: every path out of
-	/// [`WaiterList::register`] leaves the waiter registered, and folding the write
-	/// into the lookup keeps registration at one lock round-trip.
-	fn presume(&self, id: u64, epoch: u64) -> Presence {
-		let mut recorded = self.recorded.lock().expect("mutex poisoned");
-
-		if let Some(entry) = recorded.entries.iter_mut().find(|entry| entry.0 == id) {
-			let presence = match entry.1 == epoch {
-				true => Presence::Present,
-				false => Presence::Absent,
-			};
-			entry.1 = epoch;
-			return presence;
-		}
-
-		if recorded.entries.len() < RECORDED_LISTS {
-			recorded.entries.push((id, epoch));
-			return Presence::Unknown;
-		}
-
-		// Evict a pseudo-random record (a Weyl-style step, no external RNG):
-		// eviction only ever costs a scan later, and a random victim avoids the
-		// deterministic worst case where a cyclic visit pattern one list wider
-		// than the cap evicts exactly the record it needs next, every time.
-		recorded.seed = recorded.seed.wrapping_mul(0x9E37_79B9_7F4A_7C15).wrapping_add(1);
-		let victim = (recorded.seed >> 33) as usize % RECORDED_LISTS;
-		recorded.entries[victim] = (id, epoch);
-		Presence::Unknown
-	}
-}
 
 /// Handle passed to poll functions for registering with [`WaiterList`]s.
 ///
-/// Holds the task's [`Waker`] by value and, lazily, a shared identity that list
-/// entries reference weakly. The identity is allocated on the first
-/// [`Self::register`], so a poll that resolves without ever parking never touches
-/// the heap. Its `Weak`s go dead the moment the owning [`Waiter`] drops, which is
-/// how a [`WaiterList`] reclaims slots with no explicit deregister.
+/// Holds the task's [`Waker`] by value and, lazily, a shared `Arc<Waker>` that list
+/// entries reference weakly. The `Arc` is allocated on the first [`Self::register`],
+/// so a poll that resolves without ever parking never touches the heap. Its `Weak`s
+/// go dead the moment the owning [`Waiter`] drops, which is how a [`WaiterList`]
+/// reclaims slots with no explicit deregister.
 ///
 /// A clone shares this identity: it wakes the same task, its registrations count as
 /// the original's, and they all stay live until every clone drops.
@@ -149,7 +36,7 @@ pub struct Waiter {
 	// The shared handle downgraded into every list this waiter registers with. Created on the
 	// first `register` (a poll that never parks never allocates it), then reused so multiple
 	// lists in one poll share a single allocation whose `Weak`s die together when the waiter drops.
-	shared: OnceLock<Arc<Identity>>,
+	shared: OnceLock<Arc<Waker>>,
 }
 
 impl Waiter {
@@ -177,15 +64,10 @@ impl Waiter {
 		&self.waker
 	}
 
-	/// The shared identity downgraded into lists, allocated on first use and cached so
+	/// The shared waker handle downgraded into lists, allocated on first use and cached so
 	/// repeat registrations (across polls, or across lists in one poll) share one allocation.
-	fn shared(&self) -> &Arc<Identity> {
-		self.shared.get_or_init(|| {
-			Arc::new(Identity {
-				waker: self.waker.clone(),
-				recorded: Mutex::new(Records::default()),
-			})
-		})
+	fn shared(&self) -> &Arc<Waker> {
+		self.shared.get_or_init(|| Arc::new(self.waker.clone()))
 	}
 
 	/// Poll a foreign [`Future`] against this waiter, so it re-wakes the enclosing
@@ -208,18 +90,6 @@ impl Clone for Waiter {
 	}
 }
 
-/// Source of unique [`WaiterList`] ids, so a waiter's recorded registrations can
-/// never confuse two lists (ids are handed out once and never reused). IDs are
-/// assigned lazily on first registration: most channel lists never receive a waiter,
-/// so construction need not touch this process-wide cache line. Exhausting it would
-/// take 2^64 registered lists, centuries at one per nanosecond, so wraparound is
-/// unreachable in any process lifetime.
-static NEXT_LIST_ID: AtomicU64 = AtomicU64::new(1);
-
-/// A list that has not received a registration yet. Never handed out by
-/// [`NEXT_LIST_ID`].
-const UNASSIGNED: u64 = 0;
-
 /// A list of weak wakers waiting for notification.
 ///
 /// Slots live inline (up to `INLINE_WAITERS`) and only spill to the heap
@@ -227,105 +97,35 @@ const UNASSIGNED: u64 = 0;
 /// collection across many `register` calls so the list doesn't grow
 /// unboundedly while keeping per-call cost O(1).
 pub struct WaiterList {
-	entries: SmallVec<[Weak<Identity>; INLINE_WAITERS]>,
+	entries: SmallVec<[Weak<Waker>; INLINE_WAITERS]>,
 	/// Rotating cursor for opportunistic GC on `register`.
 	cursor: usize,
-	/// Never-reused identity for this list, paired with `epoch` in waiter records.
-	/// Assigned lazily on the first registration.
-	id: u64,
-	/// Bumped on every drain. A waiter whose record carries the current epoch is
-	/// still registered: live entries only ever leave through a drain.
-	epoch: u64,
 }
 
 impl WaiterList {
-	/// Create an empty list with inline entry storage.
-	///
-	/// Registration requires no list-storage growth allocation until the inline
-	/// capacity is exceeded.
+	/// Create an empty list, allocating nothing until the first [`register`](Self::register).
 	pub fn new() -> Self {
 		Self {
 			entries: SmallVec::new(),
 			cursor: 0,
-			id: UNASSIGNED,
-			epoch: 0,
 		}
 	}
 
-	/// Return this list's stable identity, assigning one on first registration.
-	fn id(&mut self) -> u64 {
-		if self.id != UNASSIGNED {
-			return self.id;
-		}
-
-		// A CAS loop rather than fetch_add, so exhaustion fails closed instead of
-		// wrapping into reissued ids (a reissued id could fake presence). List
-		// registration is normally contention-free in practice.
-		let mut id = NEXT_LIST_ID.load(std::sync::atomic::Ordering::Relaxed);
-		loop {
-			assert_ne!(id, u64::MAX, "waiter list id space exhausted");
-			match NEXT_LIST_ID.compare_exchange_weak(
-				id,
-				id + 1,
-				std::sync::atomic::Ordering::Relaxed,
-				std::sync::atomic::Ordering::Relaxed,
-			) {
-				Ok(_) => break,
-				Err(current) => id = current,
-			}
-		}
-
-		self.id = id;
-		id
-	}
-
-	/// Register a waiter. Idempotent: a waiter already in the list stays as one entry.
+	/// Register a waiter.
 	///
-	/// The cost is O(1) whenever the waiter's own records settle membership, which is
-	/// every steady state: still registered since the last drain (a re-poll while
-	/// parked) returns immediately, and registered before the last drain (rebuilding
-	/// after a wake) appends immediately. Only a waiter with no record of this list
-	/// falls back to a membership scan: pointer equality over contiguous entries,
-	/// exact because a `Weak` pins its allocation's address, so an equal pointer
-	/// always means the same waiter. The scan too is skipped when the waiter is
-	/// registered nowhere at all (one atomic load on its own allocation).
-	///
-	/// An append also performs a small, bounded amount of garbage collection: probes
-	/// the slot at the rotating cursor, replacing it in place if dead. The cursor
-	/// advances on each append so the probe window covers the whole list over time.
+	/// Performs a small, bounded amount of garbage collection: probes the
+	/// slot at the rotating cursor, replacing it in place if dead. The
+	/// cursor advances on each append so the probe window covers the
+	/// whole list over time.
 	pub fn register(&mut self, waiter: &Waiter) {
-		let shared = waiter.shared();
-		let id = self.id();
-		let presence = shared.presume(id, self.epoch);
-
-		match presence {
-			// Still registered since the last drain: nothing to do. This is what
-			// lets `Park` keep reusing a still-registered waiter instead of
-			// retiring it every poll.
-			Presence::Present => return,
-
-			// Provably not in the list: straight to the append.
-			Presence::Absent => {}
-
-			// No record either way, so membership needs the scan, except when the
-			// waiter is registered nowhere at all.
-			Presence::Unknown => {
-				if Arc::weak_count(shared) > 0 {
-					let ptr = Arc::as_ptr(shared);
-					if self.entries.iter().any(|entry| std::ptr::eq(entry.as_ptr(), ptr)) {
-						return;
-					}
-				}
-			}
-		}
-
-		let new_weak = Arc::downgrade(shared);
+		let new_weak = Arc::downgrade(waiter.shared());
 
 		for _ in 0..self.entries.len().min(2) {
 			if self.entries[self.cursor].strong_count() == 0 {
-				// Reuse the dead slot in place. Each Waiter owns a unique
-				// identity allocation, so strong_count == 0 uniquely
+				// Reuse the dead slot in place. Each Waiter owns a
+				// unique Arc<Waker>, so strong_count == 0 uniquely
 				// identifies a slot whose owner has been dropped.
+				// No will_wake / pointer comparison needed.
 				self.entries[self.cursor] = new_weak;
 				return;
 			}
@@ -338,26 +138,17 @@ impl WaiterList {
 	/// Drain all entries into a new [`WaiterList`], leaving this one empty.
 	pub fn take(&mut self) -> Self {
 		self.cursor = 0;
-		self.epoch = self.epoch.checked_add(1).expect("waiter list epoch overflow");
 		Self {
 			entries: std::mem::take(&mut self.entries),
 			cursor: 0,
-			// This runs on every notification, so the snapshot must not touch the
-			// global id counter (a shared cache line across all channels). It exists
-			// to be woken and will assign its own id if it is registered with instead.
-			id: UNASSIGNED,
-			epoch: 0,
 		}
 	}
 
 	/// Wake all live waiters, draining the list.
 	pub fn wake(&mut self) {
 		self.cursor = 0;
-		// Fail closed rather than wrap: a wrapped epoch would let a stale record
-		// claim presence. Unreachable in practice (2^64 drains of one list).
-		self.epoch = self.epoch.checked_add(1).expect("waiter list epoch overflow");
-		for identity in self.entries.drain(..).filter_map(|w| w.upgrade()) {
-			identity.waker.wake_by_ref();
+		for waker in self.entries.drain(..).filter_map(|w| w.upgrade()) {
+			waker.wake_by_ref();
 		}
 	}
 }
@@ -424,18 +215,19 @@ impl Park {
 	/// (the usual `ready!` on a nested poll) still leaves its registrations live.
 	/// There is no second call to forget.
 	///
-	/// The held waiter is reused whenever it would wake the same task, so a
-	/// steady-state park allocates nothing. Live registrations are no obstacle: a poll
-	/// that waits on several lists is re-woken by one while still parked on the rest,
-	/// and re-registering there is a no-op because [`WaiterList::register`] is
-	/// idempotent. Only a waker for a *different* task retires the waiter, dropping
-	/// its registrations so the lists can reclaim those slots.
+	/// The held waiter is reused when it would wake the same task *and* has no live
+	/// list registrations (the usual case after a wakeup, which drains every entry),
+	/// so a steady-state park allocates nothing. Otherwise it is retired for a fresh
+	/// one: a still-registered waiter must not be registered again, because
+	/// [`WaiterList`] reclaims a slot only once its `Arc` dies, so reusing one with
+	/// live entries would stack duplicates the list could never collect.
 	pub fn hold(&mut self, cx: &Context<'_>) -> &Waiter {
-		let reuse = self
-			.0
-			.as_ref()
-			.is_some_and(|waiter| cx.waker().will_wake(&waiter.waker));
+		let reuse = self.0.as_ref().is_some_and(|waiter| {
+			cx.waker().will_wake(&waiter.waker) && waiter.shared.get().is_none_or(|shared| Arc::weak_count(shared) == 0)
+		});
 		if !reuse {
+			// The outgoing waiter drops here, killing its registrations so the lists
+			// can reclaim those slots.
 			self.0 = Some(Waiter::new(cx.waker().clone()));
 		}
 		self.0.as_ref().unwrap()
@@ -915,14 +707,14 @@ mod tests {
 	/// A bound and not an equality, because `SmallVec` stores its inline array in a
 	/// union or a tagged enum depending on whether anything else in the build graph
 	/// enabled `smallvec/union` (glib and wgpu-hal both do). That moves the list
-	/// between 64 B and 72 B for reasons that have nothing to do with kio.
+	/// between 48 B and 56 B for reasons that have nothing to do with kio.
 	#[test]
 	#[cfg(target_pointer_width = "64")]
 	fn the_list_stays_small() {
 		let list = std::mem::size_of::<WaiterList>();
 		let state = std::mem::size_of::<crate::State<()>>();
-		assert!(list <= 72, "WaiterList grew to {list} B");
-		assert!(state <= 224, "State<()> grew to {state} B");
+		assert!(list <= 56, "WaiterList grew to {list} B");
+		assert!(state <= 176, "State<()> grew to {state} B");
 	}
 
 	#[test]
@@ -955,158 +747,46 @@ mod tests {
 	}
 
 	#[test]
-	fn park_reuses_a_still_registered_waiter() {
+	fn partial_wakes_retire_registrations_across_many_lists() {
 		let waker = Waker::noop().clone();
 		let cx = Context::from_waker(&waker);
 		let mut park = Park::default();
-		let mut list = WaiterList::new();
+		let mut lists: Vec<_> = (0..32).map(|_| WaiterList::new()).collect();
+		for _ in 0..100 {
+			let waiter = park.hold(&cx);
+			for list in &mut lists {
+				waiter.register(list);
+			}
+			let previous = Arc::downgrade(waiter.shared());
+			lists[0].wake();
+			park.hold(&cx);
+			assert!(previous.upgrade().is_none(), "partial wake retained old registrations");
+			for list in &lists {
+				assert!(list.entries.len() <= 2, "abandoned registrations accumulated");
+			}
+		}
+	}
 
-		// Poll 1 parks with a live registration.
+	#[test]
+	fn drained_waiter_is_reused() {
+		let waker = Waker::from(Arc::new(Flag::default()));
+		let cx = Context::from_waker(&waker);
+		let mut park = Park::default();
+		let mut list = WaiterList::new();
 		let waiter = park.hold(&cx);
 		waiter.register(&mut list);
 		let first = waiter.shared().clone();
-
-		// Poll 2 with that registration still live (a wake from some other list, say)
-		// reuses the waiter without allocating, and re-registering it dedups rather
-		// than stacking a duplicate.
-		let waiter = park.hold(&cx);
-		assert!(
-			Arc::ptr_eq(&first, waiter.shared()),
-			"a still-registered waiter was retired"
-		);
-		waiter.register(&mut list);
-		assert_eq!(list.entries.len(), 1, "re-registration stacked a duplicate");
-
-		// The wake drains the list; poll 3 reuses the same waiter and registers anew.
 		list.wake();
-		let waiter = park.hold(&cx);
-		assert!(Arc::ptr_eq(&first, waiter.shared()), "a drained waiter was not reused");
-		waiter.register(&mut list);
-		assert_eq!(list.entries.len(), 1);
-		assert!(list.entries[0].strong_count() > 0, "the registration must stay live");
-	}
-
-	#[test]
-	fn register_is_idempotent_per_identity() {
-		let mut list = WaiterList::new();
-
-		// Repeat registrations of one identity, directly or via a clone, are one entry.
-		let waiter = Waiter::new(Waker::noop().clone());
-		waiter.register(&mut list);
-		waiter.register(&mut list);
-		waiter.clone().register(&mut list);
-		assert_eq!(list.entries.len(), 1, "one identity must occupy one slot");
-
-		// A distinct waiter is a distinct entry, even for the same task.
-		let other = Waiter::new(Waker::noop().clone());
-		other.register(&mut list);
-		assert_eq!(list.entries.len(), 2);
-	}
-
-	#[test]
-	fn dedup_survives_record_eviction() {
-		// More lists than the identity keeps records for: the evicted ones fall back
-		// to the scan, which must still find the registration.
-		let waiter = Waiter::new(Waker::noop().clone());
-		let mut lists: Vec<_> = (0..2 * RECORDED_LISTS).map(|_| WaiterList::new()).collect();
-		for list in &mut lists {
-			waiter.register(list);
-		}
-
-		// Re-registering must not stack anywhere, recorded or evicted alike.
-		for list in lists.iter_mut().rev() {
-			waiter.register(list);
-			assert_eq!(list.entries.len(), 1, "re-registration stacked a duplicate");
-		}
-	}
-
-	#[test]
-	fn a_drain_invalidates_the_record() {
-		let waiter = Waiter::new(Waker::noop().clone());
-		let mut list = WaiterList::new();
-
-		// A wake drains the registration; the stale record must not convince the
-		// next register that it is still present, or its wakeup is lost.
-		waiter.register(&mut list);
-		list.wake();
-		assert_eq!(list.entries.len(), 0);
-		waiter.register(&mut list);
-		assert_eq!(list.entries.len(), 1);
-		assert!(list.entries[0].strong_count() > 0, "the registration must be live");
-
-		// Same for a drain via take.
-		let taken = list.take();
-		assert_eq!(list.entries.len(), 0);
-		drop(taken);
-		waiter.register(&mut list);
-		assert_eq!(list.entries.len(), 1);
-		assert!(list.entries[0].strong_count() > 0, "the registration must be live");
-	}
-
-	#[test]
-	fn a_taken_snapshot_tracks_nothing() {
-		let waiter = Waiter::new(Waker::noop().clone());
-		let mut list = WaiterList::new();
-		waiter.register(&mut list);
-
-		// The snapshot inherits the entries but no identity of its own. Its first
-		// registration assigns a fresh identity, then settles the unknown membership
-		// by scan: the entry moved with the snapshot, so this dedups rather than stacking.
-		let mut taken = list.take();
-		waiter.register(&mut taken);
-		assert_eq!(taken.entries.len(), 1, "the snapshot register stacked a duplicate");
-
-		// And a second waiter still gets in.
-		let other = Waiter::new(Waker::noop().clone());
-		other.register(&mut taken);
-		assert_eq!(taken.entries.len(), 2);
+		assert!(Arc::ptr_eq(&first, park.hold(&cx).shared()));
 	}
 
 	#[test]
 	fn abandoned_waiters_do_not_grow_the_list() {
 		let mut list = WaiterList::new();
-
-		// Register-and-drop, over and over, without a single wake. The rotating probe
-		// must keep reclaiming the dead slots, or the list grows by one per waiter.
 		for _ in 0..1_000 {
-			Waiter::new(Waker::noop().clone()).register(&mut list);
+			Waiter::noop().register(&mut list);
 		}
-		assert!(list.entries.len() <= 2, "the list grew to {}", list.entries.len());
-	}
-
-	/// The steady state this shape exists for: a poll waiting on several lists is
-	/// re-woken by one while still parked on the others, and the re-poll must not
-	/// allocate a new waiter or stack duplicate registrations.
-	#[test]
-	fn a_multi_list_poll_reuses_across_a_partial_wake() {
-		let waker = Waker::noop().clone();
-		let cx = Context::from_waker(&waker);
-		let mut park = Park::default();
-		let mut first = WaiterList::new();
-		let mut second = WaiterList::new();
-
-		// Poll 1 waits on both lists.
-		let waiter = park.hold(&cx);
-		waiter.register(&mut first);
-		waiter.register(&mut second);
-		let shared = waiter.shared().clone();
-
-		// One list wakes; the other still holds a live registration.
-		first.wake();
-
-		// Poll 2 reuses the waiter and re-registers with both: an append into the
-		// drained list, a no-op in the still-parked one.
-		let waiter = park.hold(&cx);
-		assert!(
-			Arc::ptr_eq(&shared, waiter.shared()),
-			"the waiter was retired mid-operation"
-		);
-		waiter.register(&mut first);
-		waiter.register(&mut second);
-
-		assert_eq!(first.entries.len(), 1);
-		assert_eq!(second.entries.len(), 1, "re-registration stacked a duplicate");
-		assert!(second.entries[0].strong_count() > 0, "the registration must stay live");
+		assert!(list.entries.len() <= 2);
 	}
 
 	#[test]

--- a/rs/kio/tests/waiter_allocs.rs
+++ b/rs/kio/tests/waiter_allocs.rs
@@ -48,7 +48,7 @@ static ALLOCATOR: Counting = Counting;
 fn cycle_allocs(waiters: &[Waiter], cycles: usize) -> usize {
 	let mut list = WaiterList::new();
 
-	// Reach the steady state first: identities allocated, records seeded, and the
+	// Reach the steady state first: identities allocated, and the
 	// list grown to whatever it settles at.
 	for _ in 0..4 {
 		for waiter in waiters {

--- a/rs/moq-net/Cargo.toml
+++ b/rs/moq-net/Cargo.toml
@@ -52,7 +52,7 @@ loom = { workspace = true }
 [target.'cfg(target_family = "wasm")'.dev-dependencies]
 getrandom = { workspace = true }
 # Keep this in lockstep with rs/moq-wasm's pinned wasm-bindgen CLI schema.
-wasm-bindgen-test = "=0.3.71"
+wasm-bindgen-test = "=0.3.77"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }

--- a/rs/moq-wasm/Cargo.toml
+++ b/rs/moq-wasm/Cargo.toml
@@ -35,7 +35,7 @@ tracing-wasm = "0.2"
 url = { workspace = true }
 # Pinned to the wasm-bindgen-cli version in the Nix dev shell: the bindgen
 # schema must match exactly between crate and CLI. Bump both together.
-wasm-bindgen = "=0.2.121"
+wasm-bindgen = "=0.2.127"
 wasm-bindgen-futures = "0.4"
 web-async = { workspace = true }
 web-transport-trait = { workspace = true }


### PR DESCRIPTION
## Summary

- Restore bounded waiter registration: inspect at most two weak entries for reclamation, otherwise append. Remove the membership cache and full-list deduplication scan.
- Retire a parked waiter before repolling when it still has registrations, so those entries can be reclaimed instead of accumulating live duplicates. Continue reusing a waiter after all registrations drain.
- Cover partial wakeups across 32 lists, update the concurrency model, and make fan-out benchmarks exercise waiter retirement.
- Document that `WaiterList::register` is not idempotent; `Park::hold` is the lifetime pairing. Add `register_appends_a_live_waiter`.
- Pin `wasm-bindgen` to 0.2.127 to match the Nix CLI schema so WASM CI can run.

## Public API

No signature changes. Repeated direct `WaiterList::register` calls no longer deduplicate; `Park` retires outstanding registrations between polls. Callers manually retaining a waiter across polls must drop the waiter before registering again. This is a 0.5.x behavior change on the published `kio` crate, documented on `register` itself.

## Wire

No changes.

## Validation

- Regression fails before the change and passes afterward.
- `register_appends_a_live_waiter` pins the new contract.
- `just fix` passes on the follow-up. Focused kio waiter tests pass.
- Original author: all 3,315 affected tests exercised; 3,314 pass, one fails because the local filesystem watcher hits `MaxFilesWatch`; seven additional tests are skipped by the existing configuration. `just rs loom` passes: 16 kio models and five moq-net models.

## Rationale

This is a maintainability simplification (delete the membership cache), not a throughput fix. The 6 Mbps × 250 comparison did not support shipping it as a hotspot rollback: after restart the original is within run noise of the candidate, and both still miss the 1,500 Mbps offered-load target.

(written by grok-4.6)