### PR TITLE
docs(quest): borrow publisher finish so abort can follow

### DIFF
--- a/quest/m1/README.md
+++ b/quest/m1/README.md
@@ -27,6 +27,7 @@ quest here and merged main into dev.
 - [FFI configuration](/quest/m1/api-ffi-configuration.md) - configuration applies or fails explicitly rather than depending on lock timing
 - [Subscription bounds](/quest/m1/api-subscription-bounds.md) - local and requested ranges use consistent exclusive ends
 - [JSON edit transaction](/quest/m1/api-json-edit-commit.md) - failed publication cannot disappear into a guard-drop warning
+- [Publisher finish borrows](/quest/m1/api-finish-borrow.md) - finish borrows the handle so abort can still run after a clean end
 - [External API proof](/quest/m1/api-release-proof.md) - packaged callers exercise real moq.pro use cases and record each audit finding's disposition
 - [Monotonic timeline](/quest/m1/monotonic-timeline.md) - a marker group of one empty frame declares a break and moves the live edge; producers refuse a rewind; consumers jump the playhead on an unproven hole and drop rewind detection
 - [Advertise](/quest/m1/wildcard-advertise.md) - moq-net encodes, forwards, and authorizes wildcard advertisements, lifting the prefix-only refusal on `dynamic(pattern, route)`

--- a/quest/m1/api-finish-borrow.md
+++ b/quest/m1/api-finish-borrow.md
@@ -1,0 +1,56 @@
+# [S] Borrow publisher finish so abort can still run
+
+## Goal
+
+A public publisher `finish` borrows the handle, matching net track, group, and
+broadcast, so `abort(self)` can still run after a clean finish.
+
+## Plan
+
+Net already documents this split at `origin/dev` `b5a289a05`:
+`track::Producer::finish(&mut self)` is not terminal (lower-numbered groups may
+still arrive; abort still consumes), `group::Producer::finish` borrows so a
+later failure can still abort, and `broadcast::Producer::finish` borrows so
+declaring the end does not depend on surrendering the handle. Abort consumes.
+
+An earlier plan to make `finish` consume the handle was abandoned for this
+reason: that makes abort-after-finish unrepresentable.
+
+Public publisher `finish(self)` still in the tree:
+
+- `moq_json::window::Producer::finish` (`rs/moq-json/src/window/producer.rs`),
+  while snapshot and stream already borrow
+- `moq_room` chat `finish` (`rs/moq-room/src/chat.rs`), which only forwards to
+  the window producer
+- `moq_audio::encode::Producer::finish` (`rs/moq-audio/src/encode/producer.rs`)
+- `moq_video::encode::Producer::finish` (`rs/moq-video/src/encode/producer.rs`)
+
+Change those to `finish(&mut self)`. Internal helpers that exist only to
+forward (audio `Reserved`, capture `Track`) follow. Encoder drain that
+returns packets (`Encoder::finish(self) -> Vec<Encoded>` and friends) stays
+consuming: that is a builder, not a publisher close.
+
+FFI already exposes `finish(&self)` but `take()`s the inner `Option` first
+(`MoqTrackProducer`, `MoqGroupProducer`, `MoqBroadcastProducer`, audio, video,
+JSON snapshot/stream). Finish in place so a later `abort` can still take the
+handle. UniFFI signatures stay `&self`.
+
+Out of scope: Drop-disarm guards (`SourceGuard`, `recv::Group` / `recv::Frame`)
+whose consuming finish is what stops `Drop` from aborting; `frame::Producer`
+commit; JS, which has no abort and already cannot consume.
+
+Do not add a consuming alias. A failed finish leaves the handle, as `&mut self`
+already does. Keep last-drop cleanup. Clones are independent, same as today.
+
+Prove abort after a successful finish on each migrated publisher, including
+the FFI take-in-place path. Existing call sites that only finish do not need
+rewrites; drop any `Option::take` that existed solely to call a consuming
+finish.
+
+Public API: breaking for callers who bind a non-`mut` producer and call
+`finish()` (Rust); FFI behavior change (finish no longer closes the handle).
+Wire: none. Run the affected Rust and FFI check/test recipes.
+
+## Related
+
+- [External API proof](/quest/m1/api-release-proof.md) - records this disposition

--- a/quest/m1/api-finish-borrow.md
+++ b/quest/m1/api-finish-borrow.md
@@ -3,7 +3,7 @@
 ## Goal
 
 A public publisher `finish` borrows the handle, matching net track, group, and
-broadcast, so `abort(self)` can still run after a clean finish.
+broadcast, so a later `abort(self)` is still representable.
 
 ## Plan
 
@@ -16,12 +16,11 @@ declaring the end does not depend on surrendering the handle. Abort consumes.
 An earlier plan to make `finish` consume the handle was abandoned for this
 reason: that makes abort-after-finish unrepresentable.
 
-Public publisher `finish(self)` still in the tree:
+Public publisher `finish(self)` still on `dev`:
 
 - `moq_json::window::Producer::finish` (`rs/moq-json/src/window/producer.rs`),
-  while snapshot and stream already borrow
-- `moq_room` chat `finish` (`rs/moq-room/src/chat.rs`), which only forwards to
-  the window producer
+  while snapshot and stream already borrow. Window has no `abort`; this is
+  signature consistency only.
 - `moq_audio::encode::Producer::finish` (`rs/moq-audio/src/encode/producer.rs`)
 - `moq_video::encode::Producer::finish` (`rs/moq-video/src/encode/producer.rs`)
 
@@ -30,26 +29,36 @@ forward (audio `Reserved`, capture `Track`) follow. Encoder drain that
 returns packets (`Encoder::finish(self) -> Vec<Encoded>` and friends) stays
 consuming: that is a builder, not a publisher close.
 
-FFI already exposes `finish(&self)` but `take()`s the inner `Option` first
-(`MoqTrackProducer`, `MoqGroupProducer`, `MoqBroadcastProducer`, audio, video,
-JSON snapshot/stream). Finish in place so a later `abort` can still take the
-handle. UniFFI signatures stay `&self`.
+FFI already exposes `finish(&self)` but `take()`s the inner `Option`. Only
+`MoqTrackProducer` and `MoqGroupProducer` also expose `abort`. Finish those
+two in place so a later `abort` can still take the handle. Do not add `abort`
+to broadcast, audio, video, or JSON FFI wrappers, and do not change their
+`take()` on finish.
+
+UniFFI signatures stay `&self`, so generated Dart/Kotlin/Python/Swift bindings
+do not regenerate. If a binding guide says finish releases the handle, fix
+that sentence (`doc/lib/{py,swift,kt,go,dart,c}` as needed). libmoq's
+id-keyed `Session::finish` is a different shape and stays out.
 
 Out of scope: Drop-disarm guards (`SourceGuard`, `recv::Group` / `recv::Frame`)
 whose consuming finish is what stops `Drop` from aborting; `frame::Producer`
-commit; JS, which has no abort and already cannot consume.
+commit; JS, which has no abort and already cannot consume; adding abort to
+types that lack it.
 
 Do not add a consuming alias. A failed finish leaves the handle, as `&mut self`
 already does. Keep last-drop cleanup. Clones are independent, same as today.
 
-Prove abort after a successful finish on each migrated publisher, including
-the FFI take-in-place path. Existing call sites that only finish do not need
+Prove abort after a successful finish on audio and video producers and on FFI
+track/group. For JSON window, prove the handle remains usable after finish
+(no `abort` to call). Existing call sites that only finish do not need
 rewrites; drop any `Option::take` that existed solely to call a consuming
 finish.
 
 Public API: breaking for callers who bind a non-`mut` producer and call
-`finish()` (Rust); FFI behavior change (finish no longer closes the handle).
-Wire: none. Run the affected Rust and FFI check/test recipes.
+`finish()` (Rust); FFI track/group finish no longer closes the handle.
+Wire: none. Run the affected Rust and `moq-ffi` check/test recipes, including
+`finish_closes_producer` and the Python local tests that encode take-on-finish,
+then `just test smoke-full` because `moq-ffi` behavior changes.
 
 ## Related
 

--- a/quest/m1/api-release-proof.md
+++ b/quest/m1/api-release-proof.md
@@ -34,7 +34,7 @@ New findings and recommendations, ordered by consequence:
 | Local inclusive ends cannot express the empty exclusive range | Existing C adapter documents the mismatch | [Bounds](/quest/m1/api-subscription-bounds.md) |
 | Typed Getter input can be rejected solely for lacking an internal brand | Fixed: getter() reuses any conforming Getter | Fixed |
 | JSON edit guard logs failed implicit publication | Source-traced error suppression | [Edit transaction](/quest/m1/api-json-edit-commit.md) |
-| Terminal publisher methods inconsistently retain the caller's handle | Abandoned: finish must be `&mut` so abort can follow | deferred |
+| Terminal publisher methods inconsistently retain the caller's handle | Signature comparison; finish must borrow so abort can follow | [Finish borrows](/quest/m1/api-finish-borrow.md) |
 
 Recommend resolving behavioral failures and published contract choices before
 merge. Cosmetic consistency can be deferred explicitly if the maintainer


### PR DESCRIPTION
## Summary
- New m1 quest: public publisher `finish` borrows (`&mut self`), `abort` still consumes, matching net track/group/broadcast.
- Migrates JSON window, room chat, audio/video encode producers, and FFI `finish` that `take()`s the inner handle.
- Leaves Drop-disarm guards and builder `finish(self) -> T` consuming.
- Replaces the consume-finish recommendation in the API proof table. The old consume-finish quest should be abandoned without the implementation.

## Public API
- Quest only. The work it describes is a breaking receiver-ownership change on those publishers, plus FFI finish no longer closing the handle.

## Wire
- None.

(written by grok-4.6)